### PR TITLE
Improve retry logic

### DIFF
--- a/cognite/client/_cognite_client.py
+++ b/cognite/client/_cognite_client.py
@@ -16,7 +16,7 @@ from cognite.client._utils.utils import DebugLogFormatter
 
 DEFAULT_BASE_URL = "https://api.cognitedata.com"
 DEFAULT_MAX_WORKERS = 10
-DEFAULT_TIMEOUT = 20
+DEFAULT_TIMEOUT = 10
 
 
 class CogniteClient:
@@ -31,7 +31,7 @@ class CogniteClient:
         max_workers (int): Max number of workers to spawn when parallelizing data fetching. Defaults to 10.
         cookies (Dict): Cookies to append to all requests. Defaults to {}
         headers (Dict): Additional headers to add to all requests.
-        timeout (int): Timeout on requests sent to the api. Defaults to 20 seconds.
+        timeout (int): Timeout on requests sent to the api. Defaults to 10 seconds.
         debug (bool): Configures logger to log extra request details to stderr.
     """
 

--- a/tests/tests_unit/test_api/test_time_series.py
+++ b/tests/tests_unit/test_api/test_time_series.py
@@ -4,10 +4,10 @@ from unittest import mock
 import pytest
 
 from cognite.client import CogniteClient, global_client
-from cognite.client._api.time_series import TimeSeries, TimeSeriesFilter, TimeSeriesList, TimeSeriesUpdate
+from cognite.client._api.time_series import TimeSeries, TimeSeriesFilter, TimeSeriesList, TimeSeriesUpdate, utils
 from tests.utils import jsgz_load
 
-COGNITE_CLIENT = CogniteClient()
+COGNITE_CLIENT = CogniteClient(debug=True)
 TS_API = COGNITE_CLIENT.time_series
 
 
@@ -137,6 +137,22 @@ class TestTimeSeries:
 class TestPlotTimeSeries:
     @pytest.fixture
     def mock_get_dps(self, rsps):
+        rsps.add(
+            rsps.POST,
+            TS_API._base_url + "/timeseries/data/get",
+            status=200,
+            json={
+                "data": {
+                    "items": [
+                        {
+                            "id": 0,
+                            "externalId": "string1",
+                            "datapoints": [{"timestamp": utils.timestamp_to_ms("1d-ago"), "average": 1}],
+                        }
+                    ]
+                }
+            },
+        )
         rsps.add(
             rsps.POST,
             TS_API._base_url + "/timeseries/data/get",


### PR DESCRIPTION
- Set maximum backoff for retries.
- Create separate adapter for retrying. This can be mounted on paths which allow retrying, once that information is available through the openapi spec.
- Decrease default timeout.


Also increased max pool size so as not to throttle concurrent requests.
