### PR TITLE
Set default amount of retries to 0

### DIFF
--- a/cognite/_constants.py
+++ b/cognite/_constants.py
@@ -16,4 +16,4 @@ Attributes:
 BASE_URL = 'https://api.cognitedata.com/api/'
 LIMIT = 100000
 LIMIT_AGG = 10000
-RETRY_LIMIT = 1
+RETRY_LIMIT = 0


### PR DESCRIPTION
I think it would be confusing for users if the default behaviour is that requests are retried by default.

(Feel fre to close this if you disagree though)