### PR TITLE
Fix geospatial importing bugs

### DIFF
--- a/cognite/client/data_classes/__init__.py
+++ b/cognite/client/data_classes/__init__.py
@@ -178,3 +178,16 @@ from cognite.client.data_classes.functions import (  # isort: skip
     FunctionCallLog,
     FunctionsLimits,
 )
+from cognite.client.data_classes.geospatial import (  # isort: skip
+    Feature,
+    FeatureList,
+    FeatureType,
+    FeatureTypeList,
+    FeatureTypePatch,
+    FeatureAggregate,
+    FeatureTypeUpdate,
+    FeatureAggregateList,
+    FeatureTypeUpdateList,
+    CoordinateReferenceSystemList,
+    CoordinateReferenceSystem,
+)

--- a/cognite/client/data_classes/geospatial.py
+++ b/cognite/client/data_classes/geospatial.py
@@ -2,8 +2,6 @@ import dataclasses
 import json
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union, cast
 
-import numpy as np
-
 from cognite.client import utils
 from cognite.client.data_classes._base import CogniteResource, CogniteResourceList
 from cognite.client.utils._auxiliary import to_snake_case
@@ -282,6 +280,8 @@ class FeatureList(CogniteResourceList):
 
 def nan_to_none(column_value: Any) -> Any:
     """Convert NaN value to None."""
+    import numpy as np
+
     return None if np.isscalar(column_value) and np.isnan(column_value) else column_value
 
 


### PR DESCRIPTION
- Import geospatial data classes into cognite.client.data_classes namespace
- Only do local import of numpy in geospatial module

## Description
Please describe the change you have made.

## Checklist:
- [ ] Tests added/updated.
- [ ] Documentation updated. Documentation is generated from docstrings - these must be updated according to your change. 
  If a new method has been added it should be referenced in [cognite.rst](https://github.com/cognitedata/cognite-sdk-python/blob/master/docs/source/cognite.rst) in order to generate docs based on its docstring. 
- [ ] Changelog updated in [CHANGELOG.md](https://github.com/cognitedata/cognite-sdk-python/blob/master/CHANGELOG.md).
- [ ] Version bumped. If triggering a new release is desired, bump the version number in [_version.py](https://github.com/cognitedata/cognite-sdk-python/blob/master/cognite/client/_version.py) per [semantic versioning](https://semver.org/).
