### PR TITLE
insert dataframe fix for older pandas / release 1.4.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,8 +21,11 @@ Changes are grouped as follows
 
 ## Unreleased
 
+## [1.4.9] - 2019-12-19
+
 ### Fixed
 - Fixed a bug where datapoints `retrieve` could return less than limit even if there were more datapoints. 
+- Fixed an issue where `insert_dataframe` would give an error with older pandas versions.
 
 ## [1.4.8] - 2019-12-19
 

--- a/cognite/client/__init__.py
+++ b/cognite/client/__init__.py
@@ -1,3 +1,3 @@
 from cognite.client._cognite_client import CogniteClient
 
-__version__ = "1.4.8"
+__version__ = "1.4.9"

--- a/cognite/client/_api/datapoints.py
+++ b/cognite/client/_api/datapoints.py
@@ -641,7 +641,7 @@ class DatapointsAPI(APIClient):
         np = utils._auxiliary.local_import("numpy")
         assert not dataframe.isnull().values.any(), "Dataframe contains NaNs. Remove them in order to insert the data."
 
-        assert np.isfinite(dataframe.select_dtypes(include=[np.number])).all(
+        assert np.isfinite(dataframe.select_dtypes(include=[np.number])).values.all(
             axis=None
         ), "Dataframe contains Infinity. Remove them in order to insert the data."
         dps = []

--- a/tests/tests_unit/test_api/test_datapoints.py
+++ b/tests/tests_unit/test_api/test_datapoints.py
@@ -1260,6 +1260,14 @@ class TestPandasIntegration:
         with pytest.raises(AssertionError, match="contains NaNs"):
             DPS_CLIENT.insert_dataframe(df)
 
+    def test_insert_dataframe_single_dp(self, mock_post_datapoints):
+        import pandas as pd
+
+        timestamps = [1500000000000]
+        df = pd.DataFrame({"a": [1.0], "b": [2.0]}, index=[utils._time.ms_to_datetime(ms) for ms in timestamps])
+        res = DPS_CLIENT.insert_dataframe(df, external_id_headers=True)
+        assert res is None
+
     def test_insert_dataframe_with_infs(self):
         import pandas as pd
         import numpy as np


### PR DESCRIPTION
turns out the axis=None option in pandas is recent enough that people are running into errors. What pandas do we require/expect anyway?