### PR TITLE
implementing query_dataframe and alternative retrieve_dataframe

### DIFF
--- a/cognite/client/_api/datapoints.py
+++ b/cognite/client/_api/datapoints.py
@@ -1071,7 +1071,7 @@ class DataFrameFetcher:
         self._idle = [False] * self.nworkers
 
     def fetch(self, dps_queries):
-        self.jobs = queue.SimpleQueue()
+        self.jobs = queue.Queue()
         self._submit_initial_jobs(dps_queries)
         self._threadpool = [threading.Thread(target=self._run_jobs, args=[tid]) for tid in range(self.nworkers)]
         for t in self._threadpool:

--- a/cognite/client/data_classes/__init__.py
+++ b/cognite/client/data_classes/__init__.py
@@ -1,7 +1,13 @@
 from typing import *
 
 from cognite.client.data_classes.assets import Asset, AssetFilter, AssetList, AssetUpdate
-from cognite.client.data_classes.datapoints import Datapoint, Datapoints, DatapointsList, DatapointsQuery
+from cognite.client.data_classes.datapoints import (
+    DataFrameQuery,
+    Datapoint,
+    Datapoints,
+    DatapointsList,
+    DatapointsQuery,
+)
 from cognite.client.data_classes.events import Event, EventFilter, EventList, EventUpdate
 from cognite.client.data_classes.files import FileMetadata, FileMetadataFilter, FileMetadataList, FileMetadataUpdate
 from cognite.client.data_classes.iam import (

--- a/cognite/client/data_classes/datapoints.py
+++ b/cognite/client/data_classes/datapoints.py
@@ -329,3 +329,13 @@ class DatapointsQuery(CogniteResource):
         self.aggregates = aggregates
         self.granularity = granularity
         self.include_outside_points = include_outside_points
+
+
+class DataFrameQuery:
+    def __init__(self, start, end, aggregates, granularity, id=None, external_id=None):
+        self.start = start
+        self.end = end
+        self.id = id
+        self.external_id = external_id
+        self.aggregates = aggregates
+        self.granularity = granularity

--- a/tests/tests_unit/test_api/test_datapoints.py
+++ b/tests/tests_unit/test_api/test_datapoints.py
@@ -746,6 +746,19 @@ class TestPandasIntegration:
         assert {"1|average", "2|max", "123|average"} == set(df.columns)
         assert df.shape[0] > 0
 
+    def test_retrieve_dataframe_alt(self, mock_get_datapoints):
+        df = DPS_CLIENT._retrieve_dataframe_alt(
+            id=[1, {"id": 2, "aggregates": ["max"]}],
+            external_id=["123"],
+            start=1000000,
+            end=1100000,
+            aggregates=["average"],
+            granularity="10s",
+        )
+
+        assert {"1|average", "2|max", "123|average"} == set(df.columns)
+        assert df.shape[0] > 0
+
     def test_retrieve_datapoints_some_aggregates_omitted(self, mock_get_datapoints_one_ts_has_missing_aggregates):
         import pandas as pd
 


### PR DESCRIPTION
The number of commits in between made merging fail very hard so here's a new branch.
This only adds query_dataframe and leaves the alternative retrieve_dataframe as a private method for testing.

**performance**
query_dataframe 226.00s 
sequential retrieve_dataframe 371.89s 

**sub tests performance**

retrieving dataframe of shape (40361, 1) check =  3 / 3
	SDK 0.77s +/- 0.05s
	New 0.32s +/- 0.01s
retrieving dataframe of shape (235584, 4) check =  3 / 3
	SDK 4.91s +/- 0.06s
	New 4.58s +/- 0.15s
retrieving dataframe of shape (2750724, 4) check =  3 / 3
	SDK 99.47s +/- 9.08s
	New 78.08s +/- 11.61s
retrieving dataframe of shape (35, 1) check =  3 / 3
	SDK 0.18s +/- 0.01s
	New 0.22s +/- 0.05s
retrieving dataframe of shape (50400, 171) check =  3 / 3
	SDK 24.46s +/- 8.14s
	New 22.38s +/- 7.33s
retrieving dataframe of shape (8, 684) check =  3 / 3
	SDK 7.53s +/- 0.07s
	New 7.92s +/- 0.06s
retrieving dataframe of shape (15946081, 1) check =  3 / 3
	SDK 161.70s +/- 6.73s
	New 125.69s +/- 12.27s



