### PR TITLE
Add template instance update

### DIFF
--- a/cognite/client/_api/templates.py
+++ b/cognite/client/_api/templates.py
@@ -383,6 +383,28 @@ class TemplateInstancesAPI(APIClient):
             return res[0]
         return res
 
+    def update(
+        self, external_id: str, version: int, item: Union[TemplateInstanceUpdate, List[TemplateInstanceUpdate]]
+    ) -> Union[TemplateInstance, List[TemplateInstance]]:
+        """`Update one or more template instances`
+        Args:
+            item (Union[TemplateInstanceUpdate, List[TemplateInstanceUpdate]]): Templates instance(s) to update
+
+        Returns:
+            Union[TemplateInstance, List[TemplateInstance]]: Updated template instance(s)
+
+        Examples:
+            Perform a partial update on a template instance::
+
+                >>> from cognite.client import CogniteClient
+                >>> from cognite.client.data_classes import TemplateInstanceUpdate
+                >>> c = CogniteClient()
+                >>> my_update = TemplateInstanceUpdate(external_id="test").field_resolvers.add({ "name": ConstantResolver("Norway") })
+                >>> res = c.templates.instances.update("sdk-test-group", 1, my_update)
+        """
+        resource_path = utils._auxiliary.interpolate_and_url_encode(self._RESOURCE_PATH, external_id, version)
+        return self._update_multiple(items=item, resource_path=resource_path)
+
     def retrieve_multiple(
         self, external_id: str, version: int, external_ids: List[str], ignore_unknown_ids: bool = False
     ) -> TemplateInstanceList:

--- a/cognite/client/_version.py
+++ b/cognite/client/_version.py
@@ -1,2 +1,2 @@
-__version__ = "2.27.0"
+__version__ = "2.28.0"
 __api_subversion__ = "V20210423"

--- a/cognite/client/data_classes/templates.py
+++ b/cognite/client/data_classes/templates.py
@@ -244,6 +244,28 @@ class TemplateInstance(CogniteResource):
         return TemplateInstance.field_resolver_mapper[resource["type"]]._load(resource, cognite_client)
 
 
+class TemplateInstanceUpdate(CogniteUpdate):
+    """Changes applied to template instance
+
+    Args:
+        external_id (str): The external ID provided by the client. Must be unique for the resource type.
+    """
+
+    class _ObjectAssetUpdate(CogniteObjectUpdate):
+        def set(self, value: Dict) -> "TemplateInstanceUpdate":
+            return self._set(value)
+
+        def add(self, value: Dict) -> "TemplateInstanceUpdate":
+            return self._add(value)
+
+        def remove(self, value: List) -> "TemplateInstanceUpdate":
+            return self._remove(value)
+
+    @property
+    def field_resolvers(self):
+        return TemplateInstanceUpdate._ObjectAssetUpdate(self, "fieldResolvers")
+
+
 class GraphQlError(CogniteResource):
     def __init__(
         self, message: str = None, path: List[str] = None, locations: List[Dict[str, Any]] = None, cognite_client=None

--- a/docs/source/cognite.rst
+++ b/docs/source/cognite.rst
@@ -923,6 +923,9 @@ Upsert Template instances
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 .. automethod:: cognite.client._api.templates.TemplateInstancesAPI.upsert
 
+Update Template instances
+.. automethod:: cognite.client._api.templates.TemplateInstancesAPI.update
+
 Retrieve Template instances
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. automethod:: cognite.client._api.templates.TemplateInstancesAPI.retrieve_multiple

--- a/tests/tests_integration/test_api/test_templates.py
+++ b/tests/tests_integration/test_api/test_templates.py
@@ -1,3 +1,4 @@
+from cognite.client.data_classes.templates import TemplateInstanceUpdate
 import uuid
 
 import pytest
@@ -126,6 +127,32 @@ class TestTemplatesAPI:
         )
         res = API_INSTANCES.upsert(ext_id, new_version.version, upserted_instance)
         assert res.external_id == new_instance.external_id
+
+    def test_instances_update_add(self, new_template_instance):
+        new_group, ext_id, new_version, new_instance = new_template_instance
+        upserted_instance = TemplateInstanceUpdate(external_id="norway").field_resolvers.add(
+            {"name": ConstantResolver("Patched")}
+        )
+        res = API_INSTANCES.update(ext_id, new_version.version, upserted_instance)
+        assert res.external_id == new_instance.external_id and res.field_resolvers["name"] == ConstantResolver(
+            "Patched"
+        )
+
+    def test_instances_update_remove(self, new_template_instance):
+        new_group, ext_id, new_version, new_instance = new_template_instance
+        upserted_instance = TemplateInstanceUpdate(external_id="norway").field_resolvers.remove(["name"])
+        res = API_INSTANCES.update(ext_id, new_version.version, upserted_instance)
+        assert res.external_id == new_instance.external_id and "name" not in res.field_resolvers
+
+    def test_instances_update_set(self, new_template_instance):
+        new_group, ext_id, new_version, new_instance = new_template_instance
+        upserted_instance = TemplateInstanceUpdate(external_id="norway").field_resolvers.set(
+            {"name": ConstantResolver("Patched")}
+        )
+        res = API_INSTANCES.update(ext_id, new_version.version, upserted_instance)
+        assert res.external_id == new_instance.external_id and res.field_resolvers == {
+            "name": ConstantResolver("Patched")
+        }
 
     def test_query(self, new_template_instance):
         new_group, ext_id, new_version, new_instance = new_template_instance


### PR DESCRIPTION
## Description
Adds support for updating / patching template instances. Currently the template instance service only supports updating the field resolvers.

## Checklist:
- [x] Tests added/updated.
- [x] Documentation updated. Documentation is generated from docstrings - these must be updated according to your change. 
  If a new method has been added it should be referenced in [cognite.rst](https://github.com/cognitedata/cognite-sdk-python/blob/master/docs/source/cognite.rst) in order to generate docs based on its docstring. 
- [x] No update to changelog as templates aren't official yet. Changelog updated in [CHANGELOG.md](https://github.com/cognitedata/cognite-sdk-python/blob/master/CHANGELOG.md).
- [x] Version bumped. If triggering a new release is desired, bump the version number in [_version.py](https://github.com/cognitedata/cognite-sdk-python/blob/master/cognite/client/_version.py) per [semantic versioning](https://semver.org/).
