### PR TITLE
Add class decorator to use on experimental APIs.

### DIFF
--- a/cognite/client/exceptions.py
+++ b/cognite/client/exceptions.py
@@ -178,3 +178,12 @@ class CogniteAPIKeyError(Exception):
     """
 
     pass
+
+
+class CogniteExperimentalFeature(Exception):
+    """Cognite Experimental Feature
+
+    Raised if an experimental feature is attempted used without having set the environment variable 'COGNITE_EXPERIMENTAL_MODE'
+    """
+
+    pass

--- a/cognite/client/utils/_client_config.py
+++ b/cognite/client/utils/_client_config.py
@@ -42,6 +42,7 @@ class _DefaultConfig:
         self.max_retry_backoff = int(os.getenv("COGNITE_MAX_RETRY_BACKOFF", 30))
         self.max_connection_pool_size = int(os.getenv("COGNITE_MAX_CONNECTION_POOL_SIZE", 50))
         self.disable_ssl = os.getenv("COGNITE_DISABLE_SSL", False)
+        self.enable_experimental = os.getenv("COGNITE_EXPERIMENTAL_MODE", False)
 
     @staticmethod
     def _get_status_forcelist():

--- a/cognite/client/utils/_experimental_warning.py
+++ b/cognite/client/utils/_experimental_warning.py
@@ -1,0 +1,42 @@
+import functools
+import warnings
+
+from cognite.client.exceptions import CogniteExperimentalFeature
+from cognite.client.utils._client_config import _DefaultConfig
+
+WARNED_EXPERIMENTAL_APIS = set()
+
+
+def experimental_fn(func=None, api_name=None):
+    if func is None:
+        return functools.partial(experimental_fn, api_name=api_name)
+
+    experimental_warning_message = (
+        "\nThe {} API is currently experimental, so this functionality does not adhere to semantic versionining."
+        "\nThis means that this API may be subject to breaking changes even between patch versions."
+        "\nYou should NOT use the {} API in any production code.".format(api_name, api_name)
+    )
+
+    @functools.wraps(func)
+    def decorator(*args, **kwargs):
+        if not _DefaultConfig().enable_experimental:
+            raise CogniteExperimentalFeature(
+                experimental_warning_message + "\nIf you still want to use this feature, set the environment variable "
+                "COGNITE_EXPERIMENTAL_MODE = '1' to enable this functionality."
+            )
+        elif api_name not in WARNED_EXPERIMENTAL_APIS:
+            warnings.warn(experimental_warning_message, stacklevel=2, category=FutureWarning)
+            WARNED_EXPERIMENTAL_APIS.add(api_name)
+        return func(*args, **kwargs)
+
+    return decorator
+
+
+def experimental_api(cls=None, api_name=None):
+    """A class decorator that will raise warnings once an experimental API is used."""
+    if cls is None:
+        return functools.partial(experimental_api, api_name=api_name)
+    for attr in cls.__dict__:
+        if not attr.startswith("_") and callable(getattr(cls, attr)):
+            setattr(cls, attr, experimental_fn(api_name=api_name)(getattr(cls, attr)))
+    return cls

--- a/docs/source/cognite.rst
+++ b/docs/source/cognite.rst
@@ -187,7 +187,7 @@ You can set default configurations with these environment variables:
     $ export COGNITE_MAX_RETRY_BACKOFF = <number-of-seconds>
     $ export COGNITE_MAX_CONNECTION_POOL_SIZE = <number-of-connections-in-pool>
     $ export COGNITE_STATUS_FORCELIST = "429,502,503"
-
+    $ export COGNITE_EXPERIMENTAL_MODE = "1"
 
 Concurrency and connection pooling
 ----------------------------------
@@ -758,6 +758,10 @@ CogniteImportError
 CogniteMissingClientError
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 .. autoexception:: cognite.client.exceptions.CogniteMissingClientError
+
+CogniteExperimentalFeature
+^^^^^^^^^^^^^^^^^^^^^^^^^^
+.. autoexception:: cognite.client.exceptions.CogniteExperimentalFeature
 
 Utils
 -----


### PR DESCRIPTION
Will require user to set env var "COGNITE_EXPERIMENTAL_MODE" to access functionality, and will issue a warning the first time the user invokes a method from that API.

Usage example:
```
@experimental_api("Sequences")
class SequencesAPI(APIClient):
    ...
```