### PR TITLE
add guide to install cognite-sdk on Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,14 @@ However, this gives you the option to only have pandas (and NumPy) support witho
 $ pip install cognite-sdk-core[pandas, geo]
 ```
 
+On Windows, it is recommended to install `geopandas` and its dependencies using `conda` package manager.
+The following commands create a new environment, install `geopandas` and `cognite-sdk`.
+```bash
+conda create -n geo_env
+conda activate geo_env
+conda install --channel conda-forge geopandas
+pip install cognite-sdk
+```
 ## Examples
 For a collection of scripts and Jupyter Notebooks that explain how to perform various tasks in Cognite Data Fusion (CDF) 
 using Python, see the GitHub repository [here](https://github.com/cognitedata/cognite-python-docs)


### PR DESCRIPTION
`geopandas` depends on `fiona` which does not provide binary wheels with the dependencies included for (Windows)[https://geopandas.org/en/stable/getting_started/install.html#installing-with-pip]

`conda` is recommended to install `geopandas` on Windows.
