### PR TITLE
Use relative time in test_retrieve_string test

### DIFF
--- a/tests/tests_integration/test_api/test_datapoints.py
+++ b/tests/tests_integration/test_api/test_datapoints.py
@@ -185,7 +185,7 @@ class TestDatapointsAPI:
         assert df.shape[1] == 1
 
     def test_retrieve_string(self, cognite_client):
-        dps = cognite_client.datapoints.retrieve(external_id="test__string_b", start=1563000000000, end=1564100000000)
+        dps = cognite_client.datapoints.retrieve(external_id="test__string_b", start="2d-ago", end="now")
         assert len(dps) > 100000
 
     def test_query(self, cognite_client, test_time_series):


### PR DESCRIPTION
## Description
Please describe the change you have made.

## Checklist:
- [ ] Tests added/updated.
- [ ] Documentation updated. Documentation is generated from docstrings - these must be updated according to your change. 
  If a new method has been added it should be referenced in [cognite.rst](https://github.com/cognitedata/cognite-sdk-python/blob/master/docs/source/cognite.rst) in order to generate docs based on its docstring. 
- [ ] Changelog updated in [CHANGELOG.md](https://github.com/cognitedata/cognite-sdk-python/blob/master/CHANGELOG.md).
- [ ] Version bumped. If triggering a new release is desired, bump the version number in [_version.py](https://github.com/cognitedata/cognite-sdk-python/blob/master/cognite/client/_version.py) per [semantic versioning](https://semver.org/).
