### PR TITLE
Add templates, add support for date-based versioning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@ Changes are grouped as follows
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
+## [2.16.0] - 2021-03-24
+
+### Added
+- support for templates.
+- date-based `cdf-version` header.
 
 ## [2.15.0] - 2021-03-12
 

--- a/cognite/client/__init__.py
+++ b/cognite/client/__init__.py
@@ -1,4 +1,3 @@
 from cognite.client._cognite_client import CogniteClient
 
-
 __version__ = "2.15.0"

--- a/cognite/client/__init__.py
+++ b/cognite/client/__init__.py
@@ -1,3 +1,3 @@
 from cognite.client._cognite_client import CogniteClient
 
-__version__ = "2.15.0"
+__version__ = "2.16.0"

--- a/cognite/client/_api/templates.py
+++ b/cognite/client/_api/templates.py
@@ -109,7 +109,7 @@ class TemplateGroupsAPI(APIClient):
         is_single = not isinstance(template_groups, list)
         if is_single:
             template_groups = [template_groups]
-        updated = self._post(path, {"items": [item.dump(camel_case=True) for item in template_groups]},).json()["items"]
+        updated = self._post(path, {"items": [item.dump(camel_case=True) for item in template_groups]}).json()["items"]
         res = self._LIST_CLASS._load(updated, cognite_client=self._cognite_client)
         if is_single:
             return res[0]
@@ -230,7 +230,7 @@ class TemplateGroupVersionsAPI(APIClient):
                 >>> c.templates.versions.upsert(template_group.external_id, template_group_version)
         """
         resource_path = utils._auxiliary.interpolate_and_url_encode(self._RESOURCE_PATH, external_id) + "/upsert"
-        version = self._post(resource_path, version.dump(camel_case=True),).json()
+        version = self._post(resource_path, version.dump(camel_case=True)).json()
         return TemplateGroupVersion._load(version)
 
     def list(
@@ -376,7 +376,7 @@ class TemplateInstancesAPI(APIClient):
             utils._auxiliary.interpolate_and_url_encode(self._RESOURCE_PATH, external_id, version) + "/upsert"
         )
         updated = self._post(
-            resource_path, {"items": [instance.dump(camel_case=True) for instance in instances]},
+            resource_path, {"items": [instance.dump(camel_case=True) for instance in instances]}
         ).json()["items"]
         res = TemplateInstanceList._load(updated, cognite_client=self._cognite_client)
         if len(res) == 1:

--- a/cognite/client/_api/templates.py
+++ b/cognite/client/_api/templates.py
@@ -1,0 +1,475 @@
+from typing import List, Union
+
+from cognite.client._api_client import APIClient
+from cognite.experimental.data_classes.templates import *
+
+
+class TemplatesAPI(APIClient):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.groups = TemplateGroupsAPI(*args, **kwargs)
+        self.versions = TemplateGroupVersionsAPI(*args, **kwargs)
+        self.instances = TemplateInstancesAPI(*args, **kwargs)
+
+    def graphql_query(self, external_id: str, version: int, query: str) -> GraphQlResponse:
+        """
+        `Run a GraphQL Query.`
+        To learn more, see https://graphql.org/learn/
+
+        Args:
+            external_id (str): The external id of the template group.
+            version (int): The version of the template group to run the query on.
+            query (str): The GraphQL query to run.
+
+        Returns:
+            GraphQlResponse: the result of the query.
+
+        Examples:
+            Run a GraphQL query:
+
+                >>> from cognite.experimental import CogniteClient
+                >>> c = CogniteClient()
+                >>> query = '''
+                >>>    {
+                >>>        countryList {
+                >>>           name,
+                >>>           demographics {
+                >>>               populationSize,
+                >>>               growthRate
+                >>>           },
+                >>>           deaths {
+                >>>               datapoints(limit: 100) {
+                >>>                   timestamp,
+                >>>                   value
+                >>>               }
+                >>>           }
+                >>>        }
+                >>>    }
+                >>>    '''
+                >>> result = c.templates.query.graphql_query("template-group-ext-id", 1, query)
+        """
+        path = "/templategroups/{}/versions/{}/graphql"
+        path = utils._auxiliary.interpolate_and_url_encode(path, external_id, version)
+        response = self._post(path, {"query": query})
+        return GraphQlResponse._load(response.json())
+
+
+class TemplateGroupsAPI(APIClient):
+    _RESOURCE_PATH = "/templategroups"
+    _LIST_CLASS = TemplateGroupList
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+    def create(
+        self, template_groups: Union[TemplateGroup, List[TemplateGroup]]
+    ) -> Union[TemplateGroup, TemplateGroupList]:
+        """`Create one or more template groups.`
+
+        Args:
+            template_groups (Union[TemplateGroup, List[TemplateGroup]])
+
+        Returns:
+            Union[TemplateGroup, TemplateGroupList]: Created template group(s)
+
+        Examples:
+            create a new template group:
+
+                >>> from cognite.experimental import CogniteClient
+                >>> from cognite.experimental.data_classes import TemplateGroup
+                >>> c = CogniteClient()
+                >>> template_group_1 = TemplateGroup("sdk-test-group", "This is a test group")
+                >>> template_group_2 = TemplateGroup("sdk-test-group-2", "This is another test group")
+                >>> c.templates.groups.create([template_group_1, template_group_2])
+        """
+        return self._create_multiple(items=template_groups)
+
+    def upsert(
+        self, template_groups: Union[TemplateGroup, List[TemplateGroup]]
+    ) -> Union[TemplateGroup, TemplateGroupList]:
+        """`Upsert one or more template groups.`
+        Will overwrite existing template group(s) with the same external id(s).
+
+        Args:
+            template_groups (Union[TemplateGroup, List[TemplateGroup]])
+
+        Returns:
+            Union[TemplateGroup, TemplateGroupList]: Created template group(s)
+
+        Examples:
+            create a new template group:
+
+                >>> from cognite.experimental import CogniteClient
+                >>> from cognite.experimental.data_classes import TemplateGroup
+                >>> c = CogniteClient()
+                >>> template_group_1 = TemplateGroup("sdk-test-group", "This is a test group")
+                >>> template_group_2 = TemplateGroup("sdk-test-group-2", "This is another test group")
+                >>> c.templates.groups.upsert([template_group_1, template_group_2])
+        """
+        path = self._RESOURCE_PATH + "/upsert"
+        is_single = not isinstance(template_groups, list)
+        if is_single:
+            template_groups = [template_groups]
+        updated = self._post(path, {"items": [item.dump(camel_case=True) for item in template_groups]},).json()["items"]
+        res = self._LIST_CLASS._load(updated, cognite_client=self._cognite_client)
+        if is_single:
+            return res[0]
+        return res
+
+    def retrieve_multiple(self, external_ids: List[str], ignore_unknown_ids: bool = False) -> TemplateGroupList:
+        """`Retrieve multiple template groups by external id.`
+
+        Args:
+            external_ids (List[str]): External IDs
+            ignore_unknown_ids (bool): Ignore external IDs that are not found rather than throw an exception.
+
+        Returns:
+            TemplateGroupList: The requested template groups.
+
+        Examples:
+            Get template groups by external id:
+
+                >>> from cognite.experimental import CogniteClient
+                >>> c = CogniteClient()
+                >>> res = c.templates.groups.retrieve_multiple(external_ids=["abc", "def"])
+        """
+        return self._retrieve_multiple(external_ids=external_ids, ignore_unknown_ids=ignore_unknown_ids, wrap_ids=True)
+
+    def list(self, limit: int = 25, owners: List[str] = None) -> TemplateGroupList:
+        """`Lists template groups stored in the project based on a query filter given in the payload of this request.`
+        Up to 1000 template groups can be retrieved in one operation.
+
+        Args:
+            owners (List[str]): Include template groups that have any of these values in their `owner` field.
+            limit (int): Maximum number of template groups to return. Defaults to 25. Set to -1, float("inf") or None
+                to return all items.
+
+        Returns:
+            TemplateGroupList: List of requested template groups
+
+        Examples:
+            List template groups:
+
+                >>> from cognite.experimental import CogniteClient
+                >>> c = CogniteClient()
+                >>> template_group_list = c.templates.groups.list(limit=5)
+        """
+        filter = {}
+        if owners is not None:
+            filter["owners"] = owners
+        return self._list(method="POST", limit=limit, filter=filter, partitions=None, sort=None)
+
+    def delete(
+        self, external_ids: Union[str, List[str]], ignore_unknown_ids: bool = False
+    ) -> Union[TemplateGroup, TemplateGroupList]:
+        """`Delete one or more template groups.`
+
+        Args:
+            external_ids (Union[str, List[str]]): External ID or list of external ids
+            ignore_unknown_ids (bool): Ignore external IDs that are not found rather than throw an exception.
+
+        Returns:
+            None
+
+        Examples:
+            Delete template groups by external id:
+
+                >>> from cognite.experimental import CogniteClient
+                >>> c = CogniteClient()
+                >>> c.templates.groups.delete(external_id=["a", "b"])
+        """
+        return self._delete_multiple(
+            True, external_ids=external_ids, extra_body_fields={"ignoreUnknownIds": ignore_unknown_ids}
+        )
+
+
+class TemplateGroupVersionsAPI(APIClient):
+    _RESOURCE_PATH = "/templategroups/{}/versions"
+    _LIST_CLASS = TemplateGroupVersionList
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+    def upsert(self, external_id: str, version: TemplateGroupVersion):
+        """`Upsert a template group version.`
+        A Template Group update supports specifying different conflict modes, which is used when an existing schema already exists.
+
+        Patch -> It diffs the new schema with the old schema and fails if there are breaking changes.
+        Update -> It sets the new schema as schema of a new version.
+        Force -> It ignores breaking changes and replaces the old schema with the new schema.
+        The default mode is "patch".
+
+        Args:
+            external_id (str): The external id of the template group.
+            version (TemplateGroupVersion): The GraphQL schema of this version.
+
+        Returns:
+            TemplateGroupVersion: Created template group version
+
+        Examples:
+            create a new template group version modeling Covid-19:
+
+                >>> from cognite.experimental import CogniteClient
+                >>> from cognite.experimental.data_classes import TemplateGroup
+                >>> c = CogniteClient()
+                >>> template_group = TemplateGroup("sdk-test-group", "This template group models Covid-19 spread")
+                >>> c.templates.groups.create(template_group)
+                >>> schema = '''
+                >>>     type Demographics @template {
+                >>>         "The amount of people"
+                >>>         populationSize: Int,
+                >>>         "The population growth rate"
+                >>>         growthRate: Float,
+                >>>     }
+                >>>     type Country @template {
+                >>>         name: String,
+                >>>         demographics: Demographics,
+                >>>         deaths: TimeSeries,
+                >>>         confirmed: TimeSeries,
+                >>>     }'''
+                >>> template_group_version = TemplateGroupVersion(schema)
+                >>> c.templates.versions.upsert(template_group.external_id, template_group_version)
+        """
+        resource_path = utils._auxiliary.interpolate_and_url_encode(self._RESOURCE_PATH, external_id) + "/upsert"
+        version = self._post(resource_path, version.dump(camel_case=True),).json()
+        return TemplateGroupVersion._load(version)
+
+    def list(
+        self, external_id: str, limit: int = 25, min_version: Optional[int] = None, max_version: Optional[int] = None
+    ) -> TemplateGroupVersionList:
+        """`Lists versions of a specified template group.`
+        Up to 1000 template group version can be retrieved in one operation.
+
+        Args:
+            external_id (str): The external id of the template group.
+            limit (int): Maximum number of template group versions to return. Defaults to 25. Set to -1, float("inf") or None
+                to return all items.
+            min_version: (Optional[int]): Exclude versions with a version number smaller than this.
+            max_version: (Optional[int]): Exclude versions with a version number larger than this.
+
+        Returns:
+            TemplateGroupVersionList: List of requested template group versions
+
+        Examples:
+            List template group versions:
+
+                >>> from cognite.experimental import CogniteClient
+                >>> c = CogniteClient()
+                >>> template_group_list = c.templates.versions.list("template-group-ext-id", limit=5)
+        """
+        resource_path = utils._auxiliary.interpolate_and_url_encode(self._RESOURCE_PATH, external_id)
+        filter = {}
+        if min_version is not None:
+            filter["minVersion"] = min_version
+        if max_version is not None:
+            filter["maxVersion"] = max_version
+        return self._list(resource_path=resource_path, method="POST", limit=limit, filter=filter)
+
+    def delete(self, external_id: str, version: int) -> None:
+        """`Delete a template group version.`
+
+        Args:
+            external_id (Union[str, List[str]]): External ID of the template group.
+            version (int): The version of the template group to delete.
+
+        Returns:
+            None
+
+        Examples:
+            Delete template groups by external id:
+
+                >>> from cognite.experimental import CogniteClient
+                >>> c = CogniteClient()
+                >>> c.templates.versions.delete("sdk-test-group", 1)
+        """
+        resource_path = utils._auxiliary.interpolate_and_url_encode(self._RESOURCE_PATH, external_id)
+        self._post(resource_path + "/delete", {"version": version})
+
+
+class TemplateInstancesAPI(APIClient):
+    _RESOURCE_PATH = "/templategroups/{}/versions/{}/instances"
+    _LIST_CLASS = TemplateInstanceList
+
+    def create(
+        self, external_id: str, version: int, instances: Union[TemplateInstance, List[TemplateInstance]]
+    ) -> Union[TemplateInstance, TemplateInstanceList]:
+        """`Create one or more template instances.`
+
+        Args:
+            external_id (str): The external id of the template group.
+            version (int): The version of the template group to create instances for.
+            instances (Union[TemplateInstance, List[TemplateInstance]]): The instances to create.
+
+        Returns:
+            Union[TemplateInstance, TemplateInstanceList]: Created template instance(s).
+
+        Examples:
+            create new template instances for Covid-19 spread:
+
+                >>> from cognite.experimental import CogniteClient
+                >>> from cognite.experimental.data_classes import TemplateInstance
+                >>> c = CogniteClient()
+                >>> template_instance_1 = TemplateInstance(
+                >>>                               external_id="norway",
+                >>>                               template_name="Country",
+                >>>                               field_resolvers={
+                >>>                                   "name": ConstantResolver("Norway"),
+                >>>                                   "demographics": ConstantResolver("norway_demographics"),
+                >>>                                   "deaths": ConstantResolver("Norway_deaths"),
+                >>>                                   "confirmed": ConstantResolver("Norway_confirmed"),
+                >>>                                   }
+                >>>                               )
+                >>> template_instance_2 = TemplateInstance(
+                >>>                               external_id="norway_demographics",
+                >>>                               template_name="Demographics",
+                >>>                               field_resolvers={
+                >>>                                   "populationSize": ConstantResolver(5328000),
+                >>>                                   "growthRate": ConstantResolver(value=0.02)
+                >>>                                   }
+                >>>                               )
+                >>> c.templates.instances.create("sdk-test-group", 1, [template_instance_1, template_instance_2])
+        """
+        resource_path = utils._auxiliary.interpolate_and_url_encode(self._RESOURCE_PATH, external_id, version)
+        return self._create_multiple(resource_path=resource_path, items=instances)
+
+    def upsert(
+        self, external_id: str, version: int, instances: Union[TemplateGroup, List[TemplateGroup]]
+    ) -> Union[TemplateInstance, TemplateInstanceList]:
+        """`Upsert one or more template instances.`
+        Will overwrite existing instances.
+
+        Args:
+         external_id (str): The external id of the template group.
+         version (int): The version of the template group to create instances for.
+         instances (Union[TemplateInstance, List[TemplateInstance]]): The instances to create.
+
+        Returns:
+         Union[TemplateInstance, TemplateInstanceList]: Created template instance(s).
+
+        Examples:
+         create new template instances for Covid-19 spread:
+
+             >>> from cognite.experimental import CogniteClient
+             >>> from cognite.experimental.data_classes import TemplateInstance
+             >>> c = CogniteClient()
+             >>> template_instance_1 = TemplateInstance(
+             >>>        external_id="norway",
+             >>>        template_name="Country",
+             >>>        field_resolvers={
+             >>>            "name": ConstantResolver("Norway"),
+             >>>            "demographics": ConstantResolver("norway_demographics"),
+             >>>            "deaths": ConstantResolver("Norway_deaths"),
+             >>>            "confirmed": ConstantResolver("Norway_confirmed"),
+             >>>        }
+             >>>    )
+             >>> template_instance_2 = TemplateInstance(external_id="norway_demographics",
+             >>>       template_name="Demographics",
+             >>>       field_resolvers={
+             >>>           "populationSize": ConstantResolver(5328000),
+             >>>           "growthRate": ConstantResolver(0.02)
+             >>>           }
+             >>>   )
+             >>> c.templates.instances.upsert("sdk-test-group", 1, [template_instance_1, template_instance_2])
+        """
+        if isinstance(instances, TemplateInstance):
+            instances = [instances]
+        resource_path = (
+            utils._auxiliary.interpolate_and_url_encode(self._RESOURCE_PATH, external_id, version) + "/upsert"
+        )
+        updated = self._post(
+            resource_path, {"items": [instance.dump(camel_case=True) for instance in instances]},
+        ).json()["items"]
+        res = TemplateInstanceList._load(updated, cognite_client=self._cognite_client)
+        if len(res) == 1:
+            return res[0]
+        return res
+
+    def retrieve_multiple(
+        self, external_id: str, version: int, external_ids: List[str], ignore_unknown_ids: bool = False
+    ) -> TemplateInstanceList:
+        """`Retrieve multiple template instances by external id.`
+
+        Args:
+            external_id (str): The template group to retrieve instances from.
+            version (int): The version of the template group.
+            external_ids (List[str]): External IDs of the instances.
+            ignore_unknown_ids (bool): Ignore external IDs that are not found rather than throw an exception.
+
+        Returns:
+            TemplateInstanceList: The requested template groups.
+
+        Examples:
+            Get template instances by external id:
+
+                >>> from cognite.experimental import CogniteClient
+                >>> c = CogniteClient()
+                >>> res = c.templates.instances.retrieve_multiple(external_id="sdk-test-group", version=1, external_ids=["abc", "def"])
+        """
+        resource_path = utils._auxiliary.interpolate_and_url_encode(self._RESOURCE_PATH, external_id, version)
+        return self._retrieve_multiple(
+            resource_path=resource_path, external_ids=external_ids, ignore_unknown_ids=ignore_unknown_ids, wrap_ids=True
+        )
+
+    def list(
+        self,
+        external_id: str,
+        version: int,
+        limit: int = 25,
+        data_set_ids: Optional[List[int]] = None,
+        template_names: Optional[List[str]] = None,
+    ) -> TemplateInstanceList:
+        """`Lists instances in a template group.`
+        Up to 1000 template instances can be retrieved in one operation.
+
+        Args:
+            external_id (str): The external id of the template group.
+            version (int): The version of the template group.
+            limit (int): Maximum number of template group versions to return. Defaults to 25. Set to -1, float("inf") or None
+                to return all items.
+            data_set_ids: (Optional[List[int]]): Only include instances which has one of these values in their `data_set_id` field.
+            template_names: (Optional[List[str]]): Only include instances which has one of these values in their `template_name` field.
+
+        Returns:
+            TemplateInstanceList: List of requested template instances
+
+        Examples:
+            List template instances:
+
+                >>> from cognite.experimental import CogniteClient
+                >>> c = CogniteClient()
+                >>> template_instances_list = c.templates.instances.list("template-group-ext-id", 1, limit=5)
+        """
+        resource_path = utils._auxiliary.interpolate_and_url_encode(self._RESOURCE_PATH, external_id, version)
+        filter = {}
+        if data_set_ids is not None:
+            filter["dataSetIds"] = data_set_ids
+        if template_names is not None:
+            filter["template_names"] = template_names
+        return self._list(resource_path=resource_path, method="POST", limit=limit, filter=filter)
+
+    def delete(self, external_id: str, version: int, external_ids: List[str], ignore_unknown_ids: bool = False) -> None:
+        """`Delete one or more template instances.`
+
+        Args:
+            external_id (Union[str, List[str]]): External ID of the template group.
+            version (int): The version of the template group.
+            external_ids (List[str]): The external ids of the template instances to delete
+            ignore_unknown_ids (bool): Ignore external IDs that are not found rather than throw an exception.
+
+        Returns:
+            None
+
+        Examples:
+            Delete template groups by external id:
+
+                >>> from cognite.experimental import CogniteClient
+                >>> c = CogniteClient()
+                >>> c.templates.instances.delete("sdk-test-group", 1, external_id=["a", "b"])
+        """
+        resource_path = utils._auxiliary.interpolate_and_url_encode(self._RESOURCE_PATH, external_id, version)
+        return self._delete_multiple(
+            resource_path=resource_path,
+            external_ids=external_ids,
+            wrap_ids=True,
+            extra_body_fields={"ignoreUnknownIds": ignore_unknown_ids},
+        )

--- a/cognite/client/_api/templates.py
+++ b/cognite/client/_api/templates.py
@@ -1,7 +1,7 @@
 from typing import List, Union
 
 from cognite.client._api_client import APIClient
-from cognite.experimental.data_classes.templates import *
+from cognite.client.data_classes.templates import *
 
 
 class TemplatesAPI(APIClient):
@@ -27,7 +27,7 @@ class TemplatesAPI(APIClient):
         Examples:
             Run a GraphQL query:
 
-                >>> from cognite.experimental import CogniteClient
+                >>> from cognite.client import CogniteClient
                 >>> c = CogniteClient()
                 >>> query = '''
                 >>>    {
@@ -74,9 +74,8 @@ class TemplateGroupsAPI(APIClient):
 
         Examples:
             create a new template group:
-
-                >>> from cognite.experimental import CogniteClient
-                >>> from cognite.experimental.data_classes import TemplateGroup
+                >>> from cognite.client import CogniteClient
+                >>> from cognite.client.data_classes import TemplateGroup
                 >>> c = CogniteClient()
                 >>> template_group_1 = TemplateGroup("sdk-test-group", "This is a test group")
                 >>> template_group_2 = TemplateGroup("sdk-test-group-2", "This is another test group")
@@ -99,8 +98,8 @@ class TemplateGroupsAPI(APIClient):
         Examples:
             create a new template group:
 
-                >>> from cognite.experimental import CogniteClient
-                >>> from cognite.experimental.data_classes import TemplateGroup
+                >>> from cognite.client import CogniteClient
+                >>> from cognite.client.data_classes import TemplateGroup
                 >>> c = CogniteClient()
                 >>> template_group_1 = TemplateGroup("sdk-test-group", "This is a test group")
                 >>> template_group_2 = TemplateGroup("sdk-test-group-2", "This is another test group")
@@ -129,7 +128,7 @@ class TemplateGroupsAPI(APIClient):
         Examples:
             Get template groups by external id:
 
-                >>> from cognite.experimental import CogniteClient
+                >>> from cognite.client import CogniteClient
                 >>> c = CogniteClient()
                 >>> res = c.templates.groups.retrieve_multiple(external_ids=["abc", "def"])
         """
@@ -150,7 +149,7 @@ class TemplateGroupsAPI(APIClient):
         Examples:
             List template groups:
 
-                >>> from cognite.experimental import CogniteClient
+                >>> from cognite.client import CogniteClient
                 >>> c = CogniteClient()
                 >>> template_group_list = c.templates.groups.list(limit=5)
         """
@@ -174,7 +173,7 @@ class TemplateGroupsAPI(APIClient):
         Examples:
             Delete template groups by external id:
 
-                >>> from cognite.experimental import CogniteClient
+                >>> from cognite.client import CogniteClient
                 >>> c = CogniteClient()
                 >>> c.templates.groups.delete(external_id=["a", "b"])
         """
@@ -209,8 +208,8 @@ class TemplateGroupVersionsAPI(APIClient):
         Examples:
             create a new template group version modeling Covid-19:
 
-                >>> from cognite.experimental import CogniteClient
-                >>> from cognite.experimental.data_classes import TemplateGroup
+                >>> from cognite.client import CogniteClient
+                >>> from cognite.client.data_classes import TemplateGroup
                 >>> c = CogniteClient()
                 >>> template_group = TemplateGroup("sdk-test-group", "This template group models Covid-19 spread")
                 >>> c.templates.groups.create(template_group)
@@ -253,7 +252,7 @@ class TemplateGroupVersionsAPI(APIClient):
         Examples:
             List template group versions:
 
-                >>> from cognite.experimental import CogniteClient
+                >>> from cognite.client import CogniteClient
                 >>> c = CogniteClient()
                 >>> template_group_list = c.templates.versions.list("template-group-ext-id", limit=5)
         """
@@ -278,7 +277,7 @@ class TemplateGroupVersionsAPI(APIClient):
         Examples:
             Delete template groups by external id:
 
-                >>> from cognite.experimental import CogniteClient
+                >>> from cognite.client import CogniteClient
                 >>> c = CogniteClient()
                 >>> c.templates.versions.delete("sdk-test-group", 1)
         """
@@ -306,8 +305,8 @@ class TemplateInstancesAPI(APIClient):
         Examples:
             create new template instances for Covid-19 spread:
 
-                >>> from cognite.experimental import CogniteClient
-                >>> from cognite.experimental.data_classes import TemplateInstance
+                >>> from cognite.client import CogniteClient
+                >>> from cognite.client.data_classes import TemplateInstance
                 >>> c = CogniteClient()
                 >>> template_instance_1 = TemplateInstance(
                 >>>                               external_id="norway",
@@ -349,8 +348,8 @@ class TemplateInstancesAPI(APIClient):
         Examples:
          create new template instances for Covid-19 spread:
 
-             >>> from cognite.experimental import CogniteClient
-             >>> from cognite.experimental.data_classes import TemplateInstance
+             >>> from cognite.client import CogniteClient
+             >>> from cognite.client.data_classes import TemplateInstance
              >>> c = CogniteClient()
              >>> template_instance_1 = TemplateInstance(
              >>>        external_id="norway",
@@ -401,7 +400,7 @@ class TemplateInstancesAPI(APIClient):
         Examples:
             Get template instances by external id:
 
-                >>> from cognite.experimental import CogniteClient
+                >>> from cognite.client import CogniteClient
                 >>> c = CogniteClient()
                 >>> res = c.templates.instances.retrieve_multiple(external_id="sdk-test-group", version=1, external_ids=["abc", "def"])
         """
@@ -435,7 +434,7 @@ class TemplateInstancesAPI(APIClient):
         Examples:
             List template instances:
 
-                >>> from cognite.experimental import CogniteClient
+                >>> from cognite.client import CogniteClient
                 >>> c = CogniteClient()
                 >>> template_instances_list = c.templates.instances.list("template-group-ext-id", 1, limit=5)
         """
@@ -462,7 +461,7 @@ class TemplateInstancesAPI(APIClient):
         Examples:
             Delete template groups by external id:
 
-                >>> from cognite.experimental import CogniteClient
+                >>> from cognite.client import CogniteClient
                 >>> c = CogniteClient()
                 >>> c.templates.instances.delete("sdk-test-group", 1, external_id=["a", "b"])
         """

--- a/cognite/client/_api_client.py
+++ b/cognite/client/_api_client.py
@@ -61,6 +61,7 @@ class APIClient:
     def __init__(self, config: utils._client_config.ClientConfig, api_version: str = None, cognite_client=None) -> None:
         self._config = config
         self._api_version = api_version
+        self._api_subversion = config.api_subversion
         self._cognite_client = cognite_client
 
         self._http_client = HTTPClient(
@@ -167,8 +168,7 @@ class APIClient:
         headers["accept"] = "application/json"
         headers["x-cdp-sdk"] = "CognitePythonSDK:{}".format(utils._auxiliary.get_current_sdk_version())
         headers["x-cdp-app"] = self._config.client_name
-        if self._api_version == "beta":
-            headers["version"] = "beta"
+        headers["cdf-version"] = self._api_subversion
         if "User-Agent" in headers:
             headers["User-Agent"] += " " + utils._auxiliary.get_user_agent()
         else:
@@ -185,10 +185,7 @@ class APIClient:
         return is_retryable, full_url
 
     def _get_base_url_with_base_path(self) -> str:
-        api_version = self._api_version
-        if api_version == "beta":
-            api_version = "v1"  # Change the URL path to /v1/ if version is 'beta'
-        base_path = "/api/{}/projects/{}".format(api_version, self._config.project) if api_version else ""
+        base_path = "/api/{}/projects/{}".format(self._api_version, self._config.project) if self._api_version else ""
         return urljoin(self._config.base_url, base_path)
 
     def _is_retryable(self, method: str, path: str) -> bool:

--- a/cognite/client/_cognite_client.py
+++ b/cognite/client/_cognite_client.py
@@ -56,6 +56,7 @@ class CogniteClient:
     def __init__(
         self,
         api_key: Optional[str] = None,
+        api_subversion: Optional[str] = None,
         project: Optional[str] = None,
         client_name: Optional[str] = None,
         base_url: Optional[str] = None,
@@ -73,6 +74,7 @@ class CogniteClient:
     ):
         self._config = ClientConfig(
             api_key=api_key,
+            api_subversion=api_subversion,
             project=project,
             client_name=client_name,
             base_url=base_url,

--- a/cognite/client/_cognite_client.py
+++ b/cognite/client/_cognite_client.py
@@ -14,6 +14,7 @@ from cognite.client._api.login import LoginAPI
 from cognite.client._api.raw import RawAPI
 from cognite.client._api.relationships import RelationshipsAPI
 from cognite.client._api.sequences import SequencesAPI
+from cognite.client._api.templates import TemplatesAPI
 from cognite.client._api.three_d import ThreeDAPI
 from cognite.client._api.time_series import TimeSeriesAPI
 from cognite.client._api_client import APIClient
@@ -106,6 +107,7 @@ class CogniteClient:
         self.labels = LabelsAPI(self._config, api_version=self._API_VERSION, cognite_client=self)
         self.relationships = RelationshipsAPI(self._config, api_version=self._API_VERSION, cognite_client=self)
         self.entity_matching = EntityMatchingAPI(self._config, api_version=self._API_VERSION, cognite_client=self)
+        self.templates = TemplatesAPI(self._config, api_version=self._API_VERSION, cognite_client=self)
         self._api_client = APIClient(self._config, cognite_client=self)
 
     def get(self, url: str, params: Dict[str, Any] = None, headers: Dict[str, Any] = None):

--- a/cognite/client/beta.py
+++ b/cognite/client/beta.py
@@ -3,4 +3,4 @@ from cognite.client._cognite_client import CogniteClient as Client
 
 class CogniteClient(Client):
     def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
+        super().__init__(api_subversion="beta", *args, **kwargs)

--- a/cognite/client/data_classes/__init__.py
+++ b/cognite/client/data_classes/__init__.py
@@ -65,13 +65,13 @@ from cognite.client.data_classes.sequences import (
 )
 from cognite.client.data_classes.shared import AggregateResult, AggregateUniqueValuesResult, TimestampRange
 from cognite.client.data_classes.templates import (
+    ConstantResolver,
     TemplateGroup,
     TemplateGroupList,
     TemplateGroupVersion,
     TemplateGroupVersionList,
     TemplateInstance,
     TemplateInstanceList,
-    ConstantResolver,
 )
 from cognite.client.data_classes.three_d import (
     BoundingBox3D,

--- a/cognite/client/data_classes/__init__.py
+++ b/cognite/client/data_classes/__init__.py
@@ -71,7 +71,7 @@ from cognite.client.data_classes.templates import (
     TemplateGroupVersionList,
     TemplateInstance,
     TemplateInstanceList,
-    ConstantResolver
+    ConstantResolver,
 )
 from cognite.client.data_classes.three_d import (
     BoundingBox3D,

--- a/cognite/client/data_classes/__init__.py
+++ b/cognite/client/data_classes/__init__.py
@@ -64,6 +64,14 @@ from cognite.client.data_classes.sequences import (
     SequenceUpdate,
 )
 from cognite.client.data_classes.shared import AggregateResult, AggregateUniqueValuesResult, TimestampRange
+from cognite.client.data_classes.templates import (
+    TemplateGroup,
+    TemplateGroupList,
+    TemplateGroupVersion,
+    TemplateGroupVersionList,
+    TemplateInstance,
+    TemplateInstanceList,
+)
 from cognite.client.data_classes.three_d import (
     BoundingBox3D,
     RevisionCameraProperties,

--- a/cognite/client/data_classes/__init__.py
+++ b/cognite/client/data_classes/__init__.py
@@ -71,6 +71,7 @@ from cognite.client.data_classes.templates import (
     TemplateGroupVersionList,
     TemplateInstance,
     TemplateInstanceList,
+    ConstantResolver
 )
 from cognite.client.data_classes.three_d import (
     BoundingBox3D,

--- a/cognite/client/data_classes/templates.py
+++ b/cognite/client/data_classes/templates.py
@@ -1,0 +1,240 @@
+from typing import List, Optional
+
+from cognite.client.data_classes._base import *
+
+
+class TemplateGroup(CogniteResource):
+    """A template group is a high level concept encapsulating a schema and a set of template instances. It also has query capability support.
+
+    Template groups are versioned, so there can be multiple template groups with the same external ID.
+    The versioning is happening automatically whenever a template groups is changed.
+
+    GraphQL schema definition language is used as the language to describe the structure of the templates and data types.
+
+    Args:
+        external_id (str): The external ID provided by the client. Must be unique for the resource type.
+        description (str): The description of the template groups.
+        owners (List[str]): The list of owners for the template groups.
+    """
+
+    def __init__(
+        self, external_id: str = None, description: str = None, owners: Optional[List[str]] = None, cognite_client=None,
+    ):
+        self.external_id = external_id
+        self.description = description
+        self.owners = owners
+        self._cognite_client = cognite_client
+
+
+class TemplateGroupList(CogniteResourceList):
+    _RESOURCE = TemplateGroup
+    _UPDATE = CogniteUpdate
+
+
+class TemplateGroupVersion(CogniteResource):
+    """
+    A Template Group Version supports specifying different conflict modes, which is used when an existing schema already exists.
+
+    Patch -> It diffs the new schema with the old schema and fails if there are breaking changes.
+    Update -> It sets the new schema as schema of a new version.
+    Force -> It ignores breaking changes and replaces the old schema with the new schema.
+    The default mode is "patch".
+
+    Args:
+        schema (str): The GraphQL schema.
+        version (int): Incremented by the server whenever the schema of a template groups changes.
+        conflict_mode (str): Can be set to 'Patch', 'Update' or 'Force'.
+    """
+
+    def __init__(
+        self, schema: str = None, version: int = None, conflict_mode: str = None, cognite_client=None,
+    ):
+        self.schema = schema
+        self.version = version
+        self.conflict_mode = conflict_mode
+        self._cognite_client = cognite_client
+
+
+class TemplateGroupVersionList(CogniteResourceList):
+    _RESOURCE = TemplateGroupVersion
+    _UPDATE = CogniteUpdate
+
+
+class ConstantResolver(CogniteResource):
+    """Resolves a field to a constant value. The value can be of any supported JSON type.
+
+    Args:
+        value (any): The value of the field.
+    """
+
+    def __init__(self, value: any = None, cognite_client=None):
+        self.type = "constant"
+        self.value = value
+        self._cognite_client = cognite_client
+
+
+class RawResolver(CogniteResource):
+    """Resolves a field to a RAW column.
+
+    Args:
+        db_name (str): The database name.
+        table_name (str): The table name.
+        row_key (str): The row key.
+        column_name (str): The column to fetch the value from.
+    """
+
+    def __init__(
+        self,
+        db_name: str = None,
+        table_name: str = None,
+        row_key: str = None,
+        column_name: str = None,
+        cognite_client=None,
+    ):
+        self.type = "raw"
+        self.db_name = db_name
+        self.table_name = table_name
+        self.row_key = row_key
+        self.column_name = column_name
+        self._cognite_client = cognite_client
+
+
+class SyntheticTimeSeriesResolver(CogniteResource):
+    """Resolves a field of type 'SyntheticTimeSeries' to a Synthetic Time Series.
+
+    Args:
+        expression (str): The synthetic time series expression. See this for syntax https://docs.cognite.com/api/v1/#tag/Synthetic-Time-Series.
+        name (Optional[str]): The name of the Time Series.
+        description (Optional[str]): The description for the Time Series.
+        metadata (Optional[Dict[str, str]]): Specifies metadata for the Time Series.
+        is_step (Optional[bool]): Specifies if the synthetic time series is step based.
+        is_string (Optional[bool]): Specifies if the synthetic time series returned contains string values.
+        unit (Optional[str]): The unit of the time series.
+    """
+
+    def __init__(
+        self,
+        expression: str = None,
+        name: Optional[str] = None,
+        description: Optional[str] = None,
+        metadata: Optional[Dict[str, str]] = None,
+        is_step: Optional[bool] = None,
+        is_string: Optional[bool] = None,
+        unit: Optional[str] = None,
+        cognite_client=None,
+    ):
+        self.type = "syntheticTimeSeries"
+        self.expression = expression
+        self.name = name
+        self.description = description
+        self.metadata = metadata
+        self.is_step = is_step
+        self.is_string = is_string
+        self.unit = unit
+        self._cognite_client = cognite_client
+
+
+FieldResolvers = Union[ConstantResolver, RawResolver, SyntheticTimeSeriesResolver, str]
+
+
+class TemplateInstance(CogniteResource):
+    field_resolver_mapper = {
+        "constant": ConstantResolver,
+        "syntheticTimeSeries": SyntheticTimeSeriesResolver,
+        "raw": RawResolver,
+    }
+    """A template instance that implements a template by specificing a resolver per field.
+
+    Args:
+        external_id (str): The id of the template instance.
+        template_name (str): The template name to implement.
+        field_resolvers (Dict[str, FieldResolvers]): A set of field resolvers where the dictionary key correspond to the field name.
+    """
+
+    def __init__(
+        self,
+        external_id: str = None,
+        template_name: str = None,
+        field_resolvers: Dict[str, FieldResolvers] = None,
+        cognite_client=None,
+    ):
+        self.external_id = external_id
+        self.template_name = template_name
+        self.field_resolvers = field_resolvers
+        self._cognite_client = cognite_client
+
+    def dump(self, camel_case: bool = False) -> Dict[str, Any]:
+        """Dump the instance into a json serializable Python data type.
+
+        Args:
+            camel_case (bool): Use camelCase for attribute names. Defaults to False.
+
+        Returns:
+            Dict[str, Any]: A dictionary representation of the instance.
+        """
+        if camel_case:
+            return {
+                utils._auxiliary.to_camel_case(key): value
+                if key != "field_resolvers"
+                else TemplateInstance._encode_field_resolvers(value, camel_case=camel_case)
+                for key, value in self.__dict__.items()
+                if value not in EXCLUDE_VALUE and not key.startswith("_")
+            }
+        return {
+            key: value
+            if key != "field_resolvers"
+            else TemplateInstance._encode_field_resolvers(value, camel_case=camel_case)
+            for key, value in self.__dict__.items()
+            if value not in EXCLUDE_VALUE and not key.startswith("_")
+        }
+
+    def _encode_field_resolvers(field_resolvers: Dict[str, FieldResolvers], camel_case):
+        return {key: value.dump(camel_case=camel_case) for key, value in field_resolvers.items()}
+
+    @classmethod
+    def _load(cls, resource: Union[Dict, str], cognite_client=None):
+        if isinstance(resource, str):
+            return cls._load(json.loads(resource), cognite_client=cognite_client)
+        elif isinstance(resource, Dict):
+            instance = cls(cognite_client=cognite_client)
+            for key, value in resource.items():
+                snake_case_key = utils._auxiliary.to_snake_case(key)
+                if hasattr(instance, snake_case_key):
+                    if key == "fieldResolvers":
+                        setattr(
+                            instance,
+                            snake_case_key,
+                            {
+                                key: TemplateInstance._field_resolver_load(field_resolver)
+                                for key, field_resolver in value.items()
+                            },
+                        )
+                    else:
+                        setattr(instance, snake_case_key, value)
+            return instance
+        raise TypeError("Resource must be json str or Dict, not {}".format(type(resource)))
+
+    def _field_resolver_load(resource: Union[Dict, str], cognite_client=None):
+        return TemplateInstance.field_resolver_mapper[resource["type"]]._load(resource, cognite_client)
+
+
+class GraphQlError(CogniteResource):
+    def __init__(
+        self, message: str = None, path: List[str] = None, locations: List[Dict[str, Any]] = None, cognite_client=None,
+    ):
+        self.message = message
+        self.path = path
+        self.locations = locations
+        self._cognite_client = cognite_client
+
+
+class GraphQlResponse(CogniteResource):
+    def __init__(self, data: any = None, errors: List[GraphQlError] = None, cognite_client=None):
+        self.data = data
+        self.errors = errors
+        self._cognite_client = cognite_client
+
+
+class TemplateInstanceList(CogniteResourceList):
+    _RESOURCE = TemplateInstance
+    _UPDATE = CogniteUpdate

--- a/cognite/client/data_classes/templates.py
+++ b/cognite/client/data_classes/templates.py
@@ -18,7 +18,7 @@ class TemplateGroup(CogniteResource):
     """
 
     def __init__(
-        self, external_id: str = None, description: str = None, owners: Optional[List[str]] = None, cognite_client=None,
+        self, external_id: str = None, description: str = None, owners: Optional[List[str]] = None, cognite_client=None
     ):
         self.external_id = external_id
         self.description = description
@@ -46,9 +46,7 @@ class TemplateGroupVersion(CogniteResource):
         conflict_mode (str): Can be set to 'Patch', 'Update' or 'Force'.
     """
 
-    def __init__(
-        self, schema: str = None, version: int = None, conflict_mode: str = None, cognite_client=None,
-    ):
+    def __init__(self, schema: str = None, version: int = None, conflict_mode: str = None, cognite_client=None):
         self.schema = schema
         self.version = version
         self.conflict_mode = conflict_mode
@@ -220,7 +218,7 @@ class TemplateInstance(CogniteResource):
 
 class GraphQlError(CogniteResource):
     def __init__(
-        self, message: str = None, path: List[str] = None, locations: List[Dict[str, Any]] = None, cognite_client=None,
+        self, message: str = None, path: List[str] = None, locations: List[Dict[str, Any]] = None, cognite_client=None
     ):
         self.message = message
         self.path = path

--- a/cognite/client/utils/_client_config.py
+++ b/cognite/client/utils/_client_config.py
@@ -8,6 +8,8 @@ from requests.exceptions import ConnectionError
 from cognite.client import utils
 from cognite.client.exceptions import CogniteAPIKeyError
 
+_DEFAULT_API_SUBVERSION = "V20210323"
+
 
 class _ThreadLocalConfig:
     def __init__(self):
@@ -28,6 +30,7 @@ class _DefaultConfig:
 
         # Per client
         self.api_key = thread_local.api_key or os.getenv("COGNITE_API_KEY")
+        self.api_subversion = os.getenv("COGNITE_API_VERSION") or _DEFAULT_API_SUBVERSION
         self.project = thread_local.project or os.getenv("COGNITE_PROJECT")
         self.client_name = os.getenv("COGNITE_CLIENT_NAME")
         self.base_url = os.getenv("COGNITE_BASE_URL", "https://api.cognitedata.com")
@@ -61,6 +64,7 @@ class ClientConfig(_DefaultConfig):
     def __init__(
         self,
         api_key: Optional[str] = None,
+        api_subversion: Optional[str] = None,
         project: Optional[str] = None,
         client_name: Optional[str] = None,
         base_url: Optional[str] = None,
@@ -91,6 +95,7 @@ class ClientConfig(_DefaultConfig):
         self.token_client_secret = token_client_secret or self.token_client_secret
         self.token_scopes = token_scopes or self.token_scopes
         self.token_custom_args = token_custom_args or self.token_custom_args
+        self.api_subversion = api_subversion or self.api_subversion
         self.disable_pypi_version_check = (
             disable_pypi_version_check if disable_pypi_version_check is not None else self.disable_pypi_version_check
         )

--- a/docs/source/cognite.rst
+++ b/docs/source/cognite.rst
@@ -856,6 +856,66 @@ Contextualization Data Classes
     :inherited-members:
 
 
+Templates
+---------
+Create Template groups
+^^^^^^^^^^^^^^^^^^^^^^
+.. automethod:: cognite.client._api.templates.TemplateGroupsAPI.create
+
+Upsert Template groups
+^^^^^^^^^^^^^^^^^^^^^^
+.. automethod:: cognite.client._api.templates.TemplateGroupsAPI.upsert
+
+Retrieve Template groups
+^^^^^^^^^^^^^^^^^^^^^^^^
+.. automethod:: cognite.client._api.templates.TemplateGroupsAPI.retrieve_multiple
+
+List Template groups
+^^^^^^^^^^^^^^^^^^^^
+.. automethod:: cognite.client._api.templates.TemplateGroupsAPI.list
+
+Delete Template groups
+^^^^^^^^^^^^^^^^^^^^^^
+.. automethod:: cognite.client._api.templates.TemplateGroupsAPI.delete
+
+Upsert a Template group version
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+.. automethod:: cognite.client._api.templates.TemplateGroupVersionsAPI.upsert
+
+List Temple Group versions
+^^^^^^^^^^^^^^^^^^^^^^^^^^
+.. automethod:: cognite.client._api.templates.TemplateGroupVersionsAPI.list
+
+Delete a Temple Group version
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+.. automethod:: cognite.client._api.templates.TemplateGroupVersionsAPI.delete
+
+Run a GraphQL query
+^^^^^^^^^^^^^^^^^^^
+.. automethod:: cognite.client._api.templates.TemplatesAPI.graphql_query
+
+Create Template instances
+^^^^^^^^^^^^^^^^^^^^^^^^^
+.. automethod:: cognite.client._api.templates.TemplateInstancesAPI.create
+
+Upsert Template instances
+^^^^^^^^^^^^^^^^^^^^^^^^^
+.. automethod:: cognite.client._api.templates.TemplateInstancesAPI.upsert
+
+Retrieve Template instances
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+.. automethod:: cognite.client._api.templates.TemplateInstancesAPI.retrieve_multiple
+
+List Template instances
+^^^^^^^^^^^^^^^^^^^^^^^
+.. automethod:: cognite.client._api.templates.TemplateInstancesAPI.list
+
+Data classes
+^^^^^^^^^^^^
+.. automodule:: cognite.client.data_classes.templates
+    :members:
+    :show-inheritance:
+
 Identity and access management
 ------------------------------
 Service accounts

--- a/tests/tests_integration/test_api/test_data_sets.py
+++ b/tests/tests_integration/test_api/test_data_sets.py
@@ -1,9 +1,7 @@
-from datetime import datetime
 from unittest import mock
 
 import pytest
 
-import cognite.client.utils._time
 from cognite.client import CogniteClient
 from cognite.client.data_classes import DataSet, DataSetFilter, DataSetUpdate
 from cognite.client.exceptions import CogniteNotFoundError

--- a/tests/tests_integration/test_api/test_templates.py
+++ b/tests/tests_integration/test_api/test_templates.py
@@ -1,0 +1,151 @@
+import uuid
+
+import pytest
+
+from cognite.client.exceptions import CogniteNotFoundError
+from cognite.experimental import CogniteClient
+from cognite.experimental.data_classes import (
+    ConstantResolver,
+    TemplateGroup,
+    TemplateGroupList,
+    TemplateGroupVersion,
+    TemplateGroupVersionList,
+    TemplateInstance,
+    TemplateInstanceList,
+)
+
+API = CogniteClient()
+API_GROUPS = API.templates.groups
+API_VERSION = API.templates.versions
+API_INSTANCES = API.templates.instances
+
+
+@pytest.fixture
+def new_template_group():
+    external_id = uuid.uuid4().hex[0:20]
+
+    template_group = API_GROUPS.create(
+        TemplateGroup(external_id=external_id, description="some description", owners=[external_id + "@cognite.com"])
+    )
+    yield template_group, external_id
+    API_GROUPS.delete(external_ids=external_id)
+    assert API_GROUPS.retrieve_multiple(external_ids=template_group.external_id) is None
+
+
+@pytest.fixture
+def new_template_group_version(new_template_group):
+    new_group, ext_id = new_template_group
+    schema = """
+    type Demographics @template {
+        "The amount of people"
+        populationSize: Int,
+        "The population growth rate"
+        growthRate: Float,
+    }
+
+    type Country @template {
+        name: String,
+        demographics: Demographics,
+        deaths: TimeSeries,
+        confirmed: TimeSeries,
+    }"""
+    version = TemplateGroupVersion(schema)
+    new_version = API_VERSION.upsert(ext_id, version=version)
+    yield new_group, ext_id, new_version
+    print(ext_id, new_version.version)
+    API_VERSION.delete(ext_id, new_version.version)
+
+
+@pytest.fixture
+def new_template_instance(new_template_group_version):
+    new_group, ext_id, new_version = new_template_group_version
+    template_instance_1 = TemplateInstance(
+        external_id="norway",
+        template_name="Country",
+        field_resolvers={
+            "name": ConstantResolver("Norway"),
+            "demographics": ConstantResolver("norway_demographics"),
+            "deaths": ConstantResolver("Norway_deaths"),
+            "confirmed": ConstantResolver("Norway_confirmed"),
+        },
+    )
+    instance = API_INSTANCES.create(ext_id, new_version.version, template_instance_1)
+    yield new_group, ext_id, new_version, instance
+    API_INSTANCES.delete(ext_id, new_version.version, instance.external_id)
+
+
+class TestTemplatesAPI:
+    def test_groups_get_single(self, new_template_group):
+        new_group, ext_id = new_template_group
+        res = API_GROUPS.retrieve_multiple(external_ids=[new_group.external_id])
+        assert isinstance(res[0], TemplateGroup)
+        assert new_group.external_id == ext_id
+
+    def test_groups_retrieve_unknown(self, new_template_group):
+        with pytest.raises(CogniteNotFoundError):
+            API_GROUPS.retrieve_multiple(external_ids=["this does not exist"])
+        assert API_GROUPS.retrieve_multiple(external_ids="this does not exist") is None
+
+    def test_groups_list_filter(self, new_template_group):
+        new_group, ext_id = new_template_group
+        res = API_GROUPS.list(owners=[ext_id + "@cognite.com"])
+        assert len(res) == 1
+        assert isinstance(res, TemplateGroupList)
+
+    def test_groups_upsert(self, new_template_group):
+        new_group, ext_id = new_template_group
+        res = API_GROUPS.upsert(TemplateGroup(ext_id))
+        assert isinstance(res, TemplateGroup)
+
+    def test_versions_list(self, new_template_group_version):
+        new_group, ext_id, new_version = new_template_group_version
+        res = API_VERSION.list(ext_id)
+        assert len(res) == 1
+        assert isinstance(res, TemplateGroupVersionList)
+
+    def test_instances_get_single(self, new_template_instance):
+        new_group, ext_id, new_version, new_instance = new_template_instance
+        res = API_INSTANCES.retrieve_multiple(ext_id, new_version.version, new_instance.external_id)
+        assert isinstance(res, TemplateInstance)
+        assert res.external_id == new_instance.external_id
+
+    def test_instances_list(self, new_template_instance):
+        new_group, ext_id, new_version, new_instance = new_template_instance
+        res = API_INSTANCES.list(ext_id, new_version.version, template_names=["Country"])
+        assert isinstance(res, TemplateInstanceList)
+        assert len(res) == 1
+
+    def test_instances_upsert(self, new_template_instance):
+        new_group, ext_id, new_version, new_instance = new_template_instance
+        upserted_instance = TemplateInstance(
+            external_id="norway",
+            template_name="Demographics",
+            field_resolvers={"populationSize": ConstantResolver(5328000), "growthRate": ConstantResolver(value=0.02)},
+        )
+        res = API_INSTANCES.upsert(ext_id, new_version.version, upserted_instance)
+        assert res.external_id == new_instance.external_id
+
+    def test_query(self, new_template_instance):
+        new_group, ext_id, new_version, new_instance = new_template_instance
+        query = """
+        { 
+        countryList 
+            { 
+                name, 
+                deaths { 
+                    externalId, 
+                    datapoints(limit: 2) { 
+                        timestamp, value 
+                    } 
+                }, 
+                confirmed { 
+                    externalId, 
+                    datapoints(limit: 2) { 
+                        timestamp, value 
+                    } 
+                } 
+            } 
+        }
+        """
+        res = API.templates.graphql_query(ext_id, 1, query)
+        assert res.data is not None

--- a/tests/tests_integration/test_api/test_templates.py
+++ b/tests/tests_integration/test_api/test_templates.py
@@ -2,9 +2,9 @@ import uuid
 
 import pytest
 
+from cognite import CogniteClient
 from cognite.client.exceptions import CogniteNotFoundError
-from cognite.experimental import CogniteClient
-from cognite.experimental.data_classes import (
+from cognite.data_classes import (
     ConstantResolver,
     TemplateGroup,
     TemplateGroupList,

--- a/tests/tests_integration/test_api/test_templates.py
+++ b/tests/tests_integration/test_api/test_templates.py
@@ -2,9 +2,9 @@ import uuid
 
 import pytest
 
-from cognite import CogniteClient
+from cognite.client import CogniteClient
 from cognite.client.exceptions import CogniteNotFoundError
-from cognite.data_classes import (
+from cognite.client.data_classes import (
     ConstantResolver,
     TemplateGroup,
     TemplateGroupList,

--- a/tests/tests_integration/test_api/test_templates.py
+++ b/tests/tests_integration/test_api/test_templates.py
@@ -3,7 +3,6 @@ import uuid
 import pytest
 
 from cognite.client import CogniteClient
-from cognite.client.exceptions import CogniteNotFoundError
 from cognite.client.data_classes import (
     ConstantResolver,
     TemplateGroup,
@@ -13,6 +12,7 @@ from cognite.client.data_classes import (
     TemplateInstance,
     TemplateInstanceList,
 )
+from cognite.client.exceptions import CogniteNotFoundError
 
 API = CogniteClient()
 API_GROUPS = API.templates.groups

--- a/tests/tests_unit/test_cognite_client.py
+++ b/tests/tests_unit/test_cognite_client.py
@@ -2,6 +2,7 @@ import datetime
 import logging
 import os
 import random
+import re
 import sys
 import threading
 import types
@@ -270,6 +271,18 @@ class TestCogniteClient:
             CogniteClient(disable_pypi_version_check=True)
         assert len(rsps_with_login_mock.calls) == 1
         assert rsps_with_login_mock.calls[0].request.url.startswith("https://greenfield.cognitedata.com")
+
+    def test_api_version_present_in_header(self, rsps_with_login_mock, default_client_config):
+        c = CogniteClient()
+        c.login.status()
+        assert rsps_with_login_mock.calls[1].request.headers["cdf-version"] == c.config.api_subversion
+
+    def test_beta_header_for_beta_client(self, rsps_with_login_mock, default_client_config):
+        from cognite.client.beta import CogniteClient as BetaClient
+
+        c = BetaClient()
+        c.login.status()
+        assert rsps_with_login_mock.calls[1].request.headers["cdf-version"] == "beta"
 
     def test_version_check_enabled(self, rsps_with_login_mock):
         with unset_env_var("COGNITE_PROJECT"):


### PR DESCRIPTION
Two things going on in this pr: 
- We want to add templates to the main sdk, and rely on the new API versioning system: https://cognitedata.atlassian.net/wiki/spaces/CDF/pages/1395228698/Core+CDF+Releases+Versioning - by version locking the sdk we can ensure that the users application does not suddenly break. 
- I found some inconsistencies/bad choices in the current versioning implementation: 
  1) It only implemented the beta part of the versioning, not the date-based part 
  2) It mixed the old api versioning concept (0.5/v1/playground) with the new, representing both in the same variable, which is hard to understand 

This PR completes/fixes the version header implementation, and adds templates to the main sdk. 