### PR TITLE
[SBS-2094] Add py.typed file to inform that package is typed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,11 @@ Changes are grouped as follows
 
 ## Unreleased
 
+## [2.3.0] - 2020-08-25
+
+### Changed
+- Provide type information to users of this package
+
 ## [2.2.2] - 2020-08-18
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ Changes are grouped as follows
 ## [2.3.0] - 2020-08-25
 
 ### Changed
-- Provide type information to users of this package
+- Add support for mypy and other type checking tools by adding packaging type information
 
 ## [2.2.2] - 2020-08-18
 

--- a/cognite/client/__init__.py
+++ b/cognite/client/__init__.py
@@ -1,3 +1,3 @@
 from cognite.client._cognite_client import CogniteClient
 
-__version__ = "2.2.2"
+__version__ = "2.3.0"


### PR DESCRIPTION
We (unstructured search) painfully discovered that mypy doesn't know types of an installed package, even when it has been typed.

This change is apparently needed, and is per [this accepted Python Enhancement Proposal](https://www.python.org/dev/peps/pep-0561/). From [mypy docs](https://mypy.readthedocs.io/en/stable/installed_packages.html#making-pep-561-compatible-packages):

> If you would like to publish a library package to a package repository (e.g. PyPI) for either internal or external use in type checking, packages that supply type information via type comments or annotations in the code should put a py.typed file in their package directory.

See also [this PR for the cognite-auth package](https://github.com/cognitedata/python-auth/pull/58).

I updated the minor version. The changelog has to be updated as well, right?