### PR TITLE
Add missing transformations.preview method in documentation

### DIFF
--- a/docs/source/cognite.rst
+++ b/docs/source/cognite.rst
@@ -1271,6 +1271,11 @@ Retrieve transformations by id
 Run transformations by id
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. automethod:: cognite.client._api.transformations.TransformationsAPI.run
+.. automethod:: cognite.client._api.transformations.TransformationsAPI.run_async
+    
+Preview transformations
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+.. automethod:: cognite.client._api.transformations.TransformationsAPI.preview
 
 Cancel transformation run by id
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
No need to follow checklist, this is just docs update.