### PR TITLE
Download openapi spec as gzip

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -56,7 +56,7 @@ podTemplate(
         container('node'){
             stage('Download and dereference OpenAPI Spec'){
                 sh('npm install -g swagger-cli')
-                sh('curl https://storage.googleapis.com/cognitedata-api-docs/dist/v1.json --output spec.json')
+                sh('curl https://storage.googleapis.com/cognitedata-api-docs/dist/v1.json --output spec.json --compressed')
                 sh('swagger-cli bundle -r spec.json -o deref-spec.json')
             }
         }


### PR DESCRIPTION
The openapi specs are now server
d as gzip -- I accidentally broke backwards compat for http clients that doesn't speak gzip (most do) on this so I thought I'd forward fix as well.

This might also shave a millisecond of your build pipeline (it's primarily for browser rendering ;-))