### PR TITLE
SBS-4753: make FeatureList.from_geopandas work in a more general case

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ Changes are grouped as follows
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
+## [2.42.0] - 2022-02-11
+### Added
+- FeatureList.from_geopandas() improvements
 
 ## [2.41.3] - 2022-02-11
 ### Fixed

--- a/cognite/client/_api/geospatial.py
+++ b/cognite/client/_api/geospatial.py
@@ -163,7 +163,7 @@ class GeospatialAPI(APIClient):
     def create_features(
         self,
         feature_type_external_id: str,
-        feature: Union[Feature, List[Feature]],
+        feature: Union[Feature, List[Feature], FeatureList],
         allow_crs_transformation: bool = False,
     ) -> Union[Feature, FeatureList]:
         """`Creates features`
@@ -171,7 +171,7 @@ class GeospatialAPI(APIClient):
 
         Args:
             feature_type_external_id : Feature type definition for the features to create.
-            feature: one feature or a list of features to create
+            feature: one feature or a list of features to create or a FeatureList object
             allow_crs_transformation: If true, then input geometries will be transformed into the Coordinate Reference
                 System defined in the feature type specification. When it is false, then requests with geometries in
                 Coordinate Reference System different from the ones defined in the feature type will result in
@@ -192,6 +192,8 @@ class GeospatialAPI(APIClient):
                 >>> res = c.geospatial.create_feature_types(feature_types)
                 >>> res = c.geospatial.create_features("my_feature_type", Feature(external_id="my_feature", location={"wkt": "POINT(1 1)"}, temperature=12.4))
         """
+        if isinstance(feature, FeatureList):
+            feature = list(feature)
         resource_path = self._feature_resource_path(feature_type_external_id)
         extra_body_fields = {"allowCrsTransformation": "true"} if allow_crs_transformation else {}
         return self._create_multiple(
@@ -276,6 +278,8 @@ class GeospatialAPI(APIClient):
                 >>> # do some stuff
                 >>> my_updated_feature = c.geospatial.update_features("my_feature_type", Feature(external_id="my_feature", temperature=6.237))
         """
+        if isinstance(feature, FeatureList):
+            feature = list(feature)
         # updates for feature are not following the patch structure from other resources
         # they are more like a replace so an update looks like a feature creation (yeah, borderline ?)
         resource_path = self._feature_resource_path(feature_type_external_id) + "/update"

--- a/cognite/client/_version.py
+++ b/cognite/client/_version.py
@@ -1,2 +1,2 @@
-__version__ = "2.41.3"
+__version__ = "2.42.0"
 __api_subversion__ = "V20220125"

--- a/cognite/client/data_classes/geospatial.py
+++ b/cognite/client/data_classes/geospatial.py
@@ -87,12 +87,40 @@ class Feature(CogniteResource):
 
 
 def _is_geometry_type(property_type: str):
-    return property_type in {"GEOMETRY", "POINT", "LINESTRING", "POLYGON", "MULTIPOINT", "MULTILINESTRING",
-                             "MULTIPOLYGON", "GEOMETRYCOLLECTION", "GEOMETRYZ", "POINTZ", "LINESTRINGZ", "POLYGONZ",
-                             "MULTIPOINTZ", "MULTILINESTRINGZ", "MULTIPOLYGONZ", "GEOMETRYCOLLECTIONZ", "GEOMETRYM",
-                             "POINTM", "LINESTRINGM", "POLYGONM", "MULTIPOINTM", "MULTILINESTRINGM", "MULTIPOLYGONM",
-                             "GEOMETRYCOLLECTIONM", "GEOMETRYZM", "POINTZM", "LINESTRINGZM", "POLYGONZM",
-                             "MULTIPOINTZM", "MULTILINESTRINGZM", "MULTIPOLYGONZM", "GEOMETRYCOLLECTIONZM"}
+    return property_type in {
+        "GEOMETRY",
+        "POINT",
+        "LINESTRING",
+        "POLYGON",
+        "MULTIPOINT",
+        "MULTILINESTRING",
+        "MULTIPOLYGON",
+        "GEOMETRYCOLLECTION",
+        "GEOMETRYZ",
+        "POINTZ",
+        "LINESTRINGZ",
+        "POLYGONZ",
+        "MULTIPOINTZ",
+        "MULTILINESTRINGZ",
+        "MULTIPOLYGONZ",
+        "GEOMETRYCOLLECTIONZ",
+        "GEOMETRYM",
+        "POINTM",
+        "LINESTRINGM",
+        "POLYGONM",
+        "MULTIPOINTM",
+        "MULTILINESTRINGM",
+        "MULTIPOLYGONM",
+        "GEOMETRYCOLLECTIONM",
+        "GEOMETRYZM",
+        "POINTZM",
+        "LINESTRINGZM",
+        "POLYGONZM",
+        "MULTIPOINTZM",
+        "MULTILINESTRINGZM",
+        "MULTIPOLYGONZM",
+        "GEOMETRYCOLLECTIONZM",
+    }
 
 
 def _is_reserved_property(property_name: str):
@@ -121,10 +149,12 @@ class FeatureList(CogniteResourceList):
         return gdf
 
     @staticmethod
-    def from_geopandas(feature_type: FeatureType,
-                       geodataframe: "geopandas.GeoDataFrame",
-                       external_id_column: str = "externalId",
-                       property_column_mapping: Dict[str, str] = None) -> "FeatureList":
+    def from_geopandas(
+        feature_type: FeatureType,
+        geodataframe: "geopandas.GeoDataFrame",
+        external_id_column: str = "externalId",
+        property_column_mapping: Dict[str, str] = None,
+    ) -> "FeatureList":
         """Convert a GeoDataFrame instance into a FeatureList.
 
         Args:
@@ -147,7 +177,7 @@ class FeatureList(CogniteResourceList):
                 >>> feature_list = FeatureList.from_geopandas(feature_type=my_feature_type, geodataframe=my_geodataframe,
                 >>>     external_id_column="id", property_column_mapping={'position': 'center_xy', 'temperature': 'temp'})
                 >>> created_features = c.geospatial.create_features(my_feature_type.external_id, feature_list)
-            
+
         """
         features = []
         if property_column_mapping is None:

--- a/cognite/client/data_classes/geospatial.py
+++ b/cognite/client/data_classes/geospatial.py
@@ -122,14 +122,14 @@ class FeatureList(CogniteResourceList):
 
     @staticmethod
     def from_geopandas(feature_type: FeatureType,
-                       gdf: "geopandas.GeoDataFrame",
+                       geodataframe: "geopandas.GeoDataFrame",
                        external_id_column: str = "externalId",
                        property_column_mapping: Dict[str, str] = None) -> "FeatureList":
         """Convert a GeoDataFrame instance into a FeatureList.
 
         Args:
             feature_type (FeatureType): The feature type the features will conform to
-            gdf (GeoDataFrame): the geodataframe instance to convert into features
+            geodataframe (GeoDataFrame): the geodataframe instance to convert into features
             external_id_column: the geodataframe column to use for the feature external id
             property_column_mapping: provides a mapping from featuretype property names to geodataframe columns
 
@@ -144,15 +144,15 @@ class FeatureList(CogniteResourceList):
                 >>> c = CogniteClient()
                 >>> my_feature_type = ... # some feature type with 'position' and 'temperature' properties
                 >>> my_geodataframe = ...  # some geodataframe with 'center_xy', 'temp' and 'id' columns
-                >>> feature_list = FeatureList.from_geopandas(feature_type=my_feature_type, gdf=my_geodataframe,
+                >>> feature_list = FeatureList.from_geopandas(feature_type=my_feature_type, geodataframe=my_geodataframe,
                 >>>     external_id_column="id", property_column_mapping={'position': 'center_xy', 'temperature': 'temp'})
-                >>> created_features = c.geospatial.create_features(my_feature_type.external_id, fl)
+                >>> created_features = c.geospatial.create_features(my_feature_type.external_id, feature_list)
             
         """
         features = []
         if property_column_mapping is None:
             property_column_mapping = {prop_name: prop_name for (prop_name, _) in feature_type.properties.items()}
-        for _, row in gdf.iterrows():
+        for _, row in geodataframe.iterrows():
             feature = Feature(external_id=row[external_id_column])
             for prop in feature_type.properties.items():
                 prop_name = prop[0]

--- a/cognite/client/data_classes/geospatial.py
+++ b/cognite/client/data_classes/geospatial.py
@@ -124,7 +124,7 @@ class FeatureList(CogniteResourceList):
     def from_geopandas(feature_type: FeatureType,
                        gdf: "geopandas.GeoDataFrame",
                        external_id_column: str = "externalId",
-                       property_column_mapping: Dict[str, str] = None) -> List[Feature]:
+                       property_column_mapping: Dict[str, str] = None) -> "FeatureList":
         """Convert a GeoDataFrame instance into a FeatureList.
 
         Args:
@@ -135,6 +135,19 @@ class FeatureList(CogniteResourceList):
 
         Returns:
             FeatureList: The list of features converted from the geodataframe rows.
+
+        Examples:
+
+            Create features from a geopandas dataframe:
+
+                >>> from cognite.client import CogniteClient
+                >>> c = CogniteClient()
+                >>> my_feature_type = ... # some feature type with 'position' and 'temperature' properties
+                >>> my_geodataframe = ...  # some geodataframe with 'center_xy', 'temp' and 'id' columns
+                >>> feature_list = FeatureList.from_geopandas(feature_type=my_feature_type, gdf=my_geodataframe,
+                >>>     external_id_column="id", property_column_mapping={'position': 'center_xy', 'temperature': 'temp'})
+                >>> created_features = c.geospatial.create_features(my_feature_type.external_id, fl)
+            
         """
         features = []
         if property_column_mapping is None:
@@ -156,7 +169,7 @@ class FeatureList(CogniteResourceList):
                 else:
                     setattr(feature, prop_name, column_value)
             features.append(feature)
-        return features
+        return FeatureList(features)
 
 
 class FeatureAggregate(CogniteResource):

--- a/tests/tests_integration/test_api/test_geospatial.py
+++ b/tests/tests_integration/test_api/test_geospatial.py
@@ -435,7 +435,7 @@ class TestGeospatialAPI:
         df = pd.DataFrame({'some_unique_id': [f"F{i}_{uuid.uuid4().hex[:10]}" for i in range(4)],
                            'some_position': ['POINT(2.2768485 48.8589506)',
                                              'POLYGON((10.689 -25.02, 38.814 -35.639, 13.502 -39.155, 10.689 -25.02))',
-                                             'LINESTRING (30 10, 10 30, 40 40)',
+                                             None,
                                              'MULTILINESTRING ((10 10, 20 20, 10 40), (40 40, 30 30, 40 20, 30 10))'],
                            'some_temperature': [12.4, 13.4, 13.4, 13.4],
                            'some_volume': [1212.0, 1313.0, 1414.0, 1515.0],

--- a/tests/tests_integration/test_api/test_geospatial.py
+++ b/tests/tests_integration/test_api/test_geospatial.py
@@ -128,7 +128,7 @@ def test_features(cognite_client, test_feature_type):
             temperature=23.4,
             volume=1212.0,
             pressure=2121.0,
-        )
+        ),
     ]
     feature = cognite_client.geospatial.create_features(test_feature_type.external_id, features)
     yield feature
@@ -205,9 +205,8 @@ class TestGeospatialAPI:
 
     def test_retrieve_single_feature_type_by_external_id(self, cognite_client, test_feature_type):
         assert (
-                test_feature_type.external_id
-                == cognite_client.geospatial.retrieve_feature_types(
-            external_id=test_feature_type.external_id).external_id
+            test_feature_type.external_id
+            == cognite_client.geospatial.retrieve_feature_types(external_id=test_feature_type.external_id).external_id
         )
 
     def test_list_feature_types(self, cognite_client, test_feature_type):
@@ -245,19 +244,19 @@ class TestGeospatialAPI:
         assert len(res) == 0
 
     def test_retrieve_multiple_feature_types_by_external_id(
-            self, cognite_client, test_feature_type, another_test_feature_type
+        self, cognite_client, test_feature_type, another_test_feature_type
     ):
         assert (
-                len(
-                    cognite_client.geospatial.retrieve_feature_types(
-                        external_id=[test_feature_type.external_id, another_test_feature_type.external_id]
-                    )
+            len(
+                cognite_client.geospatial.retrieve_feature_types(
+                    external_id=[test_feature_type.external_id, another_test_feature_type.external_id]
                 )
-                == 2
+            )
+            == 2
         )
 
     def test_retrieve_multiple_features_by_external_id(
-            self, cognite_client, test_feature_type, test_feature, another_test_feature
+        self, cognite_client, test_feature_type, test_feature, another_test_feature
     ):
         res = cognite_client.geospatial.retrieve_features(
             feature_type_external_id=test_feature_type.external_id,
@@ -330,7 +329,7 @@ class TestGeospatialAPI:
         assert not hasattr(res[1], "pressure")
 
     def test_search_with_output_srid_selection(
-            self, cognite_client, allow_crs_transformation, test_feature_type, test_feature, another_test_feature
+        self, cognite_client, allow_crs_transformation, test_feature_type, test_feature, another_test_feature
     ):
         res = cognite_client.geospatial.search_features(
             feature_type_external_id=test_feature_type.external_id,
@@ -414,39 +413,59 @@ class TestGeospatialAPI:
 
     def test_from_geopandas_basic(self, cognite_client, test_feature_type):
         pd = utils._auxiliary.local_import("pandas")
-        df = pd.DataFrame({'externalId': [f"F{i}_{uuid.uuid4().hex[:10]}" for i in range(4)],
-                           'position': ['POINT(2.2768485 48.8589506)',
-                                        'POLYGON((10.689 -25.092, 38.814 -35.639, 13.502 -39.155, 10.689 -25.092))',
-                                        'LINESTRING (30 10, 10 30, 40 40)',
-                                        'MULTILINESTRING ((10 10, 20 20, 10 40), (40 40, 30 30, 40 20, 30 10))'],
-                           'temperature': [12.4, 13.4, 13.4, 13.4],
-                           'volume': [1212.0, 1313.0, 1414.0, 1515.0],
-                           'pressure': [2121.0, 2121.0, 2121.0, 2121.0]})
+        df = pd.DataFrame(
+            {
+                "externalId": [f"F{i}_{uuid.uuid4().hex[:10]}" for i in range(4)],
+                "position": [
+                    "POINT(2.2768485 48.8589506)",
+                    "POLYGON((10.689 -25.092, 38.814 -35.639, 13.502 -39.155, 10.689 -25.092))",
+                    "LINESTRING (30 10, 10 30, 40 40)",
+                    "MULTILINESTRING ((10 10, 20 20, 10 40), (40 40, 30 30, 40 20, 30 10))",
+                ],
+                "temperature": [12.4, 13.4, 13.4, 13.4],
+                "volume": [1212.0, 1313.0, 1414.0, 1515.0],
+                "pressure": [2121.0, 2121.0, 2121.0, 2121.0],
+            }
+        )
         utils._auxiliary.local_import("shapely.wkt")
         geopandas = utils._auxiliary.local_import("geopandas")
-        df['position'] = geopandas.GeoSeries.from_wkt(df['position'])
-        gdf = geopandas.GeoDataFrame(df, geometry='position')
+        df["position"] = geopandas.GeoSeries.from_wkt(df["position"])
+        gdf = geopandas.GeoDataFrame(df, geometry="position")
         fl = FeatureList.from_geopandas(test_feature_type, gdf)
         res = cognite_client.geospatial.create_features(test_feature_type.external_id, fl)
         assert len(res) == 4
 
     def test_from_geopandas_flexible(self, cognite_client, test_feature_type):
         pd = utils._auxiliary.local_import("pandas")
-        df = pd.DataFrame({'some_unique_id': [f"F{i}_{uuid.uuid4().hex[:10]}" for i in range(4)],
-                           'some_position': ['POINT(2.2768485 48.8589506)',
-                                             'POLYGON((10.689 -25.02, 38.814 -35.639, 13.502 -39.155, 10.689 -25.02))',
-                                             None,
-                                             'MULTILINESTRING ((10 10, 20 20, 10 40), (40 40, 30 30, 40 20, 30 10))'],
-                           'some_temperature': [12.4, 13.4, 13.4, 13.4],
-                           'some_volume': [1212.0, 1313.0, 1414.0, 1515.0],
-                           'some_pressure': [2121.0, 2121.0, 2121.0, 2121.0]})
+        df = pd.DataFrame(
+            {
+                "some_unique_id": [f"F{i}_{uuid.uuid4().hex[:10]}" for i in range(4)],
+                "some_position": [
+                    "POINT(2.2768485 48.8589506)",
+                    "POLYGON((10.689 -25.02, 38.814 -35.639, 13.502 -39.155, 10.689 -25.02))",
+                    None,
+                    "MULTILINESTRING ((10 10, 20 20, 10 40), (40 40, 30 30, 40 20, 30 10))",
+                ],
+                "some_temperature": [12.4, 13.4, 13.4, 13.4],
+                "some_volume": [1212.0, 1313.0, 1414.0, 1515.0],
+                "some_pressure": [2121.0, 2121.0, 2121.0, 2121.0],
+            }
+        )
         utils._auxiliary.local_import("shapely.wkt")
         geopandas = utils._auxiliary.local_import("geopandas")
-        df['some_position'] = geopandas.GeoSeries.from_wkt(df['some_position'])
-        gdf = geopandas.GeoDataFrame(df, geometry='some_position')
-        fl = FeatureList.from_geopandas(test_feature_type, gdf, "some_unique_id",
-                                        {'position': 'some_position', 'temperature': 'some_temperature',
-                                         'volume': 'some_volume', 'pressure': 'some_pressure'})
+        df["some_position"] = geopandas.GeoSeries.from_wkt(df["some_position"])
+        gdf = geopandas.GeoDataFrame(df, geometry="some_position")
+        fl = FeatureList.from_geopandas(
+            test_feature_type,
+            gdf,
+            "some_unique_id",
+            {
+                "position": "some_position",
+                "temperature": "some_temperature",
+                "volume": "some_volume",
+                "pressure": "some_pressure",
+            },
+        )
         res = cognite_client.geospatial.create_features(test_feature_type.external_id, fl)
         assert len(res) == 4
 

--- a/tests/tests_unit/test_api/test_geospatial.py
+++ b/tests/tests_unit/test_api/test_geospatial.py
@@ -53,7 +53,7 @@ def test_features(test_feature_type):
                 temperature=13.4,
                 volume=1212.0,
                 pressure=2121.0,
-            )
+            ),
         ]
     )
 


### PR DESCRIPTION
from_geopandas improvements:
- support all geometry types
- support optional feature properties
- handle reserved property names
- don't enforce the geopandas external_id column name (i.e. allows to pass a custom name)
- add possibility to provide a mapping from feature property names to geopandas column names 