### PR TITLE
'list' is missing in the section of 'list'

### DIFF
--- a/cognite/client/_api/raw.py
+++ b/cognite/client/_api/raw.py
@@ -442,14 +442,14 @@ class RawRowsAPI(APIClient):
 
                 >>> from cognite.client import CogniteClient
                 >>> c = CogniteClient()
-                >>> for row in c.raw.rows(db_name="db1", table_name="t1", columns=["col1","col2"]):
+                >>> for row in c.raw.rows.list(db_name="db1", table_name="t1", columns=["col1","col2"]):
                 ...     row # do something with the row
 
             Iterate over chunks of rows to reduce memory load::
 
                 >>> from cognite.client import CogniteClient
                 >>> c = CogniteClient()
-                >>> for row_list in c.raw.rows(db_name="db1", table_name="t1", chunk_size=2500):
+                >>> for row_list in c.raw.rows.list(db_name="db1", table_name="t1", chunk_size=2500):
                 ...     row_list # do something with the rows
         """
         if columns is not None:


### PR DESCRIPTION
raw() and raw.list() is similar in that both show the list of raws, but raw() does not support some parameters, which list() does.

L.445 needs list() because raw() does not support `columns` param.
L.452 works as it is, but we haven't explained about raw(), so it should be somewhere else, and we should focus on list() here.