### PR TITLE
fix typos across repo excl. in Tests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -61,7 +61,7 @@ Initiate unit tests by running the following command from the root directory:
 
 `pytest tests/tests_unit`
 
-If you have an appropriate API key, you can run the integratino tests like this:
+If you have an appropriate API key, you can run the integration tests like this:
 
 `pytest tests/tests_integration`
 

--- a/cognite/client/_http_client.py
+++ b/cognite/client/_http_client.py
@@ -126,7 +126,7 @@ class HTTPClient:
     def _do_request(self, method: str, url: str, **kwargs) -> requests.Response:
         """requests/urllib3 adds 2 or 3 layers of exceptions on top of built-in networking exceptions.
 
-        Sometimes the approriate built-in networking exception is not in the context, sometimes the requests
+        Sometimes the appropriate built-in networking exception is not in the context, sometimes the requests
         exception is not in the context, so we need to check for the appropriate built-in exceptions,
         urllib3 exceptions, and requests exceptions.
         """

--- a/cognite/client/data_classes/extractionpipelines.py
+++ b/cognite/client/data_classes/extractionpipelines.py
@@ -43,9 +43,9 @@ class ExtractionPipeline(CogniteResource):
     Args:
         id (int): A server-generated ID for the object.
         external_id (str): The external ID provided by the client. Must be unique for the resource type.
-        name (str): The name of the extraction pipepeline.
-        description (str): The description of the extraction pipepeline.
-        data_set_id (int): The id of the dataset this extraction pipepeline related with.
+        name (str): The name of the extraction pipeline.
+        description (str): The description of the extraction pipeline.
+        data_set_id (int): The id of the dataset this extraction pipeline related with.
         raw_tables (List[Dict[str, str]): list of raw tables in list format: [{"dbName": "value", "tableName" : "value"}].
         last_success (int): Milliseconds value of last success status.
         last_failure (int): Milliseconds value of last failure status.
@@ -54,11 +54,11 @@ class ExtractionPipeline(CogniteResource):
         schedule (str): None/On trigger/Continuous/cron regex.
         contacts (List[ExtractionPipelineContact]): list of contacts
         metadata (Dict[str, str]): Custom, application specific metadata. String key -> String value. Limits: Maximum length of key is 128 bytes, value 10240 bytes, up to 256 key-value pairs, of total size at most 10240.
-        source (str): Source text value for extraction pipepeline.
-        documentation (str): Documentation text value for extraction pipepeline.
+        source (str): Source text value for extraction pipeline.
+        documentation (str): Documentation text value for extraction pipeline.
         created_time (int): The number of milliseconds since 00:00:00 Thursday, 1 January 1970, Coordinated Universal Time (UTC), minus leap seconds.
         last_updated_time (int): The number of milliseconds since 00:00:00 Thursday, 1 January 1970, Coordinated Universal Time (UTC), minus leap seconds.
-        created_by (str): Extraction pipepeline creator, usually an email.
+        created_by (str): Extraction pipeline creator, usually an email.
         cognite_client (CogniteClient): The client to associate with this object.
     """
 

--- a/cognite/client/data_classes/relationships.py
+++ b/cognite/client/data_classes/relationships.py
@@ -100,7 +100,7 @@ class Relationship(CogniteResource):
 
 
 class RelationshipFilter(CogniteFilter):
-    """Filter on relationships with exact match. Multiple filter elments in one property, e.g. `sourceExternalIds: [ "a", "b" ]`, will return all relationships where the `sourceExternalId` field is either `a` or `b`. Filters in multiple properties will return the relationships that match all criteria. If the filter is not specified it default to an empty filter.
+    """Filter on relationships with exact match. Multiple filter elements in one property, e.g. `sourceExternalIds: [ "a", "b" ]`, will return all relationships where the `sourceExternalId` field is either `a` or `b`. Filters in multiple properties will return the relationships that match all criteria. If the filter is not specified it default to an empty filter.
 
     Args:
         source_external_ids (List[str]): Include relationships that have any of these values in their `sourceExternalId` field
@@ -108,8 +108,8 @@ class RelationshipFilter(CogniteFilter):
         target_external_ids (List[str]): Include relationships that have any of these values in their `targetExternalId` field
         target_types (List[str]): Include relationships that have any of these values in their `targetType` field
         data_set_ids (List[Dict[str, Any]]): Either one of `internalId` (int) or `externalId` (str)
-        start_time (Dict[str, int]): Range between two timestamps, minimum and maximum milli seconds (inclusive)
-        end_time (Dict[str, int]): Range between two timestamps, minimum and maximum milli seconds (inclusive)
+        start_time (Dict[str, int]): Range between two timestamps, minimum and maximum milliseconds (inclusive)
+        end_time (Dict[str, int]): Range between two timestamps, minimum and maximum milliseconds (inclusive)
         confidence (Dict[str, int]): Range to filter the field for. (inclusive)
         last_updated_time (Dict[str, Any]): Range to filter the field for. (inclusive)
         created_time (Dict[str, int]): Range to filter the field for. (inclusive)

--- a/cognite/client/data_classes/transformations/jobs.py
+++ b/cognite/client/data_classes/transformations/jobs.py
@@ -190,7 +190,7 @@ class TransformationJob(CogniteResource):
                 >>> from cognite.client import CogniteClient
                 >>> c = CogniteClient()
                 >>>
-                >>> async def run_succesive_transformations():
+                >>> async def run_successive_transformations():
                 >>>     job1 = c.transformations.run(id = 1, wait = False)
                 >>>     job2 = c.transformations.run(id = 2, wait = False)
                 >>>     await job1.wait_async()
@@ -198,7 +198,7 @@ class TransformationJob(CogniteResource):
                 >>>     if TransformationJobStatus.FAILED not in [job1.status, job2.status]:
                 >>>         c.transformations.run(id = 3, wait = False)
                 >>>
-                >>> ensure_future(run_succesive_transformations())
+                >>> ensure_future(run_successive_transformations())
 
             wait transformation for 5 minutes and do something if still running:
 
@@ -206,7 +206,7 @@ class TransformationJob(CogniteResource):
                 >>> from cognite.client import CogniteClient
                 >>> c = CogniteClient()
                 >>>
-                >>> async def run_succesive_transformations():
+                >>> async def run_successive_transformations():
                 >>>     job = c.transformations.run(id = 1, wait = False)
                 >>>     await job.wait_async(timeout = 5.0*60)
                 >>>     if job.status == TransformationJobStatus.FAILED:
@@ -216,7 +216,7 @@ class TransformationJob(CogniteResource):
                 >>>     else:
                 >>>         # do something if job is still running
                 >>>
-                >>> ensure_future(run_succesive_transformations())
+                >>> ensure_future(run_successive_transformations())
         """
         self.update()
         if timeout is None:

--- a/cognite/client/exceptions.py
+++ b/cognite/client/exceptions.py
@@ -47,7 +47,7 @@ class CogniteAPIError(CogniteMultiException):
         code (int): The error code produced by the failure
         x_request_id (str): The request-id generated for the failed request.
         extra (Dict): A dict of any additional information.
-        successful (List): List of items which were successfully proccessed.
+        successful (List): List of items which were successfully processed.
         failed (List): List of items which failed.
         unknown (List): List of items which may or may not have been successfully processed.
 
@@ -112,7 +112,7 @@ class CogniteNotFoundError(CogniteMultiException):
 
     Args:
         not_found (List): The ids not found.
-        successful (List): List of items which were successfully proccessed.
+        successful (List): List of items which were successfully processed.
         failed (List): List of items which failed.
         unknown (List): List of items which may or may not have been successfully processed.
     """
@@ -141,7 +141,7 @@ class CogniteDuplicatedError(CogniteMultiException):
 
     Args:
         duplicated (list): The duplicated ids.
-        successful (List): List of items which were successfully proccessed.
+        successful (List): List of items which were successfully processed.
         failed (List): List of items which failed.
         unknown (List): List of items which may or may not have been successfully processed.
     """

--- a/cognite/client/utils/_auxiliary.py
+++ b/cognite/client/utils/_auxiliary.py
@@ -1,4 +1,4 @@
-"""Utilites for Cognite API SDK
+"""Utilities for Cognite API SDK
 
 This module provides helper methods and different utilities for the Cognite API Python SDK.
 

--- a/cognite/client/utils/_experimental_warning.py
+++ b/cognite/client/utils/_experimental_warning.py
@@ -12,7 +12,7 @@ def experimental_fn(func=None, api_name=None):
     def decorator(*args, **kwargs):
         if api_name not in WARNED_EXPERIMENTAL_APIS:
             warnings.warn(
-                "\nThe {} API is currently experimental, so this functionality does not adhere to semantic versionining."
+                "\nThe {} API is currently experimental, so this functionality does not adhere to semantic versioning."
                 "\nThis means that this API may be subject to breaking changes even between patch versions."
                 "\nThe experimental client is deprecated and will be removed soon. Consider using the 'beta' client instead.".format(
                     api_name, api_name

--- a/docs/source/cognite.rst
+++ b/docs/source/cognite.rst
@@ -189,7 +189,7 @@ You can set default configurations with these environment variables:
 
 .. code:: bash
 
-    # Can be overrided by Client Configuration
+    # Can be overridden by Client Configuration
     $ export COGNITE_API_KEY = <your-api-key>
     $ export COGNITE_PROJECT = <your-default-project>
     $ export COGNITE_BASE_URL = http://<host>:<port>
@@ -924,7 +924,7 @@ Data classes
 
 Contextualization
 -----------------
-These APIs will return as soon as possible, defering a blocking wait until the last moment. Nevertheless, they can block for a long time awaiting results.
+These APIs will return as soon as possible, deferring a blocking wait until the last moment. Nevertheless, they can block for a long time awaiting results.
 
 Fit Entity Matching Model
 ^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
Fixed typos across repo, excluding in `tests` (which was not checked)