### PR TITLE
WIP: Removed parent_external_id validation in _validate_asset_hierarchy.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ Changes are grouped as follows
 - Separate read/write fields on data classes
 
 ## [Unreleased]
+### Fixed
+- Removed faulty validation of parent_external_id in AssetPoster that prevented posting of assets attached to another asset referenced by parent_external_id
 
 ## [1.0.3] - 2019-07-26
 ### Fixed

--- a/cognite/client/_api/assets.py
+++ b/cognite/client/_api/assets.py
@@ -407,7 +407,6 @@ class _AssetPoster:
 
     @staticmethod
     def _validate_asset_hierarchy(assets) -> None:
-        external_ids = set([asset.external_id for asset in assets])
         external_ids_seen = set()
         for asset in assets:
             if asset.external_id:
@@ -415,16 +414,12 @@ class _AssetPoster:
                     raise AssertionError("Duplicate external_id '{}' found".format(asset.external_id))
                 external_ids_seen.add(asset.external_id)
 
-            parent_ref = asset.parent_external_id
-            if parent_ref:
-                if parent_ref not in external_ids:
-                    raise AssertionError("parent_external_id '{}' does not point to any asset".format(parent_ref))
-                if asset.parent_id is not None:
-                    raise AssertionError(
-                        "An asset has both parent_id '{}' and parent_external_id '{}' set.".format(
-                            asset.parent_id, asset.parent_external_id
-                        )
+            if asset.parent_external_id and asset.parent_id is not None:
+                raise AssertionError(
+                    "An asset has both parent_id '{}' and parent_external_id '{}' set.".format(
+                        asset.parent_id, asset.parent_external_id
                     )
+                )
 
     def _initialize(self):
         root_assets = set()

--- a/tests/tests_unit/test_api/test_assets.py
+++ b/tests/tests_unit/test_api/test_assets.py
@@ -241,11 +241,6 @@ def generate_asset_tree(root_external_id: str, depth: int, children_per_node: in
 
 
 class TestAssetPoster:
-    def test_validate_asset_hierarchy_parent_ref_null_pointer(self):
-        assets = [Asset(parent_external_id="1", external_id="2")]
-        with pytest.raises(AssertionError, match="does not point"):
-            _AssetPoster(assets, ASSETS_API)
-
     def test_validate_asset_hierarchy_asset_has_parent_id_and_parent_ref_id(self):
         assets = [Asset(external_id="1"), Asset(parent_external_id="1", parent_id=1, external_id="2")]
         with pytest.raises(AssertionError, match="has both"):


### PR DESCRIPTION
The validation checked that all assets that are being created, if they
use parent_external_id, points to an external_id that are now being created.
This doesn't work if you are creating assets pointing to existing assets,
and want to use parent_external_id.

This commit removes the parent_external_id validation completely.
Also removed the unittest.

Signed-off-by: Even Wiik Thomassen <even.thomassen@cognite.com>