### PR TITLE
Reduce request multiple timeseries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ Changes are grouped as follows
 
 ## [2.47.0] - 2022-05-02
 ### Changed
-- Performance gain for datapoints.retrieve by utilizing multiple timeseries in on requests.
+- Performance gain for `datapoints.retrieve` by grouping together time series in single requests against the underlying API.
 
 
 ## [2.46.1] - 2022-04-22

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@ Changes are grouped as follows
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
+## [2.47.0] - 2022-05-02
+### Changed
+- Performance gain for datapoints.retrieve by utilizing multiple timeseries in on requests.
+
+
 ## [2.46.1] - 2022-04-22
 ### Changed
 - POST requests to the `sessions/revoke`-endpoint are now automatically retried

--- a/cognite/client/_api/datapoints.py
+++ b/cognite/client/_api/datapoints.py
@@ -1052,24 +1052,29 @@ class DatapointsFetcher:
 
         if isinstance(ids, List):
             is_list = True
-            for item in ids:
-                items.append(DatapointsFetcher._process_single_ts_item(item, False))
+            items.extend(
+                DatapointsFetcher._process_single_ts_item(item, False)
+                for item in ids
+            )
         elif ids is not None:
             items.append(DatapointsFetcher._process_single_ts_item(ids, False))
 
         if isinstance(external_ids, List):
             is_list = True
-            for item in external_ids:
-                items.append(DatapointsFetcher._process_single_ts_item(item, True))
+            items.extend(
+                DatapointsFetcher._process_single_ts_item(item, True)
+                for item in external_ids
+            )
+
         elif external_ids is not None:
             items.append(DatapointsFetcher._process_single_ts_item(external_ids, True))
 
         return items, not is_list and len(items) == 1
 
     @staticmethod
-    def _process_single_ts_item(item, external: bool):
-        item_type = "externalId" if external else "id"
-        id_type = str if external else int
+    def _process_single_ts_item(item, is_external: bool):
+        item_type = "externalId" if is_external else "id"
+        id_type = str if is_external else int
         if isinstance(item, id_type):
             return {item_type: item}
         elif isinstance(item, Dict):

--- a/cognite/client/_api/datapoints.py
+++ b/cognite/client/_api/datapoints.py
@@ -867,7 +867,7 @@ class _DPTask:
             key = next(iter(ts_item.items()))
             result = self.results[key]
             raw_data = result_by_identifiers.get(key)
-            if raw_data is None:
+            if raw_data is None and self.ignore_unknown_ids:
                 result.mark_missing()
             else:
                 result.store(
@@ -908,7 +908,7 @@ class DatapointsFetcher:
         task_list = self._create_tasks(query, chunk_size)
         self._fetch_datapoints(task_list)
         return DatapointsList(
-            [result.compute() for task in task_list for result in task.results.values()],
+            [result.compute() for task in task_list for result in task.results.values() if not result.missing],
             cognite_client=self.client._cognite_client,
         )
 

--- a/cognite/client/_api/datapoints.py
+++ b/cognite/client/_api/datapoints.py
@@ -1020,7 +1020,7 @@ class DatapointsFetcher:
             count_granularity = task.granularity
         try:
             count_task = _DPTask(
-                self.client, start, task.end, {"id": id}, ["count"], count_granularity, False, None, False
+                self.client, start, task.end, [{"id": id}], ["count"], count_granularity, False, None, False
             )
             self._get_datapoints_with_paging(count_task, _DPWindow(start, task.end))
             # Todo Update with _DPTask

--- a/cognite/client/_api/datapoints.py
+++ b/cognite/client/_api/datapoints.py
@@ -743,15 +743,10 @@ class DatapointsPoster:
                     bin = DatapointsBin(self.client._DPS_LIMIT, self.client._POST_DPS_OBJECTS_LIMIT)
                     bin.add(dps_object_chunk)
                     self.bins.append(bin)
-        binned_dps_object_list = []
-        for bin in self.bins:
-            binned_dps_object_list.append(bin.dps_object_list)
-        return binned_dps_object_list
+        return [bin.dps_object_list for bin in self.bins]
 
     def _insert_datapoints_concurrently(self, dps_object_lists: List[List[Dict[str, Any]]]):
-        tasks = []
-        for dps_object_list in dps_object_lists:
-            tasks.append((dps_object_list,))
+        tasks = [(dps_object_list,) for dps_object_list in dps_object_lists]
         summary = utils._concurrency.execute_tasks_concurrently(
             self._insert_datapoints, tasks, max_workers=self.client._config.max_workers
         )

--- a/cognite/client/_api/datapoints.py
+++ b/cognite/client/_api/datapoints.py
@@ -878,15 +878,7 @@ class _DPTask:
 
     def as_tuples(self):
         return [
-            (
-                self.start,
-                self.end,
-                ts_item,
-                self.aggregates,
-                self.granularity,
-                self.include_outside_points,
-                self.limit,
-            )
+            (self.start, self.end, ts_item, self.aggregates, self.granularity, self.include_outside_points, self.limit)
             for ts_item in self.ts_items
         ]
 

--- a/cognite/client/_api/datapoints.py
+++ b/cognite/client/_api/datapoints.py
@@ -994,6 +994,8 @@ class DatapointsFetcher:
             return []
         remaining_tasks = []
         for result in results.values():
+            if result.datapoint_length < task.request_limit // ts_count:
+                continue
             remaining_user_limit = task.limit - result.datapoint_length
             start = result.last_timestamp + task.next_start_offset()
             tasks = self._split_task_into_windows(result.results[0].id, task, remaining_user_limit, start)

--- a/cognite/client/_api/datapoints.py
+++ b/cognite/client/_api/datapoints.py
@@ -827,7 +827,16 @@ class _DPResult:
 
 class _DPTask:
     def __init__(
-        self, client, start, end, ts_items, aggregates, granularity, include_outside_points, limit, ignore_unknown_ids
+        self,
+        client,
+        start,
+        end,
+        ts_items: List[dict],
+        aggregates,
+        granularity,
+        include_outside_points,
+        limit,
+        ignore_unknown_ids,
     ):
         self.start = cognite.client.utils._time.timestamp_to_ms(start)
         self.end = cognite.client.utils._time.timestamp_to_ms(end)

--- a/cognite/client/_api/datapoints.py
+++ b/cognite/client/_api/datapoints.py
@@ -1075,7 +1075,7 @@ class DatapointsFetcher:
     def _get_datapoints_with_paging(self, task, window):
         ndp_retrieved_total = 0
         while window.end > window.start and ndp_retrieved_total < window.limit:
-            _ = self._get_datapoints(task, window)
+            self._get_datapoints(task, window)
             last_result = task.last_result
             ndp_retrieved, last_time = last_result.datapoint_length, last_result.last_timestamp
             if ndp_retrieved < min(window.limit, task.request_limit):

--- a/cognite/client/_api/datapoints.py
+++ b/cognite/client/_api/datapoints.py
@@ -912,6 +912,10 @@ class DatapointsFetcher:
 
     def _create_tasks(self, query: DatapointsQuery, chunk_size=1) -> List[_DPTask]:
         ts_items, _ = self._process_ts_identifiers(query.id, query.external_id)
+
+        if any("aggregates" in ts_item for ts_item in ts_items):
+            chunk_size = 1
+
         tasks = [
             _DPTask(
                 self.client,

--- a/cognite/client/_api/datapoints.py
+++ b/cognite/client/_api/datapoints.py
@@ -908,7 +908,7 @@ class DatapointsFetcher:
         task_list = self._create_tasks(query, chunk_size)
         self._fetch_datapoints(task_list)
         return DatapointsList(
-            [result.compute() for task in task_list for result in task.results.values() if not result.missing],
+            [result.compute() for task in task_list for result in task.results.values()],
             cognite_client=self.client._cognite_client,
         )
 

--- a/cognite/client/_api/datapoints.py
+++ b/cognite/client/_api/datapoints.py
@@ -990,8 +990,6 @@ class DatapointsFetcher:
     def _fetch_dps_initial_and_return_remaining_tasks(self, task: _DPTask) -> List[Tuple[_DPTask, _DPWindow]]:
         results = self._get_datapoints(task, None, True)
         ts_count = len(results)
-        if all(result.datapoint_length < task.request_limit // ts_count for result in results.values()):
-            return []
         remaining_tasks = []
         for result in results.values():
             if result.datapoint_length < task.request_limit // ts_count:

--- a/cognite/client/_version.py
+++ b/cognite/client/_version.py
@@ -1,2 +1,2 @@
-__version__ = "2.46.1"
+__version__ = "2.47.0"
 __api_subversion__ = "V20220125"

--- a/cognite/client/data_classes/datapoints.py
+++ b/cognite/client/data_classes/datapoints.py
@@ -272,26 +272,24 @@ class Datapoints:
                 value.extend(other_value)
 
     def _get_non_empty_data_fields(self, get_empty_lists=False, get_error=True) -> List[Tuple[str, Any]]:
-        non_empty_data_fields = []
-        for attr, value in self.__dict__.copy().items():
+        return [
+            (attr, value)
+            for attr, value in self.__dict__.copy().items()
             if (
                 attr not in ["id", "external_id", "is_string", "is_step", "unit"]
                 and attr[0] != "_"
                 and (attr != "error" or get_error)
-            ):
-                if value is not None or attr == "timestamp":
-                    if len(value) > 0 or get_empty_lists or attr == "timestamp":
-                        non_empty_data_fields.append((attr, value))
-        return non_empty_data_fields
+            )
+            and (value is not None or attr == "timestamp")
+            and (len(value) > 0 or get_empty_lists or attr == "timestamp")
+        ]
 
     def __get_datapoint_objects(self) -> List[Datapoint]:
         if self.__datapoint_objects is None:
             fields = self._get_non_empty_data_fields(get_error=False)
             self.__datapoint_objects = []
             for i in range(len(self)):
-                dp_args = {}
-                for attr, value in fields:
-                    dp_args[attr] = value[i]
+                dp_args = {attr: value[i] for attr, value in fields}
                 self.__datapoint_objects.append(Datapoint(**dp_args))
         return self.__datapoint_objects
 

--- a/cognite/client/utils/_auxiliary.py
+++ b/cognite/client/utils/_auxiliary.py
@@ -174,7 +174,7 @@ class PriorityQueue:
 
 def split_into_chunks(collection: Union[List, Dict], chunk_size: int) -> List[Union[List, Dict]]:
     if not isinstance(collection, (dict, list)):
-        raise ValueError("Can only split list or dict")
+        raise TypeError("Can only split list or dict")
     entry_constructor = lambda x: x
     if isinstance(collection, dict):
         collection = list(collection.items())

--- a/cognite/client/utils/_auxiliary.py
+++ b/cognite/client/utils/_auxiliary.py
@@ -58,7 +58,7 @@ def assert_exactly_one_of_id_or_external_id(id, external_id):
     has_external_id = external_id is not None
 
     assert (has_id or has_external_id) and not (
-            has_id and has_external_id
+        has_id and has_external_id
     ), "Exactly one of id and external id must be specified"
 
     if has_id:
@@ -179,10 +179,7 @@ def split_into_chunks(collection: Union[List, Dict], chunk_size: int) -> List[Un
     if isinstance(collection, dict):
         collection = list(collection.items())
         entry_constructor = dict
-    return [
-        entry_constructor(collection[i: i + chunk_size])
-        for i in range(0, len(collection), chunk_size)
-    ]
+    return [entry_constructor(collection[i : i + chunk_size]) for i in range(0, len(collection), chunk_size)]
 
 
 def convert_true_match(true_match):

--- a/cognite/client/utils/_auxiliary.py
+++ b/cognite/client/utils/_auxiliary.py
@@ -58,7 +58,7 @@ def assert_exactly_one_of_id_or_external_id(id, external_id):
     has_external_id = external_id is not None
 
     assert (has_id or has_external_id) and not (
-        has_id and has_external_id
+            has_id and has_external_id
     ), "Exactly one of id and external id must be specified"
 
     if has_id:
@@ -173,17 +173,16 @@ class PriorityQueue:
 
 
 def split_into_chunks(collection: Union[List, Dict], chunk_size: int) -> List[Union[List, Dict]]:
-    chunks = []
-    if isinstance(collection, list):
-        for i in range(0, len(collection), chunk_size):
-            chunks.append(collection[i : i + chunk_size])
-        return chunks
+    if not isinstance(collection, (dict, list)):
+        raise ValueError("Can only split list or dict")
+    entry_constructor = lambda x: x
     if isinstance(collection, dict):
         collection = list(collection.items())
-        for i in range(0, len(collection), chunk_size):
-            chunks.append({k: v for k, v in collection[i : i + chunk_size]})
-        return chunks
-    raise ValueError("Can only split list or dict")
+        entry_constructor = dict
+    return [
+        entry_constructor(collection[i: i + chunk_size])
+        for i in range(0, len(collection), chunk_size)
+    ]
 
 
 def convert_true_match(true_match):

--- a/tests/tests_unit/test_api/test_datapoints.py
+++ b/tests/tests_unit/test_api/test_datapoints.py
@@ -144,15 +144,10 @@ def mock_get_datapoints_one_ts_empty(rsps, cognite_client):
                     "isString": False,
                     "isStep": False,
                     "datapoints": [{"timestamp": 1, "value": 1}],
-                }
+                },
+                {"id": 2, "externalId": "2", "isString": False, "isStep": False, "datapoints": []},
             ]
         },
-    )
-    rsps.add(
-        rsps.POST,
-        cognite_client.datapoints._get_base_url_with_base_path() + "/timeseries/data/list",
-        status=200,
-        json={"items": [{"id": 2, "externalId": "2", "isString": False, "isStep": False, "datapoints": []}]},
     )
     yield rsps
 

--- a/tests/tests_unit/test_api/test_datapoints.py
+++ b/tests/tests_unit/test_api/test_datapoints.py
@@ -300,11 +300,13 @@ def assert_dps_response_is_correct(calls, dps_object):
     datapoints = []
     for call in calls:
         if jsgz_load(call.request.body)["limit"] > 1 and jsgz_load(call.request.body).get("aggregates") != ["count"]:
-            dps_response = call.response.json()["items"][0]
-            if dps_response["id"] == dps_object.id and dps_response["externalId"] == dps_object.external_id:
-                datapoints.extend(dps_response["datapoints"])
-                id = dps_response["id"]
-                external_id = dps_response["externalId"]
+            dps_responses = call.response.json()["items"]
+            for dps_response in dps_responses:
+                if dps_response["id"] == dps_object.id and dps_response["externalId"] == dps_object.external_id:
+                    datapoints.extend(dps_response["datapoints"])
+                    id = dps_response["id"]
+                    external_id = dps_response["externalId"]
+                    break
 
     expected_dps = sorted(datapoints, key=lambda x: x["timestamp"])
     assert id == dps_object.id

--- a/tests/tests_unit/test_api/test_datapoints.py
+++ b/tests/tests_unit/test_api/test_datapoints.py
@@ -1521,7 +1521,7 @@ class TestDataFetcher:
             client=cognite_client.datapoints,
             start=start,
             end=end,
-            ts_item={},
+            ts_items=[{}],
             granularity=granularity,
             aggregates=[],
             limit=None,


### PR DESCRIPTION
## Description
**Problem** For the use case filtering + aggregation of multiple timeseries, the current implementation is prohibitively slow to use in a user application. For example 100 datapoints from 4000 timeseries which is only 4 00 000 datapoints in total are fetched through 400 calls, but could be fetched with 40 calls given the limitation of CDF.

**Solution** Chunk time series such that up to 100 timeseries are included in each requests. 

**Implementation Details**
 * Extended `_DPTask `to support timeseries items.
 * Refactored out `_DPResult `from `_DPTask `to handle results for individual timeseries.
 * Did some minor code clean ups, e.g., replacing for loops with list comprehension etc.
 * If any local aggregates are passed, chunks size 1 is used.

**Tested in Motivating use case**
The use case which motivated this PR was fetching 3 months of daily data for 3000-4000 timeseries. 
Result: 
```
No optimization
CALL TO client.datapoints.retrieve_dataframe: 18.77 seconds
Chunking approach
CALL TO client.datapoints.retrieve_dataframe: 9.71 seconds
```

## Checklist:
- [x] Tests added/updated.
- [x] Changelog updated in [CHANGELOG.md](https://github.com/cognitedata/cognite-sdk-python/blob/master/CHANGELOG.md).
- [x] Version bumped. If triggering a new release is desired, bump the version number in [_version.py](https://github.com/cognitedata/cognite-sdk-python/blob/master/cognite/client/_version.py) per [semantic versioning](https://semver.org/).
