### PR TITLE
Remove all internal use of `utils._time.ms_to_datetime`

### DIFF
--- a/cognite/client/data_classes/datapoints.py
+++ b/cognite/client/data_classes/datapoints.py
@@ -4,7 +4,6 @@ import re as regexp
 from datetime import datetime
 from typing import TYPE_CHECKING, Any, Dict, Generator, List, Optional, Tuple, Union, cast
 
-import cognite.client.utils._time
 from cognite.client import utils
 from cognite.client.data_classes._base import CogniteResource, CogniteResourceList
 from cognite.client.exceptions import CogniteDuplicateColumnsError
@@ -73,11 +72,7 @@ class Datapoint(CogniteResource):
         dumped = self.dump(camel_case=camel_case)
         timestamp = dumped.pop("timestamp")
 
-        for k, v in dumped.items():
-            dumped[k] = [v]
-        df = pd.DataFrame(dumped, index=[cognite.client.utils._time.ms_to_datetime(timestamp)])
-
-        return df
+        return pd.DataFrame(dumped, index=[pd.Timestamp(timestamp, unit="ms")])
 
 
 class Datapoints(CogniteResource):

--- a/cognite/client/utils/_time.py
+++ b/cognite/client/utils/_time.py
@@ -126,7 +126,7 @@ def _convert_time_attributes_in_dict(item: Dict) -> Dict:
     for k, v in item.items():
         if k in TIME_ATTRIBUTES:
             try:
-                v = ms_to_datetime(v).strftime("%Y-%m-%d %H:%M:%S")
+                v = str(datetime.utcfromtimestamp(v / 1000))
             except (ValueError, OSError):
                 pass
         new_item[k] = v


### PR DESCRIPTION
## Description
In #960 a warning was added to two `datetime`-related functions both using a non-standard interpretation of what "naive" means in Python. 

In #965 these were changed to `FutureWarning` since `DeprecationWarning` is ignored by default. This change was not given a new version number and as such, has not been "released to the wild" yet... which is a good thing - because I missed two uses of one of these functions internally 😄 