### PR TITLE
Make disable_pypi_version_check configurable from client creation

### DIFF
--- a/cognite/client/_cognite_client.py
+++ b/cognite/client/_cognite_client.py
@@ -1,5 +1,5 @@
 import warnings
-from typing import Any, Callable, Dict, Union
+from typing import Any, Callable, Dict, Optional, Union
 
 from cognite.client import utils
 from cognite.client._api.assets import AssetsAPI
@@ -49,7 +49,7 @@ class CogniteClient:
         headers: Dict[str, str] = None,
         timeout: int = None,
         token: Union[str, Callable[[], str], None] = None,
-        disable_pypi_version_check: bool = None,
+        disable_pypi_version_check: Optional[bool] = None,
         debug: bool = False,
     ):
         self._config = ClientConfig(

--- a/cognite/client/_cognite_client.py
+++ b/cognite/client/_cognite_client.py
@@ -33,6 +33,7 @@ class CogniteClient:
         timeout (int): Timeout on requests sent to the api. Defaults to 30 seconds.
         token (Union[str, Callable[[], str]]): A jwt or method which takes no arguments and returns a jwt to use for authentication.
             This will override any api-key set.
+        disable_pypi_version_check (bool): Don't check for newer versions of the SDK on client creation
         debug (bool): Configures logger to log extra request details to stderr.
     """
 
@@ -48,6 +49,7 @@ class CogniteClient:
         headers: Dict[str, str] = None,
         timeout: int = None,
         token: Union[str, Callable[[], str], None] = None,
+        disable_pypi_version_check: bool = None,
         debug: bool = False,
     ):
         self._config = ClientConfig(
@@ -59,6 +61,7 @@ class CogniteClient:
             headers=headers,
             timeout=timeout,
             token=token,
+            disable_pypi_version_check=disable_pypi_version_check,
             debug=debug,
         )
         self.login = LoginAPI(self._config, cognite_client=self)

--- a/cognite/client/utils/_client_config.py
+++ b/cognite/client/utils/_client_config.py
@@ -76,7 +76,9 @@ class ClientConfig(_DefaultConfig):
         self.headers = headers or self.headers
         self.timeout = timeout or self.timeout
         self.token = token
-        self.disable_pypi_version_check = disable_pypi_version_check if disable_pypi_version_check is not None else self.disable_pypi_version_check
+        self.disable_pypi_version_check = (
+            disable_pypi_version_check if disable_pypi_version_check is not None else self.disable_pypi_version_check
+        )
 
         if self.api_key is None and self.token is None:
             raise CogniteAPIKeyError("No API key or token has been specified")

--- a/cognite/client/utils/_client_config.py
+++ b/cognite/client/utils/_client_config.py
@@ -63,6 +63,7 @@ class ClientConfig(_DefaultConfig):
         headers: Dict[str, str] = None,
         timeout: int = None,
         token: Union[Callable[[], str], str] = None,
+        disable_pypi_version_check: bool = None,
         debug: bool = False,
     ):
         super().__init__()
@@ -75,6 +76,7 @@ class ClientConfig(_DefaultConfig):
         self.headers = headers or self.headers
         self.timeout = timeout or self.timeout
         self.token = token
+        self.disable_pypi_version_check = disable_pypi_version_check or self.disable_pypi_version_check
 
         if self.api_key is None and self.token is None:
             raise CogniteAPIKeyError("No API key or token has been specified")

--- a/cognite/client/utils/_client_config.py
+++ b/cognite/client/utils/_client_config.py
@@ -76,7 +76,7 @@ class ClientConfig(_DefaultConfig):
         self.headers = headers or self.headers
         self.timeout = timeout or self.timeout
         self.token = token
-        self.disable_pypi_version_check = disable_pypi_version_check or self.disable_pypi_version_check
+        self.disable_pypi_version_check = disable_pypi_version_check if disable_pypi_version_check is not None else self.disable_pypi_version_check
 
         if self.api_key is None and self.token is None:
             raise CogniteAPIKeyError("No API key or token has been specified")

--- a/cognite/client/utils/_client_config.py
+++ b/cognite/client/utils/_client_config.py
@@ -63,7 +63,7 @@ class ClientConfig(_DefaultConfig):
         headers: Dict[str, str] = None,
         timeout: int = None,
         token: Union[Callable[[], str], str] = None,
-        disable_pypi_version_check: bool = None,
+        disable_pypi_version_check: Optional[bool] = None,
         debug: bool = False,
     ):
         super().__init__()

--- a/tests/tests_unit/test_cognite_client.py
+++ b/tests/tests_unit/test_cognite_client.py
@@ -181,11 +181,19 @@ class TestCogniteClient:
         log.handlers = []
         log.propagate = False
 
-    def test_version_check_disabled(self, rsps_with_login_mock):
+    def test_version_check_disabled_env(self, rsps_with_login_mock):
         rsps_with_login_mock.assert_all_requests_are_fired = False
         with unset_env_var("COGNITE_PROJECT"):
             with set_env_var("COGNITE_DISABLE_PYPI_VERSION_CHECK", "1"):
                 CogniteClient()
+        assert len(rsps_with_login_mock.calls) == 1
+        assert rsps_with_login_mock.calls[0].request.url.startswith("https://greenfield.cognitedata.com")
+
+    def test_version_check_disabled_arg(self, rsps_with_login_mock):
+        rsps_with_login_mock.assert_all_requests_are_fired = False
+        with unset_env_var("COGNITE_PROJECT"):
+            with unset_env_var("COGNITE_DISABLE_PYPI_VERSION_CHECK"):
+                CogniteClient(disable_pypi_version_check=True)
         assert len(rsps_with_login_mock.calls) == 1
         assert rsps_with_login_mock.calls[0].request.url.startswith("https://greenfield.cognitedata.com")
 


### PR DESCRIPTION
Add an option to turn off the version check from an argument to init