### PR TITLE
Fix get_events

### DIFF
--- a/cognite/__init__.py
+++ b/cognite/__init__.py
@@ -18,4 +18,4 @@ Data Platform (CDP).
 #
 
 __all__ = ['v04', 'v05', 'preprocessing', 'config']
-__version__ = '0.8.6'
+__version__ = '0.8.7'

--- a/cognite/v05/events.py
+++ b/cognite/v05/events.py
@@ -66,17 +66,25 @@ def get_events(type=None, sub_type=None, asset_id=None, **kwargs):
         'content-type': 'application/json',
         'accept': 'application/json'
     }
-    params = {
-        'type': type,
-        'subtype': sub_type,
-        'assetId': asset_id,
-        'sort': kwargs.get('sort'),
-        'cursor': kwargs.get('cursor'),
-        'limit': kwargs.get('limit', 25) if not kwargs.get('autopaging') else _constants.LIMIT_AGG,
-        'hasDescription': kwargs.get('has_description'),
-        'minStartTime': kwargs.get('min_start_time'),
-        'maxStartTime': kwargs.get('max_start_time')
-    }
+    if asset_id:
+        params = {
+            'assetId': asset_id,
+            'sort': kwargs.get('sort'),
+            'cursor': kwargs.get('cursor'),
+            'limit': kwargs.get('limit', 25) if not kwargs.get('autopaging') else _constants.LIMIT_AGG
+        }
+    else:
+        params = {
+            'type': type,
+            'subtype': sub_type,
+            'assetId': asset_id,
+            'sort': kwargs.get('sort'),
+            'cursor': kwargs.get('cursor'),
+            'limit': kwargs.get('limit', 25) if not kwargs.get('autopaging') else _constants.LIMIT_AGG,
+            'hasDescription': kwargs.get('has_description'),
+            'minStartTime': kwargs.get('min_start_time'),
+            'maxStartTime': kwargs.get('max_start_time')
+        }
 
     res = _utils.get_request(url, headers=headers, params=params, cookies=config.get_cookies())
     events = []


### PR DESCRIPTION
Since backend changed the api, parameters 'type', 'subtype', 'hasDescription', 'minStartTime', 'maxStartTime' and 'source' are disabled when assetId is used. This causes error 400.