### PR TITLE
Timeseries asset helper function

### DIFF
--- a/cognite/client/data_classes/time_series.py
+++ b/cognite/client/data_classes/time_series.py
@@ -115,6 +115,16 @@ class TimeSeries(CogniteResource):
             return list(dps)[0]
         return None
 
+    def asset(self) -> "Asset":
+        """Returns this assets parent.
+
+        Returns:
+            Asset: The parent asset.
+        """
+        if self.asset_id is None:
+            raise ValueError("asset_id is None")
+        return self._cognite_client.assets.retrieve(id=self.asset_id)
+
 
 # GenClass: TimeSeriesSearchDTO.filter
 class TimeSeriesFilter(CogniteFilter):

--- a/cognite/client/data_classes/time_series.py
+++ b/cognite/client/data_classes/time_series.py
@@ -116,10 +116,10 @@ class TimeSeries(CogniteResource):
         return None
 
     def asset(self) -> "Asset":
-        """Returns this assets parent.
+        """Returns the asset this time series belongs to.
 
         Returns:
-            Asset: The parent asset.
+            Asset: The asset given by its `asset_id`.
         """
         if self.asset_id is None:
             raise ValueError("asset_id is None")


### PR DESCRIPTION
adding this after seeing someone type client.assets.retrieve( id = client.assets.retrieve(id =  time_series.asset_id).parent_id).metadata and seeing we have parent() but not asset()