### PR TITLE
[CDF-14081] Add support for retrieving download urls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ Changes are grouped as follows
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
+## [2.37.0] - 2021-11-30
+### Added
+- Added support for retrieving file download urls 
+
 ## [2.36.0] - 2021-11-30
 ### Fixed
 - Changes default JSON `.dumps()` behaviour to be in strict compliance with the standard: if any NaNs or +/- Infs are encountered, an exception will now be raised.

--- a/cognite/client/_version.py
+++ b/cognite/client/_version.py
@@ -1,2 +1,2 @@
-__version__ = "2.36.0"
+__version__ = "2.37.0"
 __api_subversion__ = "V20210423"

--- a/docs/source/cognite.rst
+++ b/docs/source/cognite.rst
@@ -452,6 +452,10 @@ Upload a string or bytes
 ^^^^^^^^^^^^^^^^^^^^^^^^
 .. automethod:: cognite.client._api.files.FilesAPI.upload_bytes
 
+Retrieve download urls
+^^^^^^^^^^^^^^^^^^^^^^
+.. automethod:: cognite.client._api.files.FilesAPI.retrieve_download_urls
+
 Download files to disk
 ^^^^^^^^^^^^^^^^^^^^^^
 .. automethod:: cognite.client._api.files.FilesAPI.download

--- a/tests/tests_integration/test_api/test_files.py
+++ b/tests/tests_integration/test_api/test_files.py
@@ -111,6 +111,14 @@ class TestFilesAPI:
         res = cognite_client.files.list(uploaded_time=A_WHILE_AGO, limit=2)
         assert res == cognite_client.files.retrieve_multiple([f.id for f in res])
 
+    def test_retrieve_download_urls(self, cognite_client):
+        f1 = cognite_client.files.upload_bytes(b"f1", external_id=random_string(10), name="bla")
+        f2 = cognite_client.files.upload_bytes(b"f2", external_id=random_string(10), name="bla")
+        download_links = cognite_client.files.retrieve_download_urls(id=f1.id, external_id=f2.external_id)
+        assert len(download_links.values()) == 2
+        assert download_links[f1.id].startswith("http")
+        assert download_links[f2.external_id].startswith("http")
+
     def test_list(self, cognite_client):
         res = cognite_client.files.list(limit=4)
         assert 4 == len(res)


### PR DESCRIPTION
## Description
Add support for retrieving file download urls.

## Checklist:
- [x] Tests added/updated.
- [x] Documentation updated. Documentation is generated from docstrings - these must be updated according to your change. 
  If a new method has been added it should be referenced in [cognite.rst](https://github.com/cognitedata/cognite-sdk-python/blob/master/docs/source/cognite.rst) in order to generate docs based on its docstring. 
- [x] Changelog updated in [CHANGELOG.md](https://github.com/cognitedata/cognite-sdk-python/blob/master/CHANGELOG.md).
- [x] Version bumped. If triggering a new release is desired, bump the version number in [_version.py](https://github.com/cognitedata/cognite-sdk-python/blob/master/cognite/client/_version.py) per [semantic versioning](https://semver.org/).
