### PR TITLE
[SBS-3069] Set geoLocation.type to "Feature" if missing

### DIFF
--- a/cognite/client/__init__.py
+++ b/cognite/client/__init__.py
@@ -1,3 +1,3 @@
 from cognite.client._cognite_client import CogniteClient
 
-__version__ = "2.10.1"
+__version__ = "2.10.2"

--- a/cognite/client/data_classes/files.py
+++ b/cognite/client/data_classes/files.py
@@ -119,7 +119,7 @@ class GeoLocation(dict):
     @classmethod
     def _load(self, raw_geoLocation: Dict[str, Any]):
         return GeoLocation(
-            type=raw_geoLocation["type"],
+            type=raw_geoLocation.get("type", "Feature"),
             geometry=raw_geoLocation["geometry"],
             properties=raw_geoLocation.get("properties"),
         )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,8 +4,8 @@ target_version = ['py38']
 include = '\.py$'
 
 [tool.isort]
-line_length=120                # corresponds to -w  flag
-multi_line_output=3            # corresponds to -m  flag
-include_trailing_comma=true    # corresponds to -tc flag
+line_length = 120
+multi_line_output = 3
+include_trailing_comma = true
 skip_glob = '^((?!py$).)*$'    # isort all Python files
-float_to_top=true
+float_to_top = true


### PR DESCRIPTION
It's not supposed to be allowed to do this, but it was. [This PR](https://github.com/cognitedata/ark/pull/1646) fixed it, so now the API should never allow it. But there may be some files where `geolocation.type` is not set.