### PR TITLE
Fix transfomations str method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ Changes are grouped as follows
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
+## [3.0.1] - 2022-07-27
+### Fixed
+- fixed exception when printing exceptions generated on transformations creation/update.
+
 ## [3.4.0] - 2022-07-21
 ### Added
 - added support for nonce authentication on transformations

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ Changes are grouped as follows
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
-## [3.0.1] - 2022-07-27
+## [3.4.1] - 2022-07-27
 ### Fixed
 - fixed exception when printing exceptions generated on transformations creation/update.
 

--- a/cognite/client/_version.py
+++ b/cognite/client/_version.py
@@ -1,2 +1,2 @@
-__version__ = "3.4.0"
+__version__ = "3.4.1"
 __api_subversion__ = "V20220125"

--- a/cognite/client/data_classes/transformations/__init__.py
+++ b/cognite/client/data_classes/transformations/__init__.py
@@ -251,17 +251,17 @@ class Transformation(CogniteResource):
             Dict[str, Any]: A dictionary representation of the instance.
         """
         ret = super().dump(camel_case=camel_case)
-        if self.source_oidc_credentials:
+        if isinstance(self.source_oidc_credentials, OidcCredentials):
             source_key = "sourceOidcCredentials" if camel_case else "source_oidc_credentials"
             ret[source_key] = self.source_oidc_credentials.dump(camel_case=camel_case)
-        if self.destination_oidc_credentials:
+        if isinstance(self.destination_oidc_credentials, OidcCredentials):
             destination_key = "destinationOidcCredentials" if camel_case else "destination_oidc_credentials"
             ret[destination_key] = self.destination_oidc_credentials.dump(camel_case=camel_case)
 
-        if self.source_nonce:
+        if isinstance(self.source_nonce, NonceCredentials):
             destination_key = "sourceNonce" if camel_case else "source_nonce"
             ret[destination_key] = self.source_nonce.dump(camel_case=camel_case)
-        if self.destination_nonce:
+        if isinstance(self.destination_nonce, NonceCredentials):
             destination_key = "destinationNonce" if camel_case else "destination_nonce"
             ret[destination_key] = self.destination_nonce.dump(camel_case=camel_case)
         if isinstance(self.destination, AlphaDataModelInstances) or isinstance(self.destination, SequenceRows):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "cognite-sdk"
 
-version = "3.4.0"
+version = "3.4.1"
 
 description = "Cognite Python SDK"
 readme = "README.md"

--- a/tests/tests_integration/test_api/test_transformations/test_transformations.py
+++ b/tests/tests_integration/test_api/test_transformations/test_transformations.py
@@ -44,6 +44,20 @@ other_transformation = new_transformation
 
 
 class TestTransformationsAPI:
+    def test_create_transformation_error(self, cognite_client):
+        prefix = "".join(random.choice(string.ascii_letters) for i in range(6))
+        transform_without_name = Transformation(
+            external_id=f"{prefix}-transformation", destination=TransformationDestination.assets()
+        )
+        try:
+            ts = cognite_client.transformations.create(transform_without_name)
+            failed = False
+            cognite_client.transformations.delete(id=ts.id)
+        except Exception as ex:
+            failed = True
+            str(ex)
+        assert failed
+
     def test_create_asset_transformation(self, cognite_client):
         prefix = "".join(random.choice(string.ascii_letters) for i in range(6))
         transform = Transformation(


### PR DESCRIPTION
## Description
casting exceptions thrown on transformations create and update to str caused an exception, this was caused by a bug in the `transformation.dump()` method.

## Checklist:
- [x] Tests added/updated.
- [〰️] Documentation updated. Documentation is generated from docstrings - these must be updated according to your change. 
  If a new method has been added it should be referenced in [cognite.rst](https://github.com/cognitedata/cognite-sdk-python/blob/master/docs/source/cognite.rst) in order to generate docs based on its docstring. 
- [x] Changelog updated in [CHANGELOG.md](https://github.com/cognitedata/cognite-sdk-python/blob/master/CHANGELOG.md).
- [x] Version bumped. If triggering a new release is desired, bump the version number in [_version.py](https://github.com/cognitedata/cognite-sdk-python/blob/master/cognite/client/_version.py) per [semantic versioning](https://semver.org/).
