### PR TITLE
Add 'min' as alias for 'minute'

### DIFF
--- a/cognite/client/_utils.py
+++ b/cognite/client/_utils.py
@@ -33,6 +33,7 @@ def granularity_to_ms(time_string):
         "second": 1000,
         "m": 60000,
         "minute": 60000,
+        "min": 60000,
         "h": 3600000,
         "hour": 3600000,
         "d": 86400000,


### PR DESCRIPTION
Rationale: when treated as a [frequency specifier](http://pandas.pydata.org/pandas-docs/stable/timeseries.html#offset-aliases) for resampling in `pandas`, `m` stands for "months" and `minute` is not valid. This is not an issue with `s` and `h` ([case is ignored](https://github.com/pandas-dev/pandas/blob/master/pandas/tseries/frequencies.py#L178)). It would be nice to be able to store granularity in a unified format.