### PR TITLE
Update prerequisites to python >= 3.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Python SDK to ensure excellent user experience for developers and data scientist
 
 ## Prerequisites
 In order to start using the Python SDK, you need
-- Python3 (>= 3.5) and pip
+- Python3 (>= 3.6) and pip
 - An API key. Never include the API key directly in the code or upload the key to github. Instead, set the API key as an environment variable. See the usage example for how to authenticate with the API key.
 
 This is how you set the API key as an environment variable on Mac OS and Linux:


### PR DESCRIPTION
```
Python 3.5.1 (default, Dec 30 2018, 00:15:09)
[GCC 4.2.1 Compatible Apple LLVM 10.0.0 (clang-1000.11.45.5)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> import cognite
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/msroed/.pyenv/versions/3.5.1/lib/python3.5/site-packages/cognite/__init__.py", line 1, in <module>
    from cognite.client.cognite_client import CogniteClient
  File "/Users/msroed/.pyenv/versions/3.5.1/lib/python3.5/site-packages/cognite/client/cognite_client.py", line 10, in <module>
    from cognite.client._api_client import APIClient
  File "/Users/msroed/.pyenv/versions/3.5.1/lib/python3.5/site-packages/cognite/client/_api_client.py", line 70
    _LIMIT = 100_000
```

Underscore notation was introduced in python 3.6 (https://www.python.org/dev/peps/pep-0515/). If we want to support >= 3.5 this needs to be rewritten. Otherwise, let's let our customers know the correct requirements.