### PR TITLE
Bug: `limit=0` yields `self._LIST_LIMIT` instead of raising APIError 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@ Changes are grouped as follows
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
+## [2.12.0] - 2021-02-22
+
+### Changed
+- Setting `limit=0` in list-endpoints should now correctly raise an API error instead of returning `LIST_LIMIT` number of items.
+
 ## [2.11.1] - 2021-02-18
 
 ### Changed

--- a/cognite/client/__init__.py
+++ b/cognite/client/__init__.py
@@ -1,3 +1,3 @@
 from cognite.client._cognite_client import CogniteClient
 
-__version__ = "2.11.1"
+__version__ = "2.12.0"

--- a/cognite/client/_api_client.py
+++ b/cognite/client/_api_client.py
@@ -309,7 +309,7 @@ class APIClient:
             filter = filter or {}
             current_items = []
             while True:
-                if limit:
+                if limit or limit == 0:
                     num_of_remaining_items = limit - total_items_retrieved
                     if num_of_remaining_items < self._LIST_LIMIT:
                         current_limit = num_of_remaining_items


### PR DESCRIPTION
Setting `limit=0` in the `_list`-method incorrectly returns `self._LIST_LIMIT` number of items. It should raise an APIError as `limit>0` is enforced in `context-api`.

Addresses #789 