### PR TITLE
Change filter Sequences from GET to POST

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ Changes are grouped as follows
 
 ## Unreleased	
 
+## [1.8.2] - 2020-07-08
+### Fixed
+- Fixed bug where `_call_` in SequencesAPI (`client.sequences`) was incorrectly returning a `GET` method instead of `POST`.
+
 ## [1.8.1] - 2020-07-07
 ### Changed
 - For 3d mappings delete, only use node_id and asset_id pairs in delete request to avoid potential bad request.

--- a/cognite/client/_api/sequences.py
+++ b/cognite/client/_api/sequences.py
@@ -79,7 +79,7 @@ class SequencesAPI(APIClient):
             last_updated_time=last_updated_time,
             data_set_ids=data_set_ids,
         ).dump(camel_case=True)
-        return self._list_generator(method="GET", chunk_size=chunk_size, filter=filter, limit=limit)
+        return self._list_generator(method="POST", chunk_size=chunk_size, filter=filter, limit=limit)
 
     def __iter__(self) -> Generator[Sequence, None, None]:
         """Iterate over sequences

--- a/tests/tests_integration/test_api/test_sequences.py
+++ b/tests/tests_integration/test_api/test_sequences.py
@@ -42,6 +42,13 @@ class TestSequencesAPI:
             retrieved_asset.external_id = listed_asset.external_id
         assert res == retrieved_assets
 
+    def test_call(self, post_spy):
+        with set_request_limit(COGNITE_CLIENT.sequences, 10):
+            res = [s for s in COGNITE_CLIENT.sequences(limit=20)]
+
+        assert 20 == len(res)
+        assert 2 == COGNITE_CLIENT.sequences._post.call_count
+
     def test_list(self, post_spy):
         with set_request_limit(COGNITE_CLIENT.sequences, 10):
             res = COGNITE_CLIENT.sequences.list(limit=20)


### PR DESCRIPTION
I'm wondering how to test this. We have the following test in `test_sequences.py`:

```
    def test_retrieve(self):
        listed_asset = COGNITE_CLIENT.sequences.list(limit=1)[0]
        retrieved_asset = COGNITE_CLIENT.sequences.retrieve(listed_asset.id)
        assert retrieved_asset == listed_asset
```

But I'm not sure how was is it passing before? Calling `sequences.list` with `GET` doesn't work.