### PR TITLE
Retry JSONDecodeError on datapoints retrieve

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ Changes are grouped as follows
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
+## [2.29.0] - 2021-08-10
+### Changed
+- Retry `JSONDecodeError` on datapoints retrieve to improve handling of truncated responses.
+
 ## [2.28.2] - 2021-08-10
 ### Added
 - Relationships now supports `partitions` parameter for [parallel retrieval](https://docs.cognite.com/api/v1/#section/Parallel-retrieval)

--- a/cognite/client/_version.py
+++ b/cognite/client/_version.py
@@ -1,2 +1,2 @@
-__version__ = "2.28.2"
+__version__ = "2.29.0"
 __api_subversion__ = "V20210423"

--- a/cognite/client/utils/_retry.py
+++ b/cognite/client/utils/_retry.py
@@ -1,0 +1,13 @@
+from typing import Callable, Tuple, Type, TypeVar
+
+T = TypeVar("T")
+
+
+def retry_exceptions(callable: Callable[[], T], exceptions: Tuple[Type[BaseException], ...], attempts: int = 3) -> T:
+    while True:
+        try:
+            return callable()
+        except exceptions:
+            attempts -= 1
+            if attempts == 0:
+                raise


### PR DESCRIPTION
We sometimes receive a truncated response from this endpoint. Root cause is still unidentified. See this thread for details: https://cognitedata.slack.com/archives/CG10VQPFX/p1628357875042900