### PR TITLE
Fix get_multitag_datapoitns and respective tests.

### DIFF
--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -412,7 +412,8 @@
         },
         "pluggy": {
             "hashes": [
-                "sha256:7f8ae7f5bdf75671a718d2daf0a64b7885f74510bcd98b1a0bb420eb9a9d0cff"
+                "sha256:7f8ae7f5bdf75671a718d2daf0a64b7885f74510bcd98b1a0bb420eb9a9d0cff",
+                "sha256:e160a7fcf25762bb60efc7e171d4497ff1d8d2d75a3d0df7a21b76821ecbf5c5"
             ],
             "version": "==0.6.0"
         },

--- a/cognite/__init__.py
+++ b/cognite/__init__.py
@@ -15,4 +15,4 @@ Data Platform (CDP).
 
 
 __all__ = ['assets', 'config', 'data_objects', 'tagmatching', 'timeseries', 'raw', 'preprocessing']
-__version__ = '0.4.33'
+__version__ = '0.4.34'

--- a/cognite/data_objects.py
+++ b/cognite/data_objects.py
@@ -150,6 +150,10 @@ class DatapointsQuery():
         self.aggregateFunctions = ','.join(aggregates) if aggregates is not None else None
         self.granularity = granularity
         self.start, self.end = _utils.interval_to_ms(start, end)
+        if not start:
+            self.start = None
+        if not end:
+            self.end = None
         self.limit = limit
 
 

--- a/cognite/timeseries.py
+++ b/cognite/timeseries.py
@@ -326,10 +326,10 @@ def get_multi_tag_datapoints(datapoints_queries, aggregates=None, granularity=No
                 ts_granularity = granularity if dpq.granularity is None else dpq.granularity
                 next_start = latest_timestamp + (_utils.granularity_to_ms(ts_granularity) if ts_granularity else 1)
             else:
+                next_start = end - 1
                 if datapoints_queries[i].end:
                     next_start = datapoints_queries[i].end - 1
-                else:
-                    next_start = end - 1
+
             datapoints_queries[i].start = next_start
 
     results = [{'data': {'items': [{'tagId': dpq.tagId, 'datapoints': []}]}} for dpq in datapoints_queries]

--- a/cognite/timeseries.py
+++ b/cognite/timeseries.py
@@ -323,9 +323,13 @@ def get_multi_tag_datapoints(datapoints_queries, aggregates=None, granularity=No
             if len(dpr['datapoints']) == dpq.limit:
                 has_incomplete_requests = True
                 latest_timestamp = dpr['datapoints'][-1]['timestamp']
-                next_start = latest_timestamp + (_utils.granularity_to_ms(dpq.granularity) if dpq.granularity else 1)
+                ts_granularity = granularity if dpq.granularity is None else dpq.granularity
+                next_start = latest_timestamp + (_utils.granularity_to_ms(ts_granularity) if ts_granularity else 1)
             else:
-                next_start = datapoints_queries[i].end - 1
+                if datapoints_queries[i].end:
+                    next_start = datapoints_queries[i].end - 1
+                else:
+                    next_start = end - 1
             datapoints_queries[i].start = next_start
 
     results = [{'data': {'items': [{'tagId': dpq.tagId, 'datapoints': []}]}} for dpq in datapoints_queries]

--- a/tests/test_timeseries.py
+++ b/tests/test_timeseries.py
@@ -88,6 +88,10 @@ def test_get_multitag_dps_correctly_spaced(get_multitag_dps_response_obj):
     deltas = np.diff(timestamps, 1)
     assert (deltas != 0).all()
     assert (deltas % 60000 == 0).all()
+    timestamps = m[1].to_pandas().timestamp.values
+    deltas = np.diff(timestamps, 1)
+    assert (deltas != 0).all()
+    assert (deltas % 30000 == 0).all()
 
 
 @pytest.fixture(scope='module', params=[True, False])

--- a/tests/test_timeseries.py
+++ b/tests/test_timeseries.py
@@ -65,10 +65,10 @@ def test_get_dps_frame_correctly_spaced(get_datapoints_frame_response_obj):
 @pytest.fixture(scope='module', params=dps_params[:2])
 def get_multitag_dps_response_obj(request):
     from cognite.data_objects import DatapointsQuery
-    dq1 = DatapointsQuery('constant', aggregates=['avg'], granularity='30m')
-    dq2 = DatapointsQuery('sinus')
+    dq1 = DatapointsQuery('constant')
+    dq2 = DatapointsQuery('sinus', aggregates=['avg'], granularity='30s')
     yield list(timeseries.get_multi_tag_datapoints(datapoints_queries=[dq1, dq2], start=request.param['start'],
-                                                   end=request.param['end'], aggregates=['avg'], granularity='1h'))
+                                                   end=request.param['end'], aggregates=['avg'], granularity='60s'))
 
 
 def test_get_multitag_dps_output_format(get_multitag_dps_response_obj):
@@ -87,7 +87,7 @@ def test_get_multitag_dps_correctly_spaced(get_multitag_dps_response_obj):
     timestamps = m[0].to_pandas().timestamp.values
     deltas = np.diff(timestamps, 1)
     assert (deltas != 0).all()
-    assert (deltas % 10000 == 0).all()
+    assert (deltas % 60000 == 0).all()
 
 
 @pytest.fixture(scope='module', params=[True, False])


### PR DESCRIPTION
Issue fixed with get_multitag_datapoints:
- If start & end are not set explicitly for each dp query, it will default to [2w-ago, now] instead of global default.