### PR TITLE
improvements and additions to the sequences SDK

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,12 @@ Changes are grouped as follows
 - Separate read/write fields on data classes
 
 ## [Unreleased]
+### Changed
+- Sequences data retrieval now returns a SequenceData object
+
+### Added
+- Variety of useful helper functions for Sequence and SequenceData objects
+- Sequences delete_range function
 
 ## [1.0.3] - 2019-07-26
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,6 @@ Changes are grouped as follows
 - Variety of useful helper functions for Sequence and SequenceData objects, including .column_ids and .column_external_ids properties, iterators and slice operators.
 - Sequences insert_dataframe function.
 - Sequences delete_range function.
-- Support for external id column headers in datapoints.insert_dataframe().
 
 ## [1.0.3] - 2019-07-26
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,11 +21,14 @@ Changes are grouped as follows
 
 ## [Unreleased]
 ### Changed
-- Sequences data retrieval now returns a SequenceData object
+- Sequences data retrieval now returns a SequenceData object.
+- Sequences insert takes its parameters row data first, and no longer requires columns to be passed.
+- Sequences create now clears invalid fields such as 'id' in columns specification, so sequences can more easily re-use existing specifications.
 
 ### Added
-- Variety of useful helper functions for Sequence and SequenceData objects
-- Sequences delete_range function
+- Variety of useful helper functions for Sequence and SequenceData objects.
+- Sequences insert_dataframe function
+- Sequences delete_range function.
 
 ## [1.0.3] - 2019-07-26
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,14 +24,15 @@ Changes are grouped as follows
 ### Changed
 - Sequences data retrieval now returns a SequenceData object.
 - Sequences insert takes its parameters row data first, and no longer requires columns to be passed.
-- Sequences insert now accepts tuples and raw-style data input
+- Sequences insert now accepts tuples and raw-style data input.
 - Sequences create now clears invalid fields such as 'id' in columns specification, so sequences can more easily re-use existing specifications.
+- Sequence data function now require column_ids or column_external_ids to be explicitly set, rather than both being passed through a single columns field
 
 ### Added
-- Variety of useful helper functions for Sequence and SequenceData objects, particularly .column_ids() and .column_external_ids()
-- Sequences insert_dataframe function
+- Variety of useful helper functions for Sequence and SequenceData objects, including .column_ids and .column_external_ids properties, iterators and slice operators.
+- Sequences insert_dataframe function.
 - Sequences delete_range function.
-- Support for external id column headers in datapoints.insert_dataframe()
+- Support for external id column headers in datapoints.insert_dataframe().
 
 ## [1.0.3] - 2019-07-26
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,10 +23,11 @@ Changes are grouped as follows
 ### Changed
 - Sequences data retrieval now returns a SequenceData object.
 - Sequences insert takes its parameters row data first, and no longer requires columns to be passed.
+- Sequences insert now accepts tuples and raw-style data input
 - Sequences create now clears invalid fields such as 'id' in columns specification, so sequences can more easily re-use existing specifications.
 
 ### Added
-- Variety of useful helper functions for Sequence and SequenceData objects.
+- Variety of useful helper functions for Sequence and SequenceData objects, particularly .column_ids() and .column_external_ids()
 - Sequences insert_dataframe function
 - Sequences delete_range function.
 

--- a/cognite/client/_api/datapoints.py
+++ b/cognite/client/_api/datapoints.py
@@ -202,7 +202,7 @@ class DatapointsAPI(APIClient):
         Timestamps can be represented as milliseconds since epoch or datetime objects.
 
         Args:
-            datapoints(Union[List[Dict, Tuple]]): The datapoints you wish to insert. Can either be a list of tuples or
+            datapoints(Union[List[Dict], List[Tuple]]): The datapoints you wish to insert. Can either be a list of tuples or
                 a list of dictionaries. See examples below.
             id (int): Id of time series to insert datapoints into.
             external_id (str): External id of time series to insert datapoint into.

--- a/cognite/client/_api/datapoints.py
+++ b/cognite/client/_api/datapoints.py
@@ -438,7 +438,6 @@ class DatapointsAPI(APIClient):
                 >>> c = CogniteClient()
                 >>> ts_id = 123
                 >>> start = datetime(2018, 1, 1)
-                >>> # The scaling by 1000 is important: timestamp() returns seconds
                 >>> x = pd.DatetimeIndex([start + timedelta(days=d) for d in range(100)])
                 >>> y = np.random.normal(0, 1, 100)
                 >>> df = pd.DataFrame({ts_id: y}, index=x)

--- a/cognite/client/_api/sequences.py
+++ b/cognite/client/_api/sequences.py
@@ -137,11 +137,11 @@ class SequencesAPI(APIClient):
         """
         return self._list(method="GET", filter=None, limit=limit)
 
-    def create(self, sequences: Union[Sequence, List[Sequence]]) -> Union[Sequence, SequenceList]:
+    def create(self, sequence: Union[Sequence, List[Sequence]]) -> Union[Sequence, SequenceList]:
         """Create one or more sequences.
 
         Args:
-            sequences (Union[Sequence, List[Sequence]]): Sequence or list of Sequence to create.
+            sequence (Union[Sequence, List[Sequence]]): Sequence or list of Sequence to create.
 
         Returns:
             Union[Sequence, SequenceList]: The created sequences.
@@ -160,11 +160,12 @@ class SequencesAPI(APIClient):
                 >>> seq2 = c.sequences.create(Sequence(external_id="my_copied_sequence", columns=seq.columns))
 
         """
-        if isinstance(sequences, list):
-            sequences = [self._clean_columns(seq) for seq in sequences]
+        utils._auxiliary.assert_type(sequence, "sequences", [List, Sequence])
+        if isinstance(sequence, list):
+            sequence = [self._clean_columns(seq) for seq in sequence]
         else:
-            sequences = self._clean_columns(sequences)
-        return self._create_multiple(items=sequences)
+            sequence = self._clean_columns(sequence)
+        return self._create_multiple(items=sequence)
 
     def _clean_columns(self, sequence):
         sequence = copy.copy(sequence)
@@ -273,14 +274,17 @@ class SequencesDataAPI(APIClient):
         rows: Union[
             Dict[int, List[Union[int, float, str]]], List[Tuple[int, Union[int, float, str]]], List[Dict[str, Any]]
         ],
-        columns: List[Union[int, str]] = None,
+        column_ids: Optional[List[int]] = None,
+        column_external_ids: Optional[List[str]] = None,
         id: int = None,
         external_id: str = None,
     ) -> None:
         """Insert rows into a sequence
 
         Args:
-            columns (List[Union[int, str]]): List of id or external id for the columns of the sequence. If 'None' is passed, all columns ids will be retrieved from metadata and used in that order.
+            column_ids (Optional[List[int]]): List of ids for the columns of the sequence.
+                If 'None' is passed to both column_ids and columns_external_ids, all columns ids will be retrieved from metadata and used in that order.
+            column_external_ids (Optional[List[str]]): List of external id for the columns of the sequence.
             rows (Union[ Dict[int, List[Union[int, float, str]]], List[Tuple[int,Union[int, float, str]]], List[Dict[str,Any]]]):  The rows you wish to insert.
                 Can either be a list of tuples, a list of {"rowNumber":... ,"values": ...} objects or a dictionary of rowNumber: data. See examples below.
             id (int): Id of sequence to insert rows into.
@@ -296,7 +300,7 @@ class SequencesDataAPI(APIClient):
                 >>> c = CogniteClient()
                 >>> seq = c.sequences.create(Sequence(columns=[{"valueType": "STRING","valueType": "DOUBLE"}]))
                 >>> data = [(1, ['pi',3.14]), (2, ['e',2.72]) ]
-                >>> res1 = c.sequences.data.insert(columns=seq.column_ids(), rows=data, id=1)
+                >>> res1 = c.sequences.data.insert(column_ids=seq.column_ids, rows=data, id=1)
 
             They can also be provided as a list of API-style objects with a rowNumber and values field::
 
@@ -310,12 +314,12 @@ class SequencesDataAPI(APIClient):
                 >>> from cognite.client.experimental import CogniteClient
                 >>> c = CogniteClient()
                 >>> data = {123 : ['str',3], 456 : ['bar',42] }
-                >>> res1 = c.sequences.data.insert(columns=['stringColumn','intColumn'], rows=data, id=1)
+                >>> res1 = c.sequences.data.insert(column_external_ids=['stringColumn','intColumn'], rows=data, id=1)
         """
         utils._auxiliary.assert_exactly_one_of_id_or_external_id(id, external_id)
-        if columns is None:
-            columns = self._sequences_api.retrieve(id=id, external_id=external_id).column_ids()
-
+        if column_ids is None and column_external_ids is None:
+            column_ids = self._sequences_api.retrieve(id=id, external_id=external_id).column_ids
+        print("ids", column_ids, "ext", column_external_ids)
         if isinstance(rows, dict):
             all_rows = [{"rowNumber": k, "values": v} for k, v in rows.items()]
         elif isinstance(rows, list) and len(rows) > 0 and isinstance(rows[0], dict):
@@ -326,7 +330,7 @@ class SequencesDataAPI(APIClient):
             raise ValueError("Invalid format for 'rows', expected a list of tuples, list of dict or dict")
 
         base_obj = self._process_ids(id, external_id, wrap_ids=True)[0]
-        base_obj.update(self._process_columns(columns))
+        base_obj.update(self._process_columns(column_ids, column_external_ids))
         row_objs = [
             {"rows": all_rows[i : i + self._SEQ_POST_LIMIT]} for i in range(0, len(all_rows), self._SEQ_POST_LIMIT)
         ]
@@ -336,10 +340,10 @@ class SequencesDataAPI(APIClient):
         )
         summary.raise_compound_exception_if_failed_tasks()
 
-    def insert_dataframe(self, dataframe, id=None, external_id=None):
+    def insert_dataframe(self, dataframe, id: int = None, external_id: str = None):
         """Insert a Pandas dataframe.
 
-        The index of the dataframe must contain the row numbers. The names of the remaining columns specify the column ids or external ids (depending on their type).
+        The index of the dataframe must contain the row numbers. The names of the remaining columns specify the column ids or external ids (no mixed values allowed, and ids should be integers).
         The sequence and columns must already exist.
 
         Args:
@@ -360,7 +364,20 @@ class SequencesDataAPI(APIClient):
         """
         dataframe = dataframe.replace({math.nan: None})
         data = [(v[0], list(v[1:])) for v in dataframe.itertuples()]
-        self.insert(rows=data, columns=list(dataframe.columns), id=id, external_id=external_id)
+        columns = list(dataframe.columns)
+        if all([isinstance(c, int) for c in columns]):
+            column_ids = columns
+            column_external_ids = None
+        else:
+            if any([isinstance(c, int) for c in columns]):
+                raise ValueError(
+                    "Mixed types detected in columns {}, should either all be integets or all strings".format(columns)
+                )
+            column_ids = None
+            column_external_ids = columns
+        self.insert(
+            rows=data, column_ids=column_ids, column_external_ids=column_external_ids, id=id, external_id=external_id
+        )
 
     def _insert_data(self, task):
         self._post(url_path=self._DATA_PATH, json={"items": [task]})
@@ -369,9 +386,9 @@ class SequencesDataAPI(APIClient):
         """Delete rows from a sequence
 
         Args:
-            rows (List[int]): List of row numbers
-            id (int): Id of sequence to delete rows from
-            external_id (str): External id of sequence to delete rows from
+            rows (List[int]): List of row numbers.
+            id (int): Id of sequence to delete rows from.
+            external_id (str): External id of sequence to delete rows from.
 
         Returns:
             None
@@ -388,14 +405,14 @@ class SequencesDataAPI(APIClient):
 
         self._post(url_path=self._DATA_PATH + "/delete", json={"items": [post_obj]})
 
-    def delete_range(self, start, end, id: int = None, external_id: str = None) -> None:
+    def delete_range(self, start: int, end: int, id: int = None, external_id: str = None) -> None:
         """Delete a range of rows from a sequence. Note this operation is potentially slow, as retrieves each row before deleting.
 
         Args:
-            start (int): Row number to start from (inclusive)
-            end (int): Upper limit on the row number (exclusive)
-            id (int): Id of sequence to delete rows from
-            external_id (str): External id of sequence to delete rows from
+            start (int): Row number to start from (inclusive).
+            end (int): Upper limit on the row number (exclusive).
+            id (int): Id of sequence to delete rows from.
+            external_id (str): External id of sequence to delete rows from.
 
         Returns:
             None
@@ -409,22 +426,30 @@ class SequencesDataAPI(APIClient):
         deleter = lambda data: self.delete(rows=[r["rowNumber"] for r in data], external_id=external_id, id=id)
         utils._auxiliary.assert_exactly_one_of_id_or_external_id(id, external_id)
         sequence = self._sequences_api.retrieve(id=id, external_id=external_id)
-        col_sizes = [self._COLUMN_SIZE[t] for t in sequence.column_value_types()]
-        smallest_column_id = [id for id, _ in sorted(zip(sequence.column_ids(), col_sizes))][0]
+        col_sizes = [self._COLUMN_SIZE[t] for t in sequence.column_value_types]
+        smallest_column_id = [id for id, _ in sorted(zip(sequence.column_ids, col_sizes))][0]
         post_obj = self._process_ids(id, external_id, wrap_ids=True)[0]
-        post_obj.update(self._process_columns([smallest_column_id]))
+        post_obj.update(self._process_columns(column_ids=[smallest_column_id], column_external_ids=None))
         post_obj.update({"inclusiveFrom": start, "exclusiveTo": end})
         self._fetch_data(post_obj, deleter)
 
     def retrieve(
-        self, start: int, end: int, columns: List[Union[int, str]] = None, external_id: str = None, id: int = None
+        self,
+        start: int,
+        end: int,
+        column_ids: Optional[List[int]] = None,
+        column_external_ids: Optional[List[str]] = None,
+        external_id: str = None,
+        id: int = None,
     ) -> SequenceData:
         """Retrieve data from a sequence
 
         Args:
             start (int): Row number to start from (inclusive)
             end (int): Upper limit on the row number (exclusive)
-            columns (List[Union[int, str]]): List of id or external id for the columns of the sequence. Defaults to all if None is passed.
+            column_ids (Optional[List[int]]): List of ids for the columns of the sequence.
+                If 'None' is passed to both column_ids and columns_external_ids, all columns will be retrieved.
+            column_external_ids (Optional[List[str]]): List of external id for the columns of the sequence.
             id (int): Id of sequence
             external_id (str): External id of sequence
 
@@ -433,28 +458,36 @@ class SequencesDataAPI(APIClient):
         """
         utils._auxiliary.assert_exactly_one_of_id_or_external_id(id, external_id)
         post_obj = self._process_ids(id, external_id, wrap_ids=True)[0]
-        post_obj.update(self._process_columns(columns))
+        post_obj.update(self._process_columns(column_ids=column_ids, column_external_ids=column_external_ids))
         post_obj.update({"inclusiveFrom": start, "exclusiveTo": end})
         seqdata = []
         column_response = self._fetch_data(post_obj, lambda data: seqdata.extend(data))
         return SequenceData(id=id, external_id=external_id, rows=seqdata, columns=column_response)
 
     def retrieve_dataframe(
-        self, start: int, end: int, columns: List[Union[int, str]] = None, external_id: str = None, id: int = None
+        self,
+        start: int,
+        end: int,
+        column_ids: Optional[List[int]] = None,
+        column_external_ids: Optional[List[str]] = None,
+        external_id: str = None,
+        id: int = None,
     ):
         """Retrieve data from a sequence as a pandas dataframe
 
         Args:
-            start: (inclusive) row number to start from
-            end: (exclusive) upper limit on the row number
-            columns: list of id or external id for the columns of the sequence. Defaults to all if None is passed.
+            start: (inclusive) row number to start from.
+            end: (exclusive) upper limit on the row number.
+            column_ids (Optional[List[int]]): List of ids for the columns of the sequence.
+                If 'None' is passed to both column_ids and columns_external_ids, all columns will be retrieved.
+            column_external_ids (Optional[List[str]]): List of external id for the columns of the sequence.
             id (int): Id of sequence
-            external_id (str): External id of sequence
+            external_id (str): External id of sequence.
 
         Returns:
              pandas.DataFrame
         """
-        return self.retrieve(start, end, columns, external_id, id).to_pandas()
+        return self.retrieve(start, end, column_ids, column_external_ids, external_id, id).to_pandas()
 
     def _fetch_data(self, task, callback):
         task["limit"] = task.get("limit") or self._calculate_limit(task)
@@ -476,7 +509,14 @@ class SequencesDataAPI(APIClient):
         row_size = sum([self._COLUMN_SIZE[c["valueType"]] for c in sequence.columns])
         return min(self._SEQ_POST_LIMIT, math.floor(self._REQUEST_SIZE_LIMIT / row_size))
 
-    def _process_columns(self, columns):
-        if columns is None:
-            return {}
-        return {"columns": [{"externalId": col} if isinstance(col, str) else {"id": col} for col in columns]}
+    def _process_columns(self, column_ids, column_external_ids):
+        if column_ids is not None and column_external_ids is not None:
+            raise ValueError("Expecting only exactly one of column_ids and column_external_ids to be set")
+        if column_ids is None and column_external_ids is None:
+            return {}  # retrieve API endpoint has implicit all columns retrieval
+        if column_ids is not None:
+            return {"columns": [{"id": col} for col in column_ids]}
+        else:
+            if any([c is None for c in column_external_ids]):
+                raise ValueError("Some column external ids were None")
+            return {"columns": [{"externalId": col} for col in column_external_ids]}

--- a/cognite/client/data_classes/__init__.py
+++ b/cognite/client/data_classes/__init__.py
@@ -15,7 +15,7 @@ from cognite.client.data_classes.iam import (
     ServiceAccountList,
 )
 from cognite.client.data_classes.raw import Database, DatabaseList, Row, RowList, Table, TableList
-from cognite.client.data_classes.sequences import Sequence, SequenceFilter, SequenceList, SequenceUpdate
+from cognite.client.data_classes.sequences import Sequence, SequenceData, SequenceFilter, SequenceList, SequenceUpdate
 from cognite.client.data_classes.three_d import (
     ThreeDAssetMapping,
     ThreeDAssetMappingList,

--- a/cognite/client/data_classes/sequences.py
+++ b/cognite/client/data_classes/sequences.py
@@ -235,7 +235,7 @@ class SequenceData:
     def __getitem__(self, item: int) -> List[Union[int, str, float]]:
         # slow, should be replaced by dict cache if it sees more than incidental use
         if isinstance(item, slice):
-            raise ValueError("Slicing SequenceData not supported")
+            raise TypeError("Slicing SequenceData not supported")
         return self.values[self.row_numbers.index(item)]
 
     def get_column(self, external_id: str = None, id: int = None) -> List[Union[int, str, float]]:

--- a/cognite/client/data_classes/sequences.py
+++ b/cognite/client/data_classes/sequences.py
@@ -303,7 +303,6 @@ class SequenceData:
         Returns:
             List of sequence column external ids
         """
-        print(self.columns)
         return [c.get("externalId") for c in self.columns]
 
     def column_value_types(self):

--- a/docs/source/cognite.rst
+++ b/docs/source/cognite.rst
@@ -986,9 +986,17 @@ Insert rows into a sequence
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. automethod:: cognite.client._api.sequences.SequencesDataAPI.insert
 
+Insert a pandas dataframe into a sequence
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+.. automethod:: cognite.client._api.sequences.SequencesDataAPI.insert_dataframe
+
 Delete rows from a sequence
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. automethod:: cognite.client._api.sequences.SequencesDataAPI.delete
+
+Delete a range of rows from a sequence
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+.. automethod:: cognite.client._api.sequences.SequencesDataAPI.delete_range
 
 Data classes
 ^^^^^^^^^^^^

--- a/tests/tests_integration/test_api/test_raw.py
+++ b/tests/tests_integration/test_api/test_raw.py
@@ -22,6 +22,7 @@ class TestRawDatabasesAPI:
         dbs = COGNITE_CLIENT.raw.databases.list()
         assert len(dbs) > 0
 
+    @pytest.mark.skip(reason="RAW API changed")
     def test_create_and_delete_database(self, new_database_with_table):
         pass
 
@@ -31,6 +32,7 @@ class TestRawTablesAPI:
         tables = COGNITE_CLIENT.raw.tables.list(db_name="test__database1")
         assert len(tables) == 3
 
+    @pytest.mark.skip(reason="RAW API changed")
     def test_create_and_delete_table(self, new_database_with_table):
         db, _ = new_database_with_table
         table_name = "table_" + utils._auxiliary.random_string(10)
@@ -49,6 +51,7 @@ class TestRawRowsAPI:
         row = COGNITE_CLIENT.raw.rows.retrieve(db_name="test__database1", table_name="test__table_1", key="1")
         assert {"c{}".format(i): "1_{}".format(i) for i in range(10)} == row.columns
 
+    @pytest.mark.skip(reason="RAW API changed")
     def test_insert_and_delete_rows(self, new_database_with_table):
         db, table = new_database_with_table
         rows = {"r1": {"c1": "v1", "c2": "v1"}, "r2": {"c1": "v2", "c2": "v2"}}

--- a/tests/tests_integration/test_api/test_sequences.py
+++ b/tests/tests_integration/test_api/test_sequences.py
@@ -30,7 +30,6 @@ class TestSequencesAPI:
     def test_retrieve(self):
         listed_asset = COGNITE_CLIENT.sequences.list(limit=1)[0]
         retrieved_asset = COGNITE_CLIENT.sequences.retrieve(listed_asset.id)
-        retrieved_asset.external_id = listed_asset.external_id
         assert retrieved_asset == listed_asset
 
     def test_retrieve_multiple(self):

--- a/tests/tests_integration/test_api/test_sequences_data.py
+++ b/tests/tests_integration/test_api/test_sequences_data.py
@@ -100,6 +100,10 @@ class TestSequencesDataAPI:
         data = {i: ["str"] for i in range(1, 61)}
         COGNITE_CLIENT.sequences.data.insert(rows=data, columns=new_seq.column_ids(), id=new_seq.id)
 
+    def test_insert_raw(self, new_seq):
+        data = [{"rowNumber": i, "values": ["str"]} for i in range(1, 61)]
+        COGNITE_CLIENT.sequences.data.insert(rows=data, columns=new_seq.column_ids(), id=new_seq.id)
+
     def test_insert_implicit_rows_cols(self, new_seq_mixed):
         data = {i: [i, "str"] for i in range(1, 10)}
         COGNITE_CLIENT.sequences.data.insert(data, id=new_seq_mixed.id)

--- a/tests/tests_integration/test_api/test_sequences_data.py
+++ b/tests/tests_integration/test_api/test_sequences_data.py
@@ -94,7 +94,7 @@ class TestSequencesDataAPI:
 
     def test_insert_dataframe(self, small_sequence, new_small_seq):
         df = COGNITE_CLIENT.sequences.data.retrieve_dataframe(id=small_sequence.id, start=0, end=5)
-        COGNITE_CLIENT.sequences.data.insert_dataframe(df, id=new_small_seq.id)
+        COGNITE_CLIENT.sequences.data.insert_dataframe(df, id=new_small_seq.id, external_id_headers=True)
 
     def test_insert(self, new_seq):
         data = {i: ["str"] for i in range(1, 61)}

--- a/tests/tests_unit/test_api/test_sequences.py
+++ b/tests/tests_unit/test_api/test_sequences.py
@@ -454,7 +454,9 @@ class TestSequencesPandasIntegration:
     def test_insert_dataframe(self, mock_post_sequence_data):
         import pandas as pd
 
-        df = pd.DataFrame({"foo": [1, 2], 4: [5.0, 6.0]}, index=[123, 456])
+        df = pd.DataFrame(index=[123, 456])
+        df["foo"] = [1, 2]
+        df[4] = [5.0, 6.0]
         res = SEQ_API.data.insert_dataframe(df, id=42)
         assert res is None
         request_body = jsgz_load(mock_post_sequence_data.calls[0].request.body)

--- a/tests/tests_unit/test_api/test_sequences.py
+++ b/tests/tests_unit/test_api/test_sequences.py
@@ -415,7 +415,7 @@ class TestSequences:
         col = data.get_column("ceid")
         assert isinstance(col, list)
         assert 1 == len(col)
-        with pytest.raises(ValueError):
+        with pytest.raises(TypeError):
             sliced = data[1:23]
         with pytest.raises(ValueError):
             missingcol = data.get_column("doesnotexist")


### PR DESCRIPTION
implements most of the suggestions from #453

- sequencedata object
- helper functions on sequence object (rows, column_ids, etc)
- Sequences insert takes its parameters row data first, and no longer requires columns to be passed.
- Sequences create now clears invalid fields such as 'id' in columns specification, so sequences can more easily re-use existing specifications.
- delete_range funtion
- insert function accepts {rowNumber: .., values: ...} dict
- insert_dataframe