### PR TITLE
Set read-the-docs python version to 3.8

### DIFF
--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -2,5 +2,5 @@ build:
     image: latest
 
 python:
-    version: 3.7
+    version: 3.8
     pip_install: true


### PR DESCRIPTION
## Description
Read-the-docs was built with python3.7 which is no longer supported.

[Build log:](https://readthedocs.com/projects/cognite-sdk-python/builds/1011742/)
```
Processing /home/docs/checkouts/readthedocs.org/user_builds/cognite-sdk-python/checkouts/latest
  Installing build dependencies: started
  Installing build dependencies: finished with status 'done'
  Getting requirements to build wheel: started
  Getting requirements to build wheel: finished with status 'done'
  Preparing metadata (pyproject.toml): started
  Preparing metadata (pyproject.toml): finished with status 'done'
Requirement already satisfied: requests<3,>=2 in /home/docs/checkouts/readthedocs.org/user_builds/cognite-sdk-python/envs/latest/lib/python3.7/site-packages (from cognite-sdk==3.0.0) (2.28.1)
Collecting requests_oauthlib<2,>=1
  Downloading requests_oauthlib-1.3.1-py2.py3-none-any.whl (23 kB)
Collecting msal<2,>=1
  Downloading msal-1.18.0-py2.py3-none-any.whl (82 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 82.4/82.4 kB 8.5 MB/s eta 0:00:00
ERROR: Package 'cognite-sdk' requires a different Python: 3.7.9 not in '<4.0,>=3.8'
```

Hopefully, this fixes it.
## Checklist:
- [ ] Tests added/updated.
- [ ] Documentation updated. Documentation is generated from docstrings - these must be updated according to your change. 
  If a new method has been added it should be referenced in [cognite.rst](https://github.com/cognitedata/cognite-sdk-python/blob/master/docs/source/cognite.rst) in order to generate docs based on its docstring. 
- [ ] Changelog updated in [CHANGELOG.md](https://github.com/cognitedata/cognite-sdk-python/blob/master/CHANGELOG.md).
- [ ] Version bumped. If triggering a new release is desired, bump the version number in [_version.py](https://github.com/cognitedata/cognite-sdk-python/blob/master/cognite/client/_version.py) per [semantic versioning](https://semver.org/).
