### PR TITLE
Optimize Datapoints._load()

### DIFF
--- a/cognite/client/data_classes/datapoints.py
+++ b/cognite/client/data_classes/datapoints.py
@@ -217,13 +217,12 @@ class Datapoints:
                 snake_key = utils._auxiliary.to_snake_case(key)
                 setattr(instance, snake_key, [])
         else:
-            for dp in dps_object["datapoints"]:
-                for key in expected_fields:
-                    snake_key = utils._auxiliary.to_snake_case(key)
-                    current_attr = getattr(instance, snake_key) or []
-                    value = dp.get(key)
-                    current_attr.append(value)
-                    setattr(instance, snake_key, current_attr)
+            for key in expected_fields:
+                data = []
+                for dp in dps_object["datapoints"]:
+                    data.append(dp.get(key))
+                snake_key = utils._auxiliary.to_snake_case(key)
+                setattr(instance, snake_key, data)
         return instance
 
     def _insert(self, other_dps):

--- a/cognite/client/data_classes/datapoints.py
+++ b/cognite/client/data_classes/datapoints.py
@@ -218,9 +218,7 @@ class Datapoints:
                 setattr(instance, snake_key, [])
         else:
             for key in expected_fields:
-                data = []
-                for dp in dps_object["datapoints"]:
-                    data.append(dp.get(key))
+                data = [dp[key] for dp in dps_object["datapoints"]]
                 snake_key = utils._auxiliary.to_snake_case(key)
                 setattr(instance, snake_key, data)
         return instance

--- a/cognite/client/data_classes/datapoints.py
+++ b/cognite/client/data_classes/datapoints.py
@@ -218,7 +218,7 @@ class Datapoints:
                 setattr(instance, snake_key, [])
         else:
             for key in expected_fields:
-                data = [dp[key] for dp in dps_object["datapoints"]]
+                data = [dp[key] if key in dp else None for dp in dps_object["datapoints"]]
                 snake_key = utils._auxiliary.to_snake_case(key)
                 setattr(instance, snake_key, data)
         return instance


### PR DESCRIPTION
This is a result of tracking down why a relatively big script was CPU bound with low network. 
The _load function shows up as taking 60-70% of the time. 
This commit does not fully resolve the issue, _load is still the function taking most of the time and will likely require further optimization. Still, it results in a ~33% speed up of the code in question.

An alternative is:
```
			for key in expected_fields:
				data = []
				for dp in dps_object["datapoints"]:            
					data.append(dp.get(key))
				snake_key = utils._auxiliary.to_snake_case(key)
				setattr(instance,snake_key,data)

```
This was found to be slightly slower for len(expected_fields)==2, but the difference is small.

Profiling results with yappi

![image](https://user-images.githubusercontent.com/48946947/59106690-4ed06e80-8937-11e9-9d3f-a51308206658.png)





