### PR TITLE
Do not retry read timeouts for create/update/delete operations

### DIFF
--- a/cognite/client/_api_client.py
+++ b/cognite/client/_api_client.py
@@ -55,6 +55,7 @@ def _init_requests_session():
     adapter_with_retry = HTTPAdapter(
         max_retries=RetryWithMaxBackoff(
             total=config.max_retries,
+            read=0,
             backoff_factor=0.5,
             status_forcelist=config.status_forcelist,
             method_whitelist=False,

--- a/cognite/client/_api_client.py
+++ b/cognite/client/_api_client.py
@@ -45,6 +45,7 @@ def _init_requests_session():
     adapter = HTTPAdapter(
         max_retries=RetryWithMaxBackoff(
             total=config.max_retries,
+            read=0,
             backoff_factor=0.5,
             status_forcelist=[429],
             method_whitelist=False,
@@ -55,7 +56,6 @@ def _init_requests_session():
     adapter_with_retry = HTTPAdapter(
         max_retries=RetryWithMaxBackoff(
             total=config.max_retries,
-            read=0,
             backoff_factor=0.5,
             status_forcelist=config.status_forcelist,
             method_whitelist=False,


### PR DESCRIPTION
#624 introduced retrying read timeouts for "non-retryable" endpoints (create/update/delete). Should only retry connection timeouts and 429 for those.