### PR TITLE
correct exception when model not found

### DIFF
--- a/tests/tests_integration/test_api/test_entity_matching.py
+++ b/tests/tests_integration/test_api/test_entity_matching.py
@@ -10,7 +10,7 @@ from cognite.client.data_classes import (
     EntityMatchingModelUpdate,
 )
 from cognite.client.data_classes.contextualization import ContextualizationJobList
-from cognite.client.exceptions import CogniteAPIError, ModelFailedException
+from cognite.client.exceptions import ModelFailedException, CogniteNotFoundError
 
 COGNITE_CLIENT = CogniteClient()
 EMAPI = COGNITE_CLIENT.entity_matching
@@ -21,8 +21,8 @@ def fitted_model():
     extid = "abc" + str(random.randint(1, 1000000000))
     try:
         EMAPI.delete(external_id=extid)
-    except CogniteAPIError as e:
-        pass  # expected
+    except CogniteNotFoundError as e:
+        pass # expected
     entities_from = [{"id": 1, "name": "xx-yy"}]
     entities_to = [{"id": 2, "bloop": "yy"}, {"id": 3, "bloop": "zz"}]
     model = EMAPI.fit(

--- a/tests/tests_integration/test_api/test_entity_matching.py
+++ b/tests/tests_integration/test_api/test_entity_matching.py
@@ -10,7 +10,7 @@ from cognite.client.data_classes import (
     EntityMatchingModelUpdate,
 )
 from cognite.client.data_classes.contextualization import ContextualizationJobList
-from cognite.client.exceptions import ModelFailedException, CogniteNotFoundError
+from cognite.client.exceptions import CogniteNotFoundError, ModelFailedException
 
 COGNITE_CLIENT = CogniteClient()
 EMAPI = COGNITE_CLIENT.entity_matching
@@ -22,7 +22,7 @@ def fitted_model():
     try:
         EMAPI.delete(external_id=extid)
     except CogniteNotFoundError as e:
-        pass # expected
+        pass  # expected
     entities_from = [{"id": 1, "name": "xx-yy"}]
     entities_to = [{"id": 2, "bloop": "yy"}, {"id": 3, "bloop": "zz"}]
     model = EMAPI.fit(


### PR DESCRIPTION
DB refactor with "missing" as a field causes SDK to raise a different exception.