### PR TITLE
fixed bugs and improved errors in json encoder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Changes are grouped as follows
 
 ### Fixed
 - Fixed a bug in time series pagination where getting 100k datapoints could cause a missing id error when using include_outside_points.
+- Fixed a bug where the JSON encoder would throw circular reference errors on unknown data types, including numpy floats.
 
 ## [1.1.11] - 2019-09-23
 ### Fixed

--- a/cognite/client/utils/_auxiliary.py
+++ b/cognite/client/utils/_auxiliary.py
@@ -44,11 +44,11 @@ def convert_all_keys_to_camel_case(d: Dict):
 def json_dump_default(x):
     if isinstance(x, numbers.Integral):
         return int(x)
-    if isinstance(x, Decimal):
+    if isinstance(x, (Decimal, numbers.Real)):
         return float(x)
     if hasattr(x, "__dict__"):
         return x.__dict__
-    return x
+    raise TypeError("Object {} of type {} can't be serialized by the JSON encoder".format(x, x.__class__))
 
 
 def assert_exactly_one_of_id_or_external_id(id, external_id):

--- a/tests/tests_unit/test_utils/test_auxiliary.py
+++ b/tests/tests_unit/test_utils/test_auxiliary.py
@@ -63,6 +63,24 @@ class TestJsonDumpDefault:
 
         assert json.dumps(Decimal(1), default=utils._auxiliary.json_dump_default)
 
+    def test_json_not_serializable_sets(self):
+        with pytest.raises(TypeError):
+            json.dumps({1,2})
+        with pytest.raises(TypeError):
+            json.dumps({1,2})
+
+    @pytest.mark.dsl
+    def test_json_serializable_numpy(self):
+        np = utils._auxiliary.local_import("numpy")
+        arr = np.array([1.2, 3.4]).astype(np.float32)
+        with pytest.raises(TypeError):
+            json.dumps(arr)
+        with pytest.raises(TypeError):
+            json.dumps(arr[0])
+        with pytest.raises(TypeError): # core sdk makes it hard to serialize np.ndarray
+            assert json.dumps(arr, default=utils._auxiliary.json_dump_default)
+        assert json.dumps(arr[0], default=utils._auxiliary.json_dump_default)
+
     def test_json_serializable_object(self):
         class Obj:
             def __init__(self):

--- a/tests/tests_unit/test_utils/test_auxiliary.py
+++ b/tests/tests_unit/test_utils/test_auxiliary.py
@@ -65,9 +65,9 @@ class TestJsonDumpDefault:
 
     def test_json_not_serializable_sets(self):
         with pytest.raises(TypeError):
-            json.dumps({1,2})
+            json.dumps({1, 2})
         with pytest.raises(TypeError):
-            json.dumps({1,2})
+            json.dumps({1, 2})
 
     @pytest.mark.dsl
     def test_json_serializable_numpy(self):
@@ -77,7 +77,7 @@ class TestJsonDumpDefault:
             json.dumps(arr)
         with pytest.raises(TypeError):
             json.dumps(arr[0])
-        with pytest.raises(TypeError): # core sdk makes it hard to serialize np.ndarray
+        with pytest.raises(TypeError):  # core sdk makes it hard to serialize np.ndarray
             assert json.dumps(arr, default=utils._auxiliary.json_dump_default)
         assert json.dumps(arr[0], default=utils._auxiliary.json_dump_default)
 


### PR DESCRIPTION
the 'return x' at the end of the json dump default caused a circular reference (since it tries again and again to pass it to the function). this is fixed by correctly throwing a TypeError
this was firing for @jucc on numpy.float32, which is also fixed by this by checking for all numbers.Real