### PR TITLE
Add ignore_unknown_ids parameter to files.retrieve_multiple

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,11 +14,15 @@ Changes are grouped as follows
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
-## [3.5.0] - 2022-07-28
+## [3.6.0] - 2022-08-10
+### Added
+- Add ignore_unknown_ids parameter to files.retrieve_multiple
+
+## [3.5.0] - 2022-08-10
 ### Changed
 - Improve type annotations. Use overloads in more places to help static type checkers.
 
-## [3.4.3] - 2022-07-28
+## [3.4.3] - 2022-08-10
 ### Changed
 - Cache result from pypi version check so it's not executed for every client instantiation.
 

--- a/cognite/client/_api/files.py
+++ b/cognite/client/_api/files.py
@@ -191,13 +191,17 @@ class FilesAPI(APIClient):
         return self._retrieve_multiple(list_cls=FileMetadataList, resource_cls=FileMetadata, identifiers=identifiers)
 
     def retrieve_multiple(
-        self, ids: Optional[List[int]] = None, external_ids: Optional[List[str]] = None
+        self,
+        ids: Optional[List[int]] = None,
+        external_ids: Optional[List[str]] = None,
+        ignore_unknown_ids: bool = False,
     ) -> FileMetadataList:
         """`Retrieve multiple file metadatas by id. <https://docs.cognite.com/api/v1/#operation/byIdsFiles>`_
 
         Args:
             ids (List[int], optional): IDs
             external_ids (List[str], optional): External IDs
+            ignore_unknown_ids (bool): Ignore IDs and external IDs that are not found rather than throw an exception.
 
         Returns:
             FileMetadataList: The requested file metadatas.
@@ -217,7 +221,12 @@ class FilesAPI(APIClient):
                 >>> res = c.files.retrieve_multiple(external_ids=["abc", "def"])
         """
         identifiers = IdentifierSequence.load(ids=ids, external_ids=external_ids)
-        return self._retrieve_multiple(list_cls=FileMetadataList, resource_cls=FileMetadata, identifiers=identifiers)
+        return self._retrieve_multiple(
+            list_cls=FileMetadataList,
+            resource_cls=FileMetadata,
+            identifiers=identifiers,
+            ignore_unknown_ids=ignore_unknown_ids,
+        )
 
     def list(
         self,

--- a/cognite/client/_version.py
+++ b/cognite/client/_version.py
@@ -1,2 +1,2 @@
-__version__ = "3.5.0"
+__version__ = "3.6.0"
 __api_subversion__ = "V20220125"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "cognite-sdk"
 
-version = "3.5.0"
+version = "3.6.0"
 
 description = "Cognite Python SDK"
 readme = "README.md"

--- a/tests/tests_integration/test_api/test_files.py
+++ b/tests/tests_integration/test_api/test_files.py
@@ -111,6 +111,11 @@ class TestFilesAPI:
         res = cognite_client.files.list(uploaded_time=A_WHILE_AGO, limit=2)
         assert res == cognite_client.files.retrieve_multiple([f.id for f in res])
 
+    def test_retrieve_multiple_ignore_unknown_ids(self, cognite_client):
+        assert [] == cognite_client.files.retrieve_multiple(
+            external_ids=["this file doesn't exist"], ignore_unknown_ids=True
+        )
+
     def test_retrieve_download_urls(self, cognite_client):
         f1 = cognite_client.files.upload_bytes(b"f1", external_id=random_string(10), name="bla")
         f2 = cognite_client.files.upload_bytes(b"f2", external_id=random_string(10), name="bla")

--- a/tests/tests_unit/test_api/test_files.py
+++ b/tests/tests_unit/test_api/test_files.py
@@ -480,7 +480,7 @@ class TestFilesAPI:
     def test_download(self, cognite_client, mock_file_download_response):
         with TemporaryDirectory() as dir:
             res = cognite_client.files.download(directory=dir, id=[1], external_id=["2"])
-            assert {"items": [{"id": 1}, {"externalId": "2"}]} == jsgz_load(
+            assert {"ignoreUnknownIds": False, "items": [{"id": 1}, {"externalId": "2"}]} == jsgz_load(
                 mock_file_download_response.calls[0].request.body
             )
             assert res is None
@@ -538,8 +538,8 @@ class TestFilesAPI:
             with TemporaryDirectory() as dir:
                 res = cognite_client.files.download(directory=dir, id=[1], external_id=["2"])
                 bodies = [jsgz_load(mock_file_download_response.calls[i].request.body) for i in range(2)]
-                assert {"items": [{"id": 1}]} in bodies
-                assert {"items": [{"externalId": "2"}]} in bodies
+                assert {"ignoreUnknownIds": False, "items": [{"id": 1}]} in bodies
+                assert {"ignoreUnknownIds": False, "items": [{"externalId": "2"}]} in bodies
                 assert res is None
                 assert os.path.isfile(os.path.join(dir, "file1"))
                 assert os.path.isfile(os.path.join(dir, "file2"))


### PR DESCRIPTION
## Description
The API supports a `ignoreUnknownIds` parameter to the files/byids endpoint, but the SDK didn't support this.

## Checklist:
- [x] Tests added/updated.
- [x] Documentation updated. Documentation is generated from docstrings - these must be updated according to your change. 
  If a new method has been added it should be referenced in [cognite.rst](https://github.com/cognitedata/cognite-sdk-python/blob/master/docs/source/cognite.rst) in order to generate docs based on its docstring. 
- [ ] Changelog updated in [CHANGELOG.md](https://github.com/cognitedata/cognite-sdk-python/blob/master/CHANGELOG.md).
- [ ] Version bumped. If triggering a new release is desired, bump the version number in [_version.py](https://github.com/cognitedata/cognite-sdk-python/blob/master/cognite/client/_version.py) per [semantic versioning](https://semver.org/).
