### PR TITLE
Fix bug in timeseries module.

### DIFF
--- a/cognite/__init__.py
+++ b/cognite/__init__.py
@@ -15,4 +15,4 @@ Data Platform (CDP).
 
 
 __all__ = ['assets', 'config', 'data_objects', 'tagmatching', 'timeseries', 'raw', 'preprocessing']
-__version__ = '0.4.31'
+__version__ = '0.4.32'

--- a/cognite/data_objects.py
+++ b/cognite/data_objects.py
@@ -208,7 +208,7 @@ class TimeseriesResponse(CogniteDataObject):
 
     def to_pandas(self):
         '''Returns data as a pandas dataframe'''
-        if self.internal_representation[0].get('metadata') is None:
+        if self.internal_representation and self.internal_representation[0].get('metadata') is None:
             return pd.DataFrame(self.internal_representation)
         for d in self.internal_representation:
             if d.get('metadata'):

--- a/tests/test_timeseries.py
+++ b/tests/test_timeseries.py
@@ -101,3 +101,9 @@ def test_get_timeseries_output_format(get_timeseries_response_obj):
     assert isinstance(get_timeseries_response_obj.to_ndarray(), np.ndarray)
     assert isinstance(get_timeseries_response_obj.to_pandas(), pd.DataFrame)
     assert isinstance(get_timeseries_response_obj.to_json()[0], dict)
+
+
+def test_get_timeseries_no_results():
+    result = timeseries.get_timeseries(prefix='not_a_timeseries_prefix')
+    assert result.to_pandas().empty
+    assert len(result.to_json()) == 0


### PR DESCRIPTION
- Fix TimeseriesResponse.to_pandas() breaking when no timeseries are returned by the request.
- Add test for this case.