### PR TITLE
[SBS-5101] geospatial: fix feature properies serialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ Changes are grouped as follows
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
+## [2.50.1] - 2022-06-07
+### Fixed
+- Geospatial: keep feature properties as is
+
 ## [2.50.0] - 2022-05-27
 ### Changed
 - Geospatial: deprecate update_feature_types and add patch_feature_types

--- a/cognite/client/_version.py
+++ b/cognite/client/_version.py
@@ -1,2 +1,2 @@
-__version__ = "2.50.0"
+__version__ = "2.50.1"
 __api_subversion__ = "V20220125"

--- a/cognite/client/data_classes/geospatial.py
+++ b/cognite/client/data_classes/geospatial.py
@@ -87,6 +87,9 @@ class FeatureTypeUpdateList:
 class Feature(CogniteResource):
     """A representation of a feature in the geospatial api."""
 
+    PRE_DEFINED_NAMES = ["externalId", "createdTime", "lastUpdatedTime"]
+    PRE_DEFINED_SNAKE_CASE_NAMES = ["external_id", "created_time", "last_updated_time"]
+
     def __init__(self, external_id: str = None, cognite_client=None, **properties):
         self.external_id = external_id
         for key in properties:
@@ -97,9 +100,23 @@ class Feature(CogniteResource):
     def _load(cls, resource: Dict, cognite_client=None):
         instance = cls(cognite_client=cognite_client)
         for key, value in resource.items():
-            snake_case_key = utils._auxiliary.to_snake_case(key)
-            setattr(instance, snake_case_key, value)
+            # Keep properties defined in Feature Type as is
+            normalized_key = utils._auxiliary.to_snake_case(key) if key in cls.PRE_DEFINED_NAMES else key
+            setattr(instance, normalized_key, value)
         return instance
+
+    def dump(self, camel_case: bool = False) -> Dict[str, Any]:
+        def to_camel_case(key):
+            # Keep properties defined in Feature Type as is
+            if camel_case and key in self.PRE_DEFINED_SNAKE_CASE_NAMES:
+                return utils._auxiliary.to_camel_case(key)
+            return key
+
+        return {
+            to_camel_case(key): value
+            for key, value in self.__dict__.items()
+            if value is not None and not key.startswith("_")
+        }
 
 
 def _is_geometry_type(property_type: str):

--- a/tests/tests_unit/test_data_classes/test_geospatial.py
+++ b/tests/tests_unit/test_data_classes/test_geospatial.py
@@ -1,0 +1,59 @@
+from cognite.client.data_classes.geospatial import Feature, FeatureList
+
+
+class TestFeature:
+    def test_load_feature(self):
+        feature = Feature._load(
+            {
+                "firstName": "name",
+                "temperature_Hot": 12.0,
+                "levelH2O": 12.0,
+                "externalId": "f1",
+                "createdTime": 1654612200225,
+                "lastUpdatedTime": 1654612200225,
+            }
+        )
+        assert feature.firstName == "name"
+        assert feature.temperature_Hot == 12.0
+        assert feature.levelH2O == 12.0
+        assert feature.external_id == "f1"
+        assert feature.created_time == 1654612200225
+        assert feature.last_updated_time == 1654612200225
+
+    def test_dump_feature(self):
+        feature = Feature(external_id="f1", firstName="name", temperature_Hot=12.0, levelH2O=12.0)
+        dumped = feature.dump(camel_case=True)
+        assert dumped == {"externalId": "f1", "firstName": "name", "temperature_Hot": 12.0, "levelH2O": 12.0}
+        dumped = feature.dump(camel_case=False)
+        assert dumped == {"external_id": "f1", "firstName": "name", "temperature_Hot": 12.0, "levelH2O": 12.0}
+
+
+class TestFeatureList:
+    def test_load_feature_list(self):
+        features = FeatureList._load(
+            [
+                {
+                    "firstName": "name",
+                    "temperature_Hot": 12.0,
+                    "levelH2O": 12.0,
+                    "externalId": "f1",
+                    "createdTime": 1654612200225,
+                    "lastUpdatedTime": 1654612200225,
+                }
+            ]
+        )
+        assert len(features) == 1
+        feature = features[0]
+        assert feature.firstName == "name"
+        assert feature.temperature_Hot == 12.0
+        assert feature.levelH2O == 12.0
+        assert feature.external_id == "f1"
+        assert feature.created_time == 1654612200225
+        assert feature.last_updated_time == 1654612200225
+
+    def test_dump_feature_list(self):
+        feature_list = FeatureList([Feature(external_id="f1", firstName="name", temperature_Hot=12.0, levelH2O=12.0)])
+        dumped = feature_list.dump(camel_case=True)
+        assert dumped == [{"externalId": "f1", "firstName": "name", "temperature_Hot": 12.0, "levelH2O": 12.0}]
+        dumped = feature_list.dump(camel_case=False)
+        assert dumped == [{"external_id": "f1", "firstName": "name", "temperature_Hot": 12.0, "levelH2O": 12.0}]


### PR DESCRIPTION
Define a feature type
```
FeatureType(external_id="test_snake_case",
                properties={"firstName": {"type": "DOUBLE"},
                            "temperature_Hot": {"type": "DOUBLE"},
                            "levelH20": {"type": "DOUBLE", "optional": True, "description": "level H2O"},
                            }
                )
```

Corresponding feature has following attributes: external_id, first_name, temperature__hot, level_h2_o.

The set of attributes should be: external_id, firstName, temperature_Hot, levelH20

