### PR TITLE
Add is_step to properties of Time Series that can be updated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ Changes are grouped as follows
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
+## [2.56.1] - 2022-06-22
+### Added
+- Time series property `is_step` can now be updated.
+
 ## [2.56.0] - 2022-06-21
 ### Added
 - added the diagrams API
@@ -36,11 +40,11 @@ Changes are grouped as follows
 ## [2.53.0] - 2022-06-16
 
 ### Added
-- Annotations implementation, providing access to the corresponding [Annotations API](https://docs.cognite.com/api/v1/#tag/Annotations). 
+- Annotations implementation, providing access to the corresponding [Annotations API](https://docs.cognite.com/api/v1/#tag/Annotations).
     - Added `Annotation`, `AnnotationFilter`, `AnnotationUpdate` dataclasses to `cognite.client.data_classes`
     - Added `annotations` API to `cognite.client.CogniteClient`
     - **Create** annotations with `client.annotations.create` passing `Annotation` instance(s)
-    - **Suggest** annotations with `client.annotations.suggest` passing `Annotation` instance(s) 
+    - **Suggest** annotations with `client.annotations.suggest` passing `Annotation` instance(s)
     - **Delete** annotations with `client.annotations.delete` passing the id(s) of annotation(s) to delete
     - **Filter** annotations with `client.annotations.list` passing a `AnnotationFilter `dataclass instance or a filter `dict`
     - **Update** annotations with `client.annotations.update` passing updated `Annotation` or `AnnotationUpdate` instance(s)
@@ -49,7 +53,7 @@ Changes are grouped as follows
 
 ## [2.52.0] - 2022-06-10
 ### Changed
-- Reverted the optimizations introduced to datapoints fetching in 2.47.0 due to buggy implementation. 
+- Reverted the optimizations introduced to datapoints fetching in 2.47.0 due to buggy implementation.
 
 ## [2.51.0] - 2022-06-10
 ### Added
@@ -73,7 +77,7 @@ Changes are grouped as follows
 
 ## [2.49.0] - 2022-05-09
 ### Changed
-- Geospatial: Support output selection for getting features by ids 
+- Geospatial: Support output selection for getting features by ids
 
 ## [2.48.0] - 2022-05-09
 ### Removed
@@ -105,8 +109,8 @@ Changes are grouped as follows
 
 ## [2.43.1] - 2022-03-24
 ### Added
-- update pillow dependency 9.0.0 -> 9.0.1 
- 
+- update pillow dependency 9.0.0 -> 9.0.1
+
 ## [2.43.0] - 2022-03-21
 ### Added
 - new list parameters added to `transformations.list`.
@@ -177,7 +181,7 @@ Changes are grouped as follows
 
 ## [2.37.0] - 2021-11-30
 ### Added
-- Added support for retrieving file download urls 
+- Added support for retrieving file download urls
 
 ## [2.36.0] - 2021-11-30
 ### Fixed

--- a/cognite/client/_api_client.py
+++ b/cognite/client/_api_client.py
@@ -635,6 +635,7 @@ class APIClient:
             {"url_path": resource_path + "/update", "json": {"items": chunk}, "params": params, "headers": headers}
             for chunk in patch_object_chunks
         ]
+
         tasks_summary = utils._concurrency.execute_tasks_concurrently(
             self._post, tasks, max_workers=self._config.max_workers
         )

--- a/cognite/client/_api_client.py
+++ b/cognite/client/_api_client.py
@@ -635,7 +635,6 @@ class APIClient:
             {"url_path": resource_path + "/update", "json": {"items": chunk}, "params": params, "headers": headers}
             for chunk in patch_object_chunks
         ]
-
         tasks_summary = utils._concurrency.execute_tasks_concurrently(
             self._post, tasks, max_workers=self._config.max_workers
         )

--- a/cognite/client/_version.py
+++ b/cognite/client/_version.py
@@ -1,2 +1,2 @@
-__version__ = "2.56.0"
+__version__ = "2.56.1"
 __api_subversion__ = "V20220125"

--- a/cognite/client/data_classes/time_series.py
+++ b/cognite/client/data_classes/time_series.py
@@ -254,6 +254,10 @@ class TimeSeriesUpdate(CogniteUpdate):
         return TimeSeriesUpdate._PrimitiveTimeSeriesUpdate(self, "description")
 
     @property
+    def is_step(self):
+        return TimeSeriesUpdate._PrimitiveTimeSeriesUpdate(self, "isStep")
+
+    @property
     def security_categories(self):
         return TimeSeriesUpdate._ListTimeSeriesUpdate(self, "securityCategories")
 


### PR DESCRIPTION
## Description
Made `is_step` property of TimeSeries updateable using the SDK.

## Checklist:
- [ ] Tests added/updated.
- [ ] Documentation updated. Documentation is generated from docstrings - these must be updated according to your change. 
  If a new method has been added it should be referenced in [cognite.rst](https://github.com/cognitedata/cognite-sdk-python/blob/master/docs/source/cognite.rst) in order to generate docs based on its docstring. 
- [x] Changelog updated in [CHANGELOG.md](https://github.com/cognitedata/cognite-sdk-python/blob/master/CHANGELOG.md).
- [x] Version bumped. If triggering a new release is desired, bump the version number in [_version.py](https://github.com/cognitedata/cognite-sdk-python/blob/master/cognite/client/_version.py) per [semantic versioning](https://semver.org/).
