### PR TITLE
Use only nodeId and assetId in 3d mappings delete to avoid 400 response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ Changes are grouped as follows
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
+## Unreleased	
+### Changed
+- For 3d mappings delete, only use node_id and asset_id pairs in delete request to avoid potential bad request.
+
 ## [1.8.0] - 2020-06-30
 ### Added
 - Synthetic timeseries endpoint for DatapointsApi

--- a/cognite/client/_api/three_d.py
+++ b/cognite/client/_api/three_d.py
@@ -547,11 +547,11 @@ class ThreeDAssetMappingAPI(APIClient):
         path = utils._auxiliary.interpolate_and_url_encode(self._RESOURCE_PATH, model_id, revision_id)
         utils._auxiliary.assert_type(asset_mapping, "asset_mapping", [list, ThreeDAssetMapping])
         if isinstance(asset_mapping, ThreeDAssetMapping):
-            asset_mapping = [asset_mapping]
+            asset_mapping = [ThreeDAssetMapping(asset_mapping.node_id, asset_mapping.asset_id)]
         chunks = utils._auxiliary.split_into_chunks(
             [a.dump(camel_case=True) for a in asset_mapping], self._DELETE_LIMIT
         )
-        tasks = [{"url_path": path + "/delete", "json": {"items": { "nodeId": chunk.nodeId, "assetId": chunk.assetId }}} for chunk in chunks]
+        tasks = [{"url_path": path + "/delete", "json": {"items": chunk}} for chunk in chunks]
         summary = utils._concurrency.execute_tasks_concurrently(self._post, tasks, self._config.max_workers)
         summary.raise_compound_exception_if_failed_tasks(
             task_unwrap_fn=lambda task: task["json"]["items"],

--- a/cognite/client/_api/three_d.py
+++ b/cognite/client/_api/three_d.py
@@ -551,7 +551,7 @@ class ThreeDAssetMappingAPI(APIClient):
         chunks = utils._auxiliary.split_into_chunks(
             [a.dump(camel_case=True) for a in asset_mapping], self._DELETE_LIMIT
         )
-        tasks = [{"url_path": path + "/delete", "json": {"items": chunk}} for chunk in chunks]
+        tasks = [{"url_path": path + "/delete", "json": {"items": { "nodeId": chunk.nodeId, "assetId": chunk.assetId }}} for chunk in chunks]
         summary = utils._concurrency.execute_tasks_concurrently(self._post, tasks, self._config.max_workers)
         summary.raise_compound_exception_if_failed_tasks(
             task_unwrap_fn=lambda task: task["json"]["items"],

--- a/cognite/client/_api/three_d.py
+++ b/cognite/client/_api/three_d.py
@@ -547,9 +547,9 @@ class ThreeDAssetMappingAPI(APIClient):
         path = utils._auxiliary.interpolate_and_url_encode(self._RESOURCE_PATH, model_id, revision_id)
         utils._auxiliary.assert_type(asset_mapping, "asset_mapping", [list, ThreeDAssetMapping])
         if isinstance(asset_mapping, ThreeDAssetMapping):
-            asset_mapping = [ThreeDAssetMapping(asset_mapping.node_id, asset_mapping.asset_id)]
+            asset_mapping = [asset_mapping]
         chunks = utils._auxiliary.split_into_chunks(
-            [a.dump(camel_case=True) for a in asset_mapping], self._DELETE_LIMIT
+            [ThreeDAssetMapping(a.node_id, a.asset_id).dump(camel_case=True) for a in asset_mapping], self._DELETE_LIMIT
         )
         tasks = [{"url_path": path + "/delete", "json": {"items": chunk}} for chunk in chunks]
         summary = utils._concurrency.execute_tasks_concurrently(self._post, tasks, self._config.max_workers)


### PR DESCRIPTION
3d model asset mappings delete will return http status 400 if the asset mappings objects contain all fields returned from 3d model mappings list request.

The fix makes sure only the nodeId and assetId fields are used in the delete request.

