### PR TITLE
Change naming and fix bugs in DTO module, add live data generator to timeseries module.

### DIFF
--- a/cognite/__init__.py
+++ b/cognite/__init__.py
@@ -18,4 +18,4 @@ Data Platform (CDP).
 #
 
 __all__ = ['v04', 'v05', 'preprocessing', 'config']
-__version__ = '0.6.2'
+__version__ = '0.7.0'

--- a/cognite/v04/assets.py
+++ b/cognite/v04/assets.py
@@ -10,7 +10,7 @@ from typing import List
 import cognite._constants as constants
 import cognite._utils as utils
 import cognite.config as config
-from cognite.v04.data_objects import AssetResponse, AssetDTO
+from cognite.v04.dto import AssetResponse, Asset
 
 
 # Author: TK
@@ -39,7 +39,7 @@ def get_assets(name=None, path=None, description=None, metadata=None, depth=None
 
         project (str):          Project name.
     Returns:
-        v04.data_objects.AssetResponse: A data object containing the requested assets with several getter methods with different
+        v04.dto.AssetResponse: A data object containing the requested assets with several getter methods with different
         output formats.
     '''
     api_key, project = config.get_config_variables(
@@ -82,7 +82,7 @@ def get_asset_subtree(asset_id='', depth=None, **kwargs):
 
         project (str):          Project name.
     Returns:
-        v04.data_objects.AssetResponse: A data object containing the requested assets with several getter methods with different
+        v04.dto.AssetResponse: A data object containing the requested assets with several getter methods with different
         output formats.
     '''
     api_key, project = config.get_config_variables(
@@ -102,11 +102,11 @@ def get_asset_subtree(asset_id='', depth=None, **kwargs):
     return AssetResponse(res.json())
 
 
-def post_assets(assets: List[AssetDTO], **kwargs):
+def post_assets(assets: List[Asset], **kwargs):
     '''Insert a list of assets.
 
     Args:
-        assets (list[v04.data_objects.AssetDTO]): List of asset data transfer objects.
+        assets (list[v04.dto.Asset]): List of asset data transfer objects.
 
     Keyword Args:
         api_key (str): Your api-key.
@@ -114,7 +114,7 @@ def post_assets(assets: List[AssetDTO], **kwargs):
         project (str): Project name.
 
     Returns:
-        v04.data_objects.AssetResponse: A data object containing the posted assets with several getter methods with different
+        v04.dto.AssetResponse: A data object containing the posted assets with several getter methods with different
         output formats.
     '''
     api_key, project = config.get_config_variables(
@@ -137,7 +137,7 @@ def delete_assets(asset_ids: List[int], **kwargs):
     '''Delete a list of assets.
 
     Args:
-        asset_ids (list[v04.data_objects.AssetDTO]): List of IDs of assets to delete.
+        asset_ids (list[v04.dto.Asset]): List of IDs of assets to delete.
 
     Keyword Args:
         api_key (str): Your api-key.

--- a/cognite/v04/cloud_storage.py
+++ b/cognite/v04/cloud_storage.py
@@ -13,7 +13,7 @@ import requests
 
 import cognite._utils as _utils
 import cognite.config as config
-from cognite.v04.data_objects import FileInfoResponse, FileListResponse
+from cognite.v04.dto import FileInfoResponse, FileListResponse
 
 
 def upload_file(file_name, file_path=None, directory=None, source=None, file_type=None, content_type=None, **kwargs):
@@ -179,7 +179,7 @@ def list_files(name=None, directory=None, file_type=None, source=None, **kwargs)
                                         disregarded. Defaults to False.
 
     Returns:
-        v04.data_objects.FileListResponse: A data object containing the requested files information.
+        v04.dto.FileListResponse: A data object containing the requested files information.
     '''
     api_key, project = config.get_config_variables(kwargs.get('api_key'), kwargs.get('project'))
     url = config.get_base_url(api_version=0.4) + '/projects/{}/storage'.format(project)
@@ -225,7 +225,7 @@ def get_file_info(id, **kwargs):
         project (str, optional):    Project name.
 
     Returns:
-        v04.data_objects.FileInfoResponse: A data object containing the requested file information.
+        v04.dto.FileInfoResponse: A data object containing the requested file information.
     '''
     api_key, project = config.get_config_variables(kwargs.get('api_key'), kwargs.get('project'))
     url = config.get_base_url(api_version=0.4) + '/projects/{}/storage/{}/info'.format(project, id)

--- a/cognite/v04/data_objects.py
+++ b/cognite/v04/data_objects.py
@@ -10,6 +10,7 @@ the following output formats:
 '''
 import abc
 import json
+from copy import deepcopy
 
 import pandas as pd
 import six
@@ -212,7 +213,7 @@ class TimeseriesResponse(CogniteDataObject):
 
     def to_pandas(self):
         '''Returns data as a pandas dataframe'''
-        items = self.internal_representation['data']['items']
+        items = deepcopy(self.internal_representation['data']['items'])
         if items and items[0].get('metadata') is None:
             return pd.DataFrame(items)
         for d in items:

--- a/cognite/v04/dto.py
+++ b/cognite/v04/dto.py
@@ -54,7 +54,7 @@ class CogniteDataObject():
             return self.internal_representation.get('data').get('previousCursor')
 
 
-class RawRowDTO(object):
+class RawRow(object):
     """DTO for a row in a raw database.
 
     The Raw API is a simple key/value-store. Each row in a table in a raw database consists of a
@@ -222,7 +222,7 @@ class TimeseriesResponse(CogniteDataObject):
         return pd.DataFrame(items)
 
 
-class TimeSeriesDTO(object):
+class TimeSeries(object):
     """Data Transfer Object for a timeseries.
 
     Attributes:
@@ -249,7 +249,7 @@ class TimeSeriesDTO(object):
         self.step = step
 
 
-class DatapointDTO(object):
+class Datapoint(object):
     '''Data transfer object for datapoints.
 
     Attributes:
@@ -276,7 +276,7 @@ class AssetResponse(CogniteDataObject):
         return pd.DataFrame()
 
 
-class AssetDTO(object):
+class Asset(object):
     '''Data transfer object for assets.
 
     Attributes:

--- a/cognite/v04/raw.py
+++ b/cognite/v04/raw.py
@@ -10,7 +10,7 @@ from typing import List
 
 import cognite._utils as _utils
 import cognite.config as config
-from cognite.v04.data_objects import RawResponse, RawRowDTO
+from cognite.v04.dto import RawResponse, RawRow
 
 
 def get_databases(
@@ -31,7 +31,7 @@ def get_databases(
         project (str):  Project name.
 
     Returns:
-        v04.data_objects.RawResponse: A data object containing the requested data with several getter methods with different
+        v04.dto.RawResponse: A data object containing the requested data with several getter methods with different
         output formats.
     """
     api_key, project = config.get_config_variables(api_key, project)
@@ -67,7 +67,7 @@ def create_databases(
         project (str):          Project name.
 
     Returns:
-        v04.data_objects.RawResponse: A data object containing the requested data with several getter methods with different
+        v04.dto.RawResponse: A data object containing the requested data with several getter methods with different
         output formats.
 
     """
@@ -142,7 +142,7 @@ def get_tables(
         project (str):  Project name.
 
     Returns:
-        v04.data_objects.RawResponse: A data object containing the requested data with several getter methods with different
+        v04.dto.RawResponse: A data object containing the requested data with several getter methods with different
         output formats.
     """
     api_key, project = config.get_config_variables(api_key, project)
@@ -179,7 +179,7 @@ def create_tables(
         project (str):          Project name.
 
     Returns:
-        v04.data_objects.RawResponse: A data object containing the requested data with several getter methods with different
+        v04.dto.RawResponse: A data object containing the requested data with several getter methods with different
         output formats.
 
     """
@@ -256,7 +256,7 @@ def get_rows(
         project (str):          Project name.
 
     Returns:
-        v04.data_objects.RawResponse: A data object containing the requested data with several getter methods with different
+        v04.dto.RawResponse: A data object containing the requested data with several getter methods with different
         output formats.
     """
     api_key, project = config.get_config_variables(api_key, project)
@@ -276,7 +276,7 @@ def get_rows(
 def create_rows(
         database_name: str = None,
         table_name: str = None,
-        rows: List[RawRowDTO] = None,
+        rows: List[RawRow] = None,
         api_key=None,
         project=None,
         ensure_parent=False,
@@ -289,7 +289,7 @@ def create_rows(
 
         table_name (str):       The table names to create rows in.
 
-        rows (list):            The rows to create.
+        rows (list[v04.dto.RawRow]):            The rows to create.
 
         api_key (str):          Your api-key.
 
@@ -330,7 +330,7 @@ def create_rows(
 def delete_rows(
         database_name: str = None,
         table_name: str = None,
-        rows: List[RawRowDTO] = None,
+        rows: List[RawRow] = None,
         api_key=None,
         project=None
 ):
@@ -393,7 +393,7 @@ def get_row(
         project (str):          Project name.
 
     Returns:
-        v04.data_objects.RawResponse: A data object containing the requested data with several getter methods with different
+        v04.dto.RawResponse: A data object containing the requested data with several getter methods with different
         output formats.
     """
     api_key, project = config.get_config_variables(api_key, project)

--- a/cognite/v04/tagmatching.py
+++ b/cognite/v04/tagmatching.py
@@ -7,7 +7,7 @@ https://doc.cognitedata.com/0.4/#Cognite-API-Tag-Matching
 """
 import cognite._utils as _utils
 import cognite.config as config
-from cognite.v04.data_objects import TagMatchingResponse
+from cognite.v04.dto import TagMatchingResponse
 
 
 def tag_matching(tag_ids, fuzzy_threshold=0, platform=None, **kwargs):
@@ -30,7 +30,7 @@ def tag_matching(tag_ids, fuzzy_threshold=0, platform=None, **kwargs):
         project (str):          Project name.
 
     Returns:
-        v04.data_objects.TagMatchingResponse: A data object containing the requested data with several getter methods with different
+        v04.dto.TagMatchingResponse: A data object containing the requested data with several getter methods with different
         output formats.
     '''
     api_key, project = config.get_config_variables(kwargs.get('api_key'), kwargs.get('project'))

--- a/cognite/v04/timeseries.py
+++ b/cognite/v04/timeseries.py
@@ -18,9 +18,9 @@ import cognite._constants as _constants
 import cognite._utils as _utils
 import cognite.config as config
 from cognite._protobuf_descriptors import _api_timeseries_data_v1_pb2
-from cognite.v04.data_objects import DatapointsResponse, DatapointsResponseIterator, LatestDatapointResponse, \
-    DatapointDTO, \
-    TimeSeriesDTO, TimeseriesResponse
+from cognite.v04.dto import DatapointsResponse, DatapointsResponseIterator, LatestDatapointResponse, \
+    Datapoint, \
+    TimeSeries, TimeseriesResponse
 
 
 def get_datapoints(tag_id, aggregates=None, granularity=None, start=None, end=None, **kwargs):
@@ -54,7 +54,7 @@ def get_datapoints(tag_id, aggregates=None, granularity=None, start=None, end=No
         project (str):          Project name.
 
     Returns:
-        v04.data_objects.DatapointsResponse: A data object containing the requested data with several getter methods with different
+        v04.dto.DatapointsResponse: A data object containing the requested data with several getter methods with different
         output formats.
     '''
     api_key, project = config.get_config_variables(kwargs.get('api_key'), kwargs.get('project'))
@@ -191,13 +191,13 @@ def _get_datapoints_helper(tag_id, aggregates=None, granularity=None, start=None
     return dps
 
 
-def post_datapoints(tag_id, datapoints: List[DatapointDTO], **kwargs):
+def post_datapoints(tag_id, datapoints: List[Datapoint], **kwargs):
     '''Insert a list of datapoints.
 
     Args:
         tag_id (str):       ID of timeseries to insert to.
 
-        datapoints (list[v04.data_objects.DatapointDTO): List of datapoint data transfer objects to insert.
+        datapoints (list[v04.dto.Datapoint): List of datapoint data transfer objects to insert.
 
     Keyword Args:
         api_key (str): Your api-key.
@@ -238,7 +238,7 @@ def get_latest(tag_id, **kwargs):
         project (str):          Project name.
 
     Returns:
-        v04.data_objects.LatestDatapointsResponse: A data object containing the requested data with several getter methods with different
+        v04.dto.LatestDatapointsResponse: A data object containing the requested data with several getter methods with different
         output formats.
     '''
     api_key, project = config.get_config_variables(kwargs.get('api_key'), kwargs.get('project'))
@@ -258,7 +258,7 @@ def get_multi_tag_datapoints(datapoints_queries, aggregates=None, granularity=No
     This method will automate paging for the user and return all data for the given time period(s).
 
     Args:
-        datapoints_queries (list[v04.data_objects.DatapointsQuery]): The list of DatapointsQuery objects specifying which
+        datapoints_queries (list[v04.dto.DatapointsQuery]): The list of DatapointsQuery objects specifying which
                                                                     timeseries to retrieve data for.
 
         aggregates (list, optional):    The list of aggregate functions you wish to apply to the data. Valid aggregate
@@ -281,7 +281,7 @@ def get_multi_tag_datapoints(datapoints_queries, aggregates=None, granularity=No
         project (str):                  Project name.
 
     Returns:
-        list(v04.data_objects.DatapointsResponse): A list of data objects containing the requested data with several getter methods
+        list(v04.dto.DatapointsResponse): A list of data objects containing the requested data with several getter methods
         with different output formats.
     '''
     api_key, project = config.get_config_variables(kwargs.get('api_key'), kwargs.get('project'))
@@ -557,7 +557,7 @@ def get_timeseries(prefix=None, description=None, include_metadata=False, asset_
                                 disregarded. Defaults to False.
 
     Returns:
-        v04.data_objects.TimeseriesResponse: A data object containing the requested timeseries with several getter methods with different
+        v04.dto.TimeseriesResponse: A data object containing the requested timeseries with several getter methods with different
         output formats.
     '''
     api_key, project = config.get_config_variables(kwargs.get('api_key'), kwargs.get('project'))
@@ -591,11 +591,11 @@ def get_timeseries(prefix=None, description=None, include_metadata=False, asset_
                   'items': timeseries}})
 
 
-def post_time_series(time_series: List[TimeSeriesDTO], **kwargs):
+def post_time_series(time_series: List[TimeSeries], **kwargs):
     '''Create a new time series.
 
     Args:
-        timeseries (list[v04.data_objects.TimeSeriesDTO]):   List of time series data transfer objects to create.
+        timeseries (list[v04.dto.TimeSeries]):   List of time series data transfer objects to create.
 
     Keyword Args:
         api_key (str): Your api-key.
@@ -622,13 +622,13 @@ def post_time_series(time_series: List[TimeSeriesDTO], **kwargs):
     return res.json()
 
 
-def update_time_series(time_series: List[TimeSeriesDTO], **kwargs):
+def update_time_series(time_series: List[TimeSeries], **kwargs):
     '''Update an existing time series.
 
     For each field that can be updated, a null value indicates that nothing should be done.
 
     Args:
-        timeseries (list[v04.data_objects.TimeSeriesDTO]):   List of time series data transfer objects to update.
+        timeseries (list[v04.dto.TimeSeries]):   List of time series data transfer objects to update.
 
     Keyword Args:
         api_key (str): Your api-key.

--- a/cognite/v04/timeseries.py
+++ b/cognite/v04/timeseries.py
@@ -11,6 +11,7 @@ import warnings
 from functools import partial
 from multiprocessing import Pool
 from typing import List
+from urllib.parse import quote_plus
 
 import pandas as pd
 
@@ -149,8 +150,7 @@ def _get_datapoints_helper(tag_id, aggregates=None, granularity=None, start=None
         list of datapoints: A list containing datapoint dicts.
     '''
     api_key, project = kwargs.get('api_key'), kwargs.get('project')
-    tag_id = tag_id.replace('/', '%2F')
-    url = config.get_base_url(api_version=0.4) + '/projects/{}/timeseries/data/{}'.format(project, tag_id)
+    url = config.get_base_url(api_version=0.4) + '/projects/{}/timeseries/data/{}'.format(project, quote_plus(tag_id))
 
     use_protobuf = kwargs.get('protobuf', True) and aggregates is None
     limit = _constants.LIMIT if aggregates is None else _constants.LIMIT_AGG
@@ -208,8 +208,7 @@ def post_datapoints(tag_id, datapoints: List[Datapoint], **kwargs):
         An empty response.
     '''
     api_key, project = config.get_config_variables(kwargs.get('api_key'), kwargs.get('project'))
-    tag_id = tag_id.replace('/', '%2F')
-    url = config.get_base_url(api_version=0.4) + '/projects/{}/timeseries/data/{}'.format(project, tag_id)
+    url = config.get_base_url(api_version=0.4) + '/projects/{}/timeseries/data/{}'.format(project, quote_plus(tag_id))
 
     headers = {
         'api-key': api_key,
@@ -242,8 +241,7 @@ def get_latest(tag_id, **kwargs):
         output formats.
     '''
     api_key, project = config.get_config_variables(kwargs.get('api_key'), kwargs.get('project'))
-    tag_id = tag_id.replace('/', '%2F')
-    url = config.get_base_url(api_version=0.4) + '/projects/{}/timeseries/latest/{}'.format(project, tag_id)
+    url = config.get_base_url(api_version=0.4) + '/projects/{}/timeseries/latest/{}'.format(project, quote_plus(tag_id))
     headers = {
         'api-key': api_key,
         'accept': 'application/json'

--- a/cognite/v05/assets.py
+++ b/cognite/v05/assets.py
@@ -10,7 +10,7 @@ from typing import List
 import cognite._constants as constants
 import cognite._utils as utils
 import cognite.config as config
-from cognite.v05.data_objects import AssetResponse, AssetListResponse, AssetDTO
+from cognite.v05.dto import AssetResponse, AssetListResponse, Asset
 
 
 # Author: TK
@@ -39,7 +39,7 @@ def get_assets(name=None, path=None, description=None, metadata=None, depth=None
 
         project (str):          Project name.
     Returns:
-        v05.data_objects.AssetResponse: A data object containing the requested assets with several getter methods with different
+        v05.dto.AssetResponse: A data object containing the requested assets with several getter methods with different
         output formats.
     '''
     api_key, project = config.get_config_variables(kwargs.get('api_key'), kwargs.get('project'))
@@ -73,7 +73,7 @@ def get_asset(asset_id, **kwargs):
 
         project (str):          Project name.
     Returns:
-        v05.data_objects.AssetResponse: A data object containing the requested assets with several getter methods with different
+        v05.dto.AssetResponse: A data object containing the requested assets with several getter methods with different
         output formats.
     '''
     api_key, project = config.get_config_variables(kwargs.get('api_key'), kwargs.get('project'))
@@ -104,7 +104,7 @@ def get_asset_subtree(asset_id, depth=None, **kwargs):
 
         project (str):          Project name.
     Returns:
-        v05.data_objects.AssetResponse: A data object containing the requested assets with several getter methods with different
+        v05.dto.AssetResponse: A data object containing the requested assets with several getter methods with different
         output formats.
     '''
     api_key, project = config.get_config_variables(kwargs.get('api_key'), kwargs.get('project'))
@@ -122,11 +122,11 @@ def get_asset_subtree(asset_id, depth=None, **kwargs):
     return AssetListResponse(res.json())
 
 
-def post_assets(assets: List[AssetDTO], **kwargs):
+def post_assets(assets: List[Asset], **kwargs):
     '''Insert a list of assets.
 
     Args:
-        assets (list[v05.data_objects.AssetDTO]): List of asset data transfer objects.
+        assets (list[v05.dto.Asset]): List of asset data transfer objects.
 
     Keyword Args:
         api_key (str): Your api-key.
@@ -134,7 +134,7 @@ def post_assets(assets: List[AssetDTO], **kwargs):
         project (str): Project name.
 
     Returns:
-        v05.data_objects.AssetResponse: A data object containing the posted assets with several getter methods with different
+        v05.dto.AssetResponse: A data object containing the posted assets with several getter methods with different
         output formats.
     '''
     api_key, project = config.get_config_variables(kwargs.get('api_key'), kwargs.get('project'))

--- a/cognite/v05/data_objects.py
+++ b/cognite/v05/data_objects.py
@@ -10,6 +10,7 @@ the following output formats:
 '''
 import abc
 import json
+from copy import deepcopy
 
 import pandas as pd
 import six
@@ -225,7 +226,7 @@ class TimeseriesResponse(CogniteDataObject):
 
     def to_pandas(self):
         '''Returns data as a pandas dataframe'''
-        items = self.internal_representation['data']['items']
+        items = deepcopy(self.internal_representation['data']['items'])
         if items and items[0].get('metadata') is None:
             return pd.DataFrame(items)
         for d in items:
@@ -358,7 +359,7 @@ class FileInfoResponse(CogniteDataObject):
         return self.internal_representation['data']['items'][0]
 
     def to_pandas(self):
-        file_info = self.to_json()
+        file_info = deepcopy(self.to_json())
         if file_info.get('metadata'):
             file_info.update(file_info.pop('metadata'))
         return pd.DataFrame.from_dict(file_info, orient='index')
@@ -387,10 +388,10 @@ class EventResponse(CogniteDataObject):
         return self.internal_representation['data']['items'][0]
 
     def to_pandas(self):
-        event = self.to_json()
+        event = deepcopy(self.to_json())
         if event.get('metadata'):
             event.update(event.pop('metadata'))
-        return pd.DataFrame.from_dict(self.to_json(), orient='index')
+        return pd.DataFrame.from_dict(event, orient='index')
 
 
 class EventListResponse(CogniteDataObject):
@@ -404,7 +405,7 @@ class EventListResponse(CogniteDataObject):
         return self.internal_representation['data']['items']
 
     def to_pandas(self):
-        items = self.to_json()
+        items = deepcopy(self.to_json())
         for d in items:
             if d.get('metadata'):
                 d.update(d.pop('metadata'))

--- a/cognite/v05/dto.py
+++ b/cognite/v05/dto.py
@@ -66,7 +66,7 @@ class RawResponse(CogniteDataObject):
         return pd.DataFrame(self.internal_representation['data']['items'])
 
 
-class RawRowDTO(object):
+class RawRow(object):
     """DTO for a row in a raw database.
 
     The Raw API is a simple key/value-store. Each row in a table in a raw database consists of a
@@ -188,7 +188,7 @@ class DatapointsResponseIterator():
             return self.datapoints_objects[self.counter - 1]
 
 
-class DatapointDTO(object):
+class Datapoint(object):
     '''Data transfer object for datapoints.
 
     Attributes:
@@ -235,7 +235,7 @@ class TimeseriesResponse(CogniteDataObject):
         return pd.DataFrame(items)
 
 
-class TimeSeriesDTO(object):
+class TimeSeries(object):
     """Data Transfer Object for a timeseries.
 
     Attributes:
@@ -302,7 +302,7 @@ class AssetResponse(CogniteDataObject):
         return pd.DataFrame()
 
 
-class AssetDTO(object):
+class Asset(object):
     '''Data transfer object for assets.
 
     Attributes:
@@ -422,7 +422,7 @@ class EventListResponse(CogniteDataObject):
             return EventResponse({'data': {'items': [self.to_json()[self.counter - 1]]}})
 
 
-class EventDTO(object):
+class Event(object):
     '''Data transfer object for events.
     Attributes:
         start_time (int):       Start time of the event in ms since epoch.

--- a/cognite/v05/events.py
+++ b/cognite/v05/events.py
@@ -7,7 +7,7 @@ https://doc.cognitedata.com/0.5/#Cognite-API-Events
 """
 
 from cognite import _utils, config, _constants
-from cognite.v05.data_objects import EventResponse, EventListResponse
+from cognite.v05.dto import EventResponse, EventListResponse
 
 
 def get_event(event_id, **kwargs):
@@ -22,7 +22,7 @@ def get_event(event_id, **kwargs):
         project (str):          Project name.
 
     Returns:
-        v05.data_objects.EventResponse: A data object containing the requested event.
+        v05.dto.EventResponse: A data object containing the requested event.
     '''
     api_key, project = config.get_config_variables(kwargs.get('api_key'), kwargs.get('project'))
     url = config.get_base_url(api_version=0.5) + '/projects/{}/events/{}'.format(project, event_id)
@@ -56,7 +56,7 @@ def get_events(type=None, sub_type=None, asset_id=None, **kwargs):
                                 disregarded. Defaults to False.
 
     Returns:
-        v05.data_objects.EventListResponse: A data object containing the requested event.
+        v05.dto.EventListResponse: A data object containing the requested event.
     '''
     api_key, project = config.get_config_variables(kwargs.get('api_key'), kwargs.get('project'))
     url = config.get_base_url(api_version=0.5) + '/projects/{}/events'.format(project)
@@ -98,14 +98,14 @@ def post_events(events, **kwargs):
     '''Adds a list of events and returns an EventListResponse object containing created events.
 
     Args:
-        events (List[v05.data_objects.EventDTO]):    List of events to create.
+        events (List[v05.dto.Event]):    List of events to create.
 
     Keyword Args:
         api_key (str):          Your api-key.
         project (str):          Project name.
 
     Returns:
-        v05.data_objects.EventListResponse
+        v05.dto.EventListResponse
     '''
     api_key, project = config.get_config_variables(kwargs.get('api_key'), kwargs.get('project'))
     url = config.get_base_url(api_version=0.5) + '/projects/{}/events'.format(project)

--- a/cognite/v05/files.py
+++ b/cognite/v05/files.py
@@ -13,7 +13,7 @@ import requests
 
 import cognite._utils as _utils
 import cognite.config as config
-from cognite.v05.data_objects import FileInfoResponse, FileListResponse
+from cognite.v05.dto import FileInfoResponse, FileListResponse
 
 
 def upload_file(file_name, file_path=None, directory=None, source=None, file_type=None, content_type=None, **kwargs):
@@ -184,7 +184,7 @@ def list_files(name=None, directory=None, file_type=None, source=None, **kwargs)
         cursor (str):                   Cursor to use for paging through results.
 
     Returns:
-        v05.data_objects.FileListResponse: A data object containing the requested files information.
+        v05.dto.FileListResponse: A data object containing the requested files information.
     '''
     api_key, project = config.get_config_variables(kwargs.get('api_key'), kwargs.get('project'))
     url = config.get_base_url(api_version=0.5) + '/projects/{}/files'.format(project)
@@ -231,7 +231,7 @@ def get_file_info(id, **kwargs):
         project (str, optional):    Project name.
 
     Returns:
-        v05.data_objects.FileInfoResponse: A data object containing the requested file information.
+        v05.dto.FileInfoResponse: A data object containing the requested file information.
     '''
     api_key, project = config.get_config_variables(kwargs.get('api_key'), kwargs.get('project'))
     url = config.get_base_url(api_version=0.5) + '/projects/{}/files/{}'.format(project, id)

--- a/cognite/v05/raw.py
+++ b/cognite/v05/raw.py
@@ -10,7 +10,7 @@ from typing import List
 
 import cognite._utils as _utils
 import cognite.config as config
-from cognite.v05.data_objects import RawResponse, RawRowDTO
+from cognite.v05.dto import RawResponse, RawRow
 
 
 def get_databases(
@@ -31,7 +31,7 @@ def get_databases(
         project (str):  Project name.
 
     Returns:
-        v05.data_objects.RawResponse: A data object containing the requested data with several getter methods with different
+        v05.dto.RawResponse: A data object containing the requested data with several getter methods with different
         output formats.
     """
     api_key, project = config.get_config_variables(api_key, project)
@@ -67,7 +67,7 @@ def create_databases(
         project (str):          Project name.
 
     Returns:
-        v05.data_objects.RawResponse: A data object containing the requested data with several getter methods with different
+        v05.dto.RawResponse: A data object containing the requested data with several getter methods with different
         output formats.
 
     """
@@ -142,7 +142,7 @@ def get_tables(
         project (str):  Project name.
 
     Returns:
-        v05.data_objects.RawResponse: A data object containing the requested data with several getter methods with different
+        v05.dto.RawResponse: A data object containing the requested data with several getter methods with different
         output formats.
     """
     api_key, project = config.get_config_variables(api_key, project)
@@ -179,7 +179,7 @@ def create_tables(
         project (str):          Project name.
 
     Returns:
-        v05.data_objects.RawResponse: A data object containing the requested data with several getter methods with different
+        v05.dto.RawResponse: A data object containing the requested data with several getter methods with different
         output formats.
 
     """
@@ -256,7 +256,7 @@ def get_rows(
         project (str):          Project name.
 
     Returns:
-        v05.data_objects.RawResponse: A data object containing the requested data with several getter methods with different
+        v05.dto.RawResponse: A data object containing the requested data with several getter methods with different
         output formats.
     """
     api_key, project = config.get_config_variables(api_key, project)
@@ -276,7 +276,7 @@ def get_rows(
 def create_rows(
         database_name: str = None,
         table_name: str = None,
-        rows: List[RawRowDTO] = None,
+        rows: List[RawRow] = None,
         api_key=None,
         project=None,
         ensure_parent=False,
@@ -289,7 +289,7 @@ def create_rows(
 
         table_name (str):       The table names to create rows in.
 
-        rows (list):            The rows to create.
+        rows (list[v05.dto.RawRow]):            The rows to create.
 
         api_key (str):          Your api-key.
 
@@ -330,7 +330,7 @@ def create_rows(
 def delete_rows(
         database_name: str = None,
         table_name: str = None,
-        rows: List[RawRowDTO] = None,
+        rows: List[RawRow] = None,
         api_key=None,
         project=None
 ):
@@ -393,7 +393,7 @@ def get_row(
         project (str):          Project name.
 
     Returns:
-        v05.data_objects.RawResponse: A data object containing the requested data with several getter methods with different
+        v05.dto.RawResponse: A data object containing the requested data with several getter methods with different
         output formats.
     """
     api_key, project = config.get_config_variables(api_key, project)

--- a/cognite/v05/tagmatching.py
+++ b/cognite/v05/tagmatching.py
@@ -7,7 +7,7 @@ https://doc.cognitedata.com/0.5/#Cognite-API-Tag-Matching
 """
 import cognite._utils as _utils
 import cognite.config as config
-from cognite.v05.data_objects import TagMatchingResponse
+from cognite.v05.dto import TagMatchingResponse
 
 
 def tag_matching(tag_ids, fuzzy_threshold=0, platform=None, **kwargs):
@@ -30,7 +30,7 @@ def tag_matching(tag_ids, fuzzy_threshold=0, platform=None, **kwargs):
         project (str):          Project name.
 
     Returns:
-        v05.data_objects.TagMatchingResponse: A data object containing the requested data with several getter methods with different
+        v05.dto.TagMatchingResponse: A data object containing the requested data with several getter methods with different
         output formats.
     '''
     api_key, project = config.get_config_variables(kwargs.get('api_key'), kwargs.get('project'))

--- a/cognite/v05/timeseries.py
+++ b/cognite/v05/timeseries.py
@@ -12,6 +12,7 @@ import warnings
 from functools import partial
 from multiprocessing import Pool
 from typing import List
+from urllib.parse import quote_plus
 
 import pandas as pd
 
@@ -151,8 +152,7 @@ def _get_datapoints_helper(name, aggregates=None, granularity=None, start=None, 
         list of datapoints: A list containing datapoint dicts.
     '''
     api_key, project = kwargs.get('api_key'), kwargs.get('project')
-    name = name.replace('/', '%2F')
-    url = config.get_base_url(api_version=0.5) + '/projects/{}/timeseries/data/{}'.format(project, name)
+    url = config.get_base_url(api_version=0.5) + '/projects/{}/timeseries/data/{}'.format(project, quote_plus(name))
 
     use_protobuf = kwargs.get('protobuf', True) and aggregates is None
     limit = _constants.LIMIT if aggregates is None else _constants.LIMIT_AGG
@@ -210,8 +210,7 @@ def post_datapoints(name, datapoints: List[Datapoint], **kwargs):
         An empty response.
     '''
     api_key, project = config.get_config_variables(kwargs.get('api_key'), kwargs.get('project'))
-    name = name.replace('/', '%2F')
-    url = config.get_base_url(api_version=0.5) + '/projects/{}/timeseries/data/{}'.format(project, name)
+    url = config.get_base_url(api_version=0.5) + '/projects/{}/timeseries/data/{}'.format(project, quote_plus(name))
 
     headers = {
         'api-key': api_key,
@@ -244,8 +243,7 @@ def get_latest(name, **kwargs):
         output formats.
     '''
     api_key, project = config.get_config_variables(kwargs.get('api_key'), kwargs.get('project'))
-    name = name.replace('/', '%2F')
-    url = config.get_base_url(api_version=0.5) + '/projects/{}/timeseries/latest/{}'.format(project, name)
+    url = config.get_base_url(api_version=0.5) + '/projects/{}/timeseries/latest/{}'.format(project, quote_plus(name))
     headers = {
         'api-key': api_key,
         'accept': 'application/json'

--- a/cognite/v05/timeseries.py
+++ b/cognite/v05/timeseries.py
@@ -19,9 +19,9 @@ import cognite._constants as _constants
 import cognite._utils as _utils
 import cognite.config as config
 from cognite._protobuf_descriptors import _api_timeseries_data_v2_pb2
-from cognite.v05.data_objects import DatapointsResponse, DatapointsResponseIterator, LatestDatapointResponse, \
-    DatapointDTO, \
-    TimeSeriesDTO, TimeseriesResponse
+from cognite.v05.dto import DatapointsResponse, DatapointsResponseIterator, LatestDatapointResponse, \
+    Datapoint, \
+    TimeSeries, TimeseriesResponse
 
 
 def get_datapoints(name, aggregates=None, granularity=None, start=None, end=None, **kwargs):
@@ -55,7 +55,7 @@ def get_datapoints(name, aggregates=None, granularity=None, start=None, end=None
         project (str):          Project name.
 
     Returns:
-        v05.data_objects.DatapointsResponse: A data object containing the requested data with several getter methods with different
+        v05.dto.DatapointsResponse: A data object containing the requested data with several getter methods with different
         output formats.
     '''
     api_key, project = config.get_config_variables(kwargs.get('api_key'), kwargs.get('project'))
@@ -193,13 +193,13 @@ def _get_datapoints_helper(name, aggregates=None, granularity=None, start=None, 
     return dps
 
 
-def post_datapoints(name, datapoints: List[DatapointDTO], **kwargs):
+def post_datapoints(name, datapoints: List[Datapoint], **kwargs):
     '''Insert a list of datapoints.
 
     Args:
         name (str):       Name of timeseries to insert to.
 
-        datapoints (list[v05.data_objects.DatapointDTO): List of datapoint data transfer objects to insert.
+        datapoints (list[v05.dto.Datapoint): List of datapoint data transfer objects to insert.
 
     Keyword Args:
         api_key (str): Your api-key.
@@ -240,7 +240,7 @@ def get_latest(name, **kwargs):
         project (str):          Project name.
 
     Returns:
-        v05.data_objects.LatestDatapointsResponse: A data object containing the requested data with several getter methods with different
+        v05.dto.LatestDatapointsResponse: A data object containing the requested data with several getter methods with different
         output formats.
     '''
     api_key, project = config.get_config_variables(kwargs.get('api_key'), kwargs.get('project'))
@@ -261,7 +261,7 @@ def get_multi_time_series_datapoints(datapoints_queries, aggregates=None, granul
     This method will automate paging for the user and return all data for the given time period(s).
 
     Args:
-        datapoints_queries (list[v05.data_objects.DatapointsQuery]): The list of DatapointsQuery objects specifying which
+        datapoints_queries (list[v05.dto.DatapointsQuery]): The list of DatapointsQuery objects specifying which
                                                                     timeseries to retrieve data for.
 
         aggregates (list, optional):    The list of aggregate functions you wish to apply to the data. Valid aggregate
@@ -284,7 +284,7 @@ def get_multi_time_series_datapoints(datapoints_queries, aggregates=None, granul
         project (str):                  Project name.
 
     Returns:
-        list(v05.data_objects.DatapointsResponse): A list of data objects containing the requested data with several getter methods
+        list(v05.dto.DatapointsResponse): A list of data objects containing the requested data with several getter methods
         with different output formats.
     '''
     api_key, project = config.get_config_variables(kwargs.get('api_key'), kwargs.get('project'))
@@ -504,7 +504,7 @@ def _get_datapoints_frame_helper(time_series, aggregates, granularity, start=Non
             num_aggregates += len(ts['aggregates'])
 
     per_tag_limit = int(_constants.LIMIT / num_aggregates)
-    
+
     body = {
         'items': [{'name': '{}'.format(ts)}
                   if isinstance(ts, str)
@@ -561,7 +561,7 @@ def get_timeseries(prefix=None, description=None, include_metadata=False, asset_
                                 disregarded. Defaults to False.
 
     Returns:
-        v05.data_objects.TimeseriesResponse: A data object containing the requested timeseries with several getter methods with different
+        v05.dto.TimeseriesResponse: A data object containing the requested timeseries with several getter methods with different
         output formats.
     '''
     api_key, project = config.get_config_variables(kwargs.get('api_key'), kwargs.get('project'))
@@ -595,11 +595,11 @@ def get_timeseries(prefix=None, description=None, include_metadata=False, asset_
                   'items': time_series}})
 
 
-def post_time_series(time_series: List[TimeSeriesDTO], **kwargs):
+def post_time_series(time_series: List[TimeSeries], **kwargs):
     '''Create a new time series.
 
     Args:
-        time_series (list[v05.data_objects.TimeSeriesDTO]):   List of time series data transfer objects to create.
+        time_series (list[v05.dto.TimeSeries]):   List of time series data transfer objects to create.
 
     Keyword Args:
         api_key (str): Your api-key.
@@ -626,13 +626,13 @@ def post_time_series(time_series: List[TimeSeriesDTO], **kwargs):
     return res.json()
 
 
-def update_time_series(time_series: List[TimeSeriesDTO], **kwargs):
+def update_time_series(time_series: List[TimeSeries], **kwargs):
     '''Update an existing time series.
 
     For each field that can be updated, a null value indicates that nothing should be done.
 
     Args:
-        timeseries (list[v05.data_objects.TimeSeriesDTO]):   List of time series data transfer objects to update.
+        timeseries (list[v05.dto.TimeSeries]):   List of time series data transfer objects to update.
 
     Keyword Args:
         api_key (str): Your api-key.

--- a/tests/v04/test_assets.py
+++ b/tests/v04/test_assets.py
@@ -1,7 +1,7 @@
 import pytest
 
 from cognite.v04 import assets
-from cognite.v04.data_objects import AssetDTO, AssetResponse
+from cognite.v04.dto import Asset, AssetResponse
 
 ASSET_NAME = 'test_asset'
 
@@ -17,14 +17,14 @@ def get_assets_response():
 
 
 def test_get_assets_response_object(get_assets_response):
-    from cognite.v04.data_objects import AssetResponse
+    from cognite.v04.dto import AssetResponse
     assert isinstance(get_assets_response, AssetResponse)
     assert get_assets_response.next_cursor() is not None
     assert get_assets_response.previous_cursor() is None
 
 
 def test_asset_subtree_object(get_asset_subtree_response):
-    from cognite.v04.data_objects import AssetResponse
+    from cognite.v04.dto import AssetResponse
     assert isinstance(get_asset_subtree_response, AssetResponse)
     assert get_asset_subtree_response.next_cursor() is not None
     assert get_asset_subtree_response.previous_cursor() is None
@@ -45,7 +45,7 @@ def test_ndarray(get_asset_subtree_response):
 
 
 def test_post_assets():
-    a1 = AssetDTO(name=ASSET_NAME)
+    a1 = Asset(name=ASSET_NAME)
     res = assets.post_assets([a1])
     assert isinstance(res, AssetResponse)
     assert res.to_json()[0]['name'] == ASSET_NAME

--- a/tests/v04/test_cloud_storage.py
+++ b/tests/v04/test_cloud_storage.py
@@ -23,7 +23,7 @@ def test_upload_file(tmpdir):
 
 
 def test_list_files():
-    from cognite.v04.data_objects import FileListResponse
+    from cognite.v04.dto import FileListResponse
     response = cloud_storage.list_files(limit=3)
     assert isinstance(response, FileListResponse)
     assert isinstance(response.to_pandas(), pd.DataFrame)
@@ -45,7 +45,7 @@ def file_id():
 
 
 def test_get_file_info(file_id):
-    from cognite.v04.data_objects import FileInfoResponse
+    from cognite.v04.dto import FileInfoResponse
     response = cloud_storage.get_file_info(file_id)
     assert isinstance(response, FileInfoResponse)
     assert isinstance(response.to_json(), dict)

--- a/tests/v04/test_raw.py
+++ b/tests/v04/test_raw.py
@@ -6,7 +6,7 @@ import pytest
 
 from cognite._utils import APIError
 from cognite.v04 import raw
-from cognite.v04.data_objects import RawResponse, RawRowDTO
+from cognite.v04.dto import RawResponse, RawRow
 
 DB_NAME = None
 TABLE_NAME = None
@@ -107,7 +107,7 @@ class TestRows:
         raw.delete_databases([DB_NAME], recursive=True)
 
     def test_create_rows(self):
-        response = raw.create_rows(DB_NAME, TABLE_NAME, rows=[RawRowDTO(key=ROW_KEY, columns=ROW_COLUMNS)])
+        response = raw.create_rows(DB_NAME, TABLE_NAME, rows=[RawRow(key=ROW_KEY, columns=ROW_COLUMNS)])
         assert response == {}
 
     def test_rows_response_length(self):
@@ -122,5 +122,5 @@ class TestRows:
         assert isinstance(row.to_pandas(), pd.DataFrame)
 
     def test_delete_rows(self):
-        response = raw.delete_rows(DB_NAME, TABLE_NAME, [RawRowDTO(key=ROW_KEY, columns=ROW_COLUMNS)])
+        response = raw.delete_rows(DB_NAME, TABLE_NAME, [RawRow(key=ROW_KEY, columns=ROW_COLUMNS)])
         assert response == {}

--- a/tests/v04/test_tag_matching.py
+++ b/tests/v04/test_tag_matching.py
@@ -19,7 +19,7 @@ def tagmatching_result(mock_post):
 
 
 def test_object(tagmatching_result):
-    from cognite.v04.data_objects import TagMatchingResponse
+    from cognite.v04.dto import TagMatchingResponse
     assert isinstance(tagmatching_result, TagMatchingResponse)
 
 

--- a/tests/v04/test_timeseries.py
+++ b/tests/v04/test_timeseries.py
@@ -22,7 +22,7 @@ def get_dps_response_obj(request):
 
 
 def test_get_datapoints(get_dps_response_obj):
-    from cognite.v04.data_objects import DatapointsResponse
+    from cognite.v04.dto import DatapointsResponse
     assert isinstance(get_dps_response_obj, DatapointsResponse)
 
 
@@ -40,7 +40,7 @@ def test_get_dps_correctly_spaced(get_dps_response_obj):
 
 
 def test_get_latest():
-    from cognite.v04.data_objects import LatestDatapointResponse
+    from cognite.v04.dto import LatestDatapointResponse
     response = timeseries.get_latest('constant')
     assert isinstance(response, LatestDatapointResponse)
     assert isinstance(response.to_ndarray(), np.ndarray)
@@ -67,7 +67,7 @@ def test_get_dps_frame_correctly_spaced(get_datapoints_frame_response_obj):
 
 @pytest.fixture(scope='module', params=dps_params[:2])
 def get_multitag_dps_response_obj(request):
-    from cognite.v04.data_objects import DatapointsQuery
+    from cognite.v04.dto import DatapointsQuery
     dq1 = DatapointsQuery('constant')
     dq2 = DatapointsQuery('sinus', aggregates=['avg'], granularity='30s')
     yield list(timeseries.get_multi_tag_datapoints(datapoints_queries=[dq1, dq2], start=request.param['start'],
@@ -75,7 +75,7 @@ def get_multitag_dps_response_obj(request):
 
 
 def test_get_multitag_dps_output_format(get_multitag_dps_response_obj):
-    from cognite.v04.data_objects import DatapointsResponse
+    from cognite.v04.dto import DatapointsResponse
     assert isinstance(get_multitag_dps_response_obj, list)
     for dpr in get_multitag_dps_response_obj:
         assert isinstance(dpr, DatapointsResponse)
@@ -117,14 +117,14 @@ class TestTimeseries:
         yield timeseries.get_timeseries(prefix=TS_NAME, limit=1, include_metadata=request.param)
 
     def test_post_timeseries(self):
-        from cognite.v04 import data_objects
-        tso = data_objects.TimeSeriesDTO(TS_NAME)
+        from cognite.v04 import dto
+        tso = dto.TimeSeries(TS_NAME)
         res = timeseries.post_time_series([tso])
         assert res == {}
 
     def test_update_timeseries(self):
-        from cognite.v04 import data_objects
-        tso = data_objects.TimeSeriesDTO(TS_NAME, unit='celsius')
+        from cognite.v04 import dto
+        tso = dto.TimeSeries(TS_NAME, unit='celsius')
         res = timeseries.update_time_series([tso])
         assert res == {}
 
@@ -132,7 +132,7 @@ class TestTimeseries:
         assert get_timeseries_response_obj.to_json()[0]['unit'] == 'celsius'
 
     def test_get_timeseries_output_format(self, get_timeseries_response_obj):
-        from cognite.v04.data_objects import TimeseriesResponse
+        from cognite.v04.dto import TimeseriesResponse
         assert isinstance(get_timeseries_response_obj, TimeseriesResponse)
         assert isinstance(get_timeseries_response_obj.to_ndarray(), np.ndarray)
         assert isinstance(get_timeseries_response_obj.to_pandas(), pd.DataFrame)

--- a/tests/v05/test_assets.py
+++ b/tests/v05/test_assets.py
@@ -3,7 +3,7 @@ import pandas as pd
 import pytest
 
 from cognite.v05 import assets
-from cognite.v05.data_objects import AssetDTO, AssetResponse, AssetListResponse
+from cognite.v05.dto import Asset, AssetResponse, AssetListResponse
 
 ASSET_NAME = 'test_asset'
 
@@ -51,7 +51,7 @@ def test_ndarray(get_asset_subtree_response):
 
 
 def test_post_assets():
-    a1 = AssetDTO(name=ASSET_NAME)
+    a1 = Asset(name=ASSET_NAME)
     res = assets.post_assets([a1])
     assert isinstance(res, AssetListResponse)
     assert res.to_json()[0]['name'] == ASSET_NAME

--- a/tests/v05/test_dto.py
+++ b/tests/v05/test_dto.py
@@ -1,0 +1,34 @@
+from copy import deepcopy
+
+import pytest
+
+from cognite.v05.dto import EventResponse, EventListResponse, TimeseriesResponse, FileInfoResponse
+
+
+@pytest.fixture(scope='module', params=['ts', 'file', 'event', 'eventlist'])
+def get_response_obj(request):
+    TS_INTERNAL_REPR = {'data': {'items': [{'name': '0', 'metadata': {'md1': 'val1'}}]}}
+    EVENT_LIST_INTERNAL_REPR = {'data': {'items': [{'id': 0, 'metadata': {'md1': 'val1'}}]}}
+    EVENT_INTERNAL_REPR = {'data': {'items': [{'id': 0, 'metadata': {'md1': 'val1'}, 'assetIds': []}]}}
+    FILE_INFO_INTERNAL_REPR = {'data': {'items': [{'id': 0, 'metadata': {'md1': 'val1'}}]}}
+
+    response = None
+    if request.param == 'ts':
+        response = TimeseriesResponse(TS_INTERNAL_REPR)
+    elif request.param == 'file':
+        response = FileInfoResponse(FILE_INFO_INTERNAL_REPR)
+    elif request.param == 'eventlist':
+        response = EventListResponse(EVENT_LIST_INTERNAL_REPR)
+    elif request.param == 'event':
+        response = EventResponse(EVENT_INTERNAL_REPR)
+
+    yield response
+
+
+class TestDTOs:
+    def test_internal_representation_not_mutated(self, get_response_obj):
+        repr = deepcopy(get_response_obj.internal_representation)
+        get_response_obj.to_ndarray()
+        get_response_obj.to_pandas()
+        get_response_obj.to_json()
+        assert repr == get_response_obj.internal_representation

--- a/tests/v05/test_events.py
+++ b/tests/v05/test_events.py
@@ -3,12 +3,12 @@ import pandas as pd
 import pytest
 
 from cognite import _utils
-from cognite.v05 import events, data_objects
+from cognite.v05 import events, dto
 
 
 @pytest.fixture(scope='module')
 def get_post_event_obj():
-    event = data_objects.EventDTO(start_time=1521500400000, end_time=1521586800000)
+    event = dto.Event(start_time=1521500400000, end_time=1521586800000)
     res = events.post_events([event])
     yield res
     res = events.get_events()
@@ -17,7 +17,7 @@ def get_post_event_obj():
 
 
 def test_post_events(get_post_event_obj):
-    assert isinstance(get_post_event_obj, data_objects.EventListResponse)
+    assert isinstance(get_post_event_obj, dto.EventListResponse)
     assert isinstance(get_post_event_obj.to_pandas(), pd.DataFrame)
     assert isinstance(get_post_event_obj.to_json(), list)
     assert isinstance(get_post_event_obj.to_ndarray(), np.ndarray)
@@ -30,7 +30,7 @@ def test_post_events_length(get_post_event_obj):
 def test_get_event(get_post_event_obj):
     id = get_post_event_obj.to_json()[0]['id']
     res = events.get_event(event_id=id)
-    assert isinstance(res, data_objects.EventResponse)
+    assert isinstance(res, dto.EventResponse)
     assert isinstance(res.to_pandas(), pd.DataFrame)
     assert isinstance(res.to_json(), dict)
     assert isinstance(res.to_ndarray(), np.ndarray)
@@ -43,12 +43,12 @@ def test_get_event_invalid_id():
 
 def test_get_events():
     res = events.get_events(min_start_time=1521500399999, max_start_time=1521500400001)
-    assert isinstance(res, data_objects.EventListResponse)
+    assert isinstance(res, dto.EventListResponse)
     assert isinstance(res.to_pandas(), pd.DataFrame)
     assert isinstance(res.to_json(), list)
     assert isinstance(res.to_ndarray(), np.ndarray)
     for event in res:
-        assert isinstance(event, data_objects.EventResponse)
+        assert isinstance(event, dto.EventResponse)
 
 
 def test_get_events_empty():
@@ -59,7 +59,7 @@ def test_get_events_empty():
 
 @pytest.fixture()
 def post_event():
-    event = data_objects.EventDTO(start_time=1521500400000, end_time=1521586800000)
+    event = dto.Event(start_time=1521500400000, end_time=1521586800000)
     res = events.post_events([event])
     return res
 

--- a/tests/v05/test_files.py
+++ b/tests/v05/test_files.py
@@ -23,7 +23,7 @@ def test_upload_file(tmpdir):
 
 
 def test_list_files():
-    from cognite.v05.data_objects import FileListResponse
+    from cognite.v05.dto import FileListResponse
     response = files.list_files(limit=3)
     assert isinstance(response, FileListResponse)
     assert isinstance(response.to_pandas(), pd.DataFrame)
@@ -45,7 +45,7 @@ def file_id():
 
 
 def test_get_file_info(file_id):
-    from cognite.v05.data_objects import FileInfoResponse
+    from cognite.v05.dto import FileInfoResponse
     response = files.get_file_info(file_id)
     assert isinstance(response, FileInfoResponse)
     assert isinstance(response.to_json(), dict)

--- a/tests/v05/test_raw.py
+++ b/tests/v05/test_raw.py
@@ -6,7 +6,7 @@ import pytest
 
 from cognite._utils import APIError
 from cognite.v05 import raw
-from cognite.v05.data_objects import RawResponse, RawRowDTO
+from cognite.v05.dto import RawResponse, RawRow
 
 DB_NAME = None
 TABLE_NAME = None
@@ -107,7 +107,7 @@ class TestRows:
         raw.delete_databases([DB_NAME], recursive=True)
 
     def test_create_rows(self):
-        response = raw.create_rows(DB_NAME, TABLE_NAME, rows=[RawRowDTO(key=ROW_KEY, columns=ROW_COLUMNS)])
+        response = raw.create_rows(DB_NAME, TABLE_NAME, rows=[RawRow(key=ROW_KEY, columns=ROW_COLUMNS)])
         assert response == {}
 
     def test_rows_response_length(self):
@@ -122,5 +122,5 @@ class TestRows:
         assert isinstance(row.to_pandas(), pd.DataFrame)
 
     def test_delete_rows(self):
-        response = raw.delete_rows(DB_NAME, TABLE_NAME, [RawRowDTO(key=ROW_KEY, columns=ROW_COLUMNS)])
+        response = raw.delete_rows(DB_NAME, TABLE_NAME, [RawRow(key=ROW_KEY, columns=ROW_COLUMNS)])
         assert response == {}

--- a/tests/v05/test_tag_matching.py
+++ b/tests/v05/test_tag_matching.py
@@ -19,7 +19,7 @@ def tagmatching_result(mock_post):
 
 
 def test_object(tagmatching_result):
-    from cognite.v05.data_objects import TagMatchingResponse
+    from cognite.v05.dto import TagMatchingResponse
     assert isinstance(tagmatching_result, TagMatchingResponse)
 
 

--- a/tests/v05/test_timeseries.py
+++ b/tests/v05/test_timeseries.py
@@ -5,7 +5,7 @@ import numpy as np
 import pandas as pd
 import pytest
 
-from cognite.v05 import timeseries, data_objects
+from cognite.v05 import timeseries, dto
 
 TS_NAME = None
 
@@ -27,12 +27,12 @@ class TestTimeseries:
         yield timeseries.get_timeseries(prefix=TS_NAME, limit=1, include_metadata=request.param)
 
     def test_post_timeseries(self):
-        tso = data_objects.TimeSeriesDTO(TS_NAME)
+        tso = dto.TimeSeries(TS_NAME)
         res = timeseries.post_time_series([tso])
         assert res == {}
 
     def test_update_timeseries(self):
-        tso = data_objects.TimeSeriesDTO(TS_NAME, unit='celsius')
+        tso = dto.TimeSeries(TS_NAME, unit='celsius')
         res = timeseries.update_time_series([tso])
         assert res == {}
 
@@ -41,7 +41,7 @@ class TestTimeseries:
 
     def test_get_timeseries_output_format(self, get_timeseries_response_obj):
         print(get_timeseries_response_obj.to_pandas())
-        from cognite.v05.data_objects import TimeseriesResponse
+        from cognite.v05.dto import TimeseriesResponse
         assert isinstance(get_timeseries_response_obj, TimeseriesResponse)
         assert isinstance(get_timeseries_response_obj.to_ndarray(), np.ndarray)
         assert isinstance(get_timeseries_response_obj.to_pandas(), pd.DataFrame)
@@ -59,7 +59,7 @@ class TestTimeseries:
 
 @pytest.fixture(scope='class')
 def datapoints_fixture():
-    tso = data_objects.TimeSeriesDTO(TS_NAME)
+    tso = dto.TimeSeries(TS_NAME)
     timeseries.post_time_series([tso])
     yield
     timeseries.delete_time_series(TS_NAME)
@@ -73,12 +73,12 @@ class TestDatapoints:
                                         protobuf=request.param.get('protobuf', False))
 
     def test_post_datapoints(self):
-        dps = [data_objects.DatapointDTO(i, i * 100) for i in range(10)]
+        dps = [dto.Datapoint(i, i * 100) for i in range(10)]
         res = timeseries.post_datapoints(TS_NAME, datapoints=dps)
         assert res == {}
 
     def test_get_datapoints(self, get_dps_response_obj):
-        from cognite.v05.data_objects import DatapointsResponse
+        from cognite.v05.dto import DatapointsResponse
         assert isinstance(get_dps_response_obj, DatapointsResponse)
 
     def test_get_dps_output_formats(self, get_dps_response_obj):
@@ -95,7 +95,7 @@ class TestDatapoints:
 
 class TestLatest:
     def test_get_latest(self):
-        from cognite.v05.data_objects import LatestDatapointResponse
+        from cognite.v05.dto import LatestDatapointResponse
         response = timeseries.get_latest('constant')
         assert isinstance(response, LatestDatapointResponse)
         assert isinstance(response.to_ndarray(), np.ndarray)
@@ -123,7 +123,7 @@ class TestDatapointsFrame:
 class TestMultiTimeseriesDatapoints:
     @pytest.fixture(scope='class', params=dps_params[:2])
     def get_multi_time_series_dps_response_obj(self, request):
-        from cognite.v05.data_objects import DatapointsQuery
+        from cognite.v05.dto import DatapointsQuery
         dq1 = DatapointsQuery('constant')
         dq2 = DatapointsQuery('sinus', aggregates=['avg'], granularity='30s')
         yield list(
@@ -132,7 +132,7 @@ class TestMultiTimeseriesDatapoints:
                                                         granularity='60s'))
 
     def test_get_multi_time_series_dps_output_format(self, get_multi_time_series_dps_response_obj):
-        from cognite.v05.data_objects import DatapointsResponse
+        from cognite.v05.dto import DatapointsResponse
         assert isinstance(get_multi_time_series_dps_response_obj, list)
         for dpr in get_multi_time_series_dps_response_obj:
             assert isinstance(dpr, DatapointsResponse)

--- a/tests/v05/test_timeseries.py
+++ b/tests/v05/test_timeseries.py
@@ -69,7 +69,7 @@ def datapoints_fixture():
 class TestDatapoints:
     @pytest.fixture(scope='class', params=dps_params)
     def get_dps_response_obj(self, request):
-        yield timeseries.get_datapoints(timeseries='constant', start=request.param['start'], end=request.param['end'],
+        yield timeseries.get_datapoints(name='constant', start=request.param['start'], end=request.param['end'],
                                         protobuf=request.param.get('protobuf', False))
 
     def test_post_datapoints(self):
@@ -106,7 +106,7 @@ class TestLatest:
 class TestDatapointsFrame:
     @pytest.fixture(scope='class', params=dps_params[:2])
     def get_datapoints_frame_response_obj(self, request):
-        yield timeseries.get_datapoints_frame(timeseries=['constant'], start=request.param['start'],
+        yield timeseries.get_datapoints_frame(time_series=['constant'], start=request.param['start'],
                                               end=request.param['end'],
                                               aggregates=['avg'], granularity='1m')
 


### PR DESCRIPTION
- Bug in DTOs: to_pandas() would mutate internal representation of data for certain response objects.
- Add live data generator.
- Breaking Changes:
1. rename data_objects.py -> dto.py
2. rename timeseries paremeter to 'time_series' when input is list of time series and 'name' when input is single time series.
3. rename AssetDTO -> Asset
4. rename EventDTO -> Event
5. rename TimeSeriesDTO -> TimeSeries
6. rename RawRowDTO -> RawRow
7. rename DatapointDTO -> Datapoint