### PR TITLE
Avoid using multiprocessing.Pool when processes = 1.

### DIFF
--- a/cognite/__init__.py
+++ b/cognite/__init__.py
@@ -15,4 +15,4 @@ Data Platform (CDP).
 
 
 __all__ = ['assets', 'config', 'data_objects', 'tagmatching', 'timeseries', 'raw', 'preprocessing']
-__version__ = '0.4.34'
+__version__ = '0.4.35'

--- a/cognite/timeseries.py
+++ b/cognite/timeseries.py
@@ -84,6 +84,10 @@ def get_datapoints(tag_id, aggregates=None, granularity=None, start=None, end=No
         project=project
     )
 
+    if steps == 1:
+        dps = _get_datapoints_helper(tag_id, aggregates, granularity, start, end,
+                                     protobuf=kwargs.get('protobuf', True), api_key=api_key, project=project)
+        return DatapointsResponse({'data': {'items': [{'tagId': tag_id, 'datapoints': dps}]}})
     prog_ind = _utils.ProgressIndicator([tag_id])
 
     p = Pool(steps)
@@ -413,7 +417,12 @@ def get_datapoints_frame(tag_ids, aggregates, granularity, start=None, end=None,
         project=project
     )
 
+    if steps == 1:
+        return _get_datapoints_frame_helper(tag_ids, aggregates, granularity, start, end, api_key=api_key,
+                                            project=project)
+
     prog_ind = _utils.ProgressIndicator(tag_ids)
+
     p = Pool(steps)
 
     dataframes = p.map(partial_get_dpsf, args)


### PR DESCRIPTION
Do not use multiprocessing if processes == 1 for fetching datapoints.