### PR TITLE
Fixed broken example

### DIFF
--- a/cognite/client/stable/datapoints.py
+++ b/cognite/client/stable/datapoints.py
@@ -454,8 +454,8 @@ class DatapointsClient(APIClient):
                 client = CogniteClient()
 
                 start = 1514761200000
-                my_dummy_data = [Datapoint(timestamp=ms, value=i) for i, ms in range(start, start+100)]
-                client.datapoints.post_datapoints(my_dummy_data)
+                my_dummy_data = [Datapoint(timestamp=start+off, value=off) for off in range(100)]
+                client.datapoints.post_datapoints(ts_name, my_dummy_data)
         """
         url = "/timeseries/data/{}".format(quote(name, safe=""))
 


### PR DESCRIPTION
Previously, the given example would not run (most crucially, only one parameter was passed to `post_datapoints` whereas two are required). Less importantly, `for i, ms in range(start, start+100)` was broken because `range` is not a sequence of pairs.