### PR TITLE
Rewrite http transport logic and improve error handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,12 +20,16 @@ Changes are grouped as follows
 
 ### Fixed
 - HTTP transport logic to better handle retrying of connection errors
+- read timeouts will now raise a CogniteReadTimeout
+- connection errors will now raise a CogniteConnectionError, while connection refused errors will raise the more
+ specific CogniteConnectionRefused exception.
 
 ### Added
 - Jitter to exponential backoff on retries
 
 ### Changed
 - Make HTTP requests no longer follow redirects by default
+- All exceptions now inherit from CogniteException
 
 ## [2.2.1] - 2020-08-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,14 @@ Changes are grouped as follows
 
 ## Unreleased
 
+## [2.2.2] - 2020-08-18
+
+### Fixed
+- HTTP transport logic to better handle retrying of connection errors
+
+### Added
+- Jitter to exponential backoff on retries
+
 ## [2.2.1] - 2020-08-17
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,9 @@ Changes are grouped as follows
 ### Added
 - Jitter to exponential backoff on retries
 
+### Changed
+- Make HTTP requests no longer follow redirects by default
+
 ## [2.2.1] - 2020-08-17
 
 ### Added

--- a/cognite/client/__init__.py
+++ b/cognite/client/__init__.py
@@ -1,3 +1,3 @@
 from cognite.client._cognite_client import CogniteClient
 
-__version__ = "2.2.1"
+__version__ = "2.2.2"

--- a/cognite/client/_api/files.py
+++ b/cognite/client/_api/files.py
@@ -624,7 +624,7 @@ class FilesAPI(APIClient):
         returned_file_metadata = res.json()
         upload_url = returned_file_metadata.pop("uploadUrl")
         headers = {"X-Upload-Content-Type": file_metadata.mime_type}
-        self._request_session.put(upload_url, data=content, headers=headers)
+        self._http_client.request("PUT", upload_url, data=content, timeout=180, headers=headers)
         return FileMetadata._load(returned_file_metadata)
 
     def download(
@@ -692,7 +692,7 @@ class FilesAPI(APIClient):
         self._download_file_to_path(download_link, file_path)
 
     def _download_file_to_path(self, download_link: str, path: str, chunk_size: int = 2 ** 21):
-        with self._request_session.get(download_link, stream=True) as r:
+        with self._http_client.request("GET", download_link, stream=True, timeout=180) as r:
             with open(path, "wb") as f:
                 for chunk in r.iter_content(chunk_size=chunk_size):
                     if chunk:  # filter out keep-alive new chunks
@@ -744,5 +744,5 @@ class FilesAPI(APIClient):
         return self._download_file(download_link)
 
     def _download_file(self, download_link: str) -> bytes:
-        res = self._request_session.get(download_link)
+        res = self._http_client.request("GET", download_link, timeout=180)
         return res.content

--- a/cognite/client/_api/model_hosting/source_packages.py
+++ b/cognite/client/_api/model_hosting/source_packages.py
@@ -128,7 +128,7 @@ class SourcePackagesAPI(APIClient):
     def _upload_file(self, upload_url, file_path):
         with open(file_path, "rb") as fh:
             mydata = fh.read()
-            response = self._http_client_with_retry.request("PUT", upload_url, data=mydata, timeout=180)
+            response = self._http_client.request("PUT", upload_url, data=mydata, timeout=180)
         return response
 
     def list_source_packages(

--- a/cognite/client/_api/model_hosting/source_packages.py
+++ b/cognite/client/_api/model_hosting/source_packages.py
@@ -128,7 +128,7 @@ class SourcePackagesAPI(APIClient):
     def _upload_file(self, upload_url, file_path):
         with open(file_path, "rb") as fh:
             mydata = fh.read()
-            response = self._request_session.put(upload_url, data=mydata)
+            response = self._http_client_with_retry.request("PUT", upload_url, data=mydata, timeout=180)
         return response
 
     def list_source_packages(
@@ -198,7 +198,7 @@ class SourcePackagesAPI(APIClient):
         url = "/modelhosting/models/sourcepackages/{}/code".format(id)
         download_url = self._get(url).json()["downloadUrl"]
         with open(file_path, "wb") as fh:
-            response = self._request_session.get(download_url).content
+            response = self._http_client.request("GET", download_url).content
             fh.write(response)
 
     def delete_source_package_code(self, id: int) -> None:

--- a/cognite/client/_api/model_hosting/versions.py
+++ b/cognite/client/_api/model_hosting/versions.py
@@ -206,7 +206,7 @@ class ModelVersionsAPI(APIClient):
         url = "/modelhosting/models/{}/versions/{}/artifacts/{}".format(model_name, version_name, artifact_name)
         download_url = self._get(url).json()["downloadUrl"]
         with open(file_path, "wb") as fh:
-            response = self._request_session.get(download_url).content
+            response = self._http_client.request("GET", download_url).content
             fh.write(response)
 
     def upload_artifact_from_file(self, model_name: str, version_name: str, artifact_name: str, file_path: str) -> None:
@@ -258,7 +258,7 @@ class ModelVersionsAPI(APIClient):
     def _upload_file(self, upload_url, file_path):
         with open(file_path, "rb") as fh:
             mydata = fh.read()
-            response = self._request_session.put(upload_url, data=mydata)
+            response = self._http_client.request("PUT", upload_url, data=mydata)
         return response
 
     def get_logs(self, model_name: str, version_name: str, log_type: str = None) -> ModelVersionLog:

--- a/cognite/client/_api_client.py
+++ b/cognite/client/_api_client.py
@@ -13,7 +13,7 @@ from requests import Response
 from requests.structures import CaseInsensitiveDict
 
 from cognite.client import utils
-from cognite.client._http_client import GLOBAL_REQUEST_SESSION, HTTPClient, HTTPClientConfig
+from cognite.client._http_client import HTTPClient, HTTPClientConfig
 from cognite.client.data_classes._base import CogniteFilter, CogniteResource, CogniteUpdate
 from cognite.client.exceptions import CogniteAPIError, CogniteNotFoundError
 
@@ -61,7 +61,6 @@ class APIClient:
         self._cognite_client = cognite_client
 
         self._http_client = HTTPClient(
-            session=GLOBAL_REQUEST_SESSION,
             config=HTTPClientConfig(
                 status_codes_to_retry={429},
                 backoff_factor=0.5,
@@ -70,11 +69,10 @@ class APIClient:
                 max_retries_read=0,
                 max_retries_connect=self._config.max_retries,
                 max_retries_status=self._config.max_retries,
-            ),
+            )
         )
 
         self._http_client_with_retry = HTTPClient(
-            session=GLOBAL_REQUEST_SESSION,
             config=HTTPClientConfig(
                 status_codes_to_retry=self._config.status_forcelist,
                 backoff_factor=0.5,
@@ -83,7 +81,7 @@ class APIClient:
                 max_retries_read=self._config.max_retries,
                 max_retries_connect=self._config.max_retries,
                 max_retries_status=self._config.max_retries,
-            ),
+            )
         )
 
         self._CREATE_LIMIT = 1000

--- a/cognite/client/_http_client.py
+++ b/cognite/client/_http_client.py
@@ -1,0 +1,144 @@
+import random
+import socket
+import time
+from http import cookiejar
+from typing import Optional, Set, Union
+
+import requests.exceptions
+import urllib3.exceptions
+from requests import Response, Session
+from requests.adapters import HTTPAdapter
+
+from cognite.client import utils
+from cognite.client.exceptions import CogniteConnectionError, CogniteConnectionRefused, CogniteReadTimeout
+
+
+class BlockAll(cookiejar.CookiePolicy):
+    return_ok = set_ok = domain_return_ok = path_return_ok = lambda self, *args, **kwargs: False
+    netscape = True
+    rfc2965 = hide_cookie2 = False
+
+
+def _init_requests_session():
+    session = Session()
+    session.cookies.set_policy(BlockAll())
+    cognite_config = utils._client_config._DefaultConfig()
+    adapter = HTTPAdapter(pool_maxsize=cognite_config.max_connection_pool_size)
+    session.mount("http://", adapter)
+    session.mount("https://", adapter)
+    if cognite_config.disable_ssl:
+        urllib3.disable_warnings()
+        session.verify = False
+    return session
+
+
+GLOBAL_REQUEST_SESSION = _init_requests_session()
+
+
+class HTTPClientConfig:
+    def __init__(
+        self,
+        status_codes_to_retry: Set[int],
+        backoff_factor: float,
+        max_backoff_seconds: int,
+        max_retries_total: int,
+        max_retries_status: int,
+        max_retries_read: int,
+        max_retries_connect: int,
+    ):
+        self.status_codes_to_retry = status_codes_to_retry
+        self.backoff_factor = backoff_factor
+        self.max_backoff_seconds = max_backoff_seconds
+        self.max_retries_total = max_retries_total
+        self.max_retries_status = max_retries_status
+        self.max_retries_read = max_retries_read
+        self.max_retries_connect = max_retries_connect
+
+
+class _RetryTracker:
+    def __init__(self, config: HTTPClientConfig):
+        self.config = config
+        self.status = 0
+        self.read = 0
+        self.connect = 0
+
+    @property
+    def total(self):
+        return self.status + self.read + self.connect
+
+    def _max_backoff_and_jitter(self, t: int) -> int:
+        return int(min(t, self.config.max_backoff_seconds) * random.uniform(0, 1.0))
+
+    def get_backoff_time(self) -> int:
+        backoff_time = self.config.backoff_factor * (2 ** self.total)
+        backoff_time_adjusted = self._max_backoff_and_jitter(backoff_time)
+        return backoff_time_adjusted
+
+    def should_retry(self, status_code: Optional[int]) -> bool:
+        if self.total >= self.config.max_retries_total:
+            return False
+        if self.status >= self.config.max_retries_status:
+            return False
+        if self.read >= self.config.max_retries_read:
+            return False
+        if self.connect >= self.config.max_retries_connect:
+            return False
+        if status_code and status_code not in self.config.status_codes_to_retry:
+            return False
+        return True
+
+
+class HTTPClient:
+    def __init__(self, session: Session, config: HTTPClientConfig):
+        self.session = session
+        self.config = config
+        self.retry_tracker = None
+
+    def request(self, method: str, url: str, **kwargs) -> Response:
+        self.retry_tracker = _RetryTracker(config=self.config)
+        last_status = None
+        while True:
+            try:
+                res = self._do_request(method=method, url=url, **kwargs)
+                last_status = res.status_code
+                if last_status not in self.config.status_codes_to_retry:
+                    return res
+                self.retry_tracker.status += 1
+                if not self.retry_tracker.should_retry(status_code=last_status):
+                    return res
+            except CogniteReadTimeout as e:
+                self.retry_tracker.read += 1
+                if not self.retry_tracker.should_retry(status_code=last_status):
+                    raise e
+            except CogniteConnectionError as e:
+                self.retry_tracker.connect += 1
+                if isinstance(e, CogniteConnectionRefused) or not self.retry_tracker.should_retry(
+                    status_code=last_status
+                ):
+                    raise e
+            time.sleep(self.retry_tracker.get_backoff_time())
+
+    def _do_request(self, method: str, url: str, **kwargs) -> Response:
+        try:
+            res = self.session.request(method=method, url=url, **kwargs)
+            return res
+        except requests.exceptions.RequestException as e:
+            underlying_exc = self._get_underlying_exception(e)
+            if isinstance(underlying_exc, socket.timeout):
+                raise CogniteReadTimeout from e
+            if isinstance(underlying_exc, ConnectionError):
+                if isinstance(underlying_exc, ConnectionRefusedError):
+                    raise CogniteConnectionRefused from e
+                else:
+                    raise CogniteConnectionError from e
+
+    @staticmethod
+    def _get_underlying_exception(exc: requests.exceptions.RequestException) -> Union[BaseException, None]:
+        """ requests.exceptions.RequestException adds three layers on top of built-in networking exceptions:
+        requests.exceptions.RequestException -> urllib3.exceptions.MaxRetryError -> urllib3.exceptions.HTTPError
+        -> underlying exception
+
+        requests does not use the "raise ... from ..." syntax, so we need to access the underlying exception using the
+        __context__ attribute.
+        """
+        return exc.__context__.__context__.__context__

--- a/cognite/client/_http_client.py
+++ b/cognite/client/_http_client.py
@@ -101,8 +101,6 @@ class HTTPClient:
             try:
                 res = self._do_request(method=method, url=url, **kwargs)
                 last_status = res.status_code
-                if last_status not in self.config.status_codes_to_retry:
-                    return res
                 self.retry_tracker.status += 1
                 if not self.retry_tracker.should_retry(status_code=last_status):
                     return res

--- a/cognite/client/_http_client.py
+++ b/cognite/client/_http_client.py
@@ -124,11 +124,13 @@ class HTTPClient:
             underlying_exc = self._get_underlying_exception(e)
             if isinstance(underlying_exc, socket.timeout):
                 raise CogniteReadTimeout from e
-            if isinstance(underlying_exc, ConnectionError):
+            elif isinstance(underlying_exc, ConnectionError):
                 if isinstance(underlying_exc, ConnectionRefusedError):
                     raise CogniteConnectionRefused from e
                 else:
                     raise CogniteConnectionError from e
+            else:
+                raise e
 
     @staticmethod
     def _get_underlying_exception(exc: requests.exceptions.RequestException) -> Union[BaseException, None]:

--- a/cognite/client/_http_client.py
+++ b/cognite/client/_http_client.py
@@ -2,10 +2,9 @@ import random
 import socket
 import time
 from http import cookiejar
-from typing import Optional, Set, Union
+from typing import Optional, Set
 
-import requests.exceptions
-import urllib3.exceptions
+import urllib3
 from requests import Response, Session
 from requests.adapters import HTTPAdapter
 from requests.packages.urllib3 import Retry
@@ -90,7 +89,7 @@ class _RetryTracker:
 
 
 class HTTPClient:
-    def __init__(self, session: Session, config: HTTPClientConfig):
+    def __init__(self, config: HTTPClientConfig, session: Session = GLOBAL_REQUEST_SESSION):
         self.session = session
         self.config = config
         self.retry_tracker = None
@@ -128,8 +127,7 @@ class HTTPClient:
             if isinstance(underlying_exc, ConnectionError):
                 if isinstance(underlying_exc, ConnectionRefusedError):
                     raise CogniteConnectionRefused from e
-                else:
-                    raise CogniteConnectionError from e
+                raise CogniteConnectionError from e
             raise e
 
     @classmethod

--- a/cognite/client/exceptions.py
+++ b/cognite/client/exceptions.py
@@ -2,7 +2,11 @@ import json
 from typing import *
 
 
-class CogniteConnectionError(Exception):
+class CogniteException(Exception):
+    pass
+
+
+class CogniteConnectionError(CogniteException):
     pass
 
 
@@ -10,11 +14,11 @@ class CogniteConnectionRefused(CogniteConnectionError):
     pass
 
 
-class CogniteReadTimeout(Exception):
+class CogniteReadTimeout(CogniteException):
     pass
 
 
-class CogniteMultiException(Exception):
+class CogniteMultiException(CogniteException):
     def __init__(self, successful: List = None, failed: List = None, unknown: List = None, unwrap_fn: Callable = None):
         self.successful = successful or []
         self.failed = failed or []
@@ -159,7 +163,7 @@ class CogniteDuplicatedError(CogniteMultiException):
         return msg
 
 
-class CogniteImportError(Exception):
+class CogniteImportError(CogniteException):
     """Cognite Import Error
 
     Raised if the user attempts to use functionality which requires an uninstalled package.
@@ -179,7 +183,7 @@ class CogniteImportError(Exception):
         return self.message
 
 
-class CogniteMissingClientError(Exception):
+class CogniteMissingClientError(CogniteException):
     """Cognite Missing Client Error
 
     Raised if the user attempts to make use of a method which requires the cognite_client being set, but it is not.
@@ -189,7 +193,7 @@ class CogniteMissingClientError(Exception):
         return "A CogniteClient has not been set on this object. Pass it in the constructor to use it."
 
 
-class CogniteAPIKeyError(Exception):
+class CogniteAPIKeyError(CogniteException):
     """Cognite API Key Error.
 
     Raised if the API key is missing or invalid.
@@ -198,7 +202,7 @@ class CogniteAPIKeyError(Exception):
     pass
 
 
-class CogniteDuplicateColumnsError(Exception):
+class CogniteDuplicateColumnsError(CogniteException):
     """Cognite Duplicate Columns Error
 
     Raised if the user attempts to create a dataframe through include_aggregate_names=False which results in duplicate column names.

--- a/cognite/client/exceptions.py
+++ b/cognite/client/exceptions.py
@@ -2,6 +2,18 @@ import json
 from typing import *
 
 
+class CogniteConnectionError(Exception):
+    pass
+
+
+class CogniteConnectionRefused(CogniteConnectionError):
+    pass
+
+
+class CogniteReadTimeout(Exception):
+    pass
+
+
 class CogniteMultiException(Exception):
     def __init__(self, successful: List = None, failed: List = None, unknown: List = None, unwrap_fn: Callable = None):
         self.successful = successful or []

--- a/cognite/client/utils/_client_config.py
+++ b/cognite/client/utils/_client_config.py
@@ -41,7 +41,7 @@ class _DefaultConfig:
         self.status_forcelist = self._get_status_forcelist()
         self.max_retries = int(os.getenv("COGNITE_MAX_RETRIES", 10))
         self.max_retry_backoff = int(os.getenv("COGNITE_MAX_RETRY_BACKOFF", 30))
-        self.max_connection_pool_size = int(os.getenv("COGNITE_MAX_CONNECTION_POOL_SIZE", self.max_workers))
+        self.max_connection_pool_size = int(os.getenv("COGNITE_MAX_CONNECTION_POOL_SIZE", 50))
         self.disable_ssl = os.getenv("COGNITE_DISABLE_SSL", False)
 
     @staticmethod

--- a/cognite/client/utils/_client_config.py
+++ b/cognite/client/utils/_client_config.py
@@ -41,7 +41,7 @@ class _DefaultConfig:
         self.status_forcelist = self._get_status_forcelist()
         self.max_retries = int(os.getenv("COGNITE_MAX_RETRIES", 10))
         self.max_retry_backoff = int(os.getenv("COGNITE_MAX_RETRY_BACKOFF", 30))
-        self.max_connection_pool_size = int(os.getenv("COGNITE_MAX_CONNECTION_POOL_SIZE", 50))
+        self.max_connection_pool_size = int(os.getenv("COGNITE_MAX_CONNECTION_POOL_SIZE", self.max_workers))
         self.disable_ssl = os.getenv("COGNITE_DISABLE_SSL", False)
 
     @staticmethod

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,11 @@
+[tool.black]
+line-length = 120
+target_version = ['py38']
+include = '\.py$'
+
+[tool.isort]
+line_length=120                # corresponds to -w  flag
+multi_line_output=3            # corresponds to -m  flag
+include_trailing_comma=true    # corresponds to -tc flag
+skip_glob = '^((?!py$).)*$'    # isort all Python files
+float_to_top=true

--- a/tests/tests_unit/test_api_client.py
+++ b/tests/tests_unit/test_api_client.py
@@ -1015,5 +1015,9 @@ class TestConnectionPooling:
     def test_connection_pool_is_shared_between_clients(self):
         c1 = CogniteClient()
         c2 = CogniteClient()
-        assert c1._api_client._request_session == c2._api_client._request_session
-        assert c1._api_client._request_session_with_retry == c2._api_client._request_session_with_retry
+        assert (
+            c1._api_client._http_client.session
+            == c2._api_client._http_client.session
+            == c1._api_client._http_client_with_retry.session
+            == c2._api_client._http_client_with_retry.session
+        )

--- a/tests/tests_unit/test_http_client.py
+++ b/tests/tests_unit/test_http_client.py
@@ -157,12 +157,17 @@ class UnderlyingException(Exception):
 
 
 class TestGetUnderlyingException:
+    def test_get_underlying_exception_does_not_exist_in_context(self):
+        try:
+            raise Exception
+        except Exception as e:
+            assert not HTTPClient._any_exception_in_context_isinstance(e, UnderlyingException)
+
     def test_get_underlying_exception_no_context(self):
         try:
             raise UnderlyingException
         except Exception as e:
-            underlying = HTTPClient._get_underlying_exception(e)
-            assert isinstance(e, UnderlyingException)
+            assert HTTPClient._any_exception_in_context_isinstance(e, (UnderlyingException, Exception))
 
     def test_get_underlying_exception_nested_1_layer(self):
         def testcase():
@@ -174,8 +179,7 @@ class TestGetUnderlyingException:
         try:
             testcase()
         except Exception as e:
-            assert not isinstance(e, UnderlyingException)
-            assert isinstance(HTTPClient._get_underlying_exception(e), UnderlyingException)
+            assert HTTPClient._any_exception_in_context_isinstance(e, UnderlyingException)
 
     def test_get_underlying_exception_nested_2_layers(self):
         def testcase():
@@ -190,5 +194,4 @@ class TestGetUnderlyingException:
         try:
             testcase()
         except Exception as e:
-            assert not isinstance(e, UnderlyingException)
-            assert isinstance(HTTPClient._get_underlying_exception(e), UnderlyingException)
+            assert HTTPClient._any_exception_in_context_isinstance(e, UnderlyingException)

--- a/tests/tests_unit/test_http_client.py
+++ b/tests/tests_unit/test_http_client.py
@@ -71,10 +71,7 @@ def raise_exception_wrapped_as_in_requests_lib(exc: Exception):
         try:
             raise urllib3.exceptions.RequestError(pool=None, url=None, message=None)
         except urllib3.exceptions.RequestError:
-            try:
-                raise urllib3.exceptions.MaxRetryError(pool=None, url=None)
-            except urllib3.exceptions.MaxRetryError:
-                raise requests.exceptions.ReadTimeout
+            raise requests.exceptions.RequestException
 
 
 class TestHTTPClient:

--- a/tests/tests_unit/test_http_client.py
+++ b/tests/tests_unit/test_http_client.py
@@ -1,0 +1,155 @@
+import socket
+from unittest.mock import MagicMock
+
+import pytest
+import requests.exceptions
+import urllib3.exceptions
+
+from cognite.client._http_client import HTTPClient, HTTPClientConfig, _RetryTracker
+from cognite.client.exceptions import CogniteConnectionError, CogniteConnectionRefused, CogniteReadTimeout
+
+DEFAULT_CONFIG = HTTPClientConfig(
+    status_codes_to_retry={429},
+    backoff_factor=0.5,
+    max_backoff_seconds=30,
+    max_retries_total=10,
+    max_retries_read=5,
+    max_retries_connect=5,
+    max_retries_status=10,
+)
+
+
+class TestRetryTracker:
+    def test_total_retries_exceeded(self):
+        rt = _RetryTracker(config=DEFAULT_CONFIG)
+        rt.config.max_retries_total = 10
+        rt.status = 4
+        rt.connect = 4
+        rt.read = 4
+
+        assert rt.total == 12
+        assert rt.should_retry(200) is False
+
+    def test_status_retries_exceeded(self):
+        rt = _RetryTracker(config=DEFAULT_CONFIG)
+        rt.config.max_retries_status = 1
+        assert rt.should_retry(None) is True
+        rt.status = 1
+        assert rt.should_retry(None) is False
+
+    def test_read_retries_exceeded(self):
+        rt = _RetryTracker(config=DEFAULT_CONFIG)
+        rt.config.max_retries_read = 1
+        assert rt.should_retry(None) is True
+        rt.read = 1
+        assert rt.should_retry(None) is False
+
+    def test_connect_retries_exceeded(self):
+        rt = _RetryTracker(config=DEFAULT_CONFIG)
+        rt.config.max_retries_connect = 1
+        assert rt.should_retry(None) is True
+        rt.connect = 1
+        assert rt.should_retry(None) is False
+
+    def test_correct_retry_of_status(self):
+        rt = _RetryTracker(config=DEFAULT_CONFIG)
+        assert rt.should_retry(500) is False
+        rt.config.status_codes_to_retry = {500, 429}
+        assert rt.should_retry(500) is True
+
+    def test_get_backoff_time(self):
+        rt = _RetryTracker(config=DEFAULT_CONFIG)
+        for i in range(1000):
+            rt.read += 1
+            assert 0 <= rt.get_backoff_time() <= DEFAULT_CONFIG.max_backoff_seconds
+
+
+def raise_exception_wrapped_as_in_requests_lib(exc: Exception):
+    try:
+        raise exc
+    except type(exc):
+        try:
+            raise urllib3.exceptions.RequestError(pool=None, url=None, message=None)
+        except urllib3.exceptions.RequestError:
+            try:
+                raise urllib3.exceptions.MaxRetryError(pool=None, url=None)
+            except urllib3.exceptions.MaxRetryError:
+                raise requests.exceptions.ReadTimeout
+
+
+class TestHTTPClient:
+    def test_read_timeout_errors(self):
+        cnf = DEFAULT_CONFIG
+        cnf.max_backoff_seconds = 0
+        c = HTTPClient(
+            config=cnf,
+            session=MagicMock(
+                request=MagicMock(
+                    side_effect=lambda *args, **kwargs: raise_exception_wrapped_as_in_requests_lib(socket.timeout())
+                )
+            ),
+        )
+
+        with pytest.raises(CogniteReadTimeout):
+            c.request("GET", "bla")
+
+        assert c.retry_tracker.total == DEFAULT_CONFIG.max_retries_read
+        assert c.retry_tracker.read == DEFAULT_CONFIG.max_retries_read
+        assert c.retry_tracker.connect == 0
+        assert c.retry_tracker.status == 0
+
+    @pytest.mark.parametrize("exc_type", [ConnectionAbortedError, ConnectionResetError, BrokenPipeError])
+    def test_connect_errors(self, exc_type):
+        cnf = DEFAULT_CONFIG
+        cnf.max_backoff_seconds = 0
+        c = HTTPClient(
+            config=cnf,
+            session=MagicMock(
+                request=MagicMock(
+                    side_effect=lambda *args, **kwargs: raise_exception_wrapped_as_in_requests_lib(exc_type())
+                )
+            ),
+        )
+
+        with pytest.raises(CogniteConnectionError):
+            c.request("GET", "bla")
+
+        assert c.retry_tracker.total == DEFAULT_CONFIG.max_retries_connect
+        assert c.retry_tracker.read == 0
+        assert c.retry_tracker.connect == DEFAULT_CONFIG.max_retries_connect
+        assert c.retry_tracker.status == 0
+
+    def test_connection_refused_not_retried(self):
+        cnf = DEFAULT_CONFIG
+        cnf.max_backoff_seconds = 0
+        c = HTTPClient(
+            config=cnf,
+            session=MagicMock(
+                request=MagicMock(
+                    side_effect=lambda *args, **kwargs: raise_exception_wrapped_as_in_requests_lib(
+                        ConnectionRefusedError()
+                    )
+                )
+            ),
+        )
+
+        with pytest.raises(CogniteConnectionRefused):
+            c.request("GET", "bla")
+
+        assert c.retry_tracker.total == 1
+        assert c.retry_tracker.read == 0
+        assert c.retry_tracker.connect == 1
+        assert c.retry_tracker.status == 0
+
+    def test_status_errors(self):
+        cnf = DEFAULT_CONFIG
+        cnf.max_backoff_seconds = 0
+        c = HTTPClient(config=cnf, session=MagicMock(request=MagicMock(return_value=MagicMock(status_code=429))))
+
+        res = c.request("GET", "bla")
+        assert res.status_code == 429
+
+        assert c.retry_tracker.total == DEFAULT_CONFIG.max_retries_status
+        assert c.retry_tracker.read == 0
+        assert c.retry_tracker.connect == 0
+        assert c.retry_tracker.status == DEFAULT_CONFIG.max_retries_status


### PR DESCRIPTION
A few improvements to transport logic. Hoperfully this fixes the connection errors we have been seeing, need someone who can reproduce to verify though (I was told you could help with that @pavelzubarev ?).

Changes:
- Retry logic no longer relies on urllib3's builtin Retry class. This should ensure that a new connection is used when retrying, instead of retrying on the same broken connection. This also means we no longer need two separate connection pools, as retry logic is decoupled from HTTPAdapter. ConnectionRefused (i.e. ECONNREFUSED) is treated as non-retryable, all other connection errors are treated as retryable.
- Moves retry and transport configuration into a _http_client module.
- Adds jitter to exponential backoff so no need for #672 
- Addresses #714 

requests is very inconsistent as to how it communicates connection errors, so I had to do some hacking and search the exception context chain for different requests/urrlib3/built-in exceptions, and classify the failure as either CogniteReadTimeout, CogniteConnectionError, or CogniteConnectionRefused.