### PR TITLE
move directory field and update description to differentiate it from path

### DIFF
--- a/cognite/client/_api/files.py
+++ b/cognite/client/_api/files.py
@@ -448,11 +448,11 @@ class FilesAPI(APIClient):
         self,
         path: str,
         external_id: str = None,
-        directory: str = None,
         name: str = None,
         source: str = None,
         mime_type: str = None,
         metadata: Dict[str, str] = None,
+        directory: str = None,
         asset_ids: List[int] = None,
         source_created_time: int = None,
         source_modified_time: int = None,
@@ -467,11 +467,11 @@ class FilesAPI(APIClient):
         Args:
             path (str): Path to the file you wish to upload. If path is a directory, this method will upload all files in that directory.
             external_id (str): The external ID provided by the client. Must be unique within the project.
-            directory (str): The directory provided by the client. Must be an absolute, unix-style path.
             name (str): Name of the file.
             source (str): The source of the file.
             mime_type (str): File type. E.g. text/plain, application/pdf, ...
             metadata (Dict[str, str]): Customizable extra data about the file. String key -> String value.
+            directory (str): The directory to be associated with this file. Must be an absolute, unix-style path.
             asset_ids (List[int]): No description.
             data_set_id (int): ID of the data set.
             labels (List[Label]): A list of the labels associated with this resource item.
@@ -568,11 +568,11 @@ class FilesAPI(APIClient):
         self,
         content: Union[str, bytes, TextIO, BinaryIO],
         name: str,
-        directory: str = None,
         external_id: str = None,
         source: str = None,
         mime_type: str = None,
         metadata: Dict[str, str] = None,
+        directory: str = None,
         asset_ids: List[int] = None,
         data_set_id: int = None,
         labels: List[Label] = None,
@@ -588,11 +588,11 @@ class FilesAPI(APIClient):
         Args:
             content (Union[str, bytes, TextIO, BinaryIO]): The content to upload.
             name (str): Name of the file.
-            directory (str): The directory provided by the client. Must be an absolute, unix-style path.
             external_id (str): The external ID provided by the client. Must be unique within the project.
             source (str): The source of the file.
             mime_type (str): File type. E.g. text/plain, application/pdf,...
             metadata (Dict[str, str]): Customizable extra data about the file. String key -> String value.
+            directory (str): The directory to be associated with this file. Must be an absolute, unix-style path.
             asset_ids (List[int]): No description.
             data_set_id (int): Id of the data set.
             labels (List[Label]): A list of the labels associated with this resource item.
@@ -617,11 +617,11 @@ class FilesAPI(APIClient):
         """
         file_metadata = FileMetadata(
             name=name,
-            directory=directory,
             external_id=external_id,
             source=source,
             mime_type=mime_type,
             metadata=metadata,
+            directory=directory,
             asset_ids=asset_ids,
             data_set_id=data_set_id,
             labels=labels,

--- a/cognite/client/data_classes/files.py
+++ b/cognite/client/data_classes/files.py
@@ -12,10 +12,10 @@ class FileMetadata(CogniteResource):
     Args:
         external_id (str): The external ID provided by the client. Must be unique for the resource type.
         name (str): Name of the file.
-        directory (str): Directory containing the file. Must be an absolute, unix-style path.
         source (str): The source of the file.
         mime_type (str): File type. E.g. text/plain, application/pdf, ..
         metadata (Dict[str, str]): Custom, application specific metadata. String key -> String value. Limits: Maximum length of key is 32 bytes, value 512 bytes, up to 16 key-value pairs.
+        directory (str): Directory associated with the file. Must be an absolute, unix-style path.
         asset_ids (List[int]): No description.
         data_set_id (int): The dataSet Id for the item.
         labels (List[Label]): A list of the labels associated with this resource item.
@@ -34,10 +34,10 @@ class FileMetadata(CogniteResource):
         self,
         external_id: str = None,
         name: str = None,
-        directory: str = None,
         source: str = None,
         mime_type: str = None,
         metadata: Dict[str, str] = None,
+        directory: str = None,
         asset_ids: List[int] = None,
         data_set_id: int = None,
         labels: List[Label] = None,


### PR DESCRIPTION
I realized that the new `directory` field could be a bit confused when placed right next to `path` in the documentation, so I wanted to make the difference a bit more clear.