### PR TITLE
Added a prerequisites section

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,12 @@ Python SDK to ensure excellent user experience for developers and data scientist
 [![codecov](https://codecov.io/gh/cognitedata/cognite-sdk-python/branch/master/graph/badge.svg)](https://codecov.io/gh/cognitedata/cognite-sdk-python)
 [![Documentation Status](https://readthedocs.org/projects/cognite-sdk-python/badge/?version=latest)](http://cognite-sdk-python.readthedocs.io/en/latest/?badge=latest)
 
+## Prerequisites
+In order to start using the Python SDK, you need
+- Python3 and pip3
+- An API key. Never include the API key directly in the code or upload the key to github. Instead, set the API key as an environment variable. See the usage example for how to authenticate with the API key.
+
+
 ## Installation
 ```bash
 $ pip install cognite-sdk


### PR DESCRIPTION
Added a prerequisites section to:
- specify the need for Python3 and pip3
- specify that API keys should be set as environment variables and not written in the code directly