### PR TITLE
Add methods for transformation jobs cancelation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ Changes are grouped as follows
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
+## [2.38.5] - 2021-12-17
+### Added
+- add the possibility to cancel transformation jobs.
+
 ## [2.38.4] - 2021-12-17
 ### Fixed
 - Bug where list generator helper will return more than chunk_size items.

--- a/cognite/client/_api/transformations/__init__.py
+++ b/cognite/client/_api/transformations/__init__.py
@@ -287,24 +287,17 @@ class TransformationsAPI(APIClient):
             transformation_id (int): Transformation internal id
             transformation_external_id (str): Transformation external id
 
-        Returns:
-            Canceled transformation job
-
         Examples:
 
-            Run transformation to completion by id:
+            Wait transformation for 1 minute and cancel if still running:
 
                 >>> from cognite.client import CogniteClient
+                >>> from cognite.client.data_classes import TransformationJobStatus
                 >>> c = CogniteClient()
                 >>>
-                >>> res = c.transformations.run(id = 1)
-
-            Start running transformation by id:
-
-                >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
-                >>>
-                >>> res = c.transformations.run(id = 1, wait = False)
+                >>> res = c.transformations.run(id = 1, timeout = 60.0)
+                >>> if res.status == TransformationJobStatus.RUNNING:
+                >>>     res.cancel()
         """
         utils._auxiliary.assert_exactly_one_of_id_or_external_id(transformation_id, transformation_external_id)
 

--- a/cognite/client/_api/transformations/__init__.py
+++ b/cognite/client/_api/transformations/__init__.py
@@ -276,11 +276,7 @@ class TransformationsAPI(APIClient):
         )
         return job.wait_async(timeout=timeout)
 
-    def cancel(
-        self,
-        transformation_id: int = None,
-        transformation_external_id: str = None,
-    ):
+    def cancel(self, transformation_id: int = None, transformation_external_id: str = None):
         """`Cancel a running transformation. <https://docs.cognite.com/api/v1/#operation/cancelTransformation>`_
 
         Args:

--- a/cognite/client/_api/transformations/__init__.py
+++ b/cognite/client/_api/transformations/__init__.py
@@ -276,6 +276,42 @@ class TransformationsAPI(APIClient):
         )
         return job.wait_async(timeout=timeout)
 
+    def cancel(
+        self,
+        transformation_id: int = None,
+        transformation_external_id: str = None,
+    ):
+        """`Cancel a running transformation. <https://docs.cognite.com/api/v1/#operation/cancelTransformation>`_
+
+        Args:
+            transformation_id (int): Transformation internal id
+            transformation_external_id (str): Transformation external id
+
+        Returns:
+            Canceled transformation job
+
+        Examples:
+
+            Run transformation to completion by id:
+
+                >>> from cognite.client import CogniteClient
+                >>> c = CogniteClient()
+                >>>
+                >>> res = c.transformations.run(id = 1)
+
+            Start running transformation by id:
+
+                >>> from cognite.client import CogniteClient
+                >>> c = CogniteClient()
+                >>>
+                >>> res = c.transformations.run(id = 1, wait = False)
+        """
+        utils._auxiliary.assert_exactly_one_of_id_or_external_id(transformation_id, transformation_external_id)
+
+        id = {"externalId": transformation_external_id, "id": transformation_id}
+
+        self._post(json=id, url_path=self._RESOURCE_PATH + "/cancel")
+
     def preview(
         self,
         query: str = None,

--- a/cognite/client/_version.py
+++ b/cognite/client/_version.py
@@ -1,2 +1,2 @@
-__version__ = "2.38.4"
+__version__ = "2.38.5"
 __api_subversion__ = "V20211213"

--- a/cognite/client/data_classes/transformations/__init__.py
+++ b/cognite/client/data_classes/transformations/__init__.py
@@ -95,6 +95,12 @@ class Transformation(CogniteResource):
     def run(self, wait: bool = True, timeout: Optional[float] = None) -> "TransformationJob":
         return self._cognite_client.transformations.run(transformation_id=self.id, wait=wait, timeout=timeout)
 
+    def cancel(self):
+        if self.id is None:
+            self._cognite_client.transformations.cancel(transformation_external_id=self.external_id)
+        else:
+            self._cognite_client.transformations.cancel(transformation_id=self.id)
+
     def run_async(self, timeout: Optional[float] = None) -> Awaitable["TransformationJob"]:
         return self._cognite_client.transformations.run_async(transformation_id=self.id, timeout=timeout)
 

--- a/cognite/client/data_classes/transformations/jobs.py
+++ b/cognite/client/data_classes/transformations/jobs.py
@@ -109,6 +109,12 @@ class TransformationJob(CogniteResource):
         self.finished_time = updated.finished_time
         self.last_seen_time = updated.last_seen_time
 
+    def cancel(self):
+        if self.transformation_id is None:
+            self._cognite_client.transformations.cancel(transformation_external_id=self.transformation_external_id)
+        else:
+            self._cognite_client.transformations.cancel(transformation_id=self.transformation_id)
+
     def metrics(self):
         """`Get job metrics.`"""
         return self._cognite_client.transformations.jobs.list_metrics(self.id)

--- a/docs/source/cognite.rst
+++ b/docs/source/cognite.rst
@@ -1115,6 +1115,10 @@ Run transformations by id
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. automethod:: cognite.client._api.transformations.TransformationsAPI.run
 
+Cancel transformation run by id
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+.. automethod:: cognite.client._api.transformations.TransformationsAPI.cancel
+
 List transformations
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. automethod:: cognite.client._api.transformations.TransformationsAPI.list

--- a/tests/tests_integration/test_api/test_datapoints.py
+++ b/tests/tests_integration/test_api/test_datapoints.py
@@ -234,13 +234,12 @@ class TestDatapointsAPI:
         assert len(ids) > 10
         tmp = cognite_client.datapoints._RETRIEVE_LATEST_LIMIT
         cognite_client.datapoints._RETRIEVE_LATEST_LIMIT = 10
-        res = cognite_client.datapoints.retrieve_latest(id=ids)
+        res = cognite_client.datapoints.retrieve_latest(id=ids, ignore_unknown_ids=True)
         cognite_client.datapoints._RETRIEVE_LATEST_LIMIT = tmp
-        assert len(ids) == len(res)
+        assert set(dps.id for dps in res).issubset(set(ids))
         assert 2 == cognite_client.datapoints._post.call_count
-        for i, dps in enumerate(res):
+        for dps in res:
             assert len(dps) <= 1  # could be empty
-            assert ids[i] == res[i].id
 
     def test_retrieve_latest_before(self, cognite_client, test_time_series):
         ts = test_time_series[0]

--- a/tests/tests_integration/test_api/test_transformations/test_jobs.py
+++ b/tests/tests_integration/test_api/test_transformations/test_jobs.py
@@ -71,7 +71,7 @@ async def run_transformation_without_waiting(new_transformation):
     yield (job, new_transformation)
 
     await job.wait_async()
-    assert job.status == TransformationJobStatus.COMPLETED
+    assert job.status in [TransformationJobStatus.COMPLETED, TransformationJobStatus.FAILED]
 
 
 @pytest.fixture
@@ -201,6 +201,14 @@ class TestTransformationJobsAPI:
             and job.query == new_raw_transformation.query
             and job.ignore_null_fields
         )
+
+    @pytest.mark.asyncio
+    async def test_cancel_by_transformation_id(self, cognite_client, new_running_transformation):
+        (new_job, new_transformation) = new_running_transformation
+        await asyncio.sleep(0.5)
+        cognite_client.transformations.cancel(transformation_id=new_transformation.id)
+        await new_job.wait_async()
+        assert new_job.status == TransformationJobStatus.FAILED and new_job.error == "Job cancelled by the user."
 
     @pytest.mark.asyncio
     async def test_list_jobs_by_transformation_id(self, new_running_transformation):

--- a/tests/tests_integration/test_api/test_transformations/test_jobs.py
+++ b/tests/tests_integration/test_api/test_transformations/test_jobs.py
@@ -203,10 +203,18 @@ class TestTransformationJobsAPI:
         )
 
     @pytest.mark.asyncio
-    async def test_cancel_by_transformation_id(self, cognite_client, new_running_transformation):
+    async def test_cancel_job(self, new_running_transformation):
+        (new_job, _) = new_running_transformation
+        await asyncio.sleep(0.5)
+        new_job.cancel()
+        await new_job.wait_async()
+        assert new_job.status == TransformationJobStatus.FAILED and new_job.error == "Job cancelled by the user."
+
+    @pytest.mark.asyncio
+    async def test_cancel_transformation(self, new_running_transformation):
         (new_job, new_transformation) = new_running_transformation
         await asyncio.sleep(0.5)
-        cognite_client.transformations.cancel(transformation_id=new_transformation.id)
+        new_transformation.cancel()
         await new_job.wait_async()
         assert new_job.status == TransformationJobStatus.FAILED and new_job.error == "Job cancelled by the user."
 


### PR DESCRIPTION
## Description
add transformationAPI.cancel() method

## Checklist:
- [ ✔️ ] Tests added/updated.
- [ ✔️ ] Documentation updated. Documentation is generated from docstrings - these must be updated according to your change. 
  If a new method has been added it should be referenced in [cognite.rst](https://github.com/cognitedata/cognite-sdk-python/blob/master/docs/source/cognite.rst) in order to generate docs based on its docstring. 
- [ ✔️ ] Changelog updated in [CHANGELOG.md](https://github.com/cognitedata/cognite-sdk-python/blob/master/CHANGELOG.md).
- [ ✔️ ] Version bumped. If triggering a new release is desired, bump the version number in [_version.py](https://github.com/cognitedata/cognite-sdk-python/blob/master/cognite/client/_version.py) per [semantic versioning](https://semver.org/).
