### PR TITLE
Increase parallelism in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,7 +48,7 @@ jobs:
           COGNITE_BASE_URL: https://greenfield.cognitedata.com
           COGNITE_CLIENT_NAME: python-sdk-integration-tests
           CI: 1
-      run: pytest tests/tests_unit -n4 --dist loadscope --maxfail 10 -m 'not dsl' --test-deps-only-core
+      run: pytest tests/tests_unit -n8 --dist loadscope --maxfail 10 -m 'not dsl' --test-deps-only-core
 
   test_full_and_build:
     runs-on: ubuntu-latest
@@ -76,7 +76,7 @@ jobs:
         COGNITE_CLIENT_NAME: python-sdk-integration-tests
         CI: 1
       run: |
-        pytest -v tests --cov --cov-report xml:coverage.xml -n4 --dist loadscope --reruns 2
+        pytest -v tests --cov --cov-report xml:coverage.xml -n8 --dist loadscope --reruns 2
 
     - uses: codecov/codecov-action@v3
       with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,18 +1,33 @@
-name: test_and_build
+name: build
 
 on:
   pull_request:
     branches: [ master ]
 
 jobs:
-  build:
+  lint:
     runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: 3.8
 
+      - name: Install required dependencies
+        run: |
+          python3 -m pip install --upgrade pip poetry
+          poetry config virtualenvs.create false
+          poetry install
+
+      - name: Linting and static code checks
+        run: |
+          pre-commit run --all-files
+
+  test:
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-
-    - name: Set up Python
-      uses: actions/setup-python@v4
+    - uses: actions/setup-python@v4
       with:
         python-version: 3.8
 
@@ -21,10 +36,6 @@ jobs:
         python3 -m pip install --upgrade pip poetry
         poetry config virtualenvs.create false
         poetry install
-
-    - name: Linting and static code checks
-      run: |
-        pre-commit run --all-files
 
     - name: Test core
       env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,7 @@ jobs:
         run: |
           pre-commit run --all-files
 
-  test:
+  test_core:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
@@ -31,7 +31,7 @@ jobs:
       with:
         python-version: 3.8
 
-    - name: Install required dependencies
+    - name: Install core dependencies
       run: |
         python3 -m pip install --upgrade pip poetry
         poetry config virtualenvs.create false
@@ -50,10 +50,21 @@ jobs:
           CI: 1
       run: pytest tests/tests_unit -n4 --dist loadscope --maxfail 10 -m 'not dsl' --test-deps-only-core
 
-    - name: Install optional dependencies
-      run: poetry install -E all
+  test_full_and_build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - uses: actions/setup-python@v4
+      with:
+        python-version: 3.8
 
-    - name: Test all
+    - name: Install full dependencies
+      run: |
+        python3 -m pip install --upgrade pip poetry
+        poetry config virtualenvs.create false
+        poetry install -E all
+
+    - name: Test full
       env:
         LOGIN_FLOW: client_credentials
         COGNITE_CLIENT_SECRET: ${{ secrets.COGNITE_CLIENT_SECRET }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -48,7 +48,7 @@ jobs:
         COGNITE_BASE_URL: https://greenfield.cognitedata.com
         COGNITE_CLIENT_NAME: python-sdk-integration-tests
         CI: 1
-      run: pytest tests/tests_unit -n4 --dist loadscope --maxfail 10 -m 'not dsl' --test-deps-only-core
+      run: pytest tests/tests_unit -n8 --dist loadscope --maxfail 10 -m 'not dsl' --test-deps-only-core
 
   test_full_and_build_and_release:
     runs-on: ubuntu-latest
@@ -76,7 +76,7 @@ jobs:
         COGNITE_CLIENT_NAME: python-sdk-integration-tests
         CI: 1
       run: |
-        pytest -v tests --cov --cov-report xml:coverage.xml -n4 --dist loadscope --reruns 2
+        pytest -v tests --cov --cov-report xml:coverage.xml -n8 --dist loadscope --reruns 2
 
     - uses: codecov/codecov-action@v3
       with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -5,14 +5,29 @@ on:
     branches: [ master ]
 
 jobs:
-  build:
+  lint:
     runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: 3.8
 
+      - name: Install required dependencies
+        run: |
+          python3 -m pip install --upgrade pip poetry
+          poetry config virtualenvs.create false
+          poetry install
+
+      - name: Linting and static code checks
+        run: |
+          pre-commit run --all-files
+
+  test_and_release:
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-
-    - name: Set up Python
-      uses: actions/setup-python@v4
+    - uses: actions/setup-python@v4
       with:
         python-version: 3.8
 
@@ -21,10 +36,6 @@ jobs:
         python3 -m pip install --upgrade pip poetry
         poetry config virtualenvs.create false
         poetry install
-
-    - name: Linting and static code checks
-      run: |
-        pre-commit run --all-files
 
     - name: Test core
       env:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -9,10 +9,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: 3.8
 
@@ -22,7 +22,7 @@ jobs:
         poetry config virtualenvs.create false
         poetry install
 
-    - name: Check codestyle
+    - name: Linting and static code checks
       run: |
         pre-commit run --all-files
 
@@ -56,7 +56,7 @@ jobs:
       run: |
         pytest -v tests --cov --cov-report xml:coverage.xml -n4 --dist loadscope --reruns 2
 
-    - uses: codecov/codecov-action@v1
+    - uses: codecov/codecov-action@v3
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         file: ./coverage.xml

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -23,7 +23,7 @@ jobs:
         run: |
           pre-commit run --all-files
 
-  test_and_release:
+  test_core:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
@@ -50,10 +50,21 @@ jobs:
         CI: 1
       run: pytest tests/tests_unit -n4 --dist loadscope --maxfail 10 -m 'not dsl' --test-deps-only-core
 
-    - name: Install optional dependencies
-      run: poetry install -E all
+  test_full_and_build_and_release:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - uses: actions/setup-python@v4
+      with:
+        python-version: 3.8
 
-    - name: Test all
+    - name: Install full dependencies
+      run: |
+        python3 -m pip install --upgrade pip poetry
+        poetry config virtualenvs.create false
+        poetry install -E all
+
+    - name: Test full
       env:
         LOGIN_FLOW: client_credentials
         COGNITE_CLIENT_SECRET: ${{ secrets.COGNITE_CLIENT_SECRET }}

--- a/.github/workflows/test_and_build.yml
+++ b/.github/workflows/test_and_build.yml
@@ -8,19 +8,13 @@ jobs:
   build:
     runs-on: ubuntu-latest
 
-    strategy:
-      fail-fast: false
-      max-parallel: 1
-      matrix:
-        python-version: [3.8]
-
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+    - name: Set up Python
+      uses: actions/setup-python@v4
       with:
-        python-version: ${{ matrix.python-version }}
+        python-version: 3.8
 
     - name: Install required dependencies
       run: |
@@ -28,7 +22,7 @@ jobs:
         poetry config virtualenvs.create false
         poetry install
 
-    - name: Check codestyle
+    - name: Linting and static code checks
       run: |
         pre-commit run --all-files
 
@@ -62,7 +56,7 @@ jobs:
       run: |
         pytest -v tests --cov --cov-report xml:coverage.xml -n4 --dist loadscope --reruns 2
 
-    - uses: codecov/codecov-action@v1
+    - uses: codecov/codecov-action@v3
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         file: ./coverage.xml


### PR DESCRIPTION
split workflows into 3 jobs: lint, test-core, and test-all-and-build. These are run in parallel.

Also increase parallelism on tests from 4 to 8.

Now the entire workflow runs in ~3 minutes. (compared to 15 minutes a week ago).