### PR TITLE
pagination for latest data point

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ Changes are grouped as follows
 
 ### Changed
 - Formatted output in jupyter notebooks for `SequenceData`.
+- `retrieve_latest` function in theDatapoints API extended to support more than 100 items.
 
 ## [1.1.3] - 2019-09-05
 ### Changed

--- a/cognite/client/_api/datapoints.py
+++ b/cognite/client/_api/datapoints.py
@@ -156,12 +156,9 @@ class DatapointsAPI(APIClient):
         tasks_summary = utils._concurrency.execute_tasks_concurrently(
             self._post, tasks, max_workers=self._config.max_workers
         )
-        tasks_summary.raise_compound_exception_if_failed_tasks(
-            task_unwrap_fn=lambda task: task["json"]["items"],
-            task_list_element_unwrap_fn=utils._auxiliary.unwrap_identifer,
-        )
+        if tasks_summary.exceptions:
+            raise tasks_summary.exceptions[0]
         res = tasks_summary.joined_results(lambda res: res.json()["items"])
-
         if is_single_id:
             return Datapoints._load(res[0], cognite_client=self._cognite_client)
         return DatapointsList._load(res, cognite_client=self._cognite_client)

--- a/cognite/client/_api/datapoints.py
+++ b/cognite/client/_api/datapoints.py
@@ -20,6 +20,7 @@ class DatapointsAPI(APIClient):
         self._DPS_LIMIT_AGG = 10000
         self._DPS_LIMIT = 100000
         self._POST_DPS_OBJECTS_LIMIT = 10000
+        self._RETRIEVE_LATEST_LIMIT = 100
 
     def retrieve(
         self,
@@ -148,7 +149,19 @@ class DatapointsAPI(APIClient):
             for id in all_ids:
                 id.update({"before": before})
 
-        res = self._post(url_path=self._RESOURCE_PATH + "/latest", json={"items": all_ids}).json()["items"]
+        tasks = [
+            {"url_path": self._RESOURCE_PATH + "/latest", "json": {"items": chunk}}
+            for chunk in utils._auxiliary.split_into_chunks(all_ids, self._RETRIEVE_LATEST_LIMIT)
+        ]
+        tasks_summary = utils._concurrency.execute_tasks_concurrently(
+            self._post, tasks, max_workers=self._config.max_workers
+        )
+        tasks_summary.raise_compound_exception_if_failed_tasks(
+            task_unwrap_fn=lambda task: task["json"]["items"],
+            task_list_element_unwrap_fn=utils._auxiliary.unwrap_identifer,
+        )
+        res = tasks_summary.joined_results(lambda res: res.json()["items"])
+
         if is_single_id:
             return Datapoints._load(res[0], cognite_client=self._cognite_client)
         return DatapointsList._load(res, cognite_client=self._cognite_client)

--- a/cognite/client/utils/_concurrency.py
+++ b/cognite/client/utils/_concurrency.py
@@ -5,7 +5,9 @@ from cognite.client.exceptions import CogniteAPIError, CogniteDuplicatedError, C
 
 
 class TasksSummary:
-    def __init__(self, successful_tasks, unknown_tasks, failed_tasks, results, exceptions):
+    def __init__(
+        self, successful_tasks: List, unknown_tasks: List, failed_tasks: List, results: List, exceptions: List
+    ):
         self.successful_tasks = successful_tasks
         self.unknown_tasks = unknown_tasks
         self.failed_tasks = failed_tasks
@@ -104,7 +106,7 @@ def collect_exc_info_and_raise(
         ) from dup_exc
 
 
-def execute_tasks_concurrently(func: Callable, tasks: Union[List[Tuple], List[Dict]], max_workers: int):
+def execute_tasks_concurrently(func: Callable, tasks: Union[List[Tuple], List[Dict]], max_workers: int) -> TasksSummary:
     assert max_workers > 0, "Number of workers should be >= 1, was {}".format(max_workers)
     with ThreadPoolExecutor(max_workers) as p:
         futures = []

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -44,6 +44,7 @@ def set_request_limit(client, limit):
         "_DPS_LIMIT",
         "_DPS_LIMIT_AGG",
         "_POST_DPS_OBJECTS_LIMIT",
+        "_RETRIEVE_LATEST_LIMIT",
     ]
 
     tmp = {l: 0 for l in limits}


### PR DESCRIPTION
came across
CogniteAPIError: Query contains 1038 items, but max limit is 100
when calling retrieve_latest
this pull request fixes it.

please check raise_compound_exception_if_failed_tasks in particular, not sure I understand the parameters for it.