### PR TITLE
Allow file creation without uploading a file

### DIFF
--- a/cognite/client/_api/files.py
+++ b/cognite/client/_api/files.py
@@ -287,7 +287,9 @@ class FilesAPI(APIClient):
         """Upload a file
 
         Args:
-            path (str): Path to the file you wish to upload. If path is a directory, this method will upload all files in that directory.
+            path (str): Path to the file you wish to upload. If path is a directory,
+                this method will upload all files in that directory.
+                If path is None, this method will only upload the metadata for the file.
             external_id (str): External Id provided by client. Should be unique within the project.
             name (str): No description.
             source (str): The source of the file.
@@ -326,6 +328,12 @@ class FilesAPI(APIClient):
                 >>> c = CogniteClient()
                 >>> res = c.files.upload("/path/to/my/directory")
 
+            If path is None, this method will only upload the metadata for the file
+
+                >>> from cognite.client import CogniteClient
+                >>> c = CogniteClient()
+                >>> res = c.files.upload(None, name="my_file", external_id="an_external_id")
+
         """
         file_metadata = FileMetadata(
             name=name,
@@ -335,6 +343,13 @@ class FilesAPI(APIClient):
             metadata=metadata,
             asset_ids=asset_ids,
         )
+        if not path:
+            res = self._post(
+                url_path=self._RESOURCE_PATH, json=file_metadata.dump(camel_case=True), params={"overwrite": overwrite}
+            )
+            returned_file_metadata = res.json()
+            return FileMetadata._load(returned_file_metadata)
+
         if os.path.isfile(path):
             if not name:
                 file_metadata.name = os.path.basename(path)

--- a/tests/tests_unit/test_api/test_files.py
+++ b/tests/tests_unit/test_api/test_files.py
@@ -212,6 +212,9 @@ class TestFilesAPI:
         assert {"name": "bla"} == jsgz_load(mock_file_upload_response.calls[0].request.body)
         assert isinstance(mock_file_upload_response.calls[1].request.body, BufferedReader)
 
+    def test_upload_no_path(self, mock_file_upload_response):
+        FILES_API.upload(None)
+
     def test_upload_with_external_id(self, mock_file_upload_response):
         path = os.path.join(os.path.dirname(__file__), "files_for_test_upload", "file_for_test_upload_1.txt")
         FILES_API.upload(path, external_id="blabla", name="bla")


### PR DESCRIPTION
This PR implements what’s described in #460 

The interface for creating a file without uploading content is done by setting this first argument in `FilesAPI.upload` to `None`. I first thought it would be better/cleaner to make `path` an optional argument (as described in the issue), but that would be a breaking change.

The test only checks if no exception occurs. Should maybe add a more thorough test?