### PR TITLE
Support sequence rows destination type on transformations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,9 +14,13 @@ Changes are grouped as follows
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
+## [2.45.0] - 2022-03-25
+### Added
+- support `sequence_rows` destination type on Transformations.
+
 ## [2.44.1] - 2022-03-24
 ### Fixed
-- Fix typo in `data_set_ids` parameter type on `transformations.list`.
+- fix typo in `data_set_ids` parameter type on `transformations.list`.
 
 ## [2.44.0] - 2022-03-24
 ### Added
@@ -28,7 +32,7 @@ Changes are grouped as follows
  
 ## [2.43.0] - 2022-03-21
 ### Added
-- New list parameters added to `transformations.list`.
+- new list parameters added to `transformations.list`.
 
 ## [2.42.0] - 2022-02-11
 ### Added

--- a/cognite/client/_version.py
+++ b/cognite/client/_version.py
@@ -1,2 +1,2 @@
-__version__ = "2.44.1"
+__version__ = "2.45.0"
 __api_subversion__ = "V20220125"

--- a/cognite/client/data_classes/transformations/__init__.py
+++ b/cognite/client/data_classes/transformations/__init__.py
@@ -122,6 +122,9 @@ class Transformation(CogniteResource):
             elif instance.destination.get("type") == "data_model_instances":
                 snake_dict.pop("type")
                 instance.destination = AlphaDataModelInstances(**snake_dict)
+            elif instance.destination.get("type") == "sequence_rows":
+                snake_dict.pop("type")
+                instance.destination = SequenceRows(**snake_dict)
             else:
                 instance.destination = TransformationDestination(**snake_dict)
         if isinstance(instance.running_job, Dict):
@@ -157,7 +160,7 @@ class Transformation(CogniteResource):
         if self.destination_oidc_credentials:
             destination_key = "destinationOidcCredentials" if camel_case else "destination_oidc_credentials"
             ret[destination_key] = self.destination_oidc_credentials.dump(camel_case=camel_case)
-        if isinstance(self.destination, AlphaDataModelInstances):
+        if isinstance(self.destination, AlphaDataModelInstances) or isinstance(self.destination, SequenceRows):
             ret["destination"] = self.destination.dump(camel_case=camel_case)
         return ret
 
@@ -228,7 +231,7 @@ class TransformationUpdate(CogniteUpdate):
     def dump(self, camel_case: bool = True):
         obj = super().dump()
         dest = obj.get("update", {}).get("destination", {}).get("set")
-        if isinstance(dest, AlphaDataModelInstances):
+        if isinstance(dest, AlphaDataModelInstances) or isinstance(dest, SequenceRows):
             obj["update"]["destination"]["set"] = dest.dump(camel_case=camel_case)
         return obj
 

--- a/cognite/client/data_classes/transformations/common.py
+++ b/cognite/client/data_classes/transformations/common.py
@@ -85,6 +85,18 @@ class TransformationDestination:
         """
         return RawTable(database=database, table=table)
 
+    @staticmethod
+    def sequence_rows(external_id: str = ""):
+        """To be used when the transformation is meant to produce sequence rows.
+
+        Args:
+            external_id (str): Sequence external id.
+
+        Returns:
+            TransformationDestination pointing to the target sequence rows
+        """
+        return SequenceRows(external_id=external_id)
+
 
 class RawTable(TransformationDestination):
     def __init__(self, database: str = None, table: str = None):
@@ -97,6 +109,24 @@ class RawTable(TransformationDestination):
 
     def __eq__(self, obj):
         return isinstance(obj, RawTable) and hash(obj) == hash(self)
+
+
+class SequenceRows(TransformationDestination):
+    def __init__(self, external_id: str = None):
+        super().__init__(type="sequence_rows")
+        self.external_id = external_id
+
+    def __hash__(self):
+        return hash((self.type, self.external_id))
+
+    def __eq__(self, obj):
+        return isinstance(obj, SequenceRows) and hash(obj) == hash(self)
+
+    def dump(self, camel_case: bool = False) -> Dict[str, Any]:
+        ret = {"external_id": self.external_id, "type": self.type}
+        if camel_case:
+            return {utils._auxiliary.to_camel_case(key): value for key, value in ret.items()}
+        return ret
 
 
 class OidcCredentials:

--- a/cognite/client/data_classes/transformations/jobs.py
+++ b/cognite/client/data_classes/transformations/jobs.py
@@ -4,7 +4,7 @@ from enum import Enum
 
 from cognite.client.data_classes._base import *
 from cognite.client.data_classes.transformations._alphatypes import AlphaDataModelInstances
-from cognite.client.data_classes.transformations.common import RawTable, TransformationDestination
+from cognite.client.data_classes.transformations.common import RawTable, SequenceRows, TransformationDestination
 
 
 class TransformationJobStatus(str, Enum):
@@ -244,6 +244,9 @@ class TransformationJob(CogniteResource):
             elif instance.destination.get("type") == "data_model_instances":
                 snake_dict.pop("type")
                 instance.destination = AlphaDataModelInstances(**snake_dict)
+            elif instance.destination.get("type") == "sequence_rows":
+                snake_dict.pop("type")
+                instance.destination = SequenceRows(**snake_dict)
             else:
                 instance.destination = TransformationDestination(**snake_dict)
         return instance

--- a/docs/source/cognite.rst
+++ b/docs/source/cognite.rst
@@ -1286,6 +1286,9 @@ Data classes
 .. automodule:: cognite.client.data_classes.transformations.schema
     :members:
     :show-inheritance:
+.. automodule:: cognite.client.data_classes.transformations.common
+    :members:
+    :show-inheritance:
 
 
 Base data classes

--- a/tests/tests_integration/test_api/test_transformations/test_transformations.py
+++ b/tests/tests_integration/test_api/test_transformations/test_transformations.py
@@ -5,6 +5,7 @@ import pytest
 
 from cognite.client.data_classes import DataSet, Transformation, TransformationDestination, TransformationUpdate
 from cognite.client.data_classes.transformations._alphatypes import AlphaDataModelInstances
+from cognite.client.data_classes.transformations.common import SequenceRows
 
 
 @pytest.fixture
@@ -92,6 +93,17 @@ class TestTransformationsAPI:
         assert ts.destination.type == "data_model_instances" and ts.destination.model_external_id == "testInstance"
         cognite_client.transformations.delete(id=ts.id)
 
+    def test_create_sequence_rows_transformation(self, cognite_client):
+        prefix = "".join(random.choice(string.ascii_letters) for i in range(6))
+        transform = Transformation(
+            name="any",
+            external_id=f"{prefix}-transformation",
+            destination=TransformationDestination.sequence_rows(external_id="testSequenceRows"),
+        )
+        ts = cognite_client.transformations.create(transform)
+        assert ts.destination.type == "sequence_rows" and ts.destination.external_id == "testSequenceRows"
+        cognite_client.transformations.delete(id=ts.id)
+
     def test_create(self, new_transformation):
         assert (
             new_transformation.name == "any"
@@ -177,3 +189,12 @@ class TestTransformationsAPI:
         assert updated_transformation.destination == AlphaDataModelInstances("myTest")
         partial_updated = cognite_client.transformations.update(partial_update)
         assert partial_updated.destination == AlphaDataModelInstances("myTest2")
+
+    def test_update_sequence_rows_update(self, cognite_client, new_transformation):
+        new_transformation.destination = SequenceRows("myTest")
+        updated_transformation = cognite_client.transformations.update(new_transformation)
+        assert updated_transformation.destination == TransformationDestination.sequence_rows("myTest")
+
+        partial_update = TransformationUpdate(id=new_transformation.id).destination.set(SequenceRows("myTest2"))
+        partial_updated = cognite_client.transformations.update(partial_update)
+        assert partial_updated.destination == TransformationDestination.sequence_rows("myTest2")


### PR DESCRIPTION
## Description
Add a new transformation destination

## Checklist:
- [x] Tests added/updated.
- [x] Documentation updated. Documentation is generated from docstrings - these must be updated according to your change. 
  If a new method has been added it should be referenced in [cognite.rst](https://github.com/cognitedata/cognite-sdk-python/blob/master/docs/source/cognite.rst) in order to generate docs based on its docstring. 
- [x] Changelog updated in [CHANGELOG.md](https://github.com/cognitedata/cognite-sdk-python/blob/master/CHANGELOG.md).
- [x] Version bumped. If triggering a new release is desired, bump the version number in [_version.py](https://github.com/cognitedata/cognite-sdk-python/blob/master/cognite/client/_version.py) per [semantic versioning](https://semver.org/).
