### PR TITLE
Producer-Consumer pattern in asyncio for DatapointFetcher.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,10 @@
 __pycache__/
 *.py[cod]
 
+# Local credentials
+local_cog_client.py
+cache.bin
+
 # Distribution / packaging
 .Python
 env/

--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,7 @@
 __pycache__/
 *.py[cod]
 
-# Local credentials
+# Local credentials  # TODO: remove before merge->master
 local_cog_client.py
 cache.bin
 

--- a/cognite/client/_api/datapoints.py
+++ b/cognite/client/_api/datapoints.py
@@ -988,6 +988,19 @@ class DatapointsFetcher:
         self._preprocess_tasks(tasks)
         return tasks
 
+    @staticmethod
+    def _validate_tasks(tasks: List[_DPTask]) -> None:
+        identifiers_seen = set()
+        for t in tasks:
+            identifier = utils._auxiliary.unwrap_identifer(t.ts_item)
+            if identifier in identifiers_seen:
+                raise ValueError("Time series identifier '{}' is duplicated in query".format(identifier))
+            identifiers_seen.add(identifier)
+            if t.aggregates is not None and t.granularity is None:
+                raise ValueError("When specifying aggregates, granularity must also be provided.")
+            if t.granularity is not None and not t.aggregates:
+                raise ValueError("When specifying granularity, aggregates must also be provided.")
+
     def _preprocess_tasks(self, tasks: List[_DPTask]) -> None:
         for t in tasks:
             new_start = cognite.client.utils._time.timestamp_to_ms(t.start)
@@ -1182,19 +1195,6 @@ class DatapointsFetcher:
                 )
             return item
         raise TypeError("Invalid type '{}' for argument '{}'".format(type(item), item_type))
-
-    @staticmethod
-    def _validate_tasks(tasks: List[_DPTask]) -> None:
-        identifiers_seen = set()
-        for t in tasks:
-            identifier = utils._auxiliary.unwrap_identifer(t.ts_item)
-            if identifier in identifiers_seen:
-                raise ValueError("Time series identifier '{}' is duplicated in query".format(identifier))
-            identifiers_seen.add(identifier)
-            if t.aggregates is not None and t.granularity is None:
-                raise ValueError("When specifying aggregates, granularity must also be provided.")
-            if t.granularity is not None and not t.aggregates:
-                raise ValueError("When specifying granularity, aggregates must also be provided.")
 
 
 # Temporary class to be replaced by real classes

--- a/cognite/client/_api/datapoints.py
+++ b/cognite/client/_api/datapoints.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import copy
 import dataclasses
 import itertools
@@ -7,7 +8,7 @@ import math
 import re as regexp
 from dataclasses import dataclass
 from datetime import datetime
-from typing import TYPE_CHECKING, Any, Dict, Iterable, List, Optional, Set, Tuple, Union, cast
+from typing import TYPE_CHECKING, Any, Callable, Dict, Iterable, List, Optional, Set, Tuple, Union, cast
 
 import cognite.client.utils._time
 from cognite.client import utils
@@ -26,7 +27,6 @@ from cognite.client.exceptions import CogniteAPIError
 
 if TYPE_CHECKING:
     import pandas
-
 
 print("RUNNING REPOS/COG-SDK, NOT FROM PIP")
 
@@ -988,19 +988,6 @@ class DatapointsFetcher:
         self._preprocess_tasks(tasks)
         return tasks
 
-    @staticmethod
-    def _validate_tasks(tasks: List[_DPTask]) -> None:
-        identifiers_seen = set()
-        for t in tasks:
-            identifier = utils._auxiliary.unwrap_identifer(t.ts_item)
-            if identifier in identifiers_seen:
-                raise ValueError("Time series identifier '{}' is duplicated in query".format(identifier))
-            identifiers_seen.add(identifier)
-            if t.aggregates is not None and t.granularity is None:
-                raise ValueError("When specifying aggregates, granularity must also be provided.")
-            if t.granularity is not None and not t.aggregates:
-                raise ValueError("When specifying granularity, aggregates must also be provided.")
-
     def _preprocess_tasks(self, tasks: List[_DPTask]) -> None:
         for t in tasks:
             new_start = cognite.client.utils._time.timestamp_to_ms(t.start)
@@ -1195,3 +1182,151 @@ class DatapointsFetcher:
                 )
             return item
         raise TypeError("Invalid type '{}' for argument '{}'".format(type(item), item_type))
+
+    @staticmethod
+    def _validate_tasks(tasks: List[_DPTask]) -> None:
+        identifiers_seen = set()
+        for t in tasks:
+            identifier = utils._auxiliary.unwrap_identifer(t.ts_item)
+            if identifier in identifiers_seen:
+                raise ValueError("Time series identifier '{}' is duplicated in query".format(identifier))
+            identifiers_seen.add(identifier)
+            if t.aggregates is not None and t.granularity is None:
+                raise ValueError("When specifying aggregates, granularity must also be provided.")
+            if t.granularity is not None and not t.aggregates:
+                raise ValueError("When specifying granularity, aggregates must also be provided.")
+
+
+# Temporary class to be replaced by real classes
+@dataclass
+class Task:
+    query: DatapointsQueryNew
+
+
+@dataclass
+class TaskCompleted:
+    query: DatapointsQueryNew
+    retrieved_datapoints: int
+    retrieved_start: int
+    retrieved_end: int
+    is_complete: bool
+
+
+@dataclass
+class Result:
+    query: DatapointsQueryNew
+    datapoints: List[int]
+
+
+class DatapointsFetcherNew:
+    FETCH_WORKER_QUEUE_SIZE = 15
+    FETCH_WORKER_COUNT = 5
+    RESULT_WORKER_QUEUE_SIZE = 15
+    RESULT_WORKER_COUNT = 5
+
+    RESULT_QUEUE_SIZE = 20
+    RESULT_HANDLER_COUNT = 5
+
+    REMAINING_QUEUE_SIZE = 10
+
+    def __init__(self, client: DatapointsAPI):
+        self.client = client
+
+    # Todo Return native format for datapoints
+    def fetch(self, queries: List[DatapointsQueryNew]) -> Any:
+        return asyncio.run(self._fetch(queries))
+
+    async def _fetch(self, queries: List[DatapointsQueryNew]) -> Any:
+        from collections import defaultdict
+
+        results = defaultdict(list)
+
+        def datapoint_callback(result: Result):
+            results[result.query.id].extend(result.datapoints)
+
+        task_queue = asyncio.Queue(maxsize=self.FETCH_WORKER_QUEUE_SIZE)
+        result_queue = asyncio.Queue(maxsize=self.RESULT_QUEUE_SIZE)
+        remaining_queue = asyncio.Queue(maxsize=self.REMAINING_QUEUE_SIZE)
+
+        is_producer_completed = asyncio.Event()
+        is_producer_completed.clear()
+        producer_task = asyncio.create_task(
+            self._produce_tasks(queries, task_queue, remaining_queue, is_producer_completed)
+        )
+
+        workers = [
+            asyncio.create_task(self._fetch_worker(task_queue, result_queue)) for _ in range(self.FETCH_WORKER_COUNT)
+        ]
+        workers.extend(
+            [
+                asyncio.create_task(self._result_worker(result_queue, remaining_queue, datapoint_callback))
+                for _ in range(self.RESULT_WORKER_COUNT)
+            ]
+        )
+
+        await is_producer_completed.wait()
+        await task_queue.join()
+        await result_queue.join()
+        await remaining_queue.join()
+
+        # Just to be sure
+        producer_task.cancel()
+
+        for worker in workers:
+            worker.cancel()
+
+        return dict(results)
+
+    async def _produce_tasks(
+        self,
+        initial_queries: List[DatapointsQueryNew],
+        task_queue: asyncio.Queue,
+        remaining_queue: asyncio.Queue,
+        is_completed: asyncio.Event,
+    ):
+        task_count = len(initial_queries)
+        for query in initial_queries:
+            await task_queue.put(Task(query))
+        while task_count:
+            remaining: TaskCompleted = await remaining_queue.get()
+            if remaining.is_complete:
+                task_count -= 1
+            else:
+                # Todo create new tasks
+                raise NotImplementedError()
+            remaining_queue.task_done()
+        is_completed.set()
+
+    @classmethod
+    async def _fetch_worker(cls, task_queue: asyncio.Queue, result_queue: asyncio.Queue):
+        while True:
+            task: Task = await task_queue.get()
+            query = task.query
+
+            # Simulate latency
+            await asyncio.sleep(1)
+            # Simulate retrieving data points
+            datapoint_count = query.end - query.start
+
+            result = Result(query, list(range(datapoint_count)))
+            await result_queue.put(result)
+
+            task_queue.task_done()
+
+    @classmethod
+    async def _result_worker(
+        cls, result_queue: asyncio.Queue, remaining_queue: asyncio.Queue, result_callback: Callable[[Result], None]
+    ):
+        while True:
+            result = await result_queue.get()
+            result_callback(result)
+
+            remaining = TaskCompleted(
+                query=result.query,
+                retrieved_datapoints=len(result.datapoints),
+                retrieved_start=result.datapoints[0],
+                retrieved_end=result.datapoints[-1],
+                is_complete=True,
+            )
+            await remaining_queue.put(remaining)
+            result_queue.task_done()

--- a/run_datapoints_fetcher.py
+++ b/run_datapoints_fetcher.py
@@ -1,0 +1,21 @@
+import random
+import time
+
+from cognite.client._api.datapoints import DatapointsFetcherNew
+from cognite.client.data_classes.datapoints import DatapointsQueryNew
+
+random.seed(42)
+
+queries = [
+    DatapointsQueryNew(
+        start=random.randint(0, 10),
+        end=random.randint(20, 20_000),
+        id=i,
+    )
+    for i in range(10)
+]
+
+start = time.perf_counter()
+print(f"Executing Datapoints Fetcher for {len(queries):,} queries")
+results = DatapointsFetcherNew(None).fetch(queries)
+print(f"Retrieved {len(results)} results, time elapsed {time.perf_counter() - start:.2f} seconds")


### PR DESCRIPTION
Idea for architecture
```mermaid
graph LR
    A(fetch function) -->|Queries| B(Task Producer)
    B -->|Tasks Queue| C(Fetch Workers) -->|Results Queue| D(Result Workers)
    D -->|Remaining Queue| B
    D -->|Datapoints Callback| A
```

Notes:
* The split of the workers into fetch and result might be overkill, but I thought is clean to split the logic for handling the request and the processing of the request.
* The queues can easily be replaced by Priority queues.
* Work remains to find the most efficient way of passing data between the queues.