### PR TITLE
Update documentation of limit on __call__ functions.

### DIFF
--- a/cognite/client/_api/data_sets.py
+++ b/cognite/client/_api/data_sets.py
@@ -30,8 +30,7 @@ class DataSetsAPI(APIClient):
             last_updated_time (Union[Dict[str, Any], TimestampRange]): Range between two timestamps.
             external_id_prefix (str): Filter by this (case-sensitive) prefix for the external ID.
             write_protected (bool): Specify whether the filtered data sets are write-protected, or not. Set to True to only list write-protected data sets.
-            limit (int, optional): Maximum number of data sets to return. Defaults to 25. Set to -1, float("inf") or None
-                to return all items.
+            limit (int, optional): Maximum number of data sets to return. Defaults to return all items.
 
         Yields:
             Union[DataSet, DataSetList]: yields DataSet one by one if chunk is not specified, else DataSetList objects.

--- a/cognite/client/_api/events.py
+++ b/cognite/client/_api/events.py
@@ -56,7 +56,7 @@ class EventsAPI(APIClient):
             last_updated_time (Union[Dict[str, int], TimestampRange]):  Range between two timestamps. Possible keys are `min` and `max`, with values given as time stamps in ms.
             external_id_prefix (str): External Id provided by client. Should be unique within the project
             sort (List[str]): Sort by array of selected fields. Ex: ["startTime:desc']. Default sort order is asc when ommitted. Filter accepts following field names: startTime, endTime, createdTime, lastUpdatedTime. We only support 1 field for now.
-            limit (int, optional): Maximum number of assets to return. Defaults to return all items.
+            limit (int, optional): Maximum number of events to return. Defaults to return all items.
 
         Yields:
             Union[Event, EventList]: yields Event one by one if chunk is not specified, else EventList objects.

--- a/cognite/client/_api/events.py
+++ b/cognite/client/_api/events.py
@@ -56,8 +56,7 @@ class EventsAPI(APIClient):
             last_updated_time (Union[Dict[str, int], TimestampRange]):  Range between two timestamps. Possible keys are `min` and `max`, with values given as time stamps in ms.
             external_id_prefix (str): External Id provided by client. Should be unique within the project
             sort (List[str]): Sort by array of selected fields. Ex: ["startTime:desc']. Default sort order is asc when ommitted. Filter accepts following field names: startTime, endTime, createdTime, lastUpdatedTime. We only support 1 field for now.
-            limit (int, optional): Maximum number of assets to return. Defaults to 25. Set to -1, float("inf") or None
-                to return all items.
+            limit (int, optional): Maximum number of assets to return. Defaults to return all items.
 
         Yields:
             Union[Event, EventList]: yields Event one by one if chunk is not specified, else EventList objects.

--- a/cognite/client/_api/files.py
+++ b/cognite/client/_api/files.py
@@ -65,7 +65,7 @@ class FilesAPI(APIClient):
             uploaded_time (Union[Dict[str, Any], TimestampRange]): Range between two timestamps
             external_id_prefix (str): External Id provided by client. Should be unique within the project.
             uploaded (bool): Whether or not the actual file is uploaded. This field is returned only by the API, it has no effect in a post body.
-            limit (int, optional): Maximum number of assets to return. Defaults to return all items.
+            limit (int, optional): Maximum number of files to return. Defaults to return all items.
 
         Yields:
             Union[FileMetadata, FileMetadataList]: yields FileMetadata one by one if chunk is not specified, else FileMetadataList objects.

--- a/cognite/client/_api/files.py
+++ b/cognite/client/_api/files.py
@@ -65,8 +65,7 @@ class FilesAPI(APIClient):
             uploaded_time (Union[Dict[str, Any], TimestampRange]): Range between two timestamps
             external_id_prefix (str): External Id provided by client. Should be unique within the project.
             uploaded (bool): Whether or not the actual file is uploaded. This field is returned only by the API, it has no effect in a post body.
-            limit (int, optional): Maximum number of assets to return. Defaults to 25. Set to -1, float("inf") or None
-                to return all items.
+            limit (int, optional): Maximum number of assets to return. Defaults to return all items.
 
         Yields:
             Union[FileMetadata, FileMetadataList]: yields FileMetadata one by one if chunk is not specified, else FileMetadataList objects.

--- a/cognite/client/_api/raw.py
+++ b/cognite/client/_api/raw.py
@@ -26,7 +26,7 @@ class RawDatabasesAPI(APIClient):
 
         Args:
             chunk_size (int, optional): Number of dbs to return in each chunk. Defaults to yielding one db a time.
-            limit (int, optional): Maximum number of assets to return. Defaults to return all items.
+            limit (int, optional): Maximum number of dbs to return. Defaults to return all items.
         """
         return self._list_generator(chunk_size=chunk_size, method="GET", limit=limit)
 
@@ -138,7 +138,7 @@ class RawTablesAPI(APIClient):
         Args:
             db_name (str): Name of the database to iterate over tables for
             chunk_size (int, optional): Number of tables to return in each chunk. Defaults to yielding one table a time.
-            limit (int, optional): Maximum number of assets to return. Defaults to return all items.
+            limit (int, optional): Maximum number of tables to return. Defaults to return all items.
         """
         for tb in self._list_generator(
             resource_path=utils._auxiliary.interpolate_and_url_encode(self._RESOURCE_PATH, db_name),
@@ -281,7 +281,7 @@ class RawRowsAPI(APIClient):
             db_name (str): Name of the database
             table_name (str): Name of the table to iterate over rows for
             chunk_size (int, optional): Number of rows to return in each chunk. Defaults to yielding one row a time.
-            limit (int, optional): Maximum number of assets to return. Defaults to return all items.
+            limit (int, optional): Maximum number of rows to return. Defaults to return all items.
         """
         return self._list_generator(
             resource_path=utils._auxiliary.interpolate_and_url_encode(self._RESOURCE_PATH, db_name, table_name),

--- a/cognite/client/_api/raw.py
+++ b/cognite/client/_api/raw.py
@@ -26,8 +26,7 @@ class RawDatabasesAPI(APIClient):
 
         Args:
             chunk_size (int, optional): Number of dbs to return in each chunk. Defaults to yielding one db a time.
-            limit (int, optional): Maximum number of assets to return. Defaults to 25. Set to -1, float("inf") or None
-                to return all items.
+            limit (int, optional): Maximum number of assets to return. Defaults to return all items.
         """
         return self._list_generator(chunk_size=chunk_size, method="GET", limit=limit)
 
@@ -139,8 +138,7 @@ class RawTablesAPI(APIClient):
         Args:
             db_name (str): Name of the database to iterate over tables for
             chunk_size (int, optional): Number of tables to return in each chunk. Defaults to yielding one table a time.
-            limit (int, optional): Maximum number of assets to return. Defaults to 25. Set to -1, float("inf") or None
-                to return all items.
+            limit (int, optional): Maximum number of assets to return. Defaults to return all items.
         """
         for tb in self._list_generator(
             resource_path=utils._auxiliary.interpolate_and_url_encode(self._RESOURCE_PATH, db_name),
@@ -283,8 +281,7 @@ class RawRowsAPI(APIClient):
             db_name (str): Name of the database
             table_name (str): Name of the table to iterate over rows for
             chunk_size (int, optional): Number of rows to return in each chunk. Defaults to yielding one row a time.
-            limit (int, optional): Maximum number of assets to return. Defaults to 25. Set to -1, float("inf") or None
-                to return all items.
+            limit (int, optional): Maximum number of assets to return. Defaults to return all items.
         """
         return self._list_generator(
             resource_path=utils._auxiliary.interpolate_and_url_encode(self._RESOURCE_PATH, db_name, table_name),

--- a/cognite/client/_api/three_d.py
+++ b/cognite/client/_api/three_d.py
@@ -38,7 +38,7 @@ class ThreeDModelsAPI(APIClient):
         Args:
             chunk_size (int, optional): Number of 3d models to return in each chunk. Defaults to yielding one model a time.
             published (bool): Filter based on whether or not the model has published revisions.
-            limit (int, optional): Maximum number of assets to return. DDefaults to return all items.
+            limit (int, optional): Maximum number of 3d models to return. Defaults to return all items.
 
         Yields:
             Union[ThreeDModel, ThreeDModelList]: yields ThreeDModel one by one if chunk is not specified, else ThreeDModelList objects.
@@ -200,7 +200,7 @@ class ThreeDRevisionsAPI(APIClient):
             model_id (int): Iterate over revisions for the model with this id.
             chunk_size (int, optional): Number of 3d model revisions to return in each chunk. Defaults to yielding one model a time.
             published (bool): Filter based on whether or not the revision has been published.
-            limit (int, optional): Maximum number of assets to return. Defaults to return all items.
+            limit (int, optional): Maximum number of 3d model revisions to return. Defaults to return all items.
 
         Yields:
             Union[ThreeDModelRevision, ThreeDModelRevisionList]: yields ThreeDModelRevision one by one if chunk is not

--- a/cognite/client/_api/three_d.py
+++ b/cognite/client/_api/three_d.py
@@ -38,8 +38,7 @@ class ThreeDModelsAPI(APIClient):
         Args:
             chunk_size (int, optional): Number of 3d models to return in each chunk. Defaults to yielding one model a time.
             published (bool): Filter based on whether or not the model has published revisions.
-            limit (int, optional): Maximum number of assets to return. Defaults to 25. Set to -1, float("inf") or None
-                to return all items.
+            limit (int, optional): Maximum number of assets to return. DDefaults to return all items.
 
         Yields:
             Union[ThreeDModel, ThreeDModelList]: yields ThreeDModel one by one if chunk is not specified, else ThreeDModelList objects.
@@ -201,8 +200,7 @@ class ThreeDRevisionsAPI(APIClient):
             model_id (int): Iterate over revisions for the model with this id.
             chunk_size (int, optional): Number of 3d model revisions to return in each chunk. Defaults to yielding one model a time.
             published (bool): Filter based on whether or not the revision has been published.
-            limit (int, optional): Maximum number of assets to return. Defaults to 25. Set to -1, float("inf") or None
-                to return all items.
+            limit (int, optional): Maximum number of assets to return. Defaults to return all items.
 
         Yields:
             Union[ThreeDModelRevision, ThreeDModelRevisionList]: yields ThreeDModelRevision one by one if chunk is not


### PR DESCRIPTION
The documentation stated the default limit was 25, but on
__call__ the limit is set to None, which means you will
get all resources.

This change only changes the documentation to correctly
say that the default is to return all results.