### PR TITLE
Use os.path.basename to get package name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,10 @@ Changes are grouped as follows
 - Rename methods so they reflect what the method does instead of what http method is used
 
 
+## [0.13.1] - 2019-03-14
+### Fixed
+- Make `_get_model_py_files` work on Windows
+
 ## [0.13.0] - 2019-03-12
 ### Added
 - New client for modelhosting API: `experimental.model_hosting`

--- a/cognite/client/__init__.py
+++ b/cognite/client/__init__.py
@@ -1,4 +1,4 @@
 from cognite.client.cognite_client import CogniteClient
 from cognite.client.exceptions import APIError
 
-__version__ = "0.13.0"
+__version__ = "0.13.1"

--- a/cognite/client/experimental/model_hosting/source_packages.py
+++ b/cognite/client/experimental/model_hosting/source_packages.py
@@ -92,7 +92,7 @@ class SourcePackageClient(APIClient):
         files_containing_model_py = []
         for root, dirs, files in os.walk(path):
             if "model.py" in files:
-                package_name = root.split("/")[-1]
+                package_name = os.path.basename(root)
                 file_path = os.path.join(root, "model.py")
                 files_containing_model_py.append((package_name, file_path))
         return files_containing_model_py


### PR DESCRIPTION
Windows is using `\` as the separator, and we should be using basename here anyway.