### PR TITLE
Not log content if streaming

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ Changes are grouped as follows
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
+## [2.38.2] - 2021-12-10
+### Fixed
+- Bug where client consumes all streaming content when logging request.
+
 ## [2.38.1] - 2021-12-07
 ### Fixed
 - Bug where loading `transformations.jobs` from JSON fails for raw destinations.

--- a/cognite/client/_api_client.py
+++ b/cognite/client/_api_client.py
@@ -166,7 +166,8 @@ class APIClient:
 
         if not self._status_ok(res.status_code):
             self._raise_API_error(res, payload=json_payload)
-        self._log_request(res, payload=json_payload)
+        stream = kwargs.get('stream')
+        self._log_request(res, payload=json_payload, stream=stream)
         return res
 
     def _configure_headers(self, additional_headers: Dict[str, str]) -> CaseInsensitiveDict:
@@ -786,7 +787,9 @@ class APIClient:
         if extra["payload"] is None:
             del extra["payload"]
 
-        extra["response_payload"] = cls._truncate(cls._get_response_content_safe(res))
+        stream = kwargs.get('stream')
+        if not stream:
+            extra["response_payload"] = cls._truncate(cls._get_response_content_safe(res))
         extra["response_headers"] = res.headers
 
         http_protocol_version = ".".join(list(str(res.raw.version)))

--- a/cognite/client/_api_client.py
+++ b/cognite/client/_api_client.py
@@ -166,7 +166,7 @@ class APIClient:
 
         if not self._status_ok(res.status_code):
             self._raise_API_error(res, payload=json_payload)
-        stream = kwargs.get('stream')
+        stream = kwargs.get("stream")
         self._log_request(res, payload=json_payload, stream=stream)
         return res
 
@@ -787,7 +787,7 @@ class APIClient:
         if extra["payload"] is None:
             del extra["payload"]
 
-        stream = kwargs.get('stream')
+        stream = kwargs.get("stream")
         if not stream:
             extra["response_payload"] = cls._truncate(cls._get_response_content_safe(res))
         extra["response_headers"] = res.headers

--- a/cognite/client/_version.py
+++ b/cognite/client/_version.py
@@ -1,2 +1,2 @@
-__version__ = "2.38.1"
+__version__ = "2.38.2"
 __api_subversion__ = "V20210423"


### PR DESCRIPTION
Calling _log_request will make client consumes all streaming data into internal memory which could cause memory issue.