### PR TITLE
Add RawRowsAPI.insert_dataframe method to docs

### DIFF
--- a/docs/source/cognite.rst
+++ b/docs/source/cognite.rst
@@ -691,6 +691,10 @@ Insert rows into a table
 ~~~~~~~~~~~~~~~~~~~~~~~~
 .. automethod:: cognite.client._api.raw.RawRowsAPI.insert
 
+Insert a pandas dataframe into a table
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+.. automethod:: cognite.client._api.raw.RawRowsAPI.insert_dataframe
+
 Delete rows from a table
 ~~~~~~~~~~~~~~~~~~~~~~~~
 .. automethod:: cognite.client._api.raw.RawRowsAPI.delete


### PR DESCRIPTION
## Description

Method was missing from docs, but had a docstring. Simply adding the automethod to include it in the docs.