### PR TITLE
Move raw.rows.insert under the rows header

### DIFF
--- a/docs/source/cognite.rst
+++ b/docs/source/cognite.rst
@@ -693,10 +693,6 @@ Delete tables from a database
 
 Rows
 ^^^^
-Insert rows into a table
-~~~~~~~~~~~~~~~~~~~~~~~~
-.. automethod:: cognite.client._api.raw.RawRowsAPI.insert
-
 Get a row from a table
 ~~~~~~~~~~~~~~~~~~~~~~
 .. automethod:: cognite.client._api.raw.RawRowsAPI.retrieve
@@ -705,17 +701,22 @@ List rows in a table
 ~~~~~~~~~~~~~~~~~~~~
 .. automethod:: cognite.client._api.raw.RawRowsAPI.list
 
-Retrieve pandas dataframe
-^^^^^^^^^^^^^^^^^^^^^^^^^
-.. automethod:: cognite.client._api.raw.RawRowsAPI.retrieve_dataframe
-
-Insert pandas dataframe
-^^^^^^^^^^^^^^^^^^^^^^^^^
-.. automethod:: cognite.client._api.raw.RawRowsAPI.insert_dataframe
+Insert rows into a table
+~~~~~~~~~~~~~~~~~~~~~~~~
+.. automethod:: cognite.client._api.raw.RawRowsAPI.insert
 
 Delete rows from a table
 ~~~~~~~~~~~~~~~~~~~~~~~~
 .. automethod:: cognite.client._api.raw.RawRowsAPI.delete
+
+Retrieve pandas dataframe
+~~~~~~~~~~~~~~~~~~~~~~~~~
+.. automethod:: cognite.client._api.raw.RawRowsAPI.retrieve_dataframe
+
+Insert pandas dataframe
+~~~~~~~~~~~~~~~~~~~~~~~
+.. automethod:: cognite.client._api.raw.RawRowsAPI.insert_dataframe
+
 
 Data classes
 ^^^^^^^^^^^^

--- a/docs/source/cognite.rst
+++ b/docs/source/cognite.rst
@@ -693,6 +693,10 @@ Delete tables from a database
 
 Rows
 ^^^^
+Insert rows into a table
+~~~~~~~~~~~~~~~~~~~~~~~~
+.. automethod:: cognite.client._api.raw.RawRowsAPI.insert
+
 Get a row from a table
 ~~~~~~~~~~~~~~~~~~~~~~
 .. automethod:: cognite.client._api.raw.RawRowsAPI.retrieve
@@ -704,10 +708,6 @@ List rows in a table
 Retrieve pandas dataframe
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 .. automethod:: cognite.client._api.raw.RawRowsAPI.retrieve_dataframe
-
-Insert rows into a table
-~~~~~~~~~~~~~~~~~~~~~~~~
-.. automethod:: cognite.client._api.raw.RawRowsAPI.insert
 
 Insert pandas dataframe
 ^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
## Description

The documentation for `client.raw.rows.insert` was hiding under the
`Retrieve pandas dataframe` header, so I've moved it to the `Rows`
header.

### What it used to look like
![image](https://user-images.githubusercontent.com/819391/181509732-2ff60e35-bfc2-4734-9d89-a8cfe6dc8593.png)

### New structure

    Raw
        - Databases (unchanged)
        - Tables (unchanged)
        - Rows
            - Insert rows into a table
            - Get a row from a table
            - List rows in a table
            - Delete rows from a table
            - Retrieve pandas dataframe
            - Insert pandas dataframe


## Checklist:
- [x] Tests added/updated.
- [x] Documentation updated. Documentation is generated from docstrings - these must be updated according to your change. 
  If a new method has been added it should be referenced in [cognite.rst](https://github.com/cognitedata/cognite-sdk-python/blob/master/docs/source/cognite.rst) in order to generate docs based on its docstring. 
- [ ] Changelog updated in [CHANGELOG.md](https://github.com/cognitedata/cognite-sdk-python/blob/master/CHANGELOG.md).
- [ ] Version bumped. If triggering a new release is desired, bump the version number in [_version.py](https://github.com/cognitedata/cognite-sdk-python/blob/master/cognite/client/_version.py) per [semantic versioning](https://semver.org/).
