### PR TITLE
fix: attach/detach multiple labels in a single method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,8 +15,11 @@ Changes are grouped as follows
 - `Security` in case of vulnerabilities.
 
 ## Unreleased	
+
+## [1.8.1] - 2020-07-07
 ### Changed
 - For 3d mappings delete, only use node_id and asset_id pairs in delete request to avoid potential bad request.
+- Support attaching/detaching multiple labels on assets in a single method
 
 ## [1.8.0] - 2020-06-30
 ### Added

--- a/cognite/client/__init__.py
+++ b/cognite/client/__init__.py
@@ -1,3 +1,3 @@
 from cognite.client._cognite_client import CogniteClient
 
-__version__ = "1.8.0"
+__version__ = "1.8.1"

--- a/cognite/client/_api/assets.py
+++ b/cognite/client/_api/assets.py
@@ -378,6 +378,7 @@ class AssetsAPI(APIClient):
 
     def update(self, item: Union[Asset, AssetUpdate, List[Union[Asset, AssetUpdate]]]) -> Union[Asset, AssetList]:
         """`Update one or more assets <https://docs.cognite.com/api/v1/#operation/updateAssets>`_
+        Currently, a full replacement of labels on an asset is not supported (only partial add/remove updates). See the example below on how to perform partial labels update.
 
         Args:
             item (Union[Asset, AssetUpdate, List[Union[Asset, AssetUpdate]]]): Asset(s) to update

--- a/cognite/client/_api/assets.py
+++ b/cognite/client/_api/assets.py
@@ -408,7 +408,7 @@ class AssetsAPI(APIClient):
                 >>> from cognite.client import CogniteClient
                 >>> from cognite.client.data_classes import AssetUpdate
                 >>> c = CogniteClient()
-                >>> my_update = AssetUpdate(id=1).labels.add([{"externalId", "PUMP"}])
+                >>> my_update = AssetUpdate(id=1).labels.add(["PUMP"])
                 >>> res = c.assets.update(my_update)
         """
         return self._update_multiple(items=item)

--- a/cognite/client/_api/assets.py
+++ b/cognite/client/_api/assets.py
@@ -402,6 +402,14 @@ class AssetsAPI(APIClient):
                 >>> c = CogniteClient()
                 >>> my_update = AssetUpdate(id=1).description.set("New description").metadata.add({"key": "value"})
                 >>> res = c.assets.update(my_update)
+
+            Perform a partial update on a asset, attach a label to an asset::
+
+                >>> from cognite.client import CogniteClient
+                >>> from cognite.client.data_classes import AssetUpdate
+                >>> c = CogniteClient()
+                >>> my_update = AssetUpdate(id=1).labels.add([{"externalId", "PUMP"}])
+                >>> res = c.assets.update(my_update)
         """
         return self._update_multiple(items=item)
 

--- a/cognite/client/data_classes/_base.py
+++ b/cognite/client/data_classes/_base.py
@@ -372,12 +372,15 @@ class CogniteLabelUpdate:
         self._update_object = update_object
         self._name = name
 
+    def _wrap_labels(self, value: List):
+        return [{"externalId": label} for label in value]
+
     def _add(self, value: List):
-        self._update_object._add(self._name, value)
+        self._update_object._add(self._name, self._wrap_labels(value))
         return self._update_object
 
     def _remove(self, value: List):
-        self._update_object._remove(self._name, value)
+        self._update_object._remove(self._name, self._wrap_labels(value))
         return self._update_object
 
 

--- a/cognite/client/data_classes/_base.py
+++ b/cognite/client/data_classes/_base.py
@@ -315,7 +315,7 @@ class CogniteUpdate:
 
     @classmethod
     def _get_update_properties(cls):
-        return [key for key in cls.__dict__.keys() if not key.startswith("_")]
+        return [key for key in cls.__dict__.keys() if (not key.startswith("_")) and (not key == "labels")]
 
 
 class CognitePrimitiveUpdate:

--- a/cognite/client/data_classes/_base.py
+++ b/cognite/client/data_classes/_base.py
@@ -367,6 +367,20 @@ class CogniteListUpdate:
         return self._update_object
 
 
+class CogniteLabelUpdate:
+    def __init__(self, update_object, name: str):
+        self._update_object = update_object
+        self._name = name
+
+    def _add(self, value: List):
+        self._update_object._add(self._name, value)
+        return self._update_object
+
+    def _remove(self, value: List):
+        self._update_object._remove(self._name, value)
+        return self._update_object
+
+
 class CogniteFilter:
     def __eq__(self, other):
         return type(self) == type(other) and self.dump() == other.dump()

--- a/cognite/client/data_classes/assets.py
+++ b/cognite/client/data_classes/assets.py
@@ -225,6 +225,13 @@ class AssetUpdate(CogniteUpdate):
         def remove(self, value: List) -> "AssetUpdate":
             return self._remove(value)
 
+    class _LabelAssetUpdate(CogniteLabelUpdate):
+        def add(self, value: List) -> "AssetUpdate":
+            return self._add(value)
+
+        def remove(self, value: List) -> "AssetUpdate":
+            return self._remove(value)
+
     @property
     def external_id(self):
         return AssetUpdate._PrimitiveAssetUpdate(self, "externalId")
@@ -257,29 +264,19 @@ class AssetUpdate(CogniteUpdate):
     def parent_external_id(self):
         return AssetUpdate._PrimitiveAssetUpdate(self, "parentExternalId")
 
-    # GenStop
-
     @property
     def labels(self):
-        raise Exception("Use the add_label and remove_label functions to handle label updates")
+        return AssetUpdate._LabelAssetUpdate(self, "labels")
+
+    # GenStop
 
     def add_label(self, external_id: str = None):
         """Upsert the label on the asset"""
-        if self._update_object.get("labels") is None:
-            self._update_object["labels"] = {}
-        if self._update_object["labels"].get("add") is None:
-            self._update_object["labels"]["add"] = []
-        self._update_object["labels"]["add"].append({"externalId": external_id})
-        return self
+        return self.labels.add([{"externalId": external_id}])
 
     def remove_label(self, external_id: str = None):
         """Remove the label from an asset"""
-        if self._update_object.get("labels") is None:
-            self._update_object["labels"] = {}
-        if self._update_object["labels"].get("remove") is None:
-            self._update_object["labels"]["remove"] = []
-        self._update_object["labels"]["remove"].append({"externalId": external_id})
-        return self
+        return self.labels.remove([{"externalId": external_id}])
 
 
 class AssetList(CogniteResourceList):

--- a/cognite/client/data_classes/assets.py
+++ b/cognite/client/data_classes/assets.py
@@ -272,11 +272,11 @@ class AssetUpdate(CogniteUpdate):
 
     def add_label(self, external_id: str = None):
         """Upsert the label on the asset"""
-        return self.labels.add([{"externalId": external_id}])
+        return self.labels.add([external_id])
 
     def remove_label(self, external_id: str = None):
         """Remove the label from an asset"""
-        return self.labels.remove([{"externalId": external_id}])
+        return self.labels.remove([external_id])
 
 
 class AssetList(CogniteResourceList):

--- a/cognite/client/data_classes/data_sets.py
+++ b/cognite/client/data_classes/data_sets.py
@@ -120,6 +120,13 @@ class DataSetUpdate(CogniteUpdate):
         def remove(self, value: List) -> "DataSetUpdate":
             return self._remove(value)
 
+    class _LabelDataSetUpdate(CogniteLabelUpdate):
+        def add(self, value: List) -> "DataSetUpdate":
+            return self._add(value)
+
+        def remove(self, value: List) -> "DataSetUpdate":
+            return self._remove(value)
+
     @property
     def external_id(self):
         return DataSetUpdate._PrimitiveDataSetUpdate(self, "externalId")

--- a/cognite/client/data_classes/events.py
+++ b/cognite/client/data_classes/events.py
@@ -194,6 +194,13 @@ class EventUpdate(CogniteUpdate):
         def remove(self, value: List) -> "EventUpdate":
             return self._remove(value)
 
+    class _LabelEventUpdate(CogniteLabelUpdate):
+        def add(self, value: List) -> "EventUpdate":
+            return self._add(value)
+
+        def remove(self, value: List) -> "EventUpdate":
+            return self._remove(value)
+
     @property
     def external_id(self):
         return EventUpdate._PrimitiveEventUpdate(self, "externalId")

--- a/cognite/client/data_classes/files.py
+++ b/cognite/client/data_classes/files.py
@@ -175,6 +175,13 @@ class FileMetadataUpdate(CogniteUpdate):
         def remove(self, value: List) -> "FileMetadataUpdate":
             return self._remove(value)
 
+    class _LabelFileMetadataUpdate(CogniteLabelUpdate):
+        def add(self, value: List) -> "FileMetadataUpdate":
+            return self._add(value)
+
+        def remove(self, value: List) -> "FileMetadataUpdate":
+            return self._remove(value)
+
     @property
     def external_id(self):
         return FileMetadataUpdate._PrimitiveFileMetadataUpdate(self, "externalId")

--- a/cognite/client/data_classes/sequences.py
+++ b/cognite/client/data_classes/sequences.py
@@ -167,6 +167,13 @@ class SequenceUpdate(CogniteUpdate):
         def remove(self, value: List) -> "SequenceUpdate":
             return self._remove(value)
 
+    class _LabelSequenceUpdate(CogniteLabelUpdate):
+        def add(self, value: List) -> "SequenceUpdate":
+            return self._add(value)
+
+        def remove(self, value: List) -> "SequenceUpdate":
+            return self._remove(value)
+
     @property
     def name(self):
         return SequenceUpdate._PrimitiveSequenceUpdate(self, "name")

--- a/cognite/client/data_classes/three_d.py
+++ b/cognite/client/data_classes/three_d.py
@@ -104,6 +104,13 @@ class ThreeDModelUpdate(CogniteUpdate):
         def remove(self, value: List) -> "ThreeDModelUpdate":
             return self._remove(value)
 
+    class _LabelThreeDModelUpdate(CogniteLabelUpdate):
+        def add(self, value: List) -> "ThreeDModelUpdate":
+            return self._add(value)
+
+        def remove(self, value: List) -> "ThreeDModelUpdate":
+            return self._remove(value)
+
     @property
     def name(self):
         return ThreeDModelUpdate._PrimitiveThreeDModelUpdate(self, "name")
@@ -204,6 +211,13 @@ class ThreeDModelRevisionUpdate(CogniteUpdate):
         def set(self, value: List) -> "ThreeDModelRevisionUpdate":
             return self._set(value)
 
+        def add(self, value: List) -> "ThreeDModelRevisionUpdate":
+            return self._add(value)
+
+        def remove(self, value: List) -> "ThreeDModelRevisionUpdate":
+            return self._remove(value)
+
+    class _LabelThreeDModelRevisionUpdate(CogniteLabelUpdate):
         def add(self, value: List) -> "ThreeDModelRevisionUpdate":
             return self._add(value)
 

--- a/cognite/client/data_classes/time_series.py
+++ b/cognite/client/data_classes/time_series.py
@@ -229,6 +229,13 @@ class TimeSeriesUpdate(CogniteUpdate):
         def remove(self, value: List) -> "TimeSeriesUpdate":
             return self._remove(value)
 
+    class _LabelTimeSeriesUpdate(CogniteLabelUpdate):
+        def add(self, value: List) -> "TimeSeriesUpdate":
+            return self._add(value)
+
+        def remove(self, value: List) -> "TimeSeriesUpdate":
+            return self._remove(value)
+
     @property
     def external_id(self):
         return TimeSeriesUpdate._PrimitiveTimeSeriesUpdate(self, "externalId")

--- a/openapi/generator.py
+++ b/openapi/generator.py
@@ -265,6 +265,7 @@ class UpdateClassGenerator:
             "Primitive": [("set", "Any")],
             "Object": [("set", "Dict"), ("add", "Dict"), ("remove", "List")],
             "List": [("set", "List"), ("add", "List"), ("remove", "List")],
+            "Label": [("add", "List"), ("remove", "List")],
         }
         indent = " " * 4 + xindent
         for update_class_name, methods in update_class_methods.items():

--- a/openapi/generator.py
+++ b/openapi/generator.py
@@ -240,9 +240,9 @@ class UpdateClassGenerator:
             if prop_name == "id":
                 continue
             update_prop_type_hints = {p: type_hint for p, type_hint in self._get_update_properties(prop)}
+            setter = indent + "@property\n"
+            setter += indent + "def {}(self):\n".format(utils.to_snake_case(prop_name))
             if "set" in update_prop_type_hints:
-                setter = indent + "@property\n"
-                setter += indent + "def {}(self):\n".format(utils.to_snake_case(prop_name))
                 if update_prop_type_hints["set"] == "List":
                     setter += (
                         indent + indent + "return {}._List{}(self, '{}')".format(class_name, class_name, prop_name)
@@ -255,6 +255,9 @@ class UpdateClassGenerator:
                     setter += (
                         indent + indent + "return {}._Primitive{}(self, '{}')".format(class_name, class_name, prop_name)
                     )
+                setters.append(setter)
+            elif prop_name == "labels":
+                setter += indent + indent + "return {}._Label{}(self, '{}')".format(class_name, class_name, prop_name)
                 setters.append(setter)
         return "\n\n".join(setters)
 

--- a/openapi/tests/input_output/input.py
+++ b/openapi/tests/input_output/input.py
@@ -22,6 +22,10 @@ class CogniteListUpdate:
     pass
 
 
+class CogniteLabelUpdate:
+    pass
+
+
 class CognitePropertyClassUtil:
     @staticmethod
     def declare_property(tmp):

--- a/openapi/tests/input_output/output.py
+++ b/openapi/tests/input_output/output.py
@@ -25,6 +25,10 @@ class CogniteListUpdate:
     pass
 
 
+class CogniteLabelUpdate:
+    pass
+
+
 class CognitePropertyClassUtil:
     @staticmethod
     def declare_property(tmp):
@@ -164,6 +168,13 @@ class AssetUpdate(CogniteUpdate):
         def remove(self, value: List) -> "AssetUpdate":
             return self._remove(value)
 
+    class _LabelAssetUpdate(CogniteLabelUpdate):
+        def add(self, value: List) -> "AssetUpdate":
+            return self._add(value)
+
+        def remove(self, value: List) -> "AssetUpdate":
+            return self._remove(value)
+
     @property
     def external_id(self):
         return AssetUpdate._PrimitiveAssetUpdate(self, "externalId")
@@ -195,6 +206,10 @@ class AssetUpdate(CogniteUpdate):
     @property
     def parent_external_id(self):
         return AssetUpdate._PrimitiveAssetUpdate(self, "parentExternalId")
+
+    @property
+    def labels(self):
+        return AssetUpdate._LabelAssetUpdate(self, "labels")
 
     # GenStop
 

--- a/openapi/tests/input_output/output_test.py
+++ b/openapi/tests/input_output/output_test.py
@@ -25,6 +25,10 @@ class CogniteListUpdate:
     pass
 
 
+class CogniteLabelUpdate:
+    pass
+
+
 class CognitePropertyClassUtil:
     @staticmethod
     def declare_property(tmp):
@@ -164,6 +168,13 @@ class AssetUpdate(CogniteUpdate):
         def remove(self, value: List) -> "AssetUpdate":
             return self._remove(value)
 
+    class _LabelAssetUpdate(CogniteLabelUpdate):
+        def add(self, value: List) -> "AssetUpdate":
+            return self._add(value)
+
+        def remove(self, value: List) -> "AssetUpdate":
+            return self._remove(value)
+
     @property
     def external_id(self):
         return AssetUpdate._PrimitiveAssetUpdate(self, "externalId")
@@ -195,6 +206,10 @@ class AssetUpdate(CogniteUpdate):
     @property
     def parent_external_id(self):
         return AssetUpdate._PrimitiveAssetUpdate(self, "parentExternalId")
+
+    @property
+    def labels(self):
+        return AssetUpdate._LabelAssetUpdate(self, "labels")
 
     # GenStop
 

--- a/openapi/tests/test_generator.py
+++ b/openapi/tests/test_generator.py
@@ -212,6 +212,13 @@ class _ListAssetUpdate(CogniteListUpdate):
         return self._add(value)
 
     def remove(self, value: List) -> "AssetUpdate":
+        return self._remove(value)
+
+class _LabelAssetUpdate(CogniteLabelUpdate):
+    def add(self, value: List) -> "AssetUpdate":
+        return self._add(value)
+
+    def remove(self, value: List) -> "AssetUpdate":
         return self._remove(value)"""
             == attr_update_classes
         )

--- a/tests/tests_unit/test_api/test_assets.py
+++ b/tests/tests_unit/test_api/test_assets.py
@@ -5,7 +5,6 @@ import time
 from collections import OrderedDict
 
 import pytest
-import responses
 
 from cognite.client import CogniteClient
 from cognite.client._api.assets import Asset, AssetList, AssetUpdate, _AssetPoster, _AssetPosterWorker

--- a/tests/tests_unit/test_api/test_assets.py
+++ b/tests/tests_unit/test_api/test_assets.py
@@ -21,6 +21,7 @@ EXAMPLE_ASSET = {
     "parentId": 1,
     "description": "string",
     "metadata": {"metadata-key": "metadata-value"},
+    "labels": [{"externalId": "PUMP"}],
     "source": "string",
     "id": 1,
     "lastUpdatedTime": 0,
@@ -283,6 +284,8 @@ class TestAssets:
             .external_id.set(None)
             .metadata.set({})
             .metadata.set(None)
+            .labels.add([{"externalId":"PUMP"}])
+            .labels.remove([{"externalId": "VALVE"}])
             .name.set("")
             .name.set(None)
             .source.set(1)

--- a/tests/tests_unit/test_api/test_assets.py
+++ b/tests/tests_unit/test_api/test_assets.py
@@ -259,6 +259,13 @@ class TestAssets:
         expected = {"labels": {"add": [{"externalId": "PUMP"}]}}
         assert request_body == expected
 
+    @pytest.mark.usefixtures("disable_gzip")
+    def test_ignore_labels_resource_class(self, mock_assets_response):
+        ASSETS_API.update(Asset(id=1, labels=[{"external_id": "PUMP"}], name="Abc"))
+        request_body = json.loads(mock_assets_response.calls[0].request.body)["items"][0]["update"]
+        expected = {"name": {"set": "Abc"}}
+        assert request_body == expected
+
     def test_search(self, mock_assets_response):
         res = ASSETS_API.search(filter=AssetFilter(name="1"))
         assert mock_assets_response.calls[0].response.json()["items"] == res.dump(camel_case=True)

--- a/tests/tests_unit/test_base.py
+++ b/tests/tests_unit/test_base.py
@@ -33,6 +33,10 @@ class MyUpdate(CogniteUpdate):
     def object(self):
         return ObjectUpdate(self, "object")
 
+    @property
+    def labels(self):
+        return LabelUpdate(self, "labels")
+
 
 class PrimitiveUpdate(CognitePrimitiveUpdate):
     def set(self, value: Any) -> MyUpdate:
@@ -60,6 +64,12 @@ class ListUpdate(CogniteListUpdate):
     def remove(self, value: List) -> MyUpdate:
         return self._remove(value)
 
+class LabelUpdate(CogniteLabelUpdate):
+    def add(self, value: List) -> MyUpdate:
+        return self._add(value)
+
+    def remove(self, value: List) -> MyUpdate:
+        return self._remove(value)
 
 class MyFilter(CogniteFilter):
     def __init__(self, var_a=None, var_b=None, cognite_client=None):

--- a/tests/tests_unit/test_base.py
+++ b/tests/tests_unit/test_base.py
@@ -64,12 +64,14 @@ class ListUpdate(CogniteListUpdate):
     def remove(self, value: List) -> MyUpdate:
         return self._remove(value)
 
+
 class LabelUpdate(CogniteLabelUpdate):
     def add(self, value: List) -> MyUpdate:
         return self._add(value)
 
     def remove(self, value: List) -> MyUpdate:
         return self._remove(value)
+
 
 class MyFilter(CogniteFilter):
     def __init__(self, var_a=None, var_b=None, cognite_client=None):


### PR DESCRIPTION
This PR will do the following:
- Makes it easy to attach/detach multiple labels to an asset:
```
my_update = AssetUpdate(id=1).labels.add(["PUMP, "another_label"]).labels.remove(["VALVE"])
```
- Don't fail `asset.update` requests when doing a full replacement if the resource contains labels (the API doesn't support labels.set yet). We will not support full label replacement in the SDK for now
- Adds more test to verify update of labels on assets