### PR TITLE
Do not modify expected_fields passed to Datapoints._load 

### DIFF
--- a/cognite/client/data_classes/datapoints.py
+++ b/cognite/client/data_classes/datapoints.py
@@ -223,8 +223,7 @@ class Datapoints:
         instance = cls()
         instance.id = dps_object["id"]
         instance.external_id = dps_object.get("externalId")
-        expected_fields = expected_fields or ["value"]
-        expected_fields.append("timestamp")
+        expected_fields = (expected_fields or ["value"]) + ["timestamp"]
         if len(dps_object["datapoints"]) == 0:
             for key in expected_fields:
                 snake_key = utils._auxiliary.to_snake_case(key)


### PR DESCRIPTION
I know it's an underscored method, but modifying lists passed to it is not so nice 