### PR TITLE
Make _get_response_content_safe safer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ Changes are grouped as follows
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
+## [2.31.1] - 2021-09-27
+### Fixed
+- Fixed a bug related to handling of binary response payloads.
+
 ## [2.31.0] - 2021-08-26
 ### Added
 - View resolver for template fields.

--- a/cognite/client/_api_client.py
+++ b/cognite/client/_api_client.py
@@ -796,7 +796,14 @@ class APIClient:
         try:
             return json.dumps(res.json())
         except JSONDecodeError:
+            pass
+
+        try:
             return res.content.decode()
+        except UnicodeDecodeError:
+            pass
+
+        return "<binary>"
 
     @staticmethod
     def _sanitize_headers(headers: Optional[Dict]):

--- a/cognite/client/_version.py
+++ b/cognite/client/_version.py
@@ -1,2 +1,2 @@
-__version__ = "2.31.0"
+__version__ = "2.31.1"
 __api_subversion__ = "V20210423"

--- a/tests/tests_unit/test_api_client.py
+++ b/tests/tests_unit/test_api_client.py
@@ -1,5 +1,6 @@
 import os
 from collections import namedtuple
+from requests import Response
 
 import pytest
 
@@ -1016,6 +1017,19 @@ class TestHelpers:
         assert before != after
         APIClient._sanitize_headers(before)
         assert before == after
+
+    @pytest.mark.parametrize(
+        "content, expected",
+        [
+            ('{"foo": 42}'.encode(), '{"foo": 42}'),
+            ("foobar".encode(), "foobar"),
+            (b'\xed\xbc\xad', "<binary>"),
+        ],
+    )
+    def test_get_response_content_safe(self, content, expected):
+        res = Response()
+        res._content = content
+        assert APIClient._get_response_content_safe(res) == expected
 
 
 class TestConnectionPooling:

--- a/tests/tests_unit/test_api_client.py
+++ b/tests/tests_unit/test_api_client.py
@@ -1020,11 +1020,7 @@ class TestHelpers:
 
     @pytest.mark.parametrize(
         "content, expected",
-        [
-            ('{"foo": 42}'.encode(), '{"foo": 42}'),
-            ("foobar".encode(), "foobar"),
-            (b'\xed\xbc\xad', "<binary>"),
-        ],
+        [('{"foo": 42}'.encode(), '{"foo": 42}'), ("foobar".encode(), "foobar"), (b"\xed\xbc\xad", "<binary>")],
     )
     def test_get_response_content_safe(self, content, expected):
         res = Response()


### PR DESCRIPTION
This function fails on most binary responses, such as the ones returned
from the document-preview endpoints (PDF/PNG).

This commit falls back to returning the string `"<binary>"` if both json
decoding and utf-8 string decoding fails.