### PR TITLE
Run tox on Python 3.8 as well

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -10,7 +10,7 @@ podTemplate(
     ],
     containers: [
         containerTemplate(name: 'python',
-            image: 'eu.gcr.io/cognitedata/multi-python:7040fac',
+            image: 'eu.gcr.io/cognitedata/multi-python:2019-10-18T1122-3e874f7',
             command: '/bin/cat -',
             resourceRequestCpu: '1000m',
             resourceRequestMemory: '800Mi',
@@ -86,7 +86,7 @@ podTemplate(
                 sh('pipenv run pytest openapi/tests')
             }
             stage('Test Client') {
-                sh("pyenv local 3.5.0 3.6.6 3.7.2")
+                sh("pyenv local 3.5.0 3.6.6 3.7.4 3.8.0")
                 sh("pipenv run tox -p auto")
                 junit(allowEmptyResults: true, testResults: '**/test-report.xml')
                 summarizeTestResults()

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 # content of: tox.ini , put in same dir as setup.py
 [tox]
-envlist = py35,py36,py37
+envlist = py35,py36,py37,py38
 
 [testenv]
 # install pytest in the virtualenv where commands will be executed


### PR DESCRIPTION
Change the python docker image for Jenkins, and added Python 3.8.0 to tox.

Signed-off-by: Even Wiik Thomassen <even.thomassen@cognite.com>