### PR TITLE
Docs fix for events.aggregate_unique_values

### DIFF
--- a/cognite/client/_api/events.py
+++ b/cognite/client/_api/events.py
@@ -282,7 +282,7 @@ class EventsAPI(APIClient):
 
         Returns:
             List[AggregateResult]: List of event aggregates
-        
+
         Examples:
 
             Aggregate events:
@@ -312,7 +312,7 @@ class EventsAPI(APIClient):
 
                 >>> from cognite.client import CogniteClient
                 >>> c = CogniteClient()
-                >>> aggregate_subtype = c.events.aggregate(filter={"type": "failure"}, fields=["subtype"])
+                >>> aggregate_subtype = c.events.aggregate_unique_values(filter={"type": "failure"}, fields=["subtype"])
         """
 
         return self._aggregate(filter=filter, fields=fields, aggregate="uniqueValues", cls=AggregateUniqueValuesResult)


### PR DESCRIPTION
Example in docs specifies wrong function so it throws:
`TypeError: aggregate() got an unexpected keyword argument 'field'`