### PR TITLE
#102: Support end="now" in get_datapoints()

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Python SDK to ensure excellent user experience for developers and data scientist
 
 ## Prerequisites
 In order to start using the Python SDK, you need
-- Python3 and pip
+- Python3 (>= 3.3) and pip
 - An API key. Never include the API key directly in the code or upload the key to github. Instead, set the API key as an environment variable. See the usage example for how to authenticate with the API key.
 
 This is how you set the API key as an environment variable on Mac OS and Linux:

--- a/cognite/_utils.py
+++ b/cognite/_utils.py
@@ -143,8 +143,7 @@ def _log_request(method, url, **kwargs):
 
 
 def datetime_to_ms(dt):
-    epoch = datetime.utcfromtimestamp(0)
-    return int((dt - epoch).total_seconds() * 1000)
+    return int(dt.timestamp() * 1000)
 
 
 def round_to_nearest(x, base):
@@ -170,6 +169,8 @@ def granularity_to_ms(time_string):
 
 def _time_ago_to_ms(time_ago_string):
     """Returns millisecond representation of time-ago string"""
+    if time_ago_string == 'now':
+        return 0
     pattern = r"(\d+)([a-z])-ago"
     res = re.match(pattern, str(time_ago_string))
     if res:

--- a/cognite/_utils.py
+++ b/cognite/_utils.py
@@ -10,7 +10,7 @@ import json
 import logging
 import re
 import time
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Callable, List
 
 import requests
@@ -143,7 +143,7 @@ def _log_request(method, url, **kwargs):
 
 
 def datetime_to_ms(dt):
-    return int(dt.timestamp() * 1000)
+    return int(dt.replace(tzinfo=timezone.utc).timestamp() * 1000)
 
 
 def round_to_nearest(x, base):

--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,7 @@ setup(
     author="Erlend Vollset",
     author_email="erlend.vollset@cognite.com",
     packages=packages,
+    python_requires='>=3.3',
     install_requires=["requests", "pandas", "protobuf", "cognite-logger>=0.3"],
     zip_safe=False,
     include_package_data=True,

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -277,7 +277,7 @@ class TestConversions:
         assert utils.datetime_to_ms(datetime(2018, 1, 31)) == 1517356800000
         assert utils.datetime_to_ms(datetime(2018, 1, 31, 11, 11, 11)) == 1517397071000
         assert utils.datetime_to_ms(datetime(100, 1, 31)) == -59008867200000
-        with pytest.raises(TypeError):
+        with pytest.raises(AttributeError):
             utils.datetime_to_ms(None)
 
     def test_round_to_nearest(self):

--- a/tests/v05/test_timeseries.py
+++ b/tests/v05/test_timeseries.py
@@ -94,6 +94,7 @@ class TestDatapoints:
 
         assert isinstance(get_dps_response_obj, DatapointsResponse)
 
+
     def test_get_dps_output_formats(self, get_dps_response_obj):
         assert isinstance(get_dps_response_obj.to_ndarray(), np.ndarray)
         assert isinstance(get_dps_response_obj.to_pandas(), pd.DataFrame)
@@ -108,6 +109,10 @@ class TestDatapoints:
     def test_get_dps_with_limit(self):
         res = timeseries.get_datapoints(name="constant", start=0, limit=1)
         assert len(res.to_json().get("datapoints")) == 1
+
+    def test_get_dps_with_end_now(self):
+        res = timeseries.get_datapoints(name="constant", start=0, end="now", limit=100)
+        assert len(res.to_json().get("datapoints")) == 100
 
     def test_get_dps_with_limit_with_config_variables_from_argument(self, unset_config_variables):
         res = timeseries.get_datapoints(


### PR DESCRIPTION
BTW, why all the start/end fuss (string -> int) in the SDK? AFIK the REST API supports the same string arguments. It does makes sense to support DateTime objects, but there is no need to map "now", "2w-ago", etc to ms since the epoch.

Let me know if the test could be improved to properly test end="now". As is, it pretty much just checks that the code completes without failures.