### PR TITLE
Use typing module rather than typing_extensions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ Changes are grouped as follows
 - `Security` in case of vulnerabilities.
 
 
+## [4.5.1] - 2022-09-08
+### Fixed
+- Don't depend on typing_extensions module, since we don't have it as a dependency.
+
 ## [4.5.0] - 2022-09-08
 ### Added
 - Vision extract implementation, providing access to the corresponding [Vision Extract API](https://docs.cognite.com/api/v1/#tag/Vision).

--- a/cognite/client/_version.py
+++ b/cognite/client/_version.py
@@ -1,2 +1,2 @@
-__version__ = "4.5.0"
+__version__ = "4.5.1"
 __api_subversion__ = "V20220125"

--- a/cognite/client/data_classes/contextualization.py
+++ b/cognite/client/data_classes/contextualization.py
@@ -14,10 +14,9 @@ from typing import (
     TypeVar,
     Union,
     cast,
+    get_args,
     get_type_hints,
 )
-
-from typing_extensions import get_args
 
 from cognite.client.data_classes import Annotation
 from cognite.client.data_classes._base import (

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "cognite-sdk"
 
-version = "4.5.0"
+version = "4.5.1"
 
 description = "Cognite Python SDK"
 readme = "README.md"


### PR DESCRIPTION
get_args is supported in the typing module. typing_extensions is not included as a dependency, so we fail on import errors at runtime now.

The reason we didn't catch this in CI is that our dev dependencies bring in typing_extensions.