### PR TITLE
Supporting sequences list by asset id and easier copy for SequenceData and Datapoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Changes are grouped as follows
 ### Added
 - SequencesAPI.list now accepts an asset_ids parameter for searching by asset
 - SequencesDataAPI.insert now accepts a SequenceData object for easier copying
+- DatapointsAPI.insert now accepts a Datapoints object for easier copying
 
 ## [1.0.5] - 2019-08-15
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@ Changes are grouped as follows
 - Separate read/write fields on data classes
 
 ## [Unreleased]
+### Added
+- SequencesAPI.list now accepts an asset_ids parameter for searching by asset
+- SequencesDataAPI.insert now accepts a SequenceData object for easier copying
 
 ## [1.0.5] - 2019-08-15
 ### Added

--- a/cognite/client/_api/datapoints.py
+++ b/cognite/client/_api/datapoints.py
@@ -202,8 +202,8 @@ class DatapointsAPI(APIClient):
         Timestamps can be represented as milliseconds since epoch or datetime objects.
 
         Args:
-            datapoints(Union[List[Dict], List[Tuple]]): The datapoints you wish to insert. Can either be a list of tuples or
-                a list of dictionaries. See examples below.
+            datapoints(Union[List[Dict], List[Tuple],Datapoints]): The datapoints you wish to insert. Can either be a list of tuples,
+                a list of dictionaries, or a Datapoints object. See examples below.
             id (int): Id of time series to insert datapoints into.
             external_id (str): External id of time series to insert datapoint into.
 
@@ -220,10 +220,10 @@ class DatapointsAPI(APIClient):
                 >>> c = CogniteClient()
                 >>> # with datetime objects
                 >>> datapoints = [(datetime(2018,1,1), 1000), (datetime(2018,1,2), 2000)]
-                >>> res1 = c.datapoints.insert(datapoints, id=1)
+                >>> c.datapoints.insert(datapoints, id=1)
                 >>> # with ms since epoch
                 >>> datapoints = [(150000000000, 1000), (160000000000, 2000)]
-                >>> res2 = c.datapoints.insert(datapoints, id=2)
+                >>> c.datapoints.insert(datapoints, id=2)
 
             Or they can be a list of dictionaries::
 
@@ -232,14 +232,23 @@ class DatapointsAPI(APIClient):
                 >>> # with datetime objects
                 >>> datapoints = [{"timestamp": datetime(2018,1,1), "value": 1000},
                 ...    {"timestamp": datetime(2018,1,2), "value": 2000}]
-                >>> res1 = c.datapoints.insert(datapoints, external_id="abc")
+                >>> c.datapoints.insert(datapoints, external_id="abc")
                 >>> # with ms since epoch
                 >>> datapoints = [{"timestamp": 150000000000, "value": 1000},
                 ...    {"timestamp": 160000000000, "value": 2000}]
-                >>> res2 = c.datapoints.insert(datapoints, external_id="def")
+                >>> c.datapoints.insert(datapoints, external_id="def")
+
+            Or they can be a Datapoints object::
+
+                >>> from cognite.client import CogniteClient
+                >>> c = CogniteClient()
+                >>> data = c.datapoints.retrieve(external_id="abc",start=datetime(2018,1,1),end=datetime(2018,2,2))
+                >>> c.datapoints.insert(data, external_id="def")
         """
         utils._auxiliary.assert_exactly_one_of_id_or_external_id(id, external_id)
         post_dps_object = self._process_ids(id, external_id, wrap_ids=True)[0]
+        if isinstance(datapoints, Datapoints):
+            datapoints = datapoints.dump()["datapoints"]
         post_dps_object.update({"datapoints": datapoints})
         dps_poster = DatapointsPoster(self)
         dps_poster.insert([post_dps_object])

--- a/cognite/client/_api/sequences.py
+++ b/cognite/client/_api/sequences.py
@@ -136,7 +136,7 @@ class SequencesAPI(APIClient):
                 >>> for seq_list in c.sequences(chunk_size=2500):
                 ...     seq_list # do something with the sequences
         """
-        filter = {"assetIds": asset_ids if asset_ids else None}
+        filter = {"assetIds": asset_ids}
         return self._list(method="POST", filter=filter, limit=limit)
 
     def create(self, sequence: Union[Sequence, List[Sequence]]) -> Union[Sequence, SequenceList]:

--- a/cognite/client/_api/sequences.py
+++ b/cognite/client/_api/sequences.py
@@ -136,7 +136,7 @@ class SequencesAPI(APIClient):
                 >>> for seq_list in c.sequences(chunk_size=2500):
                 ...     seq_list # do something with the sequences
         """
-        filter = {"assetIds": str(asset_ids) if asset_ids else None}
+        filter = {"assetIds": asset_ids if asset_ids else None}
         return self._list(method="POST", filter=filter, limit=limit)
 
     def create(self, sequence: Union[Sequence, List[Sequence]]) -> Union[Sequence, SequenceList]:

--- a/tests/tests_integration/test_api/test_datapoints.py
+++ b/tests/tests_integration/test_api/test_datapoints.py
@@ -121,6 +121,12 @@ class TestDatapointsAPI:
             COGNITE_CLIENT.datapoints.insert(datapoints, id=new_ts.id)
         assert 2 == COGNITE_CLIENT.datapoints._post.call_count
 
+    def test_insert_copy(self, test_time_series, new_ts, post_spy):
+        data = COGNITE_CLIENT.datapoints.retrieve(id=test_time_series[0].id, start="600d-ago", end="now", limit=100)
+        assert 100 == len(data)
+        COGNITE_CLIENT.datapoints.insert(data, id=new_ts.id)
+        assert 2 == COGNITE_CLIENT.datapoints._post.call_count
+
     def test_insert_pandas_dataframe(self, new_ts, post_spy):
         start = datetime(2018, 1, 1)
         x = pandas.DatetimeIndex([start + timedelta(days=d) for d in range(100)])

--- a/tests/tests_integration/test_api/test_sequences_data.py
+++ b/tests/tests_integration/test_api/test_sequences_data.py
@@ -110,6 +110,10 @@ class TestSequencesDataAPI:
         data = {i: [i, "str"] for i in range(1, 10)}
         COGNITE_CLIENT.sequences.data.insert(data, id=new_seq_mixed.id)
 
+    def test_insert_copy(self, small_sequence, new_small_seq):
+        data = COGNITE_CLIENT.sequences.data.retrieve(id=small_sequence.id, start=0, end=5)
+        COGNITE_CLIENT.sequences.data.insert(rows=data, id=new_small_seq.id)
+
     def test_delete_multiple(self, new_seq):
         COGNITE_CLIENT.sequences.data.delete(rows=[1, 2, 42, 3524], id=new_seq.id)
 

--- a/tests/tests_unit/test_api/test_sequences.py
+++ b/tests/tests_unit/test_api/test_sequences.py
@@ -49,7 +49,7 @@ def mock_seq_response(rsps):
         ]
     }
     url_pattern = re.compile(
-        re.escape(SEQ_API._get_base_url_with_base_path()) + "/sequences(?:/byids|/update|/delete|/search|$|\?.+)"
+        re.escape(SEQ_API._get_base_url_with_base_path()) + "/sequences(?:/byids|/list|/update|/delete|/search|$|\?.+)"
     )
     rsps.assert_all_requests_are_fired = False
 
@@ -62,7 +62,7 @@ def mock_seq_response(rsps):
 def mock_sequences_empty(rsps):
     response_body = {"items": []}
     url_pattern = re.compile(
-        re.escape(SEQ_API._get_base_url_with_base_path()) + "/sequences(?:/byids|/update|/delete|/search|$|\?.+)"
+        re.escape(SEQ_API._get_base_url_with_base_path()) + "/sequences(?:/byids|/update|/list|/delete|/search|$|\?.+)"
     )
     rsps.assert_all_requests_are_fired = False
 


### PR DESCRIPTION
- changed sequences list to go to advanced endpoint and added assetIds
- support for insert sequencedata in sequencedataapi.insert
- support for insert datapoints in datapointsapi.insert