### PR TITLE
Examples improvement

### DIFF
--- a/cognite/client/_api/assets.py
+++ b/cognite/client/_api/assets.py
@@ -236,7 +236,7 @@ class AssetsAPI(APIClient):
 
                 >>> from cognite.client import CogniteClient
                 >>> c = CogniteClient()
-                >>> res = c.assets.delete(id=[1,2,3], external_id="3")
+                >>> c.assets.delete(id=[1,2,3], external_id="3")
         """
         self._delete_multiple(
             ids=id, external_ids=external_id, wrap_ids=True, extra_body_fields={"recursive": recursive}

--- a/cognite/client/_api/datapoints.py
+++ b/cognite/client/_api/datapoints.py
@@ -268,7 +268,7 @@ class DatapointsAPI(APIClient):
                 >>> # with ms since epoch and externalId
                 >>> datapoints.append({"externalId": 1, "datapoints": [(150000000000, 1000), (160000000000, 2000)]})
 
-                >>> res = c.datapoints.insert_multiple(datapoints)
+                >>> c.datapoints.insert_multiple(datapoints)
 
             Or they can be a list of dictionaries::
 
@@ -283,7 +283,7 @@ class DatapointsAPI(APIClient):
                 >>> datapoints.append({"id": 1, "datapoints": [{"timestamp": 150000000000, "value": 1000},
                 ...                     {"timestamp": 160000000000, "value": 2000}]})
 
-                >>> res = c.datapoints.insert_multiple(datapoints)
+                >>> c.datapoints.insert_multiple(datapoints)
         """
         dps_poster = DatapointsPoster(self)
         dps_poster.insert(datapoints)
@@ -308,7 +308,7 @@ class DatapointsAPI(APIClient):
 
                 >>> from cognite.client import CogniteClient
                 >>> c = CogniteClient()
-                >>> res = c.datapoints.delete_range(start="1w-ago", end="now", id=1)
+                >>> c.datapoints.delete_range(start="1w-ago", end="now", id=1)
         """
         utils._auxiliary.assert_exactly_one_of_id_or_external_id(id, external_id)
         start = utils._time.timestamp_to_ms(start)
@@ -336,7 +336,7 @@ class DatapointsAPI(APIClient):
                 >>> c = CogniteClient()
                 >>> ranges = [{"id": 1, "start": "2d-ago", "end": "now"},
                 ...             {"externalId": "abc", "start": "2d-ago", "end": "now"}]
-                >>> res = c.datapoints.delete_ranges(ranges)
+                >>> c.datapoints.delete_ranges(ranges)
         """
         valid_ranges = []
         for range in ranges:
@@ -443,7 +443,7 @@ class DatapointsAPI(APIClient):
                 >>> x = pd.DatetimeIndex([start + timedelta(days=d) for d in range(100)])
                 >>> y = np.random.normal(0, 1, 100)
                 >>> df = pd.DataFrame({ts_id: y}, index=x)
-                >>> res = c.datapoints.insert_dataframe(df)
+                >>> c.datapoints.insert_dataframe(df)
         """
         assert not dataframe.isnull().values.any(), "Dataframe contains NaNs. Remove them in order to insert the data."
         dps = []

--- a/cognite/client/_api/events.py
+++ b/cognite/client/_api/events.py
@@ -236,7 +236,7 @@ class EventsAPI(APIClient):
 
                 >>> from cognite.client import CogniteClient
                 >>> c = CogniteClient()
-                >>> res = c.events.delete(id=[1,2,3], external_id="3")
+                >>> c.events.delete(id=[1,2,3], external_id="3")
         """
         self._delete_multiple(ids=id, external_ids=external_id, wrap_ids=True)
 

--- a/cognite/client/_api/files.py
+++ b/cognite/client/_api/files.py
@@ -214,7 +214,7 @@ class FilesAPI(APIClient):
 
                 >>> from cognite.client import CogniteClient
                 >>> c = CogniteClient()
-                >>> res = c.files.delete(id=[1,2,3], external_id="3")
+                >>> c.files.delete(id=[1,2,3], external_id="3")
         """
         self._delete_multiple(wrap_ids=True, ids=id, external_ids=external_id)
 

--- a/cognite/client/_api/iam.py
+++ b/cognite/client/_api/iam.py
@@ -82,7 +82,7 @@ class ServiceAccountsAPI(APIClient):
 
                 >>> from cognite.client import CogniteClient
                 >>> c = CogniteClient()
-                >>> res = c.iam.service_accounts.delete(1)
+                >>> c.iam.service_accounts.delete(1)
         """
         self._delete_multiple(ids=id, wrap_ids=False)
 
@@ -155,7 +155,7 @@ class APIKeysAPI(APIClient):
 
                 >>> from cognite.client import CogniteClient
                 >>> c = CogniteClient()
-                >>> res = c.iam.api_keys.delete(1)
+                >>> c.iam.api_keys.delete(1)
         """
         self._delete_multiple(ids=id, wrap_ids=False)
 
@@ -220,7 +220,7 @@ class GroupsAPI(APIClient):
 
                 >>> from cognite.client import CogniteClient
                 >>> c = CogniteClient()
-                >>> res = c.iam.groups.delete(1)
+                >>> c.iam.groups.delete(1)
         """
         self._delete_multiple(ids=id, wrap_ids=False)
 
@@ -349,6 +349,6 @@ class SecurityCategoriesAPI(APIClient):
 
                 >>> from cognite.client import CogniteClient
                 >>> c = CogniteClient()
-                >>> res = c.iam.security_categories.delete(1)
+                >>> c.iam.security_categories.delete(1)
         """
         self._delete_multiple(ids=id, wrap_ids=False)

--- a/cognite/client/_api/raw.py
+++ b/cognite/client/_api/raw.py
@@ -73,7 +73,7 @@ class RawDatabasesAPI(APIClient):
 
                 >>> from cognite.client import CogniteClient
                 >>> c = CogniteClient()
-                >>> res = c.raw.databases.delete(["db1", "db2"])
+                >>> c.raw.databases.delete(["db1", "db2"])
         """
         utils._auxiliary.assert_type(name, "name", [str, list])
         if isinstance(name, str):
@@ -357,7 +357,7 @@ class RawRowsAPI(APIClient):
                 >>> from cognite.client import CogniteClient
                 >>> c = CogniteClient()
                 >>> keys_to_delete = ["k1", "k2", "k3"]
-                >>> res = c.raw.rows.delete("db1", "table1", keys_to_delete)
+                >>> c.raw.rows.delete("db1", "table1", keys_to_delete)
         """
         utils._auxiliary.assert_type(key, "key", [str, list])
         if isinstance(key, str):

--- a/cognite/client/_api/sequences.py
+++ b/cognite/client/_api/sequences.py
@@ -190,7 +190,7 @@ class SequencesAPI(APIClient):
 
                 >>> from cognite.client.experimental import CogniteClient
                 >>> c = CogniteClient()
-                >>> res = c.sequences.delete(id=[1,2,3], external_id="3")
+                >>> c.sequences.delete(id=[1,2,3], external_id="3")
         """
         self._delete_multiple(wrap_ids=True, ids=id, external_ids=external_id)
 
@@ -300,21 +300,21 @@ class SequencesDataAPI(APIClient):
                 >>> c = CogniteClient()
                 >>> seq = c.sequences.create(Sequence(columns=[{"valueType": "STRING","valueType": "DOUBLE"}]))
                 >>> data = [(1, ['pi',3.14]), (2, ['e',2.72]) ]
-                >>> res1 = c.sequences.data.insert(column_ids=seq.column_ids, rows=data, id=1)
+                >>> c.sequences.data.insert(column_ids=seq.column_ids, rows=data, id=1)
 
             They can also be provided as a list of API-style objects with a rowNumber and values field::
 
                 >>> from cognite.client.experimental import CogniteClient
                 >>> c = CogniteClient()
                 >>> data = [{"rowNumber": 123, "values": ['str',3]}, {"rowNUmber": 456, "values": ["bar",42]} ]
-                >>> res1 = c.sequences.data.insert(data, id=1) # implicit columns are retrieved from metadata
+                >>> c.sequences.data.insert(data, id=1) # implicit columns are retrieved from metadata
 
             Or they can be a given as a dictionary with row number as the key, and the value is the data to be inserted at that row::
 
                 >>> from cognite.client.experimental import CogniteClient
                 >>> c = CogniteClient()
                 >>> data = {123 : ['str',3], 456 : ['bar',42] }
-                >>> res1 = c.sequences.data.insert(column_external_ids=['stringColumn','intColumn'], rows=data, id=1)
+                >>> c.sequences.data.insert(column_external_ids=['stringColumn','intColumn'], rows=data, id=1)
         """
         utils._auxiliary.assert_exactly_one_of_id_or_external_id(id, external_id)
         if column_ids is None and column_external_ids is None:
@@ -362,7 +362,7 @@ class SequencesDataAPI(APIClient):
                 >>> from cognite.client.experimental import CogniteClient
                 >>> c = CogniteClient()
                 >>> df = c.sequences.data.retrieve_dataframe(id=123, start=0, end=None)
-                >>> c.sequences.data.insert_dataframe(df*2, id=123, external_id_headers=True) and None
+                >>> c.sequences.data.insert_dataframe(df*2, id=123, external_id_headers=True)
         """
         dataframe = dataframe.replace({math.nan: None})
         data = [(v[0], list(v[1:])) for v in dataframe.itertuples()]
@@ -394,7 +394,7 @@ class SequencesDataAPI(APIClient):
 
                 >>> from cognite.client.experimental import CogniteClient
                 >>> c = CogniteClient()
-                >>> res1 = c.sequences.data.delete(id=0, rows=[1,2,42])
+                >>> c.sequences.data.delete(id=0, rows=[1,2,42])
         """
         utils._auxiliary.assert_exactly_one_of_id_or_external_id(id, external_id)
         post_obj = self._process_ids(id, external_id, wrap_ids=True)[0]
@@ -418,7 +418,7 @@ class SequencesDataAPI(APIClient):
 
                 >>> from cognite.client.experimental import CogniteClient
                 >>> c = CogniteClient()
-                >>> res1 = c.sequences.data.delete_range(id=0, start=0, end=None)
+                >>> c.sequences.data.delete_range(id=0, start=0, end=None)
         """
         deleter = lambda data: self.delete(rows=[r["rowNumber"] for r in data], external_id=external_id, id=id)
         utils._auxiliary.assert_exactly_one_of_id_or_external_id(id, external_id)
@@ -452,6 +452,16 @@ class SequencesDataAPI(APIClient):
 
         Returns:
             List of sequence data
+
+        Examples:
+
+                >>> from cognite.client.experimental import CogniteClient
+                >>> c = CogniteClient()
+                >>> res = c.sequences.data.retrieve(id=0, start=0, end=None)
+                >>> tuples = [(r,v) for r,v in res.iteritems()] # You can use this iterator in for loops and list comprehensions,
+                >>> single_value = res[23] # ... get the values at a single row number,
+                >>> col = res.get_column(external_id='columnExtId') # ... get the array of values for a specific column,
+                >>> df = res.to_pandas() # ... or convert the result to a dataframe
         """
         utils._auxiliary.assert_exactly_one_of_id_or_external_id(id, external_id)
         post_obj = self._process_ids(id, external_id, wrap_ids=True)[0]
@@ -483,6 +493,12 @@ class SequencesDataAPI(APIClient):
 
         Returns:
              pandas.DataFrame
+
+        Examples:
+
+                >>> from cognite.client.experimental import CogniteClient
+                >>> c = CogniteClient()
+                >>> df = c.sequences.data.retrieve_dataframe(id=0, start=0, end=None)
         """
         return self.retrieve(start, end, column_ids, column_external_ids, external_id, id).to_pandas()
 

--- a/cognite/client/_api/time_series.py
+++ b/cognite/client/_api/time_series.py
@@ -173,7 +173,7 @@ class TimeSeriesAPI(APIClient):
 
                 >>> from cognite.client import CogniteClient
                 >>> c = CogniteClient()
-                >>> res = c.time_series.delete(id=[1,2,3], external_id="3")
+                >>> c.time_series.delete(id=[1,2,3], external_id="3")
         """
         self._delete_multiple(wrap_ids=True, ids=id, external_ids=external_id)
 

--- a/tests/tests_unit/test_docstring_examples.py
+++ b/tests/tests_unit/test_docstring_examples.py
@@ -1,9 +1,15 @@
 import doctest
-from unittest import TextTestRunner
+from unittest import TextTestRunner, mock
 
 import pytest
 
 from cognite.client._api import assets, datapoints, events, files, iam, login, raw, sequences, three_d, time_series
+
+# this fixes the issue with 'got MagicMock but expected Nothing in docstrings'
+doctest.OutputChecker.__check_output = doctest.OutputChecker.check_output
+doctest.OutputChecker.check_output = lambda self, want, got, optionflags: not want or self.__check_output(
+    want, got, optionflags
+)
 
 
 def run_docstring_tests(module):


### PR DESCRIPTION
- removed 'res=' from examples based on user confusio
- hacked docstring test to support this
- added sequence retrieve examples