### PR TITLE
bug fix and test for datapoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@ Changes are grouped as follows
 
 ## [Unreleased]
 
+### Fixed
+- Fixed a bug in time series pagination where getting 100k datapoints could cause a missing id error when using include_outside_points.
+
 ## [1.1.11] - 2019-09-23
 ### Fixed
 - Fix testing.CogniteClientMock so it is possible to get attributes on child which have not been explicitly in the CogniteClientMock constructor

--- a/cognite/client/_api/datapoints.py
+++ b/cognite/client/_api/datapoints.py
@@ -942,6 +942,8 @@ class DatapointsFetcher:
         ]
 
     def _get_windows(self, id, start, end, granularity, request_limit, user_limit):
+        if start >= end:
+            return []
         count_granularity = "1d"
         if granularity and cognite.client.utils._time.granularity_to_ms(
             "1d"


### PR DESCRIPTION
when include outside points is true, and we retrieve exactly LIMIT/LIMIT+1 datapoints where the last datapoint is >= end, the SDK requests windows for start > end, resulting in empty objects down the line, similar to the previous bug where storing using id as an index results in trouble.
There's probably several ways to fix this, but this fixes the window function to return [] , saving the count request.