### PR TITLE
Added pip syntax for upgrading the SDK

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -19,6 +19,12 @@ To install this package:
 
    pip install cognite-sdk
 
+To upgrade the version of this package:
+
+.. code-block:: bash
+
+   pip install cognite-sdk --upgrade
+
 To install this package without the pandas and NumPy support:
 
 .. code-block:: bash


### PR DESCRIPTION
99 of 100 times, the user will have to do an upgrade of the SDK and not an install.   This change saves the user the need to Google the syntax.