### PR TITLE
[MLOPS-1013] Added `sessions/revoke` to retryable POST-endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ Changes are grouped as follows
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
+## [2.40.1] - 2022-04-22
+### Changed
+- POST requests to the `sessions/revoke`-endpoint are now automatically retried
+
 ## [2.40.0] - 2022-02-11
 ### Added
 - dataSetId support for transformations.

--- a/cognite/client/_api_client.py
+++ b/cognite/client/_api_client.py
@@ -57,6 +57,7 @@ class APIClient:
         "/context/entitymatching/byids",
         "/context/entitymatching/list",
         "/context/entitymatching/jobs",
+        "/sessions/revoke",
     }
 
     def __init__(self, config: utils._client_config.ClientConfig, api_version: str = None, cognite_client=None) -> None:

--- a/cognite/client/_version.py
+++ b/cognite/client/_version.py
@@ -1,2 +1,2 @@
-__version__ = "2.40.0"
+__version__ = "2.40.1"
 __api_subversion__ = "V20220125"


### PR DESCRIPTION
## Description

We want to automatically retry on POSTs to the `sessions/revoke` endpoint. The endpoint is idempotent, and [this is the corresponding design doc](https://cognitedata.atlassian.net/wiki/spaces/AUTH/pages/3385229337/2022-02-09+Session+revocation+endpoint). 

This change was sparked by this [context-API PR](https://github.com/cognitedata/context-api/pull/2739).

## Checklist:
- [ ] Tests added/updated.
- [x] Documentation updated. Documentation is generated from docstrings - these must be updated according to your change. 
  If a new method has been added it should be referenced in [cognite.rst](https://github.com/cognitedata/cognite-sdk-python/blob/master/docs/source/cognite.rst) in order to generate docs based on its docstring. 
- [x] Changelog updated in [CHANGELOG.md](https://github.com/cognitedata/cognite-sdk-python/blob/master/CHANGELOG.md).
- [x] Version bumped. If triggering a new release is desired, bump the version number in [_version.py](https://github.com/cognitedata/cognite-sdk-python/blob/master/cognite/client/_version.py) per [semantic versioning](https://semver.org/).
