### PR TITLE
Change default JSON behaviour to strict compliance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,13 +14,17 @@ Changes are grouped as follows
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
+## [2.36.0] - 2021-11-30
+### Fixed
+- Changes default JSON `.dumps()` behaviour to be in strict compliance with the standard: if any NaNs or +/- Infs are encountered, an exception will now be raised.
+
 ## [2.34.0] - 2021-11-5
 ### Added
 - Added support for `data_set_id` on template views
 
 ## [2.33.0] - 2021-10-27
 ### Security
-- Disallow downloading files to path outside download directory in `files.download()`. 
+- Disallow downloading files to path outside download directory in `files.download()`.
 
 ## [2.32.0] - 2021-10-04
 ### Added

--- a/cognite/client/_api_client.py
+++ b/cognite/client/_api_client.py
@@ -136,7 +136,12 @@ class APIClient:
         headers.update(kwargs.get("headers") or {})
 
         if json_payload:
-            data = _json.dumps(json_payload, default=utils._auxiliary.json_dump_default)
+            try:
+                data = _json.dumps(json_payload, default=utils._auxiliary.json_dump_default, allow_nan=False)
+            except ValueError as e:
+                raise ValueError(f"{e}. Make sure your data does not contain NaN(s) or +/- Inf!").with_traceback(
+                    e.__traceback__
+                ) from None
             kwargs["data"] = data
             if method in ["PUT", "POST"] and not os.getenv("COGNITE_DISABLE_GZIP", False):
                 kwargs["data"] = gzip.compress(data.encode())

--- a/cognite/client/_api_client.py
+++ b/cognite/client/_api_client.py
@@ -1,5 +1,4 @@
 import gzip
-import json
 import json as _json
 import logging
 import numbers
@@ -139,9 +138,13 @@ class APIClient:
             try:
                 data = _json.dumps(json_payload, default=utils._auxiliary.json_dump_default, allow_nan=False)
             except ValueError as e:
-                raise ValueError(f"{e}. Make sure your data does not contain NaN(s) or +/- Inf!").with_traceback(
-                    e.__traceback__
-                ) from None
+                # A lot of work to give a more human friendly error message when nans and infs are present:
+                msg = "Out of range float values are not JSON compliant"
+                if msg in str(e):  # exc. might e.g. contain an extra ": nan", depending on build (_json.make_encoder)
+                    raise ValueError(f"{msg}. Make sure your data does not contain NaN(s) or +/- Inf!").with_traceback(
+                        e.__traceback__
+                    ) from None
+                raise
             kwargs["data"] = data
             if method in ["PUT", "POST"] and not os.getenv("COGNITE_DISABLE_GZIP", False):
                 kwargs["data"] = gzip.compress(data.encode())
@@ -799,7 +802,7 @@ class APIClient:
     @classmethod
     def _get_response_content_safe(cls, res: Response) -> str:
         try:
-            return json.dumps(res.json())
+            return _json.dumps(res.json())
         except JSONDecodeError:
             pass
 

--- a/cognite/client/_version.py
+++ b/cognite/client/_version.py
@@ -1,2 +1,2 @@
-__version__ = "2.34.0"
+__version__ = "2.36.0"
 __api_subversion__ = "V20210423"

--- a/tests/tests_unit/test_api_client.py
+++ b/tests/tests_unit/test_api_client.py
@@ -175,10 +175,7 @@ class TestBasicRequests:
         assert "api-key" not in headers
         assert "Bearer {}".format(api_client_with_token._config.token) == headers["Authorization"]
 
-    @pytest.mark.parametrize(
-        "payload",
-        [math.nan, math.inf, -math.inf, {"foo": {"bar": {"baz": [[[math.nan]]]}}}],
-    )
+    @pytest.mark.parametrize("payload", [math.nan, math.inf, -math.inf, {"foo": {"bar": {"baz": [[[math.nan]]]}}}])
     def test__do_request_raises_more_verbose_exception(self, api_client_with_token, payload):
         with pytest.raises(ValueError, match=r"contain NaN\(s\) or \+/\- Inf\!"):
             api_client_with_token._do_request("POST", URL_PATH, json=payload)


### PR DESCRIPTION
- Changes default JSON behaviour to be in strict compliance with the standard.
- Adds improved error message.

Reason:
https://cognitedata.slack.com/archives/CG10VQPFX/p1637321494071900 

This PR is a oneliner if we don't want to make the error message nicer:
```py
if json_payload:
    data = _json.dumps(json_payload, default=utils._auxiliary.json_dump_default, allow_nan=False)
```

## Checklist:
- [x] Tests added/updated.
- [ ] Documentation updated. Documentation is generated from docstrings - these must be updated according to your change. 
  If a new method has been added it should be referenced in [cognite.rst](https://github.com/cognitedata/cognite-sdk-python/blob/master/docs/source/cognite.rst) in order to generate docs based on its docstring. 
- [x] Changelog updated in [CHANGELOG.md](https://github.com/cognitedata/cognite-sdk-python/blob/master/CHANGELOG.md).
- [x] Version bumped. If triggering a new release is desired, bump the version number in [_version.py](https://github.com/cognitedata/cognite-sdk-python/blob/master/cognite/client/_version.py) per [semantic versioning](https://semver.org/).
