### PR TITLE
Add more descriptive field documentation

### DIFF
--- a/cognite/client/_api/events.py
+++ b/cognite/client/_api/events.py
@@ -43,7 +43,7 @@ class EventsAPI(APIClient):
             type (str): Type of the event, e.g 'failure'.
             subtype (str): Subtype of the event, e.g 'electrical'.
             metadata (Dict[str, str]): Customizable extra data about the event. String key -> String value.
-            asset_ids (List[int]): Asset IDs of related equipments that this event relates to.
+            asset_ids (List[int]): Asset IDs of equipments that this event relates to.
             asset_external_ids (List[str]): Asset External IDs of related equipment that this event relates to.
             root_asset_ids (List[int]): The IDs of the root assets that the related assets should be children of.
             root_asset_external_ids (List[str]): The external IDs of the root assets that the related assets should be children of.
@@ -191,7 +191,7 @@ class EventsAPI(APIClient):
             type (str): Type of the event, e.g 'failure'.
             subtype (str): Subtype of the event, e.g 'electrical'.
             metadata (Dict[str, str]): Customizable extra data about the event. String key -> String value.
-            asset_ids (List[int]): Asset IDs of related equipments that this event relates to.
+            asset_ids (List[int]): Asset IDs of equipments that this event relates to.
             asset_external_ids (List[str]): Asset External IDs of related equipment that this event relates to.
             root_asset_ids (List[int]): The IDs of the root assets that the related assets should be children of.
             root_asset_external_ids (List[str]): The external IDs of the root assets that the related assets should be children of.

--- a/cognite/client/data_classes/assets.py
+++ b/cognite/client/data_classes/assets.py
@@ -35,15 +35,15 @@ class Asset(CogniteResource):
     Args:
         external_id (str): The external ID provided by the client. Must be unique for the resource type.
         name (str): The name of the asset.
-        parent_id (int): A server-generated ID for the object.
+        parent_id (int): The parent of the node, null if it is the root node.
         description (str): The description of the asset.
-        data_set_id (int): A server-generated ID for the object.
+        data_set_id (int): ID of the data set.
         metadata (Dict[str, str]): Custom, application specific metadata. String key -> String value. Limits: Maximum length of key is 32 bytes, value 512 bytes, up to 16 key-value pairs.
         source (str): The source of the asset.
         id (int): A server-generated ID for the object.
         created_time (int): The number of milliseconds since 00:00:00 Thursday, 1 January 1970, Coordinated Universal Time (UTC), minus leap seconds.
         last_updated_time (int): The number of milliseconds since 00:00:00 Thursday, 1 January 1970, Coordinated Universal Time (UTC), minus leap seconds.
-        root_id (int): A server-generated ID for the object.
+        root_id (int): ID of the root asset.
         aggregates (Union[Dict[str, Any], AggregateResultItem]): Aggregated metrics of the asset
         parent_external_id (str): The external ID of the parent. The property is omitted if the asset doesn't have a parent or if the parent doesn't have externalId.
         cognite_client (CogniteClient): The client to associate with this object.

--- a/cognite/client/data_classes/events.py
+++ b/cognite/client/data_classes/events.py
@@ -10,7 +10,7 @@ class Event(CogniteResource):
 
     Args:
         external_id (str): The external ID provided by the client. Must be unique for the resource type.
-        data_set_id (int): Data set that this Event belongs to
+        data_set_id (int): Data set that this Event belongs to.
         start_time (int): The number of milliseconds since 00:00:00 Thursday, 1 January 1970, Coordinated Universal Time (UTC), minus leap seconds.
         end_time (int): The number of milliseconds since 00:00:00 Thursday, 1 January 1970, Coordinated Universal Time (UTC), minus leap seconds.
         type (str): Type of the event, e.g 'failure'.
@@ -74,8 +74,8 @@ class EventFilter(CogniteFilter):
         asset_subtree_ids (List[Dict[str, Any]]): Only include events that have a related asset in a subtree rooted at any of these assetIds (including the roots given). If the total size of the given subtrees exceeds 100,000 assets, an error will be returned.
         data_set_ids (List[Dict[str, Any]]): Only include events that belong to these datasets.
         source (str): The source of this event.
-        type (str): The event type
-        subtype (str): The event subtype
+        type (str): The event type.
+        subtype (str): The event subtype.
         created_time (Union[Dict[str, Any], TimestampRange]): Range between two timestamps.
         last_updated_time (Union[Dict[str, Any], TimestampRange]): Range between two timestamps.
         external_id_prefix (str): Filter by this (case-sensitive) prefix for the external ID.

--- a/cognite/client/data_classes/events.py
+++ b/cognite/client/data_classes/events.py
@@ -10,7 +10,7 @@ class Event(CogniteResource):
 
     Args:
         external_id (str): The external ID provided by the client. Must be unique for the resource type.
-        data_set_id (int): A server-generated ID for the object.
+        data_set_id (int): Data set that this Event belongs to
         start_time (int): The number of milliseconds since 00:00:00 Thursday, 1 January 1970, Coordinated Universal Time (UTC), minus leap seconds.
         end_time (int): The number of milliseconds since 00:00:00 Thursday, 1 January 1970, Coordinated Universal Time (UTC), minus leap seconds.
         type (str): Type of the event, e.g 'failure'.

--- a/cognite/client/data_classes/time_series.py
+++ b/cognite/client/data_classes/time_series.py
@@ -16,7 +16,7 @@ class TimeSeries(CogniteResource):
         is_string (bool): Whether the time series is string valued or not.
         metadata (Dict[str, str]): Custom, application specific metadata. String key -> String value. Limits: Maximum length of key is 32 bytes, value 512 bytes, up to 16 key-value pairs.
         unit (str): The physical unit of the time series.
-        asset_id (int): A server-generated ID for the object.
+        asset_id (int): Asset ID of equipment linked to this time series.
         is_step (bool): Whether the time series is a step series or not.
         description (str): Description of the time series.
         security_categories (List[int]): The required security categories to access this time series.


### PR DESCRIPTION
TLDR: `A server-generated ID for the object` is not really a descriptive message. 