### PR TITLE
Improve error message when missing raw key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,11 @@ Changes are grouped as follows
 - `Security` in case of vulnerabilities.
 
 
+## [2.12.2] - 2021-03-11
+
+### Fixed
+- CogniteAPIError raised (instead of internal KeyError) when inserting a RAW row without a key.
+
 ## [2.12.1] - 2021-03-09
 
 ### Fixed
@@ -73,7 +78,7 @@ Changes are grouped as follows
 ## [2.10.1] - 2020-12-03
 
 ### Added
-- Chaining of requests to the relationships list method, 
+- Chaining of requests to the relationships list method,
 allowing the method to take arbitrarily long lists for `source_external_ids` and `target_external_ids`
 
 ## [2.10.0] - 2020-12-01

--- a/cognite/client/__init__.py
+++ b/cognite/client/__init__.py
@@ -1,4 +1,4 @@
 from cognite.client._cognite_client import CogniteClient
 
 
-__version__ = "2.12.1"
+__version__ = "2.12.2"

--- a/cognite/client/_api/raw.py
+++ b/cognite/client/_api/raw.py
@@ -326,7 +326,7 @@ class RawRowsAPI(APIClient):
         ]
         summary = utils._concurrency.execute_tasks_concurrently(self._post, tasks, max_workers=self._config.max_workers)
         summary.raise_compound_exception_if_failed_tasks(
-            task_unwrap_fn=lambda task: task["json"]["items"], task_list_element_unwrap_fn=lambda row: row["key"]
+            task_unwrap_fn=lambda task: task["json"]["items"], task_list_element_unwrap_fn=lambda row: row.get("key")
         )
 
     def _process_row_input(self, row: List[Union[List, Dict, Row]]):


### PR DESCRIPTION
If a user tries to insert a raw row without specifying key, the current error message is somewhat cryptic since there is an internal KeyError during the error handling, so
```
client.raw.rows.insert("tb", "table", Row(key=None, columns={"Key": "Hello"}), ensure_parent=True)
```
fails with `KeyError: 'key'` and not a `CogniteAPIError`. With this change it would give 
```
CogniteAPIError: The request body was invalid. | code: 400 | X-Request-ID: None
The API Failed to process some items.
Successful (2xx): []
Unknown (5xx): []
Failed (4xx): [None]
```
instead.