### PR TITLE
Fix issue with trailing slashes in base url for login endpoint

### DIFF
--- a/cognite/client/_api_client.py
+++ b/cognite/client/_api_client.py
@@ -164,7 +164,7 @@ class APIClient:
     def _resolve_url(self, method: str, url_path: str):
         if not url_path.startswith("/"):
             raise ValueError("URL path must start with '/'")
-        base_url = self._get_base_url_with_base_path()
+        base_url = self._get_base_url_with_base_path().rstrip("/")
         full_url = base_url + url_path
         is_retryable = self._is_retryable(method, full_url)
         # Hack to allow running model hosting requests against local emulator

--- a/cognite/client/_api_client.py
+++ b/cognite/client/_api_client.py
@@ -164,7 +164,7 @@ class APIClient:
     def _resolve_url(self, method: str, url_path: str):
         if not url_path.startswith("/"):
             raise ValueError("URL path must start with '/'")
-        base_url = self._get_base_url_with_base_path().rstrip("/")
+        base_url = self._get_base_url_with_base_path()
         full_url = base_url + url_path
         is_retryable = self._is_retryable(method, full_url)
         # Hack to allow running model hosting requests against local emulator

--- a/cognite/client/utils/_client_config.py
+++ b/cognite/client/utils/_client_config.py
@@ -70,7 +70,7 @@ class ClientConfig(_DefaultConfig):
         self.api_key = api_key or self.api_key
         self.project = project or self.project
         self.client_name = client_name or self.client_name
-        self.base_url = base_url or self.base_url
+        self.base_url = base_url.rstrip("/") if base_url is not None else self.base_url
         self.max_workers = max_workers or self.max_workers
         self.headers = headers or self.headers
         self.timeout = timeout or self.timeout

--- a/cognite/client/utils/_client_config.py
+++ b/cognite/client/utils/_client_config.py
@@ -70,7 +70,7 @@ class ClientConfig(_DefaultConfig):
         self.api_key = api_key or self.api_key
         self.project = project or self.project
         self.client_name = client_name or self.client_name
-        self.base_url = base_url.rstrip("/") if base_url is not None else self.base_url
+        self.base_url = (base_url or self.base_url).rstrip("/")
         self.max_workers = max_workers or self.max_workers
         self.headers = headers or self.headers
         self.timeout = timeout or self.timeout


### PR DESCRIPTION
When a client is configured with a trailing slash in the base url, the login endpoint was breaking due to the `urljoin` in `_get_base_url_with_base_path` joining with an empty string, leaving the trailing slash behind.