### PR TITLE
datapoint insertion memory reduction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ Changes are grouped as follows
 
 ## Unreleased
 
+### Changed
+- Datapoint insertion changed to be less memory intensive.
 
 ## [1.4.10] - 2019-01-24
 ### Added


### PR DESCRIPTION
based on SAs running into issues on datapoint insertion. This is a simple fix that delays generating the json long form to just before posting, with around a 50% reduction in memory usage.