### PR TITLE
bug fixes in include outside and limit

### DIFF
--- a/tests/tests_unit/test_api/test_datapoints.py
+++ b/tests/tests_unit/test_api/test_datapoints.py
@@ -1266,14 +1266,14 @@ class TestDataFetcher:
     @pytest.mark.parametrize(
         "q, expected_q",
         [
-            ([_DPTask(1, 2, None, None, None, None, None)], [_DPTask(1, 2, None, None, None, None, None)]),
+            ([_DPTask(1, 2, None, None, None, None, None, None)], [_DPTask(1, 2, None, None, None, None, None, None)]),
             (
-                [_DPTask(datetime(2018, 1, 1), datetime(2019, 1, 1), None, None, None, None, None)],
-                [_DPTask(1514764800000, 1546300800000, None, None, None, None, None)],
+                [_DPTask(datetime(2018, 1, 1), datetime(2019, 1, 1), None, None, None, None, None, None)],
+                [_DPTask(1514764800000, 1546300800000, None, None, None, None, None, None)],
             ),
             (
-                [_DPTask(gms("1h"), gms(("25h")), None, ["average"], "1d", None, None)],
-                [_DPTask(gms("1d"), gms("2d"), None, ["average"], "1d", None, None)],
+                [_DPTask(gms("1h"), gms(("25h")), None, ["average"], "1d", None, None, None)],
+                [_DPTask(gms("1d"), gms("2d"), None, ["average"], "1d", None, None, None)],
             ),
         ],
     )


### PR DESCRIPTION
- includeoutsidepoint returns a point after 'end' even if there are points in between, this broke pagination (the fix for this is mind-bogglingly filled with edge cases)
- user defined limit did not subtract first page retrieved correctly (the fix for this is a bit ugly)
- the tests for retrieve latest points are very slow, this takes them down a notch