### PR TITLE
0.12.10 Make list response objects indexable

### DIFF
--- a/cognite/__init__.py
+++ b/cognite/__init__.py
@@ -2,4 +2,4 @@ from cognite.client.cognite_client import CogniteClient
 from cognite.client.exceptions import APIError
 
 __all__ = ["data_transfer_service"]
-__version__ = "0.12.9"
+__version__ = "0.12.10"

--- a/cognite/client/stable/assets.py
+++ b/cognite/client/stable/assets.py
@@ -20,6 +20,9 @@ class AssetListResponse(CogniteResponse):
             return pd.DataFrame(self.internal_representation["data"]["items"])
         return pd.DataFrame()
 
+    def __getitem__(self, index):
+        return AssetResponse({"data": {"items": [self.to_json()[index]]}})
+
     def __iter__(self):
         return self
 

--- a/cognite/client/stable/datapoints.py
+++ b/cognite/client/stable/datapoints.py
@@ -5,7 +5,7 @@ import time
 from concurrent.futures import ThreadPoolExecutor as Pool
 from copy import copy
 from functools import partial
-from typing import Dict, List
+from typing import List
 from urllib.parse import quote
 
 import pandas as pd
@@ -68,6 +68,9 @@ class DatapointsResponseIterator:
     def __init__(self, datapoints_objects):
         self.datapoints_objects = datapoints_objects
         self.counter = 0
+
+    def __getitem__(self, index):
+        return self.datapoints_objects[index]
 
     def __iter__(self):
         return self

--- a/cognite/client/stable/events.py
+++ b/cognite/client/stable/events.py
@@ -54,6 +54,9 @@ class EventListResponse(CogniteResponse):
                 d.update(d.pop("metadata"))
         return pd.DataFrame(items)
 
+    def __getitem__(self, index):
+        return EventResponse({"data": {"items": [self.to_json()[index]]}})
+
     def __iter__(self):
         return self
 

--- a/cognite/client/stable/time_series.py
+++ b/cognite/client/stable/time_series.py
@@ -31,6 +31,9 @@ class TimeSeriesListResponse(CogniteResponse):
                     d.update(metadata)
         return pd.DataFrame(items)
 
+    def __getitem__(self, index):
+        return TimeSeriesResponse({"data": {"items": [self.to_json()[index]]}})
+
     def __iter__(self):
         return self
 

--- a/tests/test_stable/test_assets.py
+++ b/tests/test_stable/test_assets.py
@@ -24,6 +24,7 @@ def test_get_assets_response_object(get_assets_response):
     assert isinstance(get_assets_response, AssetListResponse)
     assert get_assets_response.next_cursor() is not None
     assert get_assets_response.previous_cursor() is None
+    assert isinstance(get_assets_response[0], AssetResponse)
 
 
 def test_get_assets_with_metadata_args():

--- a/tests/test_stable/test_datapoints.py
+++ b/tests/test_stable/test_datapoints.py
@@ -214,7 +214,7 @@ class TestMultiTimeseriesDatapoints:
 
     def test_get_multi_time_series_dps_output_format(self, get_multi_time_series_dps_response_obj):
         assert isinstance(get_multi_time_series_dps_response_obj, list)
-
+        assert isinstance(get_multi_time_series_dps_response_obj[0], DatapointsResponse)
         for dpr in get_multi_time_series_dps_response_obj:
             assert isinstance(dpr, DatapointsResponse)
 

--- a/tests/test_stable/test_events.py
+++ b/tests/test_stable/test_events.py
@@ -51,6 +51,7 @@ def test_get_events():
     assert isinstance(res, cognite.client.stable.events.EventListResponse)
     assert isinstance(res.to_pandas(), pd.DataFrame)
     assert isinstance(res.to_json(), list)
+    assert isinstance(res[0], cognite.client.stable.events.EventResponse)
     for event in res:
         assert isinstance(event, cognite.client.stable.events.EventResponse)
 

--- a/tests/test_stable/test_timeseries.py
+++ b/tests/test_stable/test_timeseries.py
@@ -37,6 +37,7 @@ class TestTimeseries:
         assert isinstance(get_timeseries_response_obj, TimeSeriesListResponse)
         assert isinstance(get_timeseries_response_obj.to_pandas(), pd.DataFrame)
         assert isinstance(get_timeseries_response_obj.to_json()[0], dict)
+        assert isinstance(get_timeseries_response_obj[0], TimeSeriesResponse)
 
         for ts in get_timeseries_response_obj:
             assert isinstance(ts, TimeSeriesResponse)


### PR DESCRIPTION
Implements `__getitem__()` for list response classes. 

Can now do for example:
`client.assets.get_assets()[:5]`
to get first 5 elements