### PR TITLE
bug fix for datapoints retrieval

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,9 @@ Changes are grouped as follows
 ### Changed
 - `Asset` class now has an `aggregates` property.
 
+### Fixed
+- Fixed a bug in time series pagination where getting 100k dense datapoints would cause a missing id error.
+
 ## [1.1.7] - 2019-09-13
 ### Fixed
 - `testing.mock_cognite_client()` so that it still accepts arguments after exiting from mock context.

--- a/cognite/client/_api/datapoints.py
+++ b/cognite/client/_api/datapoints.py
@@ -1042,6 +1042,7 @@ class DatapointsFetcher:
             datapoints = self._get_datapoints(
                 next_start, end, ts_item, aggregates, granularity, include_outside_points, limit_next_request
             )
+            all_datapoints._extend(datapoints)
             if len(datapoints) == 0:
                 break
 
@@ -1053,7 +1054,6 @@ class DatapointsFetcher:
             next_start = latest_timestamp + (
                 cognite.client.utils._time.granularity_to_ms(granularity) if granularity else 1
             )
-            all_datapoints._extend(datapoints)
         return all_datapoints
 
     def _get_datapoints(


### PR DESCRIPTION
bug found by @matiascognite when testing dense datapoints.
basically what happens is that >100k datapoints used to exist, but some were deleted and now exactly 100k datapoints exist in the range. This makes the SDK paginate on 0 datapoints, and break before _extend in the pagination function, which causes the .id not to be set on the task.
calling extend regardless of whether the datapoints are empty ensures the id is set.

sorry for the lack of a test, it's a difficult to reproduce edge case.