### PR TITLE
Add information to SequencesDataAPI.retrieve documentation

### DIFF
--- a/cognite/client/_api/sequences.py
+++ b/cognite/client/_api/sequences.py
@@ -669,7 +669,7 @@ class SequencesDataAPI(APIClient):
             column_external_ids (Optional[List[str]]): List of external id for the columns of the sequence. If 'None' is passed, all columns will be retrieved.
             id (int): Id of sequence.
             external_id (str): External id of sequence.
-            limit (int): Maximum number of rows to return per sequence.
+            limit (int): Maximum number of rows to return per sequence. 10000 is the maximum limit per request.
 
 
         Returns:


### PR DESCRIPTION
## Description
According to https://docs.cognite.com/dev/concepts/resource_types/sequences/#about-sequences, _10000 is the maximum limit per request._ That information is missing in the SDK documentation and I think it's relevant to include

## Checklist:
- [ ] Tests added/updated.
- [X] Documentation updated. Documentation is generated from docstrings - these must be updated according to your change. 
  If a new method has been added it should be referenced in [cognite.rst](https://github.com/cognitedata/cognite-sdk-python/blob/master/docs/source/cognite.rst) in order to generate docs based on its docstring. 
- [ ] Changelog updated in [CHANGELOG.md](https://github.com/cognitedata/cognite-sdk-python/blob/master/CHANGELOG.md).
- [ ] Version bumped. If triggering a new release is desired, bump the version number in [_version.py](https://github.com/cognitedata/cognite-sdk-python/blob/master/cognite/client/_version.py) per [semantic versioning](https://semver.org/).
