### PR TITLE
[CDF-13425] Fix typo in templates docs: external_id -> external_ids

### DIFF
--- a/cognite/client/_api/templates.py
+++ b/cognite/client/_api/templates.py
@@ -177,7 +177,7 @@ class TemplateGroupsAPI(APIClient):
 
                 >>> from cognite.client import CogniteClient
                 >>> c = CogniteClient()
-                >>> c.templates.groups.delete(external_id=["a", "b"])
+                >>> c.templates.groups.delete(external_ids=["a", "b"])
         """
         return self._delete_multiple(
             True, external_ids=external_ids, extra_body_fields={"ignoreUnknownIds": ignore_unknown_ids}


### PR DESCRIPTION
## Description
Fixes a typo in the [documentation for templates](https://cognite-docs.readthedocs-hosted.com/projects/cognite-sdk-python/en/latest/cognite.html#delete-template-groups): 
`c.templates.groups.delete(external_id=["a", "b"])` --> `c.templates.groups.delete(external_ids=["a", "b"])`

## Checklist:
- ~[ ] Tests added/updated.~
- [x] Documentation updated. Documentation is generated from docstrings - these must be updated according to your change. If a new method has been added it should be referenced in [cognite.rst](https://github.com/cognitedata/cognite-sdk-python/blob/master/docs/source/cognite.rst) in order to generate docs based on its docstring. 
- ~[] Changelog updated in [CHANGELOG.md](https://github.com/cognitedata/cognite-sdk-python/blob/master/CHANGELOG.md).~
- ~[] Version bumped. If triggering a new release is desired, bump the version number in [_version.py](https://github.com/cognitedata/cognite-sdk-python/blob/master/cognite/client/_version.py) per [semantic versioning](https://semver.org/).~
