### PR TITLE
Retry urllib3.NewConnectionError when it isn't in the context of a ConnectionRefusedError

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@ Changes are grouped as follows
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
+## [2.10.6] - 2021-02-02
+
+### Fixed
+- Retry urllib3.NewConnectionError when it isn't in the context of a ConnectionRefusedError
+
 ## [2.10.5] - 2021-01-25
 
 ### Fixed

--- a/cognite/client/__init__.py
+++ b/cognite/client/__init__.py
@@ -1,3 +1,3 @@
 from cognite.client._cognite_client import CogniteClient
 
-__version__ = "2.10.5"
+__version__ = "2.10.6"

--- a/cognite/client/_http_client.py
+++ b/cognite/client/_http_client.py
@@ -144,9 +144,7 @@ class HTTPClient:
                     requests.exceptions.ConnectionError,
                 ),
             ):
-                if self._any_exception_in_context_isinstance(
-                    e, (ConnectionRefusedError, urllib3.exceptions.NewConnectionError)
-                ):
+                if self._any_exception_in_context_isinstance(e, ConnectionRefusedError):
                     raise CogniteConnectionRefused from e
                 raise CogniteConnectionError from e
             raise e


### PR DESCRIPTION
Example stacktrace of when it should be retried, in context of `socket.gaierror`

```
.venv/lib/python3.8/site-packages/urllib3/connection.py:159: in _new_conn
    conn = connection.create_connection(
.venv/lib/python3.8/site-packages/urllib3/util/connection.py:61: in create_connection
    for res in socket.getaddrinfo(host, port, family, socket.SOCK_STREAM):
../../.pyenv/versions/3.8.6/lib/python3.8/socket.py:918: in getaddrinfo
    for res in _socket.getaddrinfo(host, port, family, type, proto, flags):
E   socket.gaierror: [Errno 8] nodename nor servname provided, or not known
During handling of the above exception, another exception occurred:
.venv/lib/python3.8/site-packages/cognite/client/_http_client.py:131: in _do_request
    res = self.session.request(method=method, url=url, **kwargs)
.venv/lib/python3.8/site-packages/requests/sessions.py:533: in request
    resp = self.send(prep, **send_kwargs)
.venv/lib/python3.8/site-packages/requests/sessions.py:646: in send
    r = adapter.send(request, **kwargs)
.venv/lib/python3.8/site-packages/requests/adapters.py:439: in send
    resp = conn.urlopen(
.venv/lib/python3.8/site-packages/urllib3/connectionpool.py:726: in urlopen
    retries = retries.increment(
.venv/lib/python3.8/site-packages/urllib3/util/retry.py:386: in increment
    raise six.reraise(type(error), error, _stacktrace)
.venv/lib/python3.8/site-packages/urllib3/packages/six.py:735: in reraise
    raise value
.venv/lib/python3.8/site-packages/urllib3/connectionpool.py:670: in urlopen
    httplib_response = self._make_request(
.venv/lib/python3.8/site-packages/urllib3/connectionpool.py:381: in _make_request
    self._validate_conn(conn)
.venv/lib/python3.8/site-packages/urllib3/connectionpool.py:978: in _validate_conn
    conn.connect()
.venv/lib/python3.8/site-packages/urllib3/connection.py:309: in connect
    conn = self._new_conn()
.venv/lib/python3.8/site-packages/urllib3/connection.py:171: in _new_conn
    raise NewConnectionError(
E   urllib3.exceptions.NewConnectionError: <urllib3.connection.HTTPSConnection object at 0x112116640>: Failed to establish a new connection: [Errno 8] nodename nor servname provided, or not known
The above exception was the direct cause of the following exception:
smoke/tests/test_relationships/tests_v1/conftest.py:136: in created_relationships
    res = cdf_client.relationships.create(relationships)
.venv/lib/python3.8/site-packages/cognite/client/_api/relationships.py:312: in create
    return self._create_multiple(items=relationship)
.venv/lib/python3.8/site-packages/cognite/client/_api_client.py:534: in _create_multiple
    summary.raise_compound_exception_if_failed_tasks(
.venv/lib/python3.8/site-packages/cognite/client/utils/_concurrency.py:53: in raise_compound_exception_if_failed_tasks
    collect_exc_info_and_raise(
.venv/lib/python3.8/site-packages/cognite/client/utils/_concurrency.py:97: in collect_exc_info_and_raise
    raise unknown_exc
.venv/lib/python3.8/site-packages/cognite/client/utils/_concurrency.py:127: in execute_tasks_concurrently
    res = f.result()
../../.pyenv/versions/3.8.6/lib/python3.8/concurrent/futures/_base.py:439: in result
    return self.__get_result()
../../.pyenv/versions/3.8.6/lib/python3.8/concurrent/futures/_base.py:388: in __get_result
    raise self._exception
../../.pyenv/versions/3.8.6/lib/python3.8/concurrent/futures/thread.py:57: in run
    result = self.fn(*self.args, **self.kwargs)
.venv/lib/python3.8/site-packages/cognite/client/_api_client.py:113: in _post
    return self._do_request(
.venv/lib/python3.8/site-packages/cognite/client/_api_client.py:148: in _do_request
    res = self._http_client.request(method=method, url=full_url, **kwargs)
.venv/lib/python3.8/site-packages/cognite/client/_http_client.py:120: in request
    raise e
.venv/lib/python3.8/site-packages/cognite/client/_http_client.py:108: in request
    res = self._do_request(method=method, url=url, **kwargs)
.venv/lib/python3.8/site-packages/cognite/client/_http_client.py:150: in _do_request
    raise CogniteConnectionRefused from e
E   cognite.client.exceptions.CogniteConnectionRefused
```