### PR TITLE
Remove obsolete typing.io import

### DIFF
--- a/cognite/client/_api/files.py
+++ b/cognite/client/_api/files.py
@@ -1,7 +1,11 @@
 import copy
 import os
+import sys
 from pathlib import Path
 from typing import *
+
+if sys.version_info < (3, 6):
+    from typing.io import BinaryIO, TextIO
 
 from cognite.client import utils
 from cognite.client._api_client import APIClient

--- a/cognite/client/_api/files.py
+++ b/cognite/client/_api/files.py
@@ -4,7 +4,7 @@ import sys
 from pathlib import Path
 from typing import *
 
-if sys.version_info < (3, 6):
+if sys.version_info < (3, 9):
     from typing.io import BinaryIO, TextIO
 
 from cognite.client import utils

--- a/cognite/client/_api/files.py
+++ b/cognite/client/_api/files.py
@@ -2,7 +2,6 @@ import copy
 import os
 from pathlib import Path
 from typing import *
-from typing.io import BinaryIO, TextIO
 
 from cognite.client import utils
 from cognite.client._api_client import APIClient


### PR DESCRIPTION
## Description
`typing.io` has been deprecated since Python 3.8 and will be removed in Python 3.12. `TextIO` and `BinaryIO` are available from the main `typing` namespace, though, so the existing star import should be sufficient.

## Checklist:
- [ ] Tests added/updated.
- [ ] Documentation updated. Documentation is generated from docstrings - these must be updated according to your change. 
  If a new method has been added it should be referenced in [cognite.rst](https://github.com/cognitedata/cognite-sdk-python/blob/master/docs/source/cognite.rst) in order to generate docs based on its docstring. 
- [ ] Changelog updated in [CHANGELOG.md](https://github.com/cognitedata/cognite-sdk-python/blob/master/CHANGELOG.md).
- [ ] Version bumped. If triggering a new release is desired, bump the version number in [_version.py](https://github.com/cognitedata/cognite-sdk-python/blob/master/cognite/client/_version.py) per [semantic versioning](https://semver.org/).

Does this require a changelog entry?