### PR TITLE
Remove python v3.6, v3.7 from test_and_build

### DIFF
--- a/.github/workflows/test_and_build.yml
+++ b/.github/workflows/test_and_build.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.5, 3.6, 3.7, 3.8]
+        python-version: [3.5, 3.8]
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
Just to give some space to concurrent tests frequently flooding APIs (and stop getting 429s)