### PR TITLE
fix: support single external id for labels update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,20 @@ Changes are grouped as follows
 
 ## Unreleased	
 
+## [2.0.1] - 2020-07-22
+
+### Added
+- Support for passing a single string to `AssetUpdate().labels.add` and `AssetUpdate().labels.remove`. Both a single string and a list of strings is supported. Example:
+  ```python
+  # using a single string
+  my_update = AssetUpdate(id=1).labels.add("PUMP").labels.remove("VALVE")
+  res = c.assets.update(my_update)
+
+  # using a list of strings
+  my_update = AssetUpdate(id=1).labels.add(["PUMP", "ROTATING_EQUIPMENT"]).labels.remove(["VALVE"])
+  res = c.assets.update(my_update)
+  ```
+
 ## [2.0.0] - 2020-07-17
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ Changes are grouped as follows
 
 ## Unreleased	
 
-## [2.0.1] - 2020-07-22
+## [2.1.0] - 2020-07-22
 
 ### Added
 - Support for passing a single string to `AssetUpdate().labels.add` and `AssetUpdate().labels.remove`. Both a single string and a list of strings is supported. Example:

--- a/cognite/client/__init__.py
+++ b/cognite/client/__init__.py
@@ -1,3 +1,3 @@
 from cognite.client._cognite_client import CogniteClient
 
-__version__ = "2.0.0"
+__version__ = "2.0.1"

--- a/cognite/client/__init__.py
+++ b/cognite/client/__init__.py
@@ -1,3 +1,3 @@
 from cognite.client._cognite_client import CogniteClient
 
-__version__ = "2.0.1"
+__version__ = "2.1.0"

--- a/cognite/client/_api/assets.py
+++ b/cognite/client/_api/assets.py
@@ -428,20 +428,20 @@ class AssetsAPI(APIClient):
                 >>> my_update = AssetUpdate(id=1).description.set("New description").metadata.add({"key": "value"})
                 >>> res = c.assets.update(my_update)
 
-            Attach a label to an asset::
+            Attach labels to an asset::
 
                 >>> from cognite.client import CogniteClient
                 >>> from cognite.client.data_classes import AssetUpdate
                 >>> c = CogniteClient()
-                >>> my_update = AssetUpdate(id=1).labels.add(["PUMP"])
+                >>> my_update = AssetUpdate(id=1).labels.add(["PUMP", "VERIFIED"])
                 >>> res = c.assets.update(my_update)
 
-            Detach a label from an asset::
+            Detach a single label from an asset::
 
                 >>> from cognite.client import CogniteClient
                 >>> from cognite.client.data_classes import AssetUpdate
                 >>> c = CogniteClient()
-                >>> my_update = AssetUpdate(id=1).labels.remove(["PUMP"])
+                >>> my_update = AssetUpdate(id=1).labels.remove("PUMP")
                 >>> res = c.assets.update(my_update)
         """
         return self._update_multiple(items=item)

--- a/cognite/client/data_classes/_base.py
+++ b/cognite/client/data_classes/_base.py
@@ -372,16 +372,19 @@ class CogniteLabelUpdate:
         self._update_object = update_object
         self._name = name
 
-    def _add(self, external_ids: List[str]):
-        self._update_object._add(self._name, self._wrap_ids(external_ids))
+    def _add(self, external_ids: Union[str, List[str]]):
+        self._update_object._add(self._name, self._wrap_ids(self._wrap_in_list(external_ids)))
         return self._update_object
 
-    def _remove(self, external_ids: List[str]):
-        self._update_object._remove(self._name, self._wrap_ids(external_ids))
+    def _remove(self, external_ids: Union[str, List[str]]):
+        self._update_object._remove(self._name, self._wrap_ids(self._wrap_in_list(external_ids)))
         return self._update_object
 
     def _wrap_ids(self, external_ids: List[str]):
         return [{"externalId": external_id} for external_id in external_ids]
+
+    def _wrap_in_list(self, external_ids: Union[str, List[str]]):
+        return external_ids if isinstance(external_ids, list) else [external_ids]
 
 
 class CogniteFilter:

--- a/cognite/client/data_classes/assets.py
+++ b/cognite/client/data_classes/assets.py
@@ -227,10 +227,10 @@ class AssetUpdate(CogniteUpdate):
             return self._remove(value)
 
     class _LabelAssetUpdate(CogniteLabelUpdate):
-        def add(self, value: List[str]) -> "AssetUpdate":
+        def add(self, value: Union[str, List[str]]) -> "AssetUpdate":
             return self._add(value)
 
-        def remove(self, value: List[str]) -> "AssetUpdate":
+        def remove(self, value: Union[str, List[str]]) -> "AssetUpdate":
             return self._remove(value)
 
     @property

--- a/tests/tests_unit/test_api/test_assets.py
+++ b/tests/tests_unit/test_api/test_assets.py
@@ -239,12 +239,19 @@ class TestAssets:
         assert isinstance(res, AssetList)
         assert mock_assets_response.calls[0].response.json()["items"] == res.dump(camel_case=True)
 
-    def test_update_labels(self, mock_assets_response):
-        ASSETS_API.update([AssetUpdate(id=1).labels.add(["PUMP", "ROTATING_EQUIPMENT"]).labels.remove(["VALVE"])])
+    def test_update_labels_single(self, mock_assets_response):
+        ASSETS_API.update([AssetUpdate(id=1).labels.add("PUMP").labels.remove("VALVE")])
+        expected = {"labels": {"add": [{"externalId": "PUMP"}], "remove": [{"externalId": "VALVE"}]}}
+        assert expected == jsgz_load(mock_assets_response.calls[0].request.body)["items"][0]["update"]
+
+    def test_update_labels_multiple(self, mock_assets_response):
+        ASSETS_API.update(
+            [AssetUpdate(id=1).labels.add(["PUMP", "ROTATING_EQUIPMENT"]).labels.remove(["VALVE", "VERIFIED"])]
+        )
         expected = {
             "labels": {
                 "add": [{"externalId": "PUMP"}, {"externalId": "ROTATING_EQUIPMENT"}],
-                "remove": [{"externalId": "VALVE"}],
+                "remove": [{"externalId": "VALVE"}, {"externalId": "VERIFIED"}],
             }
         }
         assert expected == jsgz_load(mock_assets_response.calls[0].request.body)["items"][0]["update"]


### PR DESCRIPTION
Support for passing a single string to `AssetUpdate().labels.add` and `AssetUpdate().labels.remove`. Both a single string and a list of strings is supported. Example:
  ```python
  # using a single string
  my_update = AssetUpdate(id=1).labels.add("PUMP").labels.remove("VALVE")
  res = c.assets.update(my_update)
  # using a list of strings
  my_update = AssetUpdate(id=1).labels.add(["PUMP", "ROTATING_EQUIPMENT"]).labels.remove(["VALVE"])
  res = c.assets.update(my_update)
  ```