### PR TITLE
Raw data point capability for DataTransferService

### DIFF
--- a/cognite/__init__.py
+++ b/cognite/__init__.py
@@ -2,4 +2,4 @@ from cognite.client.cognite_client import CogniteClient
 from cognite.client.exceptions import APIError
 
 __all__ = ["data_transfer_service"]
-__version__ = "0.12.8"
+__version__ = "0.12.9"

--- a/cognite/data_transfer_service.py
+++ b/cognite/data_transfer_service.py
@@ -132,7 +132,6 @@ class DataSpec:
                         raise DataSpecValidationError("Time series labels must be unique")
                     ts_labels.append(ts.label)
 
-
     def __validate_files_data_spec(self):
         if self.files_data_spec:
             if not isinstance(self.files_data_spec, FilesDataSpec):

--- a/tests/test_data_transfer_service/test_data_transfer_service.py
+++ b/tests/test_data_transfer_service/test_data_transfer_service.py
@@ -150,10 +150,7 @@ class TestDataTransferService:
             data_spec = DataSpec(
                 time_series_data_specs=[
                     TimeSeriesDataSpec(
-                        time_series=[
-                            TimeSeries(id=time_series_in_cdp[0]),
-                            TimeSeries(id=time_series_in_cdp[1])
-                        ],
+                        time_series=[TimeSeries(id=123), TimeSeries(id=456)],
                         aggregates=[],
                         granularity="raw",
                         start=TEST_TS_REASONABLE_INTERVAL["start"],
@@ -167,10 +164,7 @@ class TestDataTransferService:
             data_spec = DataSpec(
                 time_series_data_specs=[
                     TimeSeriesDataSpec(
-                        time_series=[
-                            TimeSeries(id=time_series_in_cdp[0]),
-                            TimeSeries(id=time_series_in_cdp[1], aggregates=["avg"])
-                        ],
+                        time_series=[TimeSeries(id=123), TimeSeries(id=456, aggregates=["avg"])],
                         aggregates=[],
                         granularity="raw",
                         start=TEST_TS_REASONABLE_INTERVAL["start"],
@@ -180,18 +174,18 @@ class TestDataTransferService:
             )
 
     def test_get_raw_dataframes(self, time_series_in_cdp):
-        data_spec = DataSpec(time_series_data_specs=[
-            TimeSeriesDataSpec(
-                time_series=[
-                    TimeSeries(id=time_series_in_cdp[1], label="ts1")
-                ],
-                aggregates=[],
-                granularity="raw",
-                start=TEST_TS_REASONABLE_INTERVAL["start"],
-                end=TEST_TS_REASONABLE_INTERVAL["end"],
-                label="ds1"
-            )
-        ])
+        data_spec = DataSpec(
+            time_series_data_specs=[
+                TimeSeriesDataSpec(
+                    time_series=[TimeSeries(id=time_series_in_cdp[1], label="ts1")],
+                    aggregates=[],
+                    granularity="raw",
+                    start=TEST_TS_REASONABLE_INTERVAL["start"],
+                    end=TEST_TS_REASONABLE_INTERVAL["end"],
+                    label="ds1",
+                )
+            ]
+        )
         service = DataTransferService(data_spec)
         dataframes = service.get_dataframes()
 


### PR DESCRIPTION
For our use case, it's useful to be able to fetch raw datapoints via `DataTransferService`. We are using our own helper for now, but ideally would like to see this implemented in `cognite-sdk`. This is a proposal as to how this might be done: the same convention as in `get_datapoints` is applied, i.e. that empty `aggregates` indicate a raw datapoints request.