### PR TITLE
Quote the TS names in all post methods

### DIFF
--- a/cognite/__init__.py
+++ b/cognite/__init__.py
@@ -18,4 +18,4 @@ Data Platform (CDP).
 #
 
 __all__ = ['v04', 'v05', 'preprocessing', 'config']
-__version__ = '0.8.7'
+__version__ = '0.8.8'

--- a/cognite/v05/timeseries.py
+++ b/cognite/v05/timeseries.py
@@ -262,7 +262,7 @@ def post_multi_tag_datapoints(timeseries_with_datapoints: List[TimeseriesWithDat
 
     for bin in timeseries_to_upload_binned:
         body = {
-            'items': [{"tagId": ts_with_data.name, "datapoints": [dp.__dict__ for dp in ts_with_data.datapoints]} for
+            'items': [{"tagId": quote_plus(ts_with_data.name), "datapoints": [dp.__dict__ for dp in ts_with_data.datapoints]} for
                       ts_with_data in bin]
         }
         res = _utils.post_request(url, body=body, headers=headers)
@@ -686,6 +686,10 @@ def post_time_series(time_series: List[TimeSeries], **kwargs):
 
     api_key, project = config.get_config_variables(kwargs.get('api_key'), kwargs.get('project'))
     url = config.get_base_url(api_version=0.5) + '/projects/{}/timeseries'.format(project)
+
+    # Quote the time series names
+    for ts in time_series:
+        ts.name = quote_plus(ts.name)
 
     body = {
         'items': [ts.__dict__ for ts in time_series]

--- a/cognite/v05/timeseries.py
+++ b/cognite/v05/timeseries.py
@@ -646,7 +646,7 @@ def get_timeseries(prefix=None, description=None, include_metadata=False, asset_
         'accept': 'application/json'
     }
     params = {
-        'q': prefix,
+        'q': quote_plus(prefix),
         'description': description,
         'includeMetadata': include_metadata,
         'assetId': asset_id,
@@ -725,6 +725,10 @@ def update_time_series(time_series: List[TimeSeries], **kwargs):
     api_key, project = config.get_config_variables(kwargs.get('api_key'), kwargs.get('project'))
     url = config.get_base_url(api_version=0.5) + '/projects/{}/timeseries'.format(project)
 
+    # Quote the time series names
+    for ts in time_series:
+        ts.name = quote_plus(ts.name)
+
     body = {
         'items': [ts.__dict__ for ts in time_series]
     }
@@ -754,7 +758,7 @@ def delete_time_series(name, **kwargs):
         An empty response.
     '''
     api_key, project = config.get_config_variables(kwargs.get('api_key'), kwargs.get('project'))
-    url = config.get_base_url(api_version=0.5) + '/projects/{}/timeseries/{}'.format(project, name)
+    url = config.get_base_url(api_version=0.5) + '/projects/{}/timeseries/{}'.format(project, quote_plus(name))
 
     headers = {
         'api-key': api_key,

--- a/tests/v05/test_timeseries.py
+++ b/tests/v05/test_timeseries.py
@@ -18,7 +18,7 @@ dps_params = [
 @pytest.fixture(autouse=True, scope='class')
 def ts_name():
     global TS_NAME
-    TS_NAME = 'test_ts_{}'.format(randint(1, 2 ** 53 - 1))
+    TS_NAME = 'test_ ts_{}'.format(randint(1, 2 ** 53 - 1))
 
 
 class TestTimeseries:


### PR DESCRIPTION
I found that timeseries I created with post_timeseries() weren't found when using post_datapoints() later. The fact that the TS name was quoted in post_timeseries() and not in post_datapoints() was the cause.