### PR TITLE
Sequences renaming + release 1.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,14 +21,16 @@ Changes are grouped as follows
 
 ## [Unreleased]
 
-### Changed
-- Output in jupyter notebooks is now pandas-like by default, instead of outputting long json strings.
-
+## [1.1.2] - 2019-08-27
 ### Added
 - `limit` parameter on sequence data retrieval.
 
+### Changed
+- Output in jupyter notebooks is now pandas-like by default, instead of outputting long json strings.
+
 ### Fixed
 - id parameters and timestamps now accept any integer type including numpy.int64, so values from dataframes can be passed directly.
+- Compatibility fix for renaming of sequences cursor and start/end parameters in the API.
 
 ## [1.1.1] - 2019-08-23
 ### Added

--- a/cognite/client/__init__.py
+++ b/cognite/client/__init__.py
@@ -1,3 +1,3 @@
 from cognite.client._cognite_client import CogniteClient
 
-__version__ = "1.1.1"
+__version__ = "1.1.2"

--- a/cognite/client/_api/sequences.py
+++ b/cognite/client/_api/sequences.py
@@ -489,7 +489,7 @@ class SequencesDataAPI(APIClient):
         sequence = self._sequences_api.retrieve(id=id, external_id=external_id)
         post_obj = self._process_ids(id, external_id, wrap_ids=True)[0]
         post_obj.update(self._process_columns(column_ids=[sequence.column_ids[0]], column_external_ids=None))
-        post_obj.update({"inclusiveFrom": start, "exclusiveTo": end})
+        post_obj.update({"start": start, "end": end})
         self._fetch_data(post_obj, deleter)
 
     def retrieve(
@@ -531,7 +531,7 @@ class SequencesDataAPI(APIClient):
         utils._auxiliary.assert_exactly_one_of_id_or_external_id(id, external_id)
         post_obj = self._process_ids(id, external_id, wrap_ids=True)[0]
         post_obj.update(self._process_columns(column_ids=column_ids, column_external_ids=column_external_ids))
-        post_obj.update({"inclusiveFrom": start, "exclusiveTo": end, "limit": limit})
+        post_obj.update({"start": start, "end": end, "limit": limit})
         seqdata = []
         column_response = self._fetch_data(post_obj, lambda data: seqdata.extend(data))
         return SequenceData(id=id, external_id=external_id, rows=seqdata, columns=column_response)
@@ -580,7 +580,7 @@ class SequencesDataAPI(APIClient):
             data = items[0]["rows"]
             columns = columns or items[0]["columns"]
             callback(data)
-            cursor = items[0].get("cursor")
+            cursor = items[0].get("nextCursor")
             if remaining_limit:
                 remaining_limit -= len(data)
             if not cursor or (remaining_limit is not None and remaining_limit <= 0):

--- a/cognite/client/_api/sequences.py
+++ b/cognite/client/_api/sequences.py
@@ -578,8 +578,8 @@ class SequencesDataAPI(APIClient):
         remaining_limit = task.get("limit")
         columns = []
         cursor = None
-        if task["exclusiveTo"] == -1:
-            task["exclusiveTo"] = None
+        if task["end"] == -1:
+            task["end"] = None
         while True:
             task["limit"] = min(self._SEQ_RETRIEVE_LIMIT, remaining_limit or self._SEQ_RETRIEVE_LIMIT)
             task["cursor"] = cursor

--- a/tests/tests_unit/test_api/test_sequences.py
+++ b/tests/tests_unit/test_api/test_sequences.py
@@ -352,7 +352,7 @@ class TestSequences:
 
     def test_retrieve_neg_1_end_index(self, mock_seq_response, mock_get_sequence_data):
         SEQ_API.data.retrieve(id=123, start=123, end=-1)
-        assert jsgz_load(mock_get_sequence_data.calls[0].request.body)["items"][0]["exclusiveTo"] is None
+        assert jsgz_load(mock_get_sequence_data.calls[0].request.body)["items"][0]["end"] is None
 
     def test_delete_by_id(self, mock_delete_sequence_data):
         res = SEQ_API.data.delete(id=1, rows=[1, 2, 3])


### PR DESCRIPTION
sequences API has breaking changes. This pull request aligns the SDK with these and releases 1.1.2
- inclusiveFrom/exclusiveTo renamed
- cursor renamed