### PR TITLE
New implementation for retrieve_dataframe and addition of query_dataframe

### DIFF
--- a/cognite/client/_api/datapoints.py
+++ b/cognite/client/_api/datapoints.py
@@ -938,7 +938,7 @@ class DataFrameFetcher:
                 for c in q.aggregates:
                     if c not in q.result.columns:
                         q.result[c] = self.np.nan
-            name = list(q.ts_item.values())[0]  # id or external_id
+            name = q.ts_item.get("externalId") or q.ts_item.get("id")
             q.result.rename(
                 mapper=lambda agg: "{}|{}".format(name, cognite.client.utils._auxiliary.to_camel_case(agg)),
                 axis="columns",

--- a/cognite/client/data_classes/__init__.py
+++ b/cognite/client/data_classes/__init__.py
@@ -1,7 +1,13 @@
 from typing import *
 
 from cognite.client.data_classes.assets import Asset, AssetFilter, AssetList, AssetUpdate
-from cognite.client.data_classes.datapoints import Datapoint, Datapoints, DatapointsList, DatapointsQuery
+from cognite.client.data_classes.datapoints import (
+    DataFrameQuery,
+    Datapoint,
+    Datapoints,
+    DatapointsList,
+    DatapointsQuery,
+)
 from cognite.client.data_classes.events import Event, EventFilter, EventList, EventUpdate
 from cognite.client.data_classes.files import FileMetadata, FileMetadataFilter, FileMetadataList, FileMetadataUpdate
 from cognite.client.data_classes.iam import (

--- a/cognite/client/data_classes/datapoints.py
+++ b/cognite/client/data_classes/datapoints.py
@@ -339,3 +339,21 @@ class DatapointsQuery(CogniteResource):
         self.aggregates = aggregates
         self.granularity = granularity
         self.include_outside_points = include_outside_points
+
+
+class DataFrameQuery:
+    def __init__(
+        self,
+        start: Union[str, int, datetime],
+        end: Union[str, int, datetime],
+        aggregates: List[str],
+        granularity: str,
+        id: Union[int, List[int]] = None,
+        external_id: Union[str, List[str]] = None,
+    ):
+        self.start = cognite.client.utils._time.timestamp_to_ms(start)
+        self.end = cognite.client.utils._time.timestamp_to_ms(end)
+        self.id = id
+        self.external_id = external_id
+        self.aggregates = aggregates
+        self.granularity = granularity

--- a/cognite/client/data_classes/datapoints.py
+++ b/cognite/client/data_classes/datapoints.py
@@ -351,8 +351,8 @@ class DataFrameQuery:
         id: Union[int, List[int]] = None,
         external_id: Union[str, List[str]] = None,
     ):
-        self.start = cognite.client.utils._time.timestamp_to_ms(start)
-        self.end = cognite.client.utils._time.timestamp_to_ms(end)
+        self.start = start
+        self.end = end
         self.id = id
         self.external_id = external_id
         self.aggregates = aggregates

--- a/tests/tests_unit/test_api/test_datapoints.py
+++ b/tests/tests_unit/test_api/test_datapoints.py
@@ -10,7 +10,7 @@ import pytest
 
 from cognite.client import CogniteClient, utils
 from cognite.client._api.datapoints import _DatapointsFetcher, _DPQuery, _DPWindow
-from cognite.client.data_classes import Datapoint, Datapoints, DatapointsList, DatapointsQuery
+from cognite.client.data_classes import DataFrameQuery, Datapoint, Datapoints, DatapointsList, DatapointsQuery
 from cognite.client.exceptions import CogniteAPIError, CogniteNotFoundError
 from tests.utils import jsgz_load, set_request_limit
 
@@ -719,6 +719,26 @@ class TestPandasIntegration:
 
         assert {"1|average", "2|max", "123|average"} == set(df.columns)
         assert df.shape[0] > 0
+
+    def test_query_dataframe_single(self, mock_get_datapoints):
+        q = DataFrameQuery(
+            id=[1, 2], external_id=["123"], start=1000000, end=1100000, aggregates=["average"], granularity="10s"
+        )
+        df = DPS_CLIENT.query_dataframe(q)
+        assert {"1|average", "2|average", "123|average"} == set(df.columns)
+        assert df.shape[0] > 0
+
+    def test_query_dataframe_multiple(self, mock_get_datapoints):
+        import pandas as pd
+
+        q = DataFrameQuery(
+            id=[1, 2], external_id=["123"], start=1000000, end=1100000, aggregates=["average"], granularity="10s"
+        )
+        queries = [q, q, q]
+        dfs = DPS_CLIENT.query_dataframe(queries)
+        for i in range(len(queries)):
+            assert {"1|average", "2|average", "123|average"} == set(dfs[i].columns)
+            assert dfs[i].shape[0] > 0
 
     def test_retrieve_datapoints_some_aggregates_omitted(self, mock_get_datapoints_one_ts_has_missing_aggregates):
         import pandas as pd


### PR DESCRIPTION
This work was started from trying to get around some of the limitations in query(), as well as the performance of DataPointsList for larger queries. Particularly, calling retrieve_dataframe several times in threads causes major problems with the multiple threadpools getting in each other's way (either in the GIL or the connection pool)

This re-implements retrieve_dataframe to be completely pandas based, and not requiring multiple successive thread pools or getting count aggregates. The strategy is probably applicable to the existing datapoints fetcher, but for now I've stayed away from touching that.

Advantages:
* For single dataframes, it can be significantly faster (usually 25% faster, but up to 8x, see below)
* Allows retrieval of multiple dataframes with same id (as in quality filtering use cases etc)
* Strategy for getting datapoints is somewhat simpler, could also simplify existing code when merged.

Disadvantages:
* Some code duplication for now.
* Concurrency doesn't use existing SDK tools due to adding jobs on the fly

Performance tests (SDK here is a30):
retrieving dataframe of shape (42538, 4) check =  3 / 3
	SDK 1.38s +/- 0.21s
	New 1.08s +/- 0.07s
retrieving dataframe of shape (235584, 4) check =  3 / 3
	SDK 5.25s +/- 0.09s
	New 4.62s +/- 0.11s
retrieving dataframe of shape (2750724, 4) check =  3 / 3
	**SDK 161.30s +/- 9.15s
	New 67.67s +/- 2.14s**
retrieving dataframe of shape (35, 1) check =  3 / 3
	SDK 0.18s +/- 0.01s
	New 0.18s +/- 0.01s
retrieving dataframe of shape (50400, 171) check =  3 / 3
	SDK 16.04s +/- 0.24s
	New 13.93s +/- 0.17s
retrieving dataframe of shape (8, 684) check =  3 / 3
	SDK 5.96s +/- 0.03s
	New 6.41s +/- 0.31s <- slightly worse for many very shallow queries
retrieving dataframe of shape (15946081, 1) check =  3 / 3
	**SDK 914.30s +/- 5.93s
	New 110.46s +/- 12.32s**
