### PR TITLE
Generate random external id for annotation integration test file to a void simultaneous tests conflicting with each other

### DIFF
--- a/tests/tests_integration/test_api/test_annotations.py
+++ b/tests/tests_integration/test_api/test_annotations.py
@@ -1,3 +1,4 @@
+import uuid
 from copy import deepcopy
 from typing import Any, Dict, List, Optional
 
@@ -54,7 +55,8 @@ def annotation() -> Annotation:
 @pytest.fixture
 def file_id(cognite_client: CogniteClient) -> int:
     # Create a test file
-    name = "annotation_unit_test_file"
+    random_id = uuid.uuid4()
+    name = f"annotation_unit_test_file_{random_id}"
     file = cognite_client.files.create(FileMetadata(external_id=name, name=name), overwrite=True)[0]
     yield file.id
     # Teardown all annotations to the file


### PR DESCRIPTION
## Description
Changed annotation integration test file external id to avoid tests conflicting with each other when run at the same time. 

## Checklist:
- [x] Tests added/updated.
- [ ] Documentation updated. Documentation is generated from docstrings - these must be updated according to your change. 
  If a new method has been added it should be referenced in [cognite.rst](https://github.com/cognitedata/cognite-sdk-python/blob/master/docs/source/cognite.rst) in order to generate docs based on its docstring. 
- [ ] Changelog updated in [CHANGELOG.md](https://github.com/cognitedata/cognite-sdk-python/blob/master/CHANGELOG.md).
- [ ] Version bumped. If triggering a new release is desired, bump the version number in [_version.py](https://github.com/cognitedata/cognite-sdk-python/blob/master/cognite/client/_version.py) per [semantic versioning](https://semver.org/).
