### PR TITLE
add the possibility to pass extra body fields to APIClient._create_multiple

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ Changes are grouped as follows
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
+## [2.38.2] - 2021-12-09
+### Added
+- add the possibility to pass extra body fields to APIClient._create_multiple.
+
 ## [2.38.1] - 2021-12-07
 ### Fixed
 - Bug where loading `transformations.jobs` from JSON fails for raw destinations.

--- a/cognite/client/_api_client.py
+++ b/cognite/client/_api_client.py
@@ -528,6 +528,7 @@ class APIClient:
         resource_path: str = None,
         params: Dict = None,
         headers: Dict = None,
+        extra_body_fields: Dict = None,
         limit=None,
     ):
         cls = cls or self._LIST_CLASS
@@ -543,7 +544,7 @@ class APIClient:
                 items_chunk = [item.dump(camel_case=True) for item in items[i : i + limit]]
             else:
                 items_chunk = [item for item in items[i : i + limit]]
-            items_split.append({"items": items_chunk})
+            items_split.append({"items": items_chunk, **(extra_body_fields or {})})
 
         tasks = [(resource_path, task_items, params, headers) for task_items in items_split]
         summary = utils._concurrency.execute_tasks_concurrently(self._post, tasks, max_workers=self._config.max_workers)

--- a/cognite/client/_version.py
+++ b/cognite/client/_version.py
@@ -1,2 +1,2 @@
-__version__ = "2.38.1"
-__api_subversion__ = "V20210423"
+__version__ = "2.38.2"
+__api_subversion__ = "V20211209"

--- a/tests/tests_unit/test_api_client.py
+++ b/tests/tests_unit/test_api_client.py
@@ -627,6 +627,14 @@ class TestStandardCreate:
         assert SomeResource(1, 2) == res[0]
         assert SomeResource(1) == res[1]
 
+    def test_standard_create_extra_body_fields(self, api_client_with_api_key, rsps):
+        rsps.add(rsps.POST, BASE_URL + URL_PATH, status=200, json={"items": [{"x": 1, "y": 2}, {"x": 1}]})
+        res = api_client_with_api_key._create_multiple(
+            cls=SomeResourceList, resource_path=URL_PATH, items=[SomeResource(1, 1), SomeResource(1)],
+            extra_body_fields={"foo": "bar"}
+        )
+        assert {"items": [{"x": 1, "y": 1}, {"x": 1}], "foo": "bar"} == jsgz_load(rsps.calls[0].request.body)
+
     def test_standard_create_single_item_ok(self, api_client_with_api_key, rsps):
         rsps.add(rsps.POST, BASE_URL + URL_PATH, status=200, json={"items": [{"x": 1, "y": 2}]})
         res = api_client_with_api_key._create_multiple(

--- a/tests/tests_unit/test_api_client.py
+++ b/tests/tests_unit/test_api_client.py
@@ -630,8 +630,10 @@ class TestStandardCreate:
     def test_standard_create_extra_body_fields(self, api_client_with_api_key, rsps):
         rsps.add(rsps.POST, BASE_URL + URL_PATH, status=200, json={"items": [{"x": 1, "y": 2}, {"x": 1}]})
         res = api_client_with_api_key._create_multiple(
-            cls=SomeResourceList, resource_path=URL_PATH, items=[SomeResource(1, 1), SomeResource(1)],
-            extra_body_fields={"foo": "bar"}
+            cls=SomeResourceList,
+            resource_path=URL_PATH,
+            items=[SomeResource(1, 1), SomeResource(1)],
+            extra_body_fields={"foo": "bar"},
         )
         assert {"items": [{"x": 1, "y": 1}, {"x": 1}], "foo": "bar"} == jsgz_load(rsps.calls[0].request.body)
 


### PR DESCRIPTION
Using the same principle as _delete_multiple(...)