### PR TITLE
fix typo, unify str fmt, flake8, whitespace

### DIFF
--- a/cognite/client/_api/datapoints.py
+++ b/cognite/client/_api/datapoints.py
@@ -1118,9 +1118,9 @@ class DatapointsFetcher:
             return {item_type: item}
         elif isinstance(item, Dict):
             for key in item:
-                if not key in [item_type, "aggregates"]:
+                if key not in [item_type, "aggregates"]:
                     raise ValueError("Unknown key '{}' in {} dict argument".format(key, item_type))
-            if not item_type in item:
+            if item_type not in item:
                 raise ValueError(
                     "When passing a dict to the {} argument, '{}' must be specified.".format(item_type, item_type)
                 )

--- a/cognite/client/_api/model_hosting/models.py
+++ b/cognite/client/_api/model_hosting/models.py
@@ -212,7 +212,7 @@ class ModelsAPI(APIClient):
             artifacts_directory (str, optional): Absolute path of directory containing artifacts.
             description (str, optional):  Description of model version
             metadata (Dict[str, Any], optional):  Metadata about model version
-            
+
         Returns:
             ModelVersion: The created model version.
         """

--- a/cognite/client/_api/three_d.py
+++ b/cognite/client/_api/three_d.py
@@ -1,4 +1,3 @@
-import json
 from typing import *
 
 from cognite.client import utils
@@ -139,7 +138,7 @@ class ThreeDModelsAPI(APIClient):
         self, item: Union[ThreeDModel, ThreeDModelUpdate, List[Union[ThreeDModel, ThreeDModelList]]]
     ) -> Union[ThreeDModel, ThreeDModelList]:
         """Update 3d models.
-        
+
         Args:
             item (Union[ThreeDModel, ThreeDModelUpdate, List[Union[ThreeDModel, ThreeDModelUpdate]]]): ThreeDModel(s) to update
 
@@ -304,7 +303,7 @@ class ThreeDRevisionsAPI(APIClient):
 
         Returns:
             Union[ThreeDModelRevision, ThreeDModelRevisionList]: Updated ThreeDModelRevision(s)
-            
+
         Examples:
 
             Update a revision that you have fetched. This will perform a full update of the revision::
@@ -425,7 +424,7 @@ class ThreeDRevisionsAPI(APIClient):
 
         Returns:
             ThreeDNodeList: The list of 3d nodes.
-            
+
         Example:
 
             Get a list of ancestor nodes of a given node::

--- a/cognite/client/_api_client.py
+++ b/cognite/client/_api_client.py
@@ -636,7 +636,7 @@ class APIClient:
             error_details["duplicated"] = duplicated
         error_details["headers"] = res.request.headers.copy()
         APIClient._sanitize_headers(error_details["headers"])
-        log.debug("HTTP Error {} {} {}: {}".format(code, res.request.method, res.request.url, msg, extra=error_details))
+        log.debug("HTTP Error {} {} {}: {}".format(code, res.request.method, res.request.url, msg), extra=error_details)
         raise CogniteAPIError(msg, code, x_request_id, missing=missing, duplicated=duplicated, extra=extra)
 
     @staticmethod

--- a/cognite/client/_api_client.py
+++ b/cognite/client/_api_client.py
@@ -304,7 +304,7 @@ class APIClient:
                 body = {"filter": filter, "limit": current_limit, "cursor": next_cursor, **(other_params or {})}
                 res = self._post(url_path=resource_path + "/list", json=body, headers=headers)
             else:
-                raise ValueError("_list_generator parameter `method` must be GET or POST, not %s", method)
+                raise ValueError("_list_generator parameter `method` must be GET or POST, not {}".format(method))
             last_received_items = res.json()["items"]
             total_items_retrieved += len(last_received_items)
 
@@ -624,7 +624,7 @@ class APIClient:
                         extra[k] = v
             else:
                 msg = res.content
-        except:
+        except Exception:
             msg = res.content
 
         error_details = {"X-Request-ID": x_request_id}
@@ -636,7 +636,7 @@ class APIClient:
             error_details["duplicated"] = duplicated
         error_details["headers"] = res.request.headers.copy()
         APIClient._sanitize_headers(error_details["headers"])
-        log.debug("HTTP Error %s %s %s: %s", code, res.request.method, res.request.url, msg, extra=error_details)
+        log.debug("HTTP Error {} {} {}: {}".format(code, res.request.method, res.request.url, msg, extra=error_details))
         raise CogniteAPIError(msg, code, x_request_id, missing=missing, duplicated=duplicated, extra=extra)
 
     @staticmethod

--- a/cognite/client/data_classes/__init__.py
+++ b/cognite/client/data_classes/__init__.py
@@ -16,7 +16,7 @@ from cognite.client.data_classes.iam import (
 )
 from cognite.client.data_classes.login import LoginStatus
 from cognite.client.data_classes.raw import Database, DatabaseList, Row, RowList, Table, TableList
-from cognite.client.data_classes.relationships import Relationship, RelationshipList, RelationshipFilter
+from cognite.client.data_classes.relationships import Relationship, RelationshipFilter, RelationshipList
 from cognite.client.data_classes.sequences import Sequence, SequenceData, SequenceFilter, SequenceList, SequenceUpdate
 from cognite.client.data_classes.three_d import (
     ThreeDAssetMapping,

--- a/cognite/client/data_classes/_base.py
+++ b/cognite/client/data_classes/_base.py
@@ -1,4 +1,3 @@
-import functools
 import json
 from collections import UserList
 from typing import *

--- a/cognite/client/data_classes/login.py
+++ b/cognite/client/data_classes/login.py
@@ -1,5 +1,3 @@
-from typing import *
-
 from cognite.client.data_classes._base import CogniteResponse
 
 

--- a/cognite/client/data_classes/sequences.py
+++ b/cognite/client/data_classes/sequences.py
@@ -243,7 +243,7 @@ class SequenceData:
         """
         try:
             ix = self.column_external_ids.index(external_id)
-        except ValueError as e:
+        except ValueError:
             raise ValueError(
                 "Column {} not found, Sequence column external ids are {}".format(external_id, self.column_external_ids)
             )

--- a/cognite/client/utils/_client_config.py
+++ b/cognite/client/utils/_client_config.py
@@ -1,8 +1,6 @@
-import json
 import os
 import pprint
 import sys
-import warnings
 from typing import *
 
 from requests.exceptions import ConnectionError

--- a/tests/tests_integration/test_api/test_events.py
+++ b/tests/tests_integration/test_api/test_events.py
@@ -1,4 +1,3 @@
-import time
 from datetime import datetime
 from unittest import mock
 
@@ -7,7 +6,6 @@ import pytest
 import cognite.client.utils._time
 from cognite.client import CogniteClient, utils
 from cognite.client.data_classes import Event, EventFilter, EventUpdate
-from cognite.client.exceptions import CogniteAPIError
 from tests.utils import set_request_limit
 
 COGNITE_CLIENT = CogniteClient()

--- a/tests/tests_integration/test_api/test_files.py
+++ b/tests/tests_integration/test_api/test_files.py
@@ -33,7 +33,7 @@ class TestFilesAPI:
     def test_create(self):
         file_metadata = FileMetadata(name="mytestfile")
         returned_file_metadata, upload_url = COGNITE_CLIENT.files.create(file_metadata)
-        assert False == returned_file_metadata.uploaded
+        assert returned_file_metadata.uploaded is False
         COGNITE_CLIENT.files.delete(id=returned_file_metadata.id)
 
     def test_retrieve(self):

--- a/tests/tests_integration/test_api/test_iam.py
+++ b/tests/tests_integration/test_api/test_iam.py
@@ -1,5 +1,3 @@
-import time
-
 import pytest
 
 from cognite.client import CogniteClient

--- a/tests/tests_integration/test_api/test_model_hosting/test_schedules.py
+++ b/tests/tests_integration/test_api/test_model_hosting/test_schedules.py
@@ -1,5 +1,3 @@
-from unittest import mock
-
 import pytest
 
 from cognite.client.data_classes.model_hosting.schedules import Schedule, ScheduleList, ScheduleLog

--- a/tests/tests_integration/test_api/test_raw.py
+++ b/tests/tests_integration/test_api/test_raw.py
@@ -1,5 +1,3 @@
-import time
-
 import pytest
 
 from cognite.client import CogniteClient, utils
@@ -37,7 +35,7 @@ class TestRawTablesAPI:
         table = COGNITE_CLIENT.raw.tables.create(db.name, table_name)
         assert table in COGNITE_CLIENT.raw.tables.list(db.name)
         COGNITE_CLIENT.raw.tables.delete(db.name, table.name)
-        assert not table in COGNITE_CLIENT.raw.tables.list(db.name)
+        assert table not in COGNITE_CLIENT.raw.tables.list(db.name)
 
 
 class TestRawRowsAPI:

--- a/tests/tests_integration/test_api/test_sequences.py
+++ b/tests/tests_integration/test_api/test_sequences.py
@@ -1,11 +1,9 @@
-import time
 from unittest import mock
 
 import pytest
 
-from cognite.client import CogniteClient, utils
+from cognite.client import CogniteClient
 from cognite.client.data_classes import Sequence, SequenceFilter, SequenceUpdate
-from cognite.client.exceptions import CogniteAPIError
 from tests.utils import set_request_limit
 
 COGNITE_CLIENT = CogniteClient()

--- a/tests/tests_integration/test_api/test_sequences_data.py
+++ b/tests/tests_integration/test_api/test_sequences_data.py
@@ -158,7 +158,7 @@ class TestSequencesDataAPI:
             dps.get_column("missingcol")
 
     def test_retrieve_paginate_end_coinciding_with_page(self, string200, post_spy):
-        _ = COGNITE_CLIENT.sequences.data.retrieve(start=1, end=118, id=string200.id)
+        COGNITE_CLIENT.sequences.data.retrieve(start=1, end=118, id=string200.id)
         assert 1 == COGNITE_CLIENT.sequences.data._post.call_count
 
     def test_delete_range(self, new_seq_long):
@@ -167,7 +167,7 @@ class TestSequencesDataAPI:
             column_external_ids=new_seq_long.column_external_ids, rows=data, id=new_seq_long.id
         )
         COGNITE_CLIENT.sequences.data.delete_range(start=4, end=15, id=new_seq_long.id)
-        dps = COGNITE_CLIENT.sequences.data.retrieve(start=0, end=None, id=new_seq_long.id)  # noqa F841
+        dps = COGNITE_CLIENT.sequences.data.retrieve(start=0, end=None, id=new_seq_long.id)
         # potential delay, so can't assert, but tested in notebook
         # assert [10, 20, 30, 210, 340] == [d[0] for d in dps.values]
         # assert [1, 2, 3, 21, 34] == dps.row_numbers

--- a/tests/tests_integration/test_api/test_sequences_data.py
+++ b/tests/tests_integration/test_api/test_sequences_data.py
@@ -1,14 +1,10 @@
-import re
-from datetime import datetime, timedelta
 from unittest import mock
 
 import numpy as np
-import pandas as pd
 import pytest
 
-from cognite.client import CogniteClient, utils
+from cognite.client import CogniteClient
 from cognite.client.data_classes import Sequence, SequenceData
-from tests.utils import set_request_limit
 
 COGNITE_CLIENT = CogniteClient()
 
@@ -162,7 +158,7 @@ class TestSequencesDataAPI:
             dps.get_column("missingcol")
 
     def test_retrieve_paginate_end_coinciding_with_page(self, string200, post_spy):
-        data = COGNITE_CLIENT.sequences.data.retrieve(start=1, end=118, id=string200.id)
+        _ = COGNITE_CLIENT.sequences.data.retrieve(start=1, end=118, id=string200.id)
         assert 1 == COGNITE_CLIENT.sequences.data._post.call_count
 
     def test_delete_range(self, new_seq_long):
@@ -171,7 +167,7 @@ class TestSequencesDataAPI:
             column_external_ids=new_seq_long.column_external_ids, rows=data, id=new_seq_long.id
         )
         COGNITE_CLIENT.sequences.data.delete_range(start=4, end=15, id=new_seq_long.id)
-        dps = COGNITE_CLIENT.sequences.data.retrieve(start=0, end=None, id=new_seq_long.id)
+        dps = COGNITE_CLIENT.sequences.data.retrieve(start=0, end=None, id=new_seq_long.id)  # noqa F841
         # potential delay, so can't assert, but tested in notebook
         # assert [10, 20, 30, 210, 340] == [d[0] for d in dps.values]
         # assert [1, 2, 3, 21, 34] == dps.row_numbers

--- a/tests/tests_integration/test_api/test_three_d.py
+++ b/tests/tests_integration/test_api/test_three_d.py
@@ -2,8 +2,6 @@ import pytest
 
 from cognite.client import CogniteClient
 from cognite.client.data_classes import (
-    ThreeDAssetMapping,
-    ThreeDModelRevision,
     ThreeDModelRevisionUpdate,
     ThreeDModelUpdate,
 )

--- a/tests/tests_integration/test_api/test_three_d.py
+++ b/tests/tests_integration/test_api/test_three_d.py
@@ -1,10 +1,7 @@
 import pytest
 
 from cognite.client import CogniteClient
-from cognite.client.data_classes import (
-    ThreeDModelRevisionUpdate,
-    ThreeDModelUpdate,
-)
+from cognite.client.data_classes import ThreeDModelRevisionUpdate, ThreeDModelUpdate
 
 COGNITE_CLIENT = CogniteClient()
 

--- a/tests/tests_integration/test_api/test_time_series.py
+++ b/tests/tests_integration/test_api/test_time_series.py
@@ -1,11 +1,9 @@
-import time
 from unittest import mock
 
 import pytest
 
-from cognite.client import CogniteClient, utils
+from cognite.client import CogniteClient
 from cognite.client.data_classes import TimeSeries, TimeSeriesFilter, TimeSeriesUpdate
-from cognite.client.exceptions import CogniteAPIError
 from tests.utils import set_request_limit
 
 COGNITE_CLIENT = CogniteClient()

--- a/tests/tests_unit/test_api/test_assets.py
+++ b/tests/tests_unit/test_api/test_assets.py
@@ -107,11 +107,11 @@ class TestAssets:
         assert mock_assets_response.calls[0].response.json()["items"] == res.dump(camel_case=True)
 
     def test_list_with_aggregated_properties_param(self, mock_assets_response):
-        _ = ASSETS_API.list(name="bla", aggregated_properties=["childCount"])
+        ASSETS_API.list(name="bla", aggregated_properties=["childCount"])
         assert ["childCount"] == jsgz_load(mock_assets_response.calls[0].request.body)["aggregatedProperties"]
 
     def test_list_with_aggregated_properties_param_when_snake_cased(self, mock_assets_response):
-        _ = ASSETS_API.list(name="bla", aggregated_properties=["child_count"])
+        ASSETS_API.list(name="bla", aggregated_properties=["child_count"])
         assert ["childCount"] == jsgz_load(mock_assets_response.calls[0].request.body)["aggregatedProperties"]
 
     def test_list_root(self, mock_assets_response):

--- a/tests/tests_unit/test_api/test_assets.py
+++ b/tests/tests_unit/test_api/test_assets.py
@@ -10,7 +10,7 @@ from cognite.client import CogniteClient
 from cognite.client._api.assets import Asset, AssetList, AssetUpdate, _AssetPoster, _AssetPosterWorker
 from cognite.client.data_classes import AssetFilter
 from cognite.client.exceptions import CogniteAPIError
-from tests.utils import jsgz_load, profilectx, set_request_limit
+from tests.utils import jsgz_load, set_request_limit
 
 COGNITE_CLIENT = CogniteClient()
 ASSETS_API = COGNITE_CLIENT.assets
@@ -107,11 +107,11 @@ class TestAssets:
         assert mock_assets_response.calls[0].response.json()["items"] == res.dump(camel_case=True)
 
     def test_list_with_aggregated_properties_param(self, mock_assets_response):
-        res = ASSETS_API.list(name="bla", aggregated_properties=["childCount"])
+        _ = ASSETS_API.list(name="bla", aggregated_properties=["childCount"])
         assert ["childCount"] == jsgz_load(mock_assets_response.calls[0].request.body)["aggregatedProperties"]
 
     def test_list_with_aggregated_properties_param_when_snake_cased(self, mock_assets_response):
-        res = ASSETS_API.list(name="bla", aggregated_properties=["child_count"])
+        _ = ASSETS_API.list(name="bla", aggregated_properties=["child_count"])
         assert ["childCount"] == jsgz_load(mock_assets_response.calls[0].request.body)["aggregatedProperties"]
 
     def test_list_root(self, mock_assets_response):

--- a/tests/tests_unit/test_api/test_datapoints.py
+++ b/tests/tests_unit/test_api/test_datapoints.py
@@ -1,11 +1,9 @@
 import json
 import math
-from contextlib import contextmanager
 from datetime import datetime
-from random import choice, random
+from random import random
 from typing import List
 from unittest import mock
-from unittest.mock import PropertyMock
 
 import pytest
 
@@ -411,8 +409,8 @@ class TestGetDatapoints:
     def test_retrieve_datapoints_empty_extrafields_set(self, mock_get_datapoints_empty):
         res = DPS_CLIENT.retrieve(id=1, start=0, end=10000)
         assert "kPa" == res.unit
-        assert False == res.is_step
-        assert False == res.is_string
+        assert res.is_step is False
+        assert res.is_string is False
 
     def test_aggregate_limits_correct(self, mock_get_datapoints):
         DPS_CLIENT.retrieve(id={"id": 1, "aggregates": ["average"]}, start=0, end=10, granularity="1d")
@@ -787,8 +785,8 @@ class TestDatapointsObject:
         assert [1, 2] == res.timestamp
         assert [1, 2] == res.value
         assert "kPa" == res.unit
-        assert False == res.is_step
-        assert False == res.is_string
+        assert res.is_step is False
+        assert res.is_string is False
 
     def test_load_string(self):
         res = Datapoints._load(
@@ -803,7 +801,7 @@ class TestDatapointsObject:
         assert "1" == res.external_id
         assert [1, 2] == res.timestamp
         assert [1, 2] == res.value
-        assert True == res.is_string
+        assert res.is_string is True
         assert res.is_step is None
         assert res.unit is None
 
@@ -822,21 +820,21 @@ class TestDatapointsObject:
         assert [1, 2, 3] == d0.value
         assert 1 == d0.id
         assert "1" == d0.external_id
-        assert d0.sum == None
+        assert d0.sum is None
 
         d0._extend(d2)
         assert [1, 2, 3, 4, 5, 6] == d0.value
         assert [1, 2, 3, 4, 5, 6] == d0.timestamp
         assert 1 == d0.id
         assert "1" == d0.external_id
-        assert d0.sum == None
+        assert d0.sum is None
 
         d0._extend(d3)
         assert [1, 2, 3, 4, 5, 6, 7, 8, 9, 10] == d0.timestamp
         assert [1, 2, 3, 4, 5, 6, 7, 8, 9, 10] == d0.value
         assert 1 == d0.id
         assert "1" == d0.external_id
-        assert d0.sum == None
+        assert d0.sum is None
 
 
 @pytest.mark.dsl
@@ -947,7 +945,7 @@ class TestPandasIntegration:
         )
         pd.testing.assert_frame_equal(expected_df, dps_list.to_pandas())
         with pytest.raises(CogniteDuplicateColumnsError):
-            df = dps_list.to_pandas(include_aggregate_name=False)
+            _ = dps_list.to_pandas(include_aggregate_name=False)
 
     def test_datapoints_list_non_aligned(self):
         import pandas as pd
@@ -999,8 +997,6 @@ class TestPandasIntegration:
         pd.testing.assert_frame_equal(df, expected_df)
 
     def test_retrieve_datapoints_last_beyond_end(self, mock_get_datapoints_include_outside):
-        import pandas as pd
-
         dpt = DPS_CLIENT.retrieve(id=1, include_outside_points=True, start=1000000000, end=1000000000 + 100000)
         assert 100001 == len(dpt)
 
@@ -1070,8 +1066,6 @@ class TestPandasIntegration:
         pd.testing.assert_frame_equal(df, expected_df)
 
     def test_retrieve_dataframe_dict_empty(self, mock_get_datapoints_empty):
-        import pandas as pd
-
         dfd = DPS_CLIENT.retrieve_dataframe_dict(
             id=1,
             aggregates=["count", "interpolation", "stepInterpolation", "totalVariation"],
@@ -1083,8 +1077,6 @@ class TestPandasIntegration:
         assert 4 == len(dfd)
 
     def test_retrieve_dataframe_dict_empty_single_aggregate(self, mock_get_datapoints_empty):
-        import pandas as pd
-
         dfd = DPS_CLIENT.retrieve_dataframe_dict(id=1, aggregates=["count"], start=0, end=1, granularity="1s")
         assert isinstance(dfd, dict)
         assert ["count"] == list(dfd.keys())
@@ -1284,7 +1276,7 @@ def mock_get_dps_count(rsps):
     def request_callback(request):
         payload = jsgz_load(request.body)
         granularity = payload["granularity"]
-        aggregates = payload["aggregates"]
+        # aggregates = payload["aggregates"]  # TODO: Unused
         start = payload["start"]
         end = payload["end"]
 
@@ -1330,7 +1322,7 @@ class TestDataPoster:
         assert not bin.will_fit(1)
 
 
-gms = lambda s: utils._time.granularity_to_ms(s)
+gms = utils._time.granularity_to_ms
 
 
 class TestDataFetcher:

--- a/tests/tests_unit/test_api/test_datapoints.py
+++ b/tests/tests_unit/test_api/test_datapoints.py
@@ -945,7 +945,7 @@ class TestPandasIntegration:
         )
         pd.testing.assert_frame_equal(expected_df, dps_list.to_pandas())
         with pytest.raises(CogniteDuplicateColumnsError):
-            _ = dps_list.to_pandas(include_aggregate_name=False)
+            dps_list.to_pandas(include_aggregate_name=False)
 
     def test_datapoints_list_non_aligned(self):
         import pandas as pd
@@ -1276,7 +1276,6 @@ def mock_get_dps_count(rsps):
     def request_callback(request):
         payload = jsgz_load(request.body)
         granularity = payload["granularity"]
-        # aggregates = payload["aggregates"]  # TODO: Unused
         start = payload["start"]
         end = payload["end"]
 

--- a/tests/tests_unit/test_api/test_files.py
+++ b/tests/tests_unit/test_api/test_files.py
@@ -129,7 +129,6 @@ def mock_file_download_response_one_fails(rsps):
 
     def download_link_callback(request):
         identifier = jsgz_load(request.body)["items"][0]
-        response = {}
         if "id" in identifier:
             return 200, {}, json.dumps({"items": [{"id": 1, "downloadUrl": "https://download.file1.here"}]})
         elif "externalId" in identifier:

--- a/tests/tests_unit/test_api/test_relationships.py
+++ b/tests/tests_unit/test_api/test_relationships.py
@@ -128,7 +128,7 @@ class TestRelationships:
 
     def test_create_wrong_type(self, mock_rel_response):
         with pytest.raises(ValueError):
-            _ = REL_API.create(
+            REL_API.create(
                 Relationship(
                     external_id="1",
                     confidence=0.5,

--- a/tests/tests_unit/test_api/test_relationships.py
+++ b/tests/tests_unit/test_api/test_relationships.py
@@ -1,9 +1,6 @@
 import gzip
 import json
-import math
-import os
 import re
-from unittest import mock
 
 import pytest
 
@@ -131,7 +128,7 @@ class TestRelationships:
 
     def test_create_wrong_type(self, mock_rel_response):
         with pytest.raises(ValueError):
-            res = REL_API.create(
+            _ = REL_API.create(
                 Relationship(
                     external_id="1",
                     confidence=0.5,

--- a/tests/tests_unit/test_api/test_sequences.py
+++ b/tests/tests_unit/test_api/test_sequences.py
@@ -1,8 +1,4 @@
-import json
-import math
-import os
 import re
-from unittest import mock
 
 import pytest
 
@@ -394,9 +390,9 @@ class TestSequences:
         assert isinstance(col, list)
         assert 1 == len(col)
         with pytest.raises(TypeError):
-            sliced = data[1:23]
+            _ = data[1:23]
         with pytest.raises(ValueError):
-            missingcol = data.get_column("doesnotexist")
+            _ = data.get_column("doesnotexist")
 
     def test_sequence_builtins(self, mock_seq_response):
         r1 = SEQ_API.retrieve(id=0)

--- a/tests/tests_unit/test_api/test_sequences.py
+++ b/tests/tests_unit/test_api/test_sequences.py
@@ -390,9 +390,9 @@ class TestSequences:
         assert isinstance(col, list)
         assert 1 == len(col)
         with pytest.raises(TypeError):
-            _ = data[1:23]
+            data[1:23]
         with pytest.raises(ValueError):
-            _ = data.get_column("doesnotexist")
+            data.get_column("doesnotexist")
 
     def test_sequence_builtins(self, mock_seq_response):
         r1 = SEQ_API.retrieve(id=0)

--- a/tests/tests_unit/test_api/test_signatures.py
+++ b/tests/tests_unit/test_api/test_signatures.py
@@ -1,6 +1,5 @@
 import inspect
 import json
-from typing import Dict
 
 import pytest
 

--- a/tests/tests_unit/test_api_client.py
+++ b/tests/tests_unit/test_api_client.py
@@ -410,7 +410,7 @@ class TestStandardList:
             rsps.POST, BASE_URL + URL_PATH + "/list", callback=request_callback, content_type="application/json"
         )
         with pytest.raises(CogniteAPIError) as exc:
-            _ = API_CLIENT_WITH_API_KEY._list(
+            API_CLIENT_WITH_API_KEY._list(
                 cls=SomeResourceList, resource_path=URL_PATH, method="POST", partitions=4, limit=None
             )
         assert 503 == exc.value.code
@@ -708,7 +708,7 @@ class TestStandardUpdate:
         assert {"items": [{"id": 1, "update": {"y": {"set": 100}}}]} == jsgz_load(mock_update.calls[0].request.body)
 
     def test_standard_update_with_cognite_resource__subject_to_camel_case_issue(self, mock_update):
-        _ = API_CLIENT_WITH_API_KEY._update_multiple(
+        API_CLIENT_WITH_API_KEY._update_multiple(
             cls=SomeResourceList, resource_path=URL_PATH, items=[SomeResource(id=1, external_id="abc", y=100)]
         )
         assert {"items": [{"id": 1, "update": {"y": {"set": 100}, "externalId": {"set": "abc"}}}]} == jsgz_load(

--- a/tests/tests_unit/test_api_client.py
+++ b/tests/tests_unit/test_api_client.py
@@ -410,7 +410,7 @@ class TestStandardList:
             rsps.POST, BASE_URL + URL_PATH + "/list", callback=request_callback, content_type="application/json"
         )
         with pytest.raises(CogniteAPIError) as exc:
-            res = API_CLIENT_WITH_API_KEY._list(
+            _ = API_CLIENT_WITH_API_KEY._list(
                 cls=SomeResourceList, resource_path=URL_PATH, method="POST", partitions=4, limit=None
             )
         assert 503 == exc.value.code
@@ -708,7 +708,7 @@ class TestStandardUpdate:
         assert {"items": [{"id": 1, "update": {"y": {"set": 100}}}]} == jsgz_load(mock_update.calls[0].request.body)
 
     def test_standard_update_with_cognite_resource__subject_to_camel_case_issue(self, mock_update):
-        res = API_CLIENT_WITH_API_KEY._update_multiple(
+        _ = API_CLIENT_WITH_API_KEY._update_multiple(
             cls=SomeResourceList, resource_path=URL_PATH, items=[SomeResource(id=1, external_id="abc", y=100)]
         )
         assert {"items": [{"id": 1, "update": {"y": {"set": 100}, "externalId": {"set": "abc"}}}]} == jsgz_load(

--- a/tests/tests_unit/test_cognite_client.py
+++ b/tests/tests_unit/test_cognite_client.py
@@ -208,7 +208,7 @@ class TestCogniteClient:
     @patch("cognite.client.utils._version_checker.requests")
     def test_verify_ssl_disabled(self, mock_requests, mock_findall):
         with set_env_var("COGNITE_DISABLE_SSL", "1"):
-            _ = CogniteClient()
+            CogniteClient()
             mock_requests.get.assert_called_with(_PYPI_ADDRESS, verify=False)
 
 

--- a/tests/tests_unit/test_cognite_client.py
+++ b/tests/tests_unit/test_cognite_client.py
@@ -201,14 +201,14 @@ class TestCogniteClient:
         c = CogniteClient()
 
         mock_requests.get.assert_called_with(_PYPI_ADDRESS, verify=True)
-        assert c._api_client._request_session.verify == True
-        assert c._api_client._request_session_with_retry.verify == True
+        assert c._api_client._request_session.verify is True
+        assert c._api_client._request_session_with_retry.verify is True
 
     @patch("cognite.client.utils._version_checker.re.findall")
     @patch("cognite.client.utils._version_checker.requests")
     def test_verify_ssl_disabled(self, mock_requests, mock_findall):
         with set_env_var("COGNITE_DISABLE_SSL", "1"):
-            c = CogniteClient()
+            _ = CogniteClient()
             mock_requests.get.assert_called_with(_PYPI_ADDRESS, verify=False)
 
 

--- a/tests/tests_unit/test_data_classes/test_assets.py
+++ b/tests/tests_unit/test_data_classes/test_assets.py
@@ -3,14 +3,7 @@ from unittest.mock import call
 
 import pytest
 
-from cognite.client.data_classes import (
-    Asset,
-    AssetList,
-    Event,
-    EventList,
-    FileMetadata,
-    FileMetadataList,
-)
+from cognite.client.data_classes import Asset, AssetList, Event, EventList, FileMetadata, FileMetadataList
 from cognite.client.experimental import CogniteClient
 
 c = CogniteClient()

--- a/tests/tests_unit/test_data_classes/test_assets.py
+++ b/tests/tests_unit/test_data_classes/test_assets.py
@@ -10,8 +10,6 @@ from cognite.client.data_classes import (
     EventList,
     FileMetadata,
     FileMetadataList,
-    Sequence,
-    SequenceList,
 )
 from cognite.client.experimental import CogniteClient
 

--- a/tests/tests_unit/test_docstring_examples.py
+++ b/tests/tests_unit/test_docstring_examples.py
@@ -1,5 +1,5 @@
 import doctest
-from unittest import TextTestRunner, mock
+from unittest import TextTestRunner
 
 import pytest
 

--- a/tests/tests_unit/test_utils/test_auxiliary.py
+++ b/tests/tests_unit/test_utils/test_auxiliary.py
@@ -1,10 +1,8 @@
 import json
-from datetime import datetime
 from decimal import Decimal
 
 import pytest
 
-import cognite.client.utils._time
 from cognite.client import utils
 from cognite.client.exceptions import CogniteImportError
 
@@ -30,7 +28,8 @@ class TestLocalImport:
 
     @pytest.mark.dsl
     def test_local_import_multiple_ok(self):
-        import pandas, numpy
+        import pandas
+        import numpy
 
         assert (pandas, numpy) == utils._auxiliary.local_import("pandas", "numpy")
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -5,8 +5,6 @@ import json
 import os
 from contextlib import contextmanager
 from typing import List, Union
-from unittest import mock
-from unittest.mock import PropertyMock
 
 BASE_URL = "https://greenfield.cognitedata.com"
 


### PR DESCRIPTION
Initially; wanted to fix a typo, then the ball started rolling..^^ If any of the "stylistic" changes are unwanted, I'll remove them.

Regarding comparison to `False` or `True`. Do we need this or is it sufficient to use `assert some_value / assert not some_value`?