### PR TITLE
Adding missing requirement to setup-core

### DIFF
--- a/setup-core.py
+++ b/setup-core.py
@@ -17,7 +17,7 @@ setup(
     download_url="https://github.com/cognitedata/cognite-sdk-python/archive/{}.tar.gz".format(version),
     author="Erlend Vollset",
     author_email="erlend.vollset@cognite.com",
-    install_requires=["requests>=2.21.0,<3.0.0"],
+    install_requires=["requests>=2.21.0,<3.0.0", "requests_oauthlib==1.3.0"],
     python_requires=">=3.5",
     packages=["cognite." + p for p in find_packages(where="cognite")],
     include_package_data=True,


### PR DESCRIPTION
Missed adding the requirement for `requests_oauthlib` to `setup-core.py`