### PR TITLE
Do not fetch windows if remaining data points is <= 0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@ Changes are grouped as follows
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
+## [2.27.0] - 2021-07-20
+
+### Changed
+- Optimization. Do not get windows if remaining data points is 0. Reduces number of requests when asking for 100k data points/10k aggregates from 2 to 1.
+
 ## [2.26.0] - 2021-07-08
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ Changes are grouped as follows
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
-## [2.27.0] - 2021-07-20
+## [2.26.1] - 2021-07-20
 
 ### Changed
 - Optimization. Do not get windows if remaining data points is 0. Reduces number of requests when asking for 100k data points/10k aggregates from 2 to 1.

--- a/cognite/client/_api/datapoints.py
+++ b/cognite/client/_api/datapoints.py
@@ -958,6 +958,8 @@ class DatapointsFetcher:
         return [(task, w) for w in windows]
 
     def _get_windows(self, id, task, remaining_user_limit):
+        if remaining_user_limit <= 0:
+            return []
         if task.start >= task.end:
             return []
         count_granularity = "1d"

--- a/cognite/client/_version.py
+++ b/cognite/client/_version.py
@@ -1,2 +1,2 @@
-__version__ = "2.27.0"
+__version__ = "2.26.1"
 __api_subversion__ = "V20210423"

--- a/cognite/client/_version.py
+++ b/cognite/client/_version.py
@@ -1,2 +1,2 @@
-__version__ = "2.26.0"
+__version__ = "2.27.0"
 __api_subversion__ = "V20210423"


### PR DESCRIPTION
## Description
Optimization:
Do not divide into windows if there are 0 remaining data points. Clients asking for 100k data points (the limit per request) will do one request instead of two.

## Checklist:
- [ ] Tests added/updated.
- [ ] Documentation updated. Documentation is generated from docstrings - these must be updated according to your change. 
  If a new method has been added it should be referenced in [cognite.rst](https://github.com/cognitedata/cognite-sdk-python/blob/master/docs/source/cognite.rst) in order to generate docs based on its docstring. 
- [x] Changelog updated in [CHANGELOG.md](https://github.com/cognitedata/cognite-sdk-python/blob/master/CHANGELOG.md).
- [x] Version bumped. If triggering a new release is desired, bump the version number in [_version.py](https://github.com/cognitedata/cognite-sdk-python/blob/master/cognite/client/_version.py) per [semantic versioning](https://semver.org/).
