### PR TITLE
dont retrieve metadata in to retrieve_dataframe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,9 @@ Changes are grouped as follows
 ### Added
 - Datapoints objects now store is_string, is_step and unit to allow for better interpretation of the data.
 
+### Changed
+- retrieve_dataframe with `complete` using Datapoints fields instead of retrieving time series metadata. 
+
 ## [1.3.1] - 2019-10-09
 ### Fixed
 - Fixed support for totalVariation aggregate completion.

--- a/cognite/client/_api/datapoints.py
+++ b/cognite/client/_api/datapoints.py
@@ -467,11 +467,12 @@ class DatapointsAPI(APIClient):
                 for dpl in [id_dpl, external_id_dpl]
                 for dp in (dpl.data if isinstance(dpl, DatapointsList) else [dpl])
             }
-            ts_meta = self._cognite_client.time_series.retrieve_multiple(
-                ids=[id for id, aggs_used in ag_used_by_id.items() if "interpolation" in aggs_used]
-            )
             is_step_dict = {
-                str(field): bool(ts.is_step) for ts in ts_meta for field in [ts.id, ts.external_id] if field
+                str(field): bool(dp.is_step)
+                for dpl in [id_dpl, external_id_dpl]
+                for dp in (dpl.data if isinstance(dpl, DatapointsList) else [dpl])
+                for field in [dp.id, dp.external_id]
+                if field
             }
             df = self._dataframe_fill(df, granularity, is_step_dict)
 

--- a/tests/tests_unit/test_api/test_datapoints.py
+++ b/tests/tests_unit/test_api/test_datapoints.py
@@ -271,7 +271,7 @@ def mock_get_datapoints_single_isstep(rsps):
             dps = {
                 "id": 3,
                 "externalId": "abc",
-                "isStep": False,
+                "isStep": True,
                 "isString": False,
                 "datapoints": [{"timestamp": 1000, "interpolation": 1}, {"timestamp": 3000, "interpolation": 3}],
             }
@@ -283,9 +283,6 @@ def mock_get_datapoints_single_isstep(rsps):
         callback=callback,
         content_type="application/json",
     )
-    response_body = {"items": [{"id": 3, "isStep": True, "isString": False}]}
-    rsps.add(rsps.POST, DPS_CLIENT._get_base_url_with_base_path() + "/timeseries/byids", status=200, json=response_body)
-    rsps.assert_all_requests_are_fired = False
     yield rsps
 
 


### PR DESCRIPTION
Only a small change. 
Redoing it properly kind of gets stuck on the mix of ids and external ids resulting in different .to_pandas() calls -> but complete needs to know start/end -> awkward!
Who actually uses a mix of ids and external ids anyway, grumble grumble :P