### PR TITLE
Replace Datapoints ._insert() with ._extend() to improve performance

### DIFF
--- a/cognite/client/_api/datapoints.py
+++ b/cognite/client/_api/datapoints.py
@@ -579,7 +579,7 @@ class _DPQuery:
 class _DatapointsFetcher:
     def __init__(self, client: DatapointsAPI):
         self.client = client
-        self.id_to_datapoints = defaultdict(lambda: Datapoints())
+        self.id_to_datapoints_objects = defaultdict(lambda: [])
         self.id_to_finalized_query = {}
         self.lock = threading.Lock()
 
@@ -617,8 +617,16 @@ class _DatapointsFetcher:
             query.end = new_end
 
     def _get_dps_results(self):
+        def custom_sort_key(x):
+            if x.timestamp:
+                return x.timestamp[0]
+            return 0
+
         dps_list = DatapointsList([], cognite_client=self.client._cognite_client)
-        for id, dps in self.id_to_datapoints.items():
+        for id, dps_objects in self.id_to_datapoints_objects.items():
+            dps = Datapoints()
+            for dps_object in sorted(dps_objects, key=custom_sort_key):
+                dps._extend(dps_object)
             finalized_query = self.id_to_finalized_query[id]
             if finalized_query.include_outside_points:
                 dps = self._remove_duplicates(dps)
@@ -695,7 +703,7 @@ class _DatapointsFetcher:
 
     def _store_finalized_query(self, query: _DPQuery):
         with self.lock:
-            self.id_to_datapoints[query.dps_result.id]._insert(query.dps_result)
+            self.id_to_datapoints_objects[query.dps_result.id].append(query.dps_result)
             self.id_to_finalized_query[query.dps_result.id] = query
 
     @staticmethod
@@ -828,7 +836,7 @@ class _DatapointsFetcher:
             next_start = latest_timestamp + (
                 cognite.client.utils._time.granularity_to_ms(granularity) if granularity else 1
             )
-            all_datapoints._insert(datapoints)
+            all_datapoints._extend(datapoints)
         return all_datapoints
 
     def _get_datapoints(

--- a/cognite/client/data_classes/datapoints.py
+++ b/cognite/client/data_classes/datapoints.py
@@ -223,31 +223,17 @@ class Datapoints:
                 setattr(instance, snake_key, data)
         return instance
 
-    def _insert(self, other_dps):
+    def _extend(self, other_dps):
         if self.id is None and self.external_id is None:
             self.id = other_dps.id
             self.external_id = other_dps.external_id
-
-        if other_dps.timestamp:
-            other_first_ts = other_dps.timestamp[0]
-            index_to_split_on = None
-            for i, ts in enumerate(self.timestamp):
-                if ts > other_first_ts:
-                    index_to_split_on = i
-                    break
-        else:
-            index_to_split_on = 0
 
         for attr, other_value in other_dps._get_non_empty_data_fields(get_empty_lists=True):
             value = getattr(self, attr)
             if not value:
                 setattr(self, attr, other_value)
             else:
-                if index_to_split_on is not None:
-                    new_value = value[:index_to_split_on] + other_value + value[index_to_split_on:]
-                else:
-                    new_value = value + other_value
-                setattr(self, attr, new_value)
+                value.extend(other_value)
 
     def _get_non_empty_data_fields(self, get_empty_lists=False) -> List[Tuple[str, Any]]:
         non_empty_data_fields = []

--- a/tests/tests_unit/test_api/test_datapoints.py
+++ b/tests/tests_unit/test_api/test_datapoints.py
@@ -588,29 +588,29 @@ class TestDatapointsObject:
         res = Datapoints(id=1, timestamp=[1, 2, 3])._slice(slice(None, 1))
         assert [1] == res.timestamp
 
-    def test_insert(self):
+    def test_extend(self):
         d0 = Datapoints()
-        d1 = Datapoints(id=1, external_id="1", timestamp=[7, 8, 9], value=[7, 8, 9])
-        d2 = Datapoints(id=1, external_id="1", timestamp=[1, 2, 3], value=[1, 2, 3])
-        d3 = Datapoints(id=1, external_id="1", timestamp=[4, 5, 6], value=[4, 5, 6])
+        d1 = Datapoints(id=1, external_id="1", timestamp=[1, 2, 3], value=[1, 2, 3])
+        d2 = Datapoints(id=1, external_id="1", timestamp=[4, 5, 6], value=[4, 5, 6])
+        d3 = Datapoints(id=1, external_id="1", timestamp=[7, 8, 9, 10], value=[7, 8, 9, 10])
 
-        d0._insert(d1)
-        assert [7, 8, 9] == d0.timestamp
-        assert [7, 8, 9] == d0.value
+        d0._extend(d1)
+        assert [1, 2, 3] == d0.timestamp
+        assert [1, 2, 3] == d0.value
         assert 1 == d0.id
         assert "1" == d0.external_id
         assert d0.sum == None
 
-        d0._insert(d2)
-        assert [1, 2, 3, 7, 8, 9] == d0.timestamp
-        assert [1, 2, 3, 7, 8, 9] == d0.value
+        d0._extend(d2)
+        assert [1, 2, 3, 4, 5, 6] == d0.value
+        assert [1, 2, 3, 4, 5, 6] == d0.timestamp
         assert 1 == d0.id
         assert "1" == d0.external_id
         assert d0.sum == None
 
-        d0._insert(d3)
-        assert [1, 2, 3, 4, 5, 6, 7, 8, 9] == d0.timestamp
-        assert [1, 2, 3, 4, 5, 6, 7, 8, 9] == d0.value
+        d0._extend(d3)
+        assert [1, 2, 3, 4, 5, 6, 7, 8, 9, 10] == d0.timestamp
+        assert [1, 2, 3, 4, 5, 6, 7, 8, 9, 10] == d0.value
         assert 1 == d0.id
         assert "1" == d0.external_id
         assert d0.sum == None


### PR DESCRIPTION
I fixed the enormous overhead of ._insert() here. Could you rerun your benchmarks against this version? @sanderland 