### PR TITLE
Fix the name of the geo_location property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ Changes are grouped as follows
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
+## [3.6.1] - 2022-07-28
+### Fixed
+- Fixed a minor casing error for the geo_location field on files
+
 ## [3.6.0] - 2022-08-10
 ### Added
 - Add ignore_unknown_ids parameter to files.retrieve_multiple

--- a/cognite/client/_version.py
+++ b/cognite/client/_version.py
@@ -1,2 +1,2 @@
-__version__ = "3.6.0"
+__version__ = "3.6.1"
 __api_subversion__ = "V20220125"

--- a/cognite/client/data_classes/files.py
+++ b/cognite/client/data_classes/files.py
@@ -270,8 +270,13 @@ class FileMetadataUpdate(CogniteUpdate):
     def labels(self) -> _LabelFileMetadataUpdate:
         return FileMetadataUpdate._LabelFileMetadataUpdate(self, "labels")
 
+    # TODO: This is left here for backwards compatibility. Should be removed on next major version change
     @property
     def geoLocation(self) -> _PrimitiveFileMetadataUpdate:
+        return self.geo_location
+
+    @property
+    def geo_location(self) -> _PrimitiveFileMetadataUpdate:
         return FileMetadataUpdate._PrimitiveFileMetadataUpdate(self, "geoLocation")
 
     @property

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "cognite-sdk"
 
-version = "3.6.0"
+version = "3.6.1"
 
 description = "Cognite Python SDK"
 readme = "README.md"

--- a/tests/tests_unit/test_api/test_files.py
+++ b/tests/tests_unit/test_api/test_files.py
@@ -556,8 +556,8 @@ class TestFilesAPI:
             .metadata.remove([])
             .labels.add(["WELL LOG"])
             .labels.remove(["CV"])
-            .geoLocation.set(mock_geo_location)
-            .geoLocation.set(None)
+            .geo_location.set(mock_geo_location)
+            .geo_location.set(None)
             .source.set(1)
             .source.set(None),
             FileMetadataUpdate,


### PR DESCRIPTION
## Description
It's supposed to be in snake_case, not camel case.

## Checklist:
- [x] Tests added/updated.
- [x] Documentation updated. Documentation is generated from docstrings - these must be updated according to your change. 
  If a new method has been added it should be referenced in [cognite.rst](https://github.com/cognitedata/cognite-sdk-python/blob/master/docs/source/cognite.rst) in order to generate docs based on its docstring. 
- [x] Changelog updated in [CHANGELOG.md](https://github.com/cognitedata/cognite-sdk-python/blob/master/CHANGELOG.md).
- [x] Version bumped. If triggering a new release is desired, bump the version number in [_version.py](https://github.com/cognitedata/cognite-sdk-python/blob/master/cognite/client/_version.py) per [semantic versioning](https://semver.org/).
