### PR TITLE
geospatial: fix issue for FeatureList.from_geopandas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ Changes are grouped as follows
 
 ## [2.50.2] - 2022-06-09
 ### Fixed
-- Geospatial: fix FeatureList.from_geopandas issue with optional properties 
+- Geospatial: fix FeatureList.from_geopandas issue with optional properties
 
 ## [2.50.1] - 2022-06-07
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ Changes are grouped as follows
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
+## [2.50.1] - 2022-06-08
+### Fixed
+- Geospatial: fix FeatureList.from_geopandas issue with optional properties 
+
 ## [2.50.0] - 2022-05-27
 ### Changed
 - Geospatial: deprecate update_feature_types and add patch_feature_types

--- a/cognite/client/_version.py
+++ b/cognite/client/_version.py
@@ -1,2 +1,2 @@
-__version__ = "2.50.1"
+__version__ = "2.50.2"
 __api_subversion__ = "V20220125"

--- a/cognite/client/_version.py
+++ b/cognite/client/_version.py
@@ -1,2 +1,2 @@
-__version__ = "2.50.0"
+__version__ = "2.50.1"
 __api_subversion__ = "V20220125"

--- a/cognite/client/data_classes/geospatial.py
+++ b/cognite/client/data_classes/geospatial.py
@@ -206,10 +206,14 @@ class FeatureList(CogniteResourceList):
                 prop_optional = prop[1].get("optional", False)
                 if _is_reserved_property(prop_name):
                     continue
-                column_name = property_column_mapping[prop[0]]
-                column_value = row[column_name]
-                if column_value is None and prop_optional:
-                    continue
+                column_name = property_column_mapping.get(prop[0], None)
+                column_value = row.get(column_name, None)
+                if column_name is None or column_value is None:
+                    if prop_optional:
+                        continue
+                    else:
+                        raise ValueError(f"Missing value for property {prop_name}")
+
                 if _is_geometry_type(prop_type):
                     setattr(feature, prop_name, {"wkt": column_value.wkt})
                 else:

--- a/cognite/client/data_classes/geospatial.py
+++ b/cognite/client/data_classes/geospatial.py
@@ -187,8 +187,8 @@ class FeatureList(CogniteResourceList):
         feature_type: FeatureType,
         geodataframe: "geopandas.GeoDataFrame",
         external_id_column: str = "externalId",
-        data_set_id_column: str = "dataSetId",
         property_column_mapping: Dict[str, str] = None,
+        data_set_id_column: str = "dataSetId",
     ) -> "FeatureList":
         """Convert a GeoDataFrame instance into a FeatureList.
 

--- a/tests/tests_unit/test_api/test_geospatial.py
+++ b/tests/tests_unit/test_api/test_geospatial.py
@@ -17,7 +17,7 @@ def test_feature_type():
             "temperature": {"type": "DOUBLE"},
             "pressure": {"type": "DOUBLE"},
             "description": {"type": "STRING", "optional": "true"},
-            "dataSetId": {"type": "LONG", "optional": "true"}
+            "dataSetId": {"type": "LONG", "optional": "true"},
         },
         search_spec={"vol_press_idx": {"properties": ["volume", "pressure"]}},
     )
@@ -48,6 +48,7 @@ def test_features(test_feature_type):
                 temperature=13.4,
                 volume=1212.0,
                 pressure=2121.0,
+                data_set_id=12,
             ),
             Feature(
                 external_id=external_ids[3],
@@ -55,6 +56,7 @@ def test_features(test_feature_type):
                 temperature=13.4,
                 volume=1212.0,
                 pressure=2121.0,
+                data_set_id=12,
             ),
         ]
     )
@@ -64,12 +66,12 @@ class TestGeospatialAPI:
     @pytest.mark.dsl
     def test_to_pandas(self, test_feature_type, test_features):
         df = test_features.to_pandas()
-        assert set(list(df)) == set(["externalId", "position", "volume", "temperature", "pressure"])
+        assert set(list(df)) == {"externalId", "dataSetId", "position", "volume", "temperature", "pressure"}
 
     @pytest.mark.dsl
     def test_to_geopandas(self, test_feature_type, test_features):
         gdf = test_features.to_geopandas(geometry="position")
-        assert set(gdf) == set(["externalId", "position", "volume", "temperature", "pressure"])
+        assert set(gdf) == {"externalId", "dataSetId", "position", "volume", "temperature", "pressure"}
         geopandas = utils._auxiliary.local_import("geopandas")
         assert type(gdf.dtypes["position"]) == geopandas.array.GeometryDtype
 
@@ -79,12 +81,14 @@ class TestGeospatialAPI:
         fl = FeatureList.from_geopandas(test_feature_type, gdf)
         assert type(fl) == FeatureList
         assert len(fl) == 4
-        for f in fl:
-            for attr in test_feature_type.properties.items():
-                attr_name = attr[0]
+        for idx, f in enumerate(fl):
+            for attr_name in test_feature_type.properties:
                 if attr_name.startswith("_") or attr_name in ["description", "dataSetId"]:
                     continue
                 assert hasattr(f, attr_name)
+            assert not hasattr(f, "description")
+            if idx > 1:
+                assert hasattr(f, "data_set_id")
 
     @pytest.mark.dsl
     def test_from_geopandas_missing_column(self, test_feature_type):

--- a/tests/tests_unit/test_api/test_geospatial.py
+++ b/tests/tests_unit/test_api/test_geospatial.py
@@ -16,7 +16,8 @@ def test_feature_type():
             "volume": {"type": "DOUBLE"},
             "temperature": {"type": "DOUBLE"},
             "pressure": {"type": "DOUBLE"},
-            "description": {"type": "STRING", "optional": "true"}
+            "description": {"type": "STRING", "optional": "true"},
+            "dataSetId": {"type": "LONG", "optional": "true"}
         },
         search_spec={"vol_press_idx": {"properties": ["volume", "pressure"]}},
     )
@@ -81,7 +82,7 @@ class TestGeospatialAPI:
         for f in fl:
             for attr in test_feature_type.properties.items():
                 attr_name = attr[0]
-                if attr_name.startswith("_") or attr_name == "description":
+                if attr_name.startswith("_") or attr_name in ["description", "dataSetId"]:
                     continue
                 assert hasattr(f, attr_name)
 

--- a/tests/tests_unit/test_data_classes/test_geospatial.py
+++ b/tests/tests_unit/test_data_classes/test_geospatial.py
@@ -11,6 +11,7 @@ class TestFeature:
                 "externalId": "f1",
                 "createdTime": 1654612200225,
                 "lastUpdatedTime": 1654612200225,
+                "dataSetId": 12,
             }
         )
         assert feature.firstName == "name"
@@ -19,13 +20,26 @@ class TestFeature:
         assert feature.external_id == "f1"
         assert feature.created_time == 1654612200225
         assert feature.last_updated_time == 1654612200225
+        assert feature.data_set_id == 12
 
     def test_dump_feature(self):
-        feature = Feature(external_id="f1", firstName="name", temperature_Hot=12.0, levelH2O=12.0)
+        feature = Feature(external_id="f1", firstName="name", temperature_Hot=12.0, levelH2O=12.0, data_set_id=12)
         dumped = feature.dump(camel_case=True)
-        assert dumped == {"externalId": "f1", "firstName": "name", "temperature_Hot": 12.0, "levelH2O": 12.0}
+        assert dumped == {
+            "externalId": "f1",
+            "firstName": "name",
+            "temperature_Hot": 12.0,
+            "levelH2O": 12.0,
+            "dataSetId": 12,
+        }
         dumped = feature.dump(camel_case=False)
-        assert dumped == {"external_id": "f1", "firstName": "name", "temperature_Hot": 12.0, "levelH2O": 12.0}
+        assert dumped == {
+            "external_id": "f1",
+            "firstName": "name",
+            "temperature_Hot": 12.0,
+            "levelH2O": 12.0,
+            "data_set_id": 12,
+        }
 
 
 class TestFeatureList:
@@ -39,6 +53,7 @@ class TestFeatureList:
                     "externalId": "f1",
                     "createdTime": 1654612200225,
                     "lastUpdatedTime": 1654612200225,
+                    "dataSetId": 12,
                 }
             ]
         )
@@ -52,8 +67,14 @@ class TestFeatureList:
         assert feature.last_updated_time == 1654612200225
 
     def test_dump_feature_list(self):
-        feature_list = FeatureList([Feature(external_id="f1", firstName="name", temperature_Hot=12.0, levelH2O=12.0)])
+        feature_list = FeatureList(
+            [Feature(external_id="f1", firstName="name", temperature_Hot=12.0, levelH2O=12.0, data_set_id=12)]
+        )
         dumped = feature_list.dump(camel_case=True)
-        assert dumped == [{"externalId": "f1", "firstName": "name", "temperature_Hot": 12.0, "levelH2O": 12.0}]
+        assert dumped == [
+            {"externalId": "f1", "firstName": "name", "temperature_Hot": 12.0, "levelH2O": 12.0, "dataSetId": 12}
+        ]
         dumped = feature_list.dump(camel_case=False)
-        assert dumped == [{"external_id": "f1", "firstName": "name", "temperature_Hot": 12.0, "levelH2O": 12.0}]
+        assert dumped == [
+            {"external_id": "f1", "firstName": "name", "temperature_Hot": 12.0, "levelH2O": 12.0, "data_set_id": 12}
+        ]


### PR DESCRIPTION
FeatureList.from_geopandas throws KeyError when feature type contains optional property which geopandas dataframe does not have the corresponding column.