### PR TITLE
Limit number of values per request insert rows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,12 @@ Changes are grouped as follows
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
-## [3.6.1] - 2022-07-28
+
+## [3.7.0] - 2022-08-10
+### Changed
+- Changed grouping of Sequence rows on ingest. Each group now contains at most 100k values
+
+## [3.6.1] - 2022-08-10
 ### Fixed
 - Fixed a minor casing error for the geo_location field on files
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ Changes are grouped as follows
 
 ## [3.7.0] - 2022-08-10
 ### Changed
-- Changed grouping of Sequence rows on ingest. Each group now contains at most 100k values
+- Changed grouping of Sequence rows on insert. Each group now contains at most 100k values and at most 10k rows.
 
 ## [3.6.1] - 2022-08-10
 ### Fixed

--- a/cognite/client/_api/sequences.py
+++ b/cognite/client/_api/sequences.py
@@ -477,7 +477,8 @@ class SequencesDataAPI(APIClient):
     def __init__(self, sequences_api: SequencesAPI, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
         self._sequences_api = sequences_api
-        self._SEQ_POST_LIMIT = 10000
+        self._SEQ_POST_LIMIT_ROWS = 10000
+        self._SEQ_POST_LIMIT_VALUES = 100000
         self._SEQ_RETRIEVE_LIMIT = 10000
 
     def insert(
@@ -549,8 +550,14 @@ class SequencesDataAPI(APIClient):
 
         base_obj = Identifier.of_either(id, external_id).as_dict()
         base_obj.update(self._process_columns(column_external_ids))
+
+        if(len(all_rows) > 0):
+            rows_per_request = min(self._SEQ_POST_LIMIT_ROWS, int(self._SEQ_POST_LIMIT_VALUES/len(all_rows[0].values)))
+        else:
+            rows_per_request = self._SEQ_POST_LIMIT_ROWS
+
         row_objs = [
-            {"rows": all_rows[i : i + self._SEQ_POST_LIMIT]} for i in range(0, len(all_rows), self._SEQ_POST_LIMIT)
+            {"rows": all_rows[i : i + rows_per_request]} for i in range(0, len(all_rows), rows_per_request)
         ]
         tasks = [({**base_obj, **rows},) for rows in row_objs]  # type: ignore
         summary = utils._concurrency.execute_tasks_concurrently(

--- a/cognite/client/_api/sequences.py
+++ b/cognite/client/_api/sequences.py
@@ -551,14 +551,14 @@ class SequencesDataAPI(APIClient):
         base_obj = Identifier.of_either(id, external_id).as_dict()
         base_obj.update(self._process_columns(column_external_ids))
 
-        if(len(all_rows) > 0):
-            rows_per_request = min(self._SEQ_POST_LIMIT_ROWS, int(self._SEQ_POST_LIMIT_VALUES/len(all_rows[0].values)))
+        if len(all_rows) > 0:
+            rows_per_request = min(
+                self._SEQ_POST_LIMIT_ROWS, int(self._SEQ_POST_LIMIT_VALUES / len(all_rows[0]["values"]))
+            )
         else:
             rows_per_request = self._SEQ_POST_LIMIT_ROWS
 
-        row_objs = [
-            {"rows": all_rows[i : i + rows_per_request]} for i in range(0, len(all_rows), rows_per_request)
-        ]
+        row_objs = [{"rows": all_rows[i : i + rows_per_request]} for i in range(0, len(all_rows), rows_per_request)]
         tasks = [({**base_obj, **rows},) for rows in row_objs]  # type: ignore
         summary = utils._concurrency.execute_tasks_concurrently(
             self._insert_data, tasks, max_workers=self._config.max_workers

--- a/cognite/client/_version.py
+++ b/cognite/client/_version.py
@@ -1,2 +1,2 @@
-__version__ = "3.6.1"
+__version__ = "3.7.0"
 __api_subversion__ = "V20220125"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "cognite-sdk"
 
-version = "3.6.1"
+version = "3.7.0"
 
 description = "Cognite Python SDK"
 readme = "README.md"


### PR DESCRIPTION
## Description
The current implementation does not explicitly limit the number of values per insert request of sequence rows, only the number of rows. As a row can contain up to 400 values, a single request can contain up to 4 million values. 
With this change the number of values in an insert request can be at most 100k. The same limit that is documented in https://docs.cognite.com/api/v1/#tag/Sequences/operation/postSequenceData

## Checklist:
- [ ] Tests added/updated.
- [ ] Documentation updated. Documentation is generated from docstrings - these must be updated according to your change. 
  If a new method has been added it should be referenced in [cognite.rst](https://github.com/cognitedata/cognite-sdk-python/blob/master/docs/source/cognite.rst) in order to generate docs based on its docstring. 
- [x] Changelog updated in [CHANGELOG.md](https://github.com/cognitedata/cognite-sdk-python/blob/master/CHANGELOG.md).
- [x] Version bumped. If triggering a new release is desired, bump the version number in [_version.py](https://github.com/cognitedata/cognite-sdk-python/blob/master/cognite/client/_version.py) per [semantic versioning](https://semver.org/).
