### PR TITLE
Add convenient str format for DataSpec

### DIFF
--- a/cognite/data_transfer_service.py
+++ b/cognite/data_transfer_service.py
@@ -146,6 +146,9 @@ class DataSpec:
 
     def to_JSON(self):
         return DataSpec._to_json(self)
+    
+    def __str__(self):
+        return json.dumps(self.to_JSON(), indent=4)
 
     @staticmethod
     def _to_json(obj):


### PR DESCRIPTION
This will make it possible to simply do print(data_spec) and get a
nice human readable printout.