### PR TITLE
Fix jobs._load when destination is raw

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ Changes are grouped as follows
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
+## [2.38.1] - 2021-11-30
+### Fixed
+- Bug where loading `transformations.jobs` from JSON fails for raw destinations.
 
 ## [2.38.0] - 2021-11-30
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ Changes are grouped as follows
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
-## [2.38.1] - 2021-11-30
+## [2.38.1] - 2021-12-07
 ### Fixed
 - Bug where loading `transformations.jobs` from JSON fails for raw destinations.
 

--- a/cognite/client/_version.py
+++ b/cognite/client/_version.py
@@ -1,2 +1,2 @@
-__version__ = "2.38.0"
+__version__ = "2.38.1"
 __api_subversion__ = "V20210423"

--- a/cognite/client/data_classes/__init__.py
+++ b/cognite/client/data_classes/__init__.py
@@ -101,10 +101,12 @@ from cognite.client.data_classes.time_series import (
 )
 from cognite.client.data_classes.transformations import (
     OidcCredentials,
+    RawTable,
     Transformation,
     TransformationBlockedInfo,
     TransformationDestination,
     TransformationList,
+    TransformationPreviewResult,
     TransformationUpdate,
 )
 from cognite.client.data_classes.transformations.jobs import (

--- a/cognite/client/data_classes/transformations/jobs.py
+++ b/cognite/client/data_classes/transformations/jobs.py
@@ -232,6 +232,7 @@ class TransformationJob(CogniteResource):
         if isinstance(instance.destination, Dict):
             snake_dict = {utils._auxiliary.to_snake_case(key): value for (key, value) in instance.destination.items()}
             if instance.destination.get("type") == "raw":
+                snake_dict.pop("type")
                 instance.destination = RawTable(**snake_dict)
             else:
                 instance.destination = TransformationDestination(**snake_dict)


### PR DESCRIPTION
## Description
pops `type` from the dictionary before calling the `RawTable` initializer.

## Checklist:
- [✔️] Tests added/updated.
- [〰️] Documentation updated. Documentation is generated from docstrings - these must be updated according to your change. 
  If a new method has been added it should be referenced in [cognite.rst](https://github.com/cognitedata/cognite-sdk-python/blob/master/docs/source/cognite.rst) in order to generate docs based on its docstring. 
- [✔️] Changelog updated in [CHANGELOG.md](https://github.com/cognitedata/cognite-sdk-python/blob/master/CHANGELOG.md).
- [✔️] Version bumped. If triggering a new release is desired, bump the version number in [_version.py](https://github.com/cognitedata/cognite-sdk-python/blob/master/cognite/client/_version.py) per [semantic versioning](https://semver.org/).
