### PR TITLE
Cache version response from pypi in version checker

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,6 +47,7 @@ jobs:
           COGNITE_PROJECT: python-sdk-test
           COGNITE_BASE_URL: https://greenfield.cognitedata.com
           COGNITE_CLIENT_NAME: python-sdk-integration-tests
+          COGNITE_DISABLE_PYPI_VERSION_CHECK: 1
           CI: 1
       run: pytest tests/tests_unit -n8 --dist loadscope --maxfail 10 -m 'not dsl' --test-deps-only-core
 
@@ -74,6 +75,7 @@ jobs:
         COGNITE_PROJECT: python-sdk-test
         COGNITE_BASE_URL: https://greenfield.cognitedata.com
         COGNITE_CLIENT_NAME: python-sdk-integration-tests
+        COGNITE_DISABLE_PYPI_VERSION_CHECK: 1
         CI: 1
       run: |
         pytest tests --cov --cov-report xml:coverage.xml -n8 --dist loadscope --reruns 2

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -47,6 +47,7 @@ jobs:
         COGNITE_PROJECT: python-sdk-test
         COGNITE_BASE_URL: https://greenfield.cognitedata.com
         COGNITE_CLIENT_NAME: python-sdk-integration-tests
+        COGNITE_DISABLE_PYPI_VERSION_CHECK: 1
         CI: 1
       run: pytest tests/tests_unit -n8 --dist loadscope --maxfail 10 -m 'not dsl' --test-deps-only-core
 
@@ -74,6 +75,7 @@ jobs:
         COGNITE_PROJECT: python-sdk-test
         COGNITE_BASE_URL: https://greenfield.cognitedata.com
         COGNITE_CLIENT_NAME: python-sdk-integration-tests
+        COGNITE_DISABLE_PYPI_VERSION_CHECK: 1
         CI: 1
       run: |
         pytest tests --cov --cov-report xml:coverage.xml -n8 --dist loadscope --reruns 2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ Changes are grouped as follows
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
+## [3.4.3] - 2022-07-28
+### Changed
+- Cache result from pypi version check so it's not executed for every client instantiation.
+
 ## [3.4.2] - 2022-07-28
 ### Fixed
 - Fix the wrong destination name in transformations.

--- a/cognite/client/_version.py
+++ b/cognite/client/_version.py
@@ -1,2 +1,2 @@
-__version__ = "3.4.2"
+__version__ = "3.4.3"
 __api_subversion__ = "V20220125"

--- a/cognite/client/utils/_version_checker.py
+++ b/cognite/client/utils/_version_checker.py
@@ -1,4 +1,5 @@
 import argparse
+import functools
 import os
 import re
 from typing import List, Optional, Tuple
@@ -11,6 +12,7 @@ def check_if_version_exists(package_name: str, version: str) -> bool:
     return version in versions
 
 
+@functools.lru_cache(maxsize=1)
 def get_newest_version_in_major_release(package_name: str, version: str) -> str:
     major, minor, micro, pr_cycle, pr_version = _parse_version(version)
     versions = get_all_versions(package_name)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "cognite-sdk"
 
-version = "3.4.2"
+version = "3.4.3"
 
 description = "Cognite Python SDK"
 readme = "README.md"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -33,7 +33,6 @@ dotenv.load_dotenv()
 @pytest.fixture
 def rsps_with_login_mock():
     with responses.RequestsMock() as rsps:
-        rsps.add(rsps.GET, "https://pypi.python.org/simple/cognite-sdk/#history", status=200, body="")
         rsps.add(
             rsps.GET,
             BASE_URL + "/login/status",

--- a/tests/tests_integration/test_api/test_files.py
+++ b/tests/tests_integration/test_api/test_files.py
@@ -114,6 +114,7 @@ class TestFilesAPI:
     def test_retrieve_download_urls(self, cognite_client):
         f1 = cognite_client.files.upload_bytes(b"f1", external_id=random_string(10), name="bla")
         f2 = cognite_client.files.upload_bytes(b"f2", external_id=random_string(10), name="bla")
+        time.sleep(0.5)
         download_links = cognite_client.files.retrieve_download_urls(id=f1.id, external_id=f2.external_id)
         assert len(download_links.values()) == 2
         assert download_links[f1.id].startswith("http")


### PR DESCRIPTION
We only want to do this once per session, not per client instance.