### PR TITLE
Added delete_time_series_by_id

### DIFF
--- a/cognite/client/experimental/time_series.py
+++ b/cognite/client/experimental/time_series.py
@@ -43,8 +43,7 @@ class TimeSeriesClient(APIClient):
         """
         url = "/timeseries/delete"
         body = {"items": ids}
-        params = {}
-        self._post(url, body=body, params=params)
+        self._post(url, body=body)
 
     def get_time_series_by_id(self, id: int) -> TimeSeriesResponse:
         """Returns a TimeseriesResponse object containing the requested timeseries.

--- a/cognite/client/experimental/time_series.py
+++ b/cognite/client/experimental/time_series.py
@@ -25,6 +25,27 @@ class TimeSeriesClient(APIClient):
     def __init__(self, **kwargs):
         super().__init__(version="0.6", **kwargs)
 
+    def delete_time_series_by_id(self, ids: List[int]) -> None:
+        """Delete multiple time series by id.
+
+        Args:
+            ids (List[int]):   IDs of time series to delete.
+
+        Returns:
+            None
+
+        Examples:
+            Delete a single time series by id::
+
+                client = CogniteClient()
+
+                client.time_series.delete_time_series_by_id(ids=[my_ts_id])
+        """
+        url = "/timeseries/delete"
+        body = {"items": ids}
+        params = {}
+        self._post(url, body=body, params=params)
+
     def get_time_series_by_id(self, id: int) -> TimeSeriesResponse:
         """Returns a TimeseriesResponse object containing the requested timeseries.
 

--- a/tests/test_experimental/test_time_series.py
+++ b/tests/test_experimental/test_time_series.py
@@ -24,7 +24,7 @@ class TestTimeseries:
     @pytest.fixture(scope="class")
     def created_ts_id(self):
         tso = TimeSeries(TS_NAME)
-        res = stable_time_series.post_time_series([tso])
+        stable_time_series.post_time_series([tso])
         yield stable_time_series.get_time_series(prefix=TS_NAME).to_json()[0]["id"]
 
     def test_delete_time_series_by_id(self, created_ts_id):

--- a/tests/test_experimental/test_time_series.py
+++ b/tests/test_experimental/test_time_series.py
@@ -12,15 +12,15 @@ time_series = CogniteClient().experimental.time_series
 
 
 @pytest.fixture
-def created_ts_id(self):
+def new_ts_id():
     name = "test_ts_{}".format(randint(1, 2 ** 53 - 1))
     stable_time_series.post_time_series([TimeSeries(name)])
     yield stable_time_series.get_time_series(prefix=name).to_json()[0]["id"]
 
 
 class TestTimeseries:
-    def test_delete_time_series_by_id(self, created_ts_id):
-        res = time_series.delete_time_series_by_id([created_ts_id])
+    def test_delete_time_series_by_id(self, new_ts_id):
+        res = time_series.delete_time_series_by_id([new_ts_id])
         assert res is None
 
     @pytest.fixture(scope="class")

--- a/tests/test_experimental/test_time_series.py
+++ b/tests/test_experimental/test_time_series.py
@@ -11,21 +11,12 @@ stable_time_series = CogniteClient().time_series
 time_series = CogniteClient().experimental.time_series
 
 
-TS_NAME = None
-
-
-@pytest.fixture(autouse=True, scope="class")
-def ts_name():
-    global TS_NAME
-    TS_NAME = "test_ts_{}".format(randint(1, 2 ** 53 - 1))
-
-
 class TestTimeseries:
-    @pytest.fixture(scope="class")
+    @pytest.fixture
     def created_ts_id(self):
-        tso = TimeSeries(TS_NAME)
-        stable_time_series.post_time_series([tso])
-        yield stable_time_series.get_time_series(prefix=TS_NAME).to_json()[0]["id"]
+        name = "test_ts_{}".format(randint(1, 2 ** 53 - 1))
+        stable_time_series.post_time_series([TimeSeries(name)])
+        yield stable_time_series.get_time_series(prefix=name).to_json()[0]["id"]
 
     def test_delete_time_series_by_id(self, created_ts_id):
         res = time_series.delete_time_series_by_id([created_ts_id])

--- a/tests/test_experimental/test_time_series.py
+++ b/tests/test_experimental/test_time_series.py
@@ -11,13 +11,14 @@ stable_time_series = CogniteClient().time_series
 time_series = CogniteClient().experimental.time_series
 
 
-class TestTimeseries:
-    @pytest.fixture
-    def created_ts_id(self):
-        name = "test_ts_{}".format(randint(1, 2 ** 53 - 1))
-        stable_time_series.post_time_series([TimeSeries(name)])
-        yield stable_time_series.get_time_series(prefix=name).to_json()[0]["id"]
+@pytest.fixture
+def created_ts_id(self):
+    name = "test_ts_{}".format(randint(1, 2 ** 53 - 1))
+    stable_time_series.post_time_series([TimeSeries(name)])
+    yield stable_time_series.get_time_series(prefix=name).to_json()[0]["id"]
 
+
+class TestTimeseries:
     def test_delete_time_series_by_id(self, created_ts_id):
         res = time_series.delete_time_series_by_id([created_ts_id])
         assert res is None

--- a/tests/test_experimental/test_time_series.py
+++ b/tests/test_experimental/test_time_series.py
@@ -3,11 +3,13 @@ from random import randint
 import pytest
 
 from cognite import CogniteClient
+from cognite.client.stable.time_series import TimeSeries
 from cognite.client.experimental.time_series import TimeSeriesClient, TimeSeriesResponse
 from tests.conftest import TEST_TS_1_NAME
 
-time_series = CogniteClient().experimental.time_series
-
+_client = CogniteClient()
+time_series = _client.experimental.time_series
+stable_time_series = _client.time_series
 
 TS_NAME = None
 
@@ -19,6 +21,16 @@ def ts_name():
 
 
 class TestTimeseries:
+    @pytest.fixture(scope="class")
+    def created_ts_id(self):
+        tso = TimeSeries(TS_NAME)
+        res = stable_time_series.post_time_series([tso])
+        yield time_series.search_for_time_series().to_json()[0]["id"]
+
+    def test_delete_time_series_by_id(self, created_ts_id):
+        res = time_series.delete_time_series_by_id([created_ts_id])
+        assert res is None
+
     @pytest.fixture(scope="class")
     def get_time_series_by_id_response_obj(self, time_series_in_cdp):
         yield time_series.get_time_series_by_id(id=time_series_in_cdp[0])

--- a/tests/test_experimental/test_time_series.py
+++ b/tests/test_experimental/test_time_series.py
@@ -25,7 +25,7 @@ class TestTimeseries:
     def created_ts_id(self):
         tso = TimeSeries(TS_NAME)
         res = stable_time_series.post_time_series([tso])
-        yield time_series.search_for_time_series(name=TS_NAME).to_json()[0]["id"]
+        yield stable_time_series.get_time_series(prefix=TS_NAME).to_json()[0]["id"]
 
     def test_delete_time_series_by_id(self, created_ts_id):
         res = time_series.delete_time_series_by_id([created_ts_id])

--- a/tests/test_experimental/test_time_series.py
+++ b/tests/test_experimental/test_time_series.py
@@ -7,9 +7,8 @@ from cognite.client.stable.time_series import TimeSeries
 from cognite.client.experimental.time_series import TimeSeriesClient, TimeSeriesResponse
 from tests.conftest import TEST_TS_1_NAME
 
-_client = CogniteClient()
-time_series = _client.experimental.time_series
-stable_time_series = _client.time_series
+stable_time_series = CogniteClient().time_series
+time_series = CogniteClient().experimental.time_series
 
 TS_NAME = None
 

--- a/tests/test_experimental/test_time_series.py
+++ b/tests/test_experimental/test_time_series.py
@@ -25,7 +25,7 @@ class TestTimeseries:
     def created_ts_id(self):
         tso = TimeSeries(TS_NAME)
         res = stable_time_series.post_time_series([tso])
-        yield time_series.search_for_time_series().to_json()[0]["id"]
+        yield time_series.search_for_time_series(name=TS_NAME).to_json()[0]["id"]
 
     def test_delete_time_series_by_id(self, created_ts_id):
         res = time_series.delete_time_series_by_id([created_ts_id])

--- a/tests/test_experimental/test_time_series.py
+++ b/tests/test_experimental/test_time_series.py
@@ -10,6 +10,7 @@ from tests.conftest import TEST_TS_1_NAME
 stable_time_series = CogniteClient().time_series
 time_series = CogniteClient().experimental.time_series
 
+
 TS_NAME = None
 
 


### PR DESCRIPTION
Rationale: starting with API `v0.6`, time series names may be non-unique.

There isn't necessarily a huge need for this change right now (afaik posting a time series with a duplicate name is not possible), but I wanted to try this simple change first to get a feel of implementation/testing in `cognite_sdk`.