### PR TITLE
Fix: Move EM and Diagrams API to beta client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ Changes are grouped as follows
 
 ## [4.5.1] - 2022-09-08
 ### Fixed
-- Fixed requests to the Diagrams and Entity Matching API by setting their API version to "beta".
+- Fixed EM and diagrams tests by using the beta clients there. This is because the mentioned APIs now check for `cdf-version` in the request headers.
 
 ## [4.5.0] - 2022-09-08
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ Changes are grouped as follows
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
+## [4.5.1] - 2022-09-08
+### Fixed
+- Fixed requests to the Diagrams and Entity Matching API by setting their API version to "beta".
 
 ## [4.5.0] - 2022-09-08
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,9 +14,9 @@ Changes are grouped as follows
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
-## [4.5.1] - 2022-09-08
+## [5.0.0] - 2022-09-08
 ### Fixed
-- Fixed EM and diagrams tests by using the beta clients there. This is because the mentioned APIs now check for `cdf-version` in the request headers.
+- Fixed EM and Diagrams API by using the beta clients for them. This is because the mentioned APIs now check for `cdf-version` in the request headers.
 
 ## [4.5.0] - 2022-09-08
 ### Added

--- a/cognite/client/_cognite_client.py
+++ b/cognite/client/_cognite_client.py
@@ -62,7 +62,7 @@ class CogniteClient:
         self.three_d = ThreeDAPI(self._config, api_version=self._API_VERSION, cognite_client=self)
         self.labels = LabelsAPI(self._config, api_version=self._API_VERSION, cognite_client=self)
         self.relationships = RelationshipsAPI(self._config, api_version=self._API_VERSION, cognite_client=self)
-        self.entity_matching = EntityMatchingAPI(self._config, api_version=self._API_VERSION, cognite_client=self)
+        self.entity_matching = EntityMatchingAPI(self._config, api_version="beta", cognite_client=self)
         self.templates = TemplatesAPI(self._config, api_version=self._API_VERSION, cognite_client=self)
         self.vision = VisionAPI(self._config, api_version=self._API_VERSION, cognite_client=self)
         self.extraction_pipelines = ExtractionPipelinesAPI(self._config, api_version="playground", cognite_client=self)
@@ -70,7 +70,7 @@ class CogniteClient:
             self._config, api_version="playground", cognite_client=self
         )
         self.transformations = TransformationsAPI(self._config, api_version=self._API_VERSION, cognite_client=self)
-        self.diagrams = DiagramsAPI(self._config, api_version=self._API_VERSION, cognite_client=self)
+        self.diagrams = DiagramsAPI(self._config, api_version="beta", cognite_client=self)
         self.annotations = AnnotationsAPI(self._config, api_version=self._API_VERSION, cognite_client=self)
         self.functions = FunctionsAPI(self._config, api_version=self._API_VERSION, cognite_client=self)
 

--- a/cognite/client/_cognite_client.py
+++ b/cognite/client/_cognite_client.py
@@ -7,8 +7,6 @@ from cognite.client._api.annotations import AnnotationsAPI
 from cognite.client._api.assets import AssetsAPI
 from cognite.client._api.data_sets import DataSetsAPI
 from cognite.client._api.datapoints import DatapointsAPI
-from cognite.client._api.diagrams import DiagramsAPI
-from cognite.client._api.entity_matching import EntityMatchingAPI
 from cognite.client._api.events import EventsAPI
 from cognite.client._api.extractionpipelines import ExtractionPipelineRunsAPI, ExtractionPipelinesAPI
 from cognite.client._api.files import FilesAPI
@@ -62,7 +60,6 @@ class CogniteClient:
         self.three_d = ThreeDAPI(self._config, api_version=self._API_VERSION, cognite_client=self)
         self.labels = LabelsAPI(self._config, api_version=self._API_VERSION, cognite_client=self)
         self.relationships = RelationshipsAPI(self._config, api_version=self._API_VERSION, cognite_client=self)
-        self.entity_matching = EntityMatchingAPI(self._config, api_version=self._API_VERSION, cognite_client=self)
         self.templates = TemplatesAPI(self._config, api_version=self._API_VERSION, cognite_client=self)
         self.vision = VisionAPI(self._config, api_version=self._API_VERSION, cognite_client=self)
         self.extraction_pipelines = ExtractionPipelinesAPI(self._config, api_version="playground", cognite_client=self)
@@ -70,7 +67,6 @@ class CogniteClient:
             self._config, api_version="playground", cognite_client=self
         )
         self.transformations = TransformationsAPI(self._config, api_version=self._API_VERSION, cognite_client=self)
-        self.diagrams = DiagramsAPI(self._config, api_version=self._API_VERSION, cognite_client=self)
         self.annotations = AnnotationsAPI(self._config, api_version=self._API_VERSION, cognite_client=self)
         self.functions = FunctionsAPI(self._config, api_version=self._API_VERSION, cognite_client=self)
 

--- a/cognite/client/_cognite_client.py
+++ b/cognite/client/_cognite_client.py
@@ -62,7 +62,7 @@ class CogniteClient:
         self.three_d = ThreeDAPI(self._config, api_version=self._API_VERSION, cognite_client=self)
         self.labels = LabelsAPI(self._config, api_version=self._API_VERSION, cognite_client=self)
         self.relationships = RelationshipsAPI(self._config, api_version=self._API_VERSION, cognite_client=self)
-        self.entity_matching = EntityMatchingAPI(self._config, api_version="beta", cognite_client=self)
+        self.entity_matching = EntityMatchingAPI(self._config, api_version=self._API_VERSION, cognite_client=self)
         self.templates = TemplatesAPI(self._config, api_version=self._API_VERSION, cognite_client=self)
         self.vision = VisionAPI(self._config, api_version=self._API_VERSION, cognite_client=self)
         self.extraction_pipelines = ExtractionPipelinesAPI(self._config, api_version="playground", cognite_client=self)
@@ -70,7 +70,7 @@ class CogniteClient:
             self._config, api_version="playground", cognite_client=self
         )
         self.transformations = TransformationsAPI(self._config, api_version=self._API_VERSION, cognite_client=self)
-        self.diagrams = DiagramsAPI(self._config, api_version="beta", cognite_client=self)
+        self.diagrams = DiagramsAPI(self._config, api_version=self._API_VERSION, cognite_client=self)
         self.annotations = AnnotationsAPI(self._config, api_version=self._API_VERSION, cognite_client=self)
         self.functions = FunctionsAPI(self._config, api_version=self._API_VERSION, cognite_client=self)
 

--- a/cognite/client/_version.py
+++ b/cognite/client/_version.py
@@ -1,2 +1,2 @@
-__version__ = "4.5.1"
+__version__ = "5.0.0"
 __api_subversion__ = "V20220125"

--- a/cognite/client/_version.py
+++ b/cognite/client/_version.py
@@ -1,2 +1,2 @@
-__version__ = "4.5.0"
+__version__ = "4.5.1"
 __api_subversion__ = "V20220125"

--- a/cognite/client/beta.py
+++ b/cognite/client/beta.py
@@ -1,4 +1,6 @@
 from cognite.client import ClientConfig
+from cognite.client._api.diagrams import DiagramsAPI
+from cognite.client._api.entity_matching import EntityMatchingAPI
 from cognite.client._cognite_client import CogniteClient as Client
 
 
@@ -6,3 +8,6 @@ class CogniteClient(Client):
     def __init__(self, config: ClientConfig) -> None:
         config.api_subversion = "beta"
         super().__init__(config)
+
+        self.diagrams = DiagramsAPI(self._config, api_version=self._API_VERSION, cognite_client=self)
+        self.entity_matching = EntityMatchingAPI(self._config, api_version=self._API_VERSION, cognite_client=self)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "cognite-sdk"
 
-version = "4.5.0"
+version = "4.5.1"
 
 description = "Cognite Python SDK"
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "cognite-sdk"
 
-version = "4.5.1"
+version = "5.0.0"
 
 description = "Cognite Python SDK"
 readme = "README.md"

--- a/tests/tests_integration/conftest.py
+++ b/tests/tests_integration/conftest.py
@@ -9,7 +9,7 @@ from cognite.client.credentials import CredentialProvider, OAuthClientCredential
 
 
 @pytest.fixture(scope="session")
-def _get_credentials() -> CredentialProvider:
+def credentials() -> CredentialProvider:
     login_flow = os.environ["LOGIN_FLOW"].lower()
     if login_flow == "client_credentials":
         return OAuthClientCredentials(
@@ -31,24 +31,24 @@ def _get_credentials() -> CredentialProvider:
 
 
 @pytest.fixture(scope="session")
-def cognite_client() -> CogniteClient:
+def cognite_client(credentials: CredentialProvider) -> CogniteClient:
     return CogniteClient(
         ClientConfig(
             client_name=os.environ["COGNITE_CLIENT_NAME"],
             project=os.environ["COGNITE_PROJECT"],
             base_url=os.environ["COGNITE_BASE_URL"],
-            credentials=_get_credentials(),
+            credentials=credentials,
         )
     )
 
 
 @pytest.fixture(scope="session")
-def cognite_beta_client() -> CogniteBetaClient:
+def cognite_beta_client(credentials: CredentialProvider) -> CogniteBetaClient:
     return CogniteBetaClient(
         ClientConfig(
             client_name=os.environ["COGNITE_CLIENT_NAME"],
             project=os.environ["COGNITE_PROJECT"],
             base_url=os.environ["COGNITE_BASE_URL"],
-            credentials=_get_credentials(),
+            credentials=credentials,
         )
     )

--- a/tests/tests_integration/conftest.py
+++ b/tests/tests_integration/conftest.py
@@ -5,10 +5,10 @@ import pytest
 
 from cognite.client import ClientConfig, CogniteClient
 from cognite.client.beta import CogniteClient as CogniteBetaClient
-from cognite.client.credentials import ClientCredentials, OAuthClientCredentials, OAuthInteractive
+from cognite.client.credentials import CredentialProvider, OAuthClientCredentials, OAuthInteractive
 
 
-def _get_credentials() -> ClientCredentials:
+def _get_credentials() -> CredentialProvider:
     login_flow = os.environ["LOGIN_FLOW"].lower()
     if login_flow == "client_credentials":
         return OAuthClientCredentials(

--- a/tests/tests_integration/conftest.py
+++ b/tests/tests_integration/conftest.py
@@ -4,21 +4,21 @@ import random
 import pytest
 
 from cognite.client import ClientConfig, CogniteClient
-from cognite.client.credentials import OAuthClientCredentials, OAuthInteractive
+from cognite.client.beta import CogniteClient as CogniteBetaClient
+from cognite.client.credentials import ClientCredentials, OAuthClientCredentials, OAuthInteractive
 
 
-@pytest.fixture(scope="session")
-def cognite_client() -> CogniteClient:
+def _get_credentials() -> ClientCredentials:
     login_flow = os.environ["LOGIN_FLOW"].lower()
     if login_flow == "client_credentials":
-        credentials = OAuthClientCredentials(
+        return OAuthClientCredentials(
             token_url=os.environ["COGNITE_TOKEN_URL"],
             client_id=os.environ["COGNITE_CLIENT_ID"],
             client_secret=os.environ["COGNITE_CLIENT_SECRET"],
             scopes=os.environ["COGNITE_TOKEN_SCOPES"].split(","),
         )
     elif login_flow == "interactive":
-        credentials = OAuthInteractive(
+        return OAuthInteractive(
             authority_url=os.environ["COGNITE_AUTHORITY_URL"],
             client_id=os.environ["COGNITE_CLIENT_ID"],
             scopes=os.environ.get("COGNITE_TOKEN_SCOPES", "").split(","),
@@ -27,11 +27,27 @@ def cognite_client() -> CogniteClient:
 
     else:
         raise ValueError("Environment variable LOGIN_FLOW must be set to either 'client_credentials' or 'interactive'")
+
+
+@pytest.fixture(scope="session")
+def cognite_client() -> CogniteClient:
     return CogniteClient(
         ClientConfig(
             client_name=os.environ["COGNITE_CLIENT_NAME"],
             project=os.environ["COGNITE_PROJECT"],
             base_url=os.environ["COGNITE_BASE_URL"],
-            credentials=credentials,
+            credentials=_get_credentials(),
+        )
+    )
+
+
+@pytest.fixture(scope="session")
+def cognite_beta_client() -> CogniteBetaClient:
+    return CogniteBetaClient(
+        ClientConfig(
+            client_name=os.environ["COGNITE_CLIENT_NAME"],
+            project=os.environ["COGNITE_PROJECT"],
+            base_url=os.environ["COGNITE_BASE_URL"],
+            credentials=_get_credentials(),
         )
     )

--- a/tests/tests_integration/conftest.py
+++ b/tests/tests_integration/conftest.py
@@ -8,6 +8,7 @@ from cognite.client.beta import CogniteClient as CogniteBetaClient
 from cognite.client.credentials import CredentialProvider, OAuthClientCredentials, OAuthInteractive
 
 
+@pytest.fixture(scope="session")
 def _get_credentials() -> CredentialProvider:
     login_flow = os.environ["LOGIN_FLOW"].lower()
     if login_flow == "client_credentials":

--- a/tests/tests_integration/test_api/test_diagrams.py
+++ b/tests/tests_integration/test_api/test_diagrams.py
@@ -4,10 +4,10 @@ PNID_FILE_ID = 3261066797848581
 
 
 class TestPNIDParsingIntegration:
-    def test_run_diagram_detect(self, cognite_client):
+    def test_run_diagram_detect(self, cognite_beta_client):
         entities = [{"name": "YT-96122"}, {"name": "XE-96125", "ee": 123}, {"name": "XWDW-9615"}]
         file_id = PNID_FILE_ID
-        job = cognite_client.diagrams.detect(file_ids=[file_id], entities=entities)
+        job = cognite_beta_client.diagrams.detect(file_ids=[file_id], entities=entities)
         assert isinstance(job, DiagramDetectResults)
         assert {"statusCount", "numFiles", "items", "partialMatch", "minTokens", "searchField"}.issubset(job.result)
         assert {"fileId", "annotations"}.issubset(job.result["items"][0])

--- a/tests/tests_integration/test_api/test_entity_matching.py
+++ b/tests/tests_integration/test_api/test_entity_matching.py
@@ -13,16 +13,16 @@ from cognite.client.exceptions import CogniteAPIError
 
 
 @pytest.fixture
-def fitted_model(cognite_client):
+def fitted_model(cognite_beta_client):
     extid = "abc" + str(random.randint(1, 1000000000))
     try:
-        cognite_client.entity_matching.delete(external_id=extid)
+        cognite_beta_client.entity_matching.delete(external_id=extid)
     except CogniteAPIError as e:
         if e.code != 404:
             raise
     entities_from = [{"id": 1, "name": "xx-yy"}]
     entities_to = [{"id": 2, "bloop": "yy"}, {"id": 3, "bloop": "zz"}]
-    model = cognite_client.entity_matching.fit(
+    model = cognite_beta_client.entity_matching.fit(
         sources=entities_from,
         targets=entities_to,
         true_matches=[{"sourceId": 1, "targetId": 2}],
@@ -31,11 +31,11 @@ def fitted_model(cognite_client):
         external_id=extid,
     )
     yield model
-    cognite_client.entity_matching.delete(id=model.id)
+    cognite_beta_client.entity_matching.delete(id=model.id)
 
 
 class TestEntityMatchingIntegration:
-    def test_fit_retrieve_update(self, cognite_client, fitted_model):
+    def test_fit_retrieve_update(self, cognite_beta_client, fitted_model):
         assert isinstance(fitted_model, EntityMatchingModel)
         assert "Queued" == fitted_model.status
 
@@ -53,30 +53,30 @@ class TestEntityMatchingIntegration:
         assert "Completed" == job.status
 
         # Retrieve model
-        model = cognite_client.entity_matching.retrieve(id=fitted_model.id)
+        model = cognite_beta_client.entity_matching.retrieve(id=fitted_model.id)
         assert model.classifier == "randomforest"
         assert model.feature_type == "bigram"
         assert model.match_fields == [{"source": "name", "target": "bloop"}]
 
         # Retrieve models
-        models = cognite_client.entity_matching.retrieve_multiple(ids=[model.id, model.id])
+        models = cognite_beta_client.entity_matching.retrieve_multiple(ids=[model.id, model.id])
         assert 2 == len(models)
         assert model == models[0]
         assert model == models[1]
 
         # Update model
         model.name = "new_name"
-        updated_model = cognite_client.entity_matching.update(model)
+        updated_model = cognite_beta_client.entity_matching.update(model)
         assert type(updated_model) == EntityMatchingModel
         assert updated_model.name == "new_name"
 
-        updated_model2 = cognite_client.entity_matching.update(
+        updated_model2 = cognite_beta_client.entity_matching.update(
             EntityMatchingModelUpdate(id=model.id).description.set("new description")
         )
         assert type(updated_model2) == EntityMatchingModel
         assert updated_model2.description == "new description"
 
-    def test_refit(self, cognite_client, fitted_model):
+    def test_refit(self, cognite_beta_client, fitted_model):
         new_model = fitted_model.refit(true_matches=[(1, 3)])
         assert new_model.id is not None
         assert new_model.id != fitted_model.id
@@ -87,22 +87,22 @@ class TestEntityMatchingIntegration:
         job = new_model.predict(sources=[{"name": "foo-bar"}], targets=[{"bloop": "foo-42"}])
         assert {"matches", "source"} == set(job.result["items"][0].keys()) - {"matchFrom"}
         assert "Completed" == job.status
-        cognite_client.entity_matching.delete(id=new_model.id)
+        cognite_beta_client.entity_matching.delete(id=new_model.id)
 
-    def test_true_match_formats(self, cognite_client):
+    def test_true_match_formats(self, cognite_beta_client):
         entities_from = [{"id": 1, "name": "xx-yy"}]
         entities_to = [{"id": 2, "name": "yy"}, {"id": 3, "externalId": "aa", "name": "xx"}]
-        model = cognite_client.entity_matching.fit(
+        model = cognite_beta_client.entity_matching.fit(
             sources=entities_from, targets=entities_to, true_matches=[{"sourceId": 1, "targetExternalId": "aa"}, (1, 2)]
         )
         assert isinstance(model, EntityMatchingModel)
         assert "Queued" == model.status
-        cognite_client.entity_matching.delete(id=model.id)
+        cognite_beta_client.entity_matching.delete(id=model.id)
 
-    def test_extra_options(self, cognite_client):
+    def test_extra_options(self, cognite_beta_client):
         entities_from = [{"id": 1, "name": "xx-yy"}]
         entities_to = [{"id": 2, "name": "yy"}, {"id": 3, "name": "xx", "missing": "yy"}]
-        model = cognite_client.entity_matching.fit(
+        model = cognite_beta_client.entity_matching.fit(
             sources=entities_from,
             targets=entities_to,
             true_matches=[(1, 2)],
@@ -118,33 +118,35 @@ class TestEntityMatchingIntegration:
         job = model.predict()
         assert {"matches", "source"} == set(job.result["items"][0].keys()) - {"matchFrom"}
 
-        cognite_client.entity_matching.delete(id=model.id)
+        cognite_beta_client.entity_matching.delete(id=model.id)
 
-    def test_list(self, cognite_client):
-        models_list = cognite_client.entity_matching.list()
+    def test_list(self, cognite_beta_client):
+        models_list = cognite_beta_client.entity_matching.list()
         assert len(models_list) > 0
         assert type(models_list) == EntityMatchingModelList
         assert all([type(x) == EntityMatchingModel for x in models_list])
         # Add filter
-        models_list = cognite_client.entity_matching.list(feature_type="bigram")
+        models_list = cognite_beta_client.entity_matching.list(feature_type="bigram")
         assert set([model.feature_type for model in models_list]) == {"bigram"}
 
-    def test_list_jobs(self, cognite_client):
-        jobs_list = cognite_client.entity_matching.list_jobs()
+    def test_list_jobs(self, cognite_beta_client):
+        jobs_list = cognite_beta_client.entity_matching.list_jobs()
         assert len(jobs_list) > 0
         assert type(jobs_list) == ContextualizationJobList
         assert all([type(x) == ContextualizationJob for x in jobs_list])
 
-    def test_direct_predict(self, cognite_client, fitted_model):
-        job = cognite_client.entity_matching.predict(external_id=fitted_model.external_id)
-        job2 = cognite_client.entity_matching.predict(id=fitted_model.id)
+    def test_direct_predict(self, cognite_beta_client, fitted_model):
+        job = cognite_beta_client.entity_matching.predict(external_id=fitted_model.external_id)
+        job2 = cognite_beta_client.entity_matching.predict(id=fitted_model.id)
         assert isinstance(job, ContextualizationJob)
         assert "Queued" == job.status
         assert isinstance(job2, ContextualizationJob)
 
-    def test_direct_refit(self, cognite_client, fitted_model):
-        new_model = cognite_client.entity_matching.refit(external_id=fitted_model.external_id, true_matches=[(1, 3)])
-        new_model2 = cognite_client.entity_matching.refit(id=fitted_model.id, true_matches=[(1, 3)])
+    def test_direct_refit(self, cognite_beta_client, fitted_model):
+        new_model = cognite_beta_client.entity_matching.refit(
+            external_id=fitted_model.external_id, true_matches=[(1, 3)]
+        )
+        new_model2 = cognite_beta_client.entity_matching.refit(id=fitted_model.id, true_matches=[(1, 3)])
         assert isinstance(new_model, EntityMatchingModel)
         assert isinstance(new_model2, EntityMatchingModel)
-        cognite_client.entity_matching.delete(id=[new_model.id, new_model2.id])
+        cognite_beta_client.entity_matching.delete(id=[new_model.id, new_model2.id])

--- a/tests/tests_unit/conftest.py
+++ b/tests/tests_unit/conftest.py
@@ -1,10 +1,20 @@
 import pytest
 
 from cognite.client import ClientConfig, CogniteClient
+from cognite.client.beta import CogniteClient as CogniteBetaClient
 from cognite.client.credentials import APIKey
 
 
 @pytest.fixture(scope="module")
-def cognite_client():
-    cnf = ClientConfig(client_name="any", project="dummy", credentials=APIKey("bla"))
-    yield CogniteClient(cnf)
+def client_config() -> ClientConfig:
+    return ClientConfig(client_name="any", project="dummy", credentials=APIKey("bla"))
+
+
+@pytest.fixture(scope="module")
+def cognite_client(client_config: ClientConfig) -> CogniteClient:
+    yield CogniteClient(client_config)
+
+
+@pytest.fixture(scope="module")
+def cognite_beta_client(client_config: ClientConfig) -> CogniteBetaClient:
+    yield CogniteBetaClient(client_config)

--- a/tests/tests_unit/test_api/test_entity_matching.py
+++ b/tests/tests_unit/test_api/test_entity_matching.py
@@ -8,12 +8,12 @@ from tests.utils import jsgz_load
 
 
 @pytest.fixture
-def mock_fit(rsps, cognite_client):
+def mock_fit(rsps, cognite_beta_client):
     response_body = {"id": 123, "status": "Queued", "createdTime": 42}
     rsps.add(
         rsps.POST,
-        cognite_client.entity_matching._get_base_url_with_base_path()
-        + cognite_client.entity_matching._RESOURCE_PATH
+        cognite_beta_client.entity_matching._get_base_url_with_base_path()
+        + cognite_beta_client.entity_matching._RESOURCE_PATH
         + "/",
         status=200,
         json=response_body,
@@ -22,12 +22,12 @@ def mock_fit(rsps, cognite_client):
 
 
 @pytest.fixture
-def mock_status_ok(rsps, cognite_client):
+def mock_status_ok(rsps, cognite_beta_client):
     response_body = {"id": 123, "status": "Completed", "createdTime": 42, "statusTime": 456, "startTime": 789}
     rsps.add(
         rsps.GET,
         re.compile(
-            f"{cognite_client.entity_matching._get_base_url_with_base_path()}{cognite_client.entity_matching._RESOURCE_PATH}/\\d+"
+            f"{cognite_beta_client.entity_matching._get_base_url_with_base_path()}{cognite_beta_client.entity_matching._RESOURCE_PATH}/\\d+"
         ),
         status=200,
         json=response_body,
@@ -36,14 +36,14 @@ def mock_status_ok(rsps, cognite_client):
 
 
 @pytest.fixture
-def mock_retrieve(rsps, cognite_client):
+def mock_retrieve(rsps, cognite_beta_client):
     response_body = {
         "items": [{"id": 123, "status": "Completed", "createdTime": 42, "statusTime": 456, "startTime": 789}]
     }
     rsps.add(
         rsps.POST,
         re.compile(
-            f"{cognite_client.entity_matching._get_base_url_with_base_path()}{cognite_client.entity_matching._RESOURCE_PATH}/byids"
+            f"{cognite_beta_client.entity_matching._get_base_url_with_base_path()}{cognite_beta_client.entity_matching._RESOURCE_PATH}/byids"
         ),
         status=200,
         json=response_body,
@@ -52,12 +52,12 @@ def mock_retrieve(rsps, cognite_client):
 
 
 @pytest.fixture
-def mock_status_failed(rsps, cognite_client):
+def mock_status_failed(rsps, cognite_beta_client):
     response_body = {"id": 123, "status": "Failed", "errorMessage": "error message"}
     rsps.add(
         rsps.GET,
         re.compile(
-            f"{cognite_client.entity_matching._get_base_url_with_base_path()}{cognite_client.entity_matching._RESOURCE_PATH}/\\d+"
+            f"{cognite_beta_client.entity_matching._get_base_url_with_base_path()}{cognite_beta_client.entity_matching._RESOURCE_PATH}/\\d+"
         ),
         status=200,
         json=response_body,
@@ -66,12 +66,12 @@ def mock_status_failed(rsps, cognite_client):
 
 
 @pytest.fixture
-def mock_status_rules_ok(rsps, cognite_client):
+def mock_status_rules_ok(rsps, cognite_beta_client):
     response_body = {"jobId": 456, "status": "Completed", "items": [1]}
     rsps.add(
         rsps.GET,
         re.compile(
-            f"{cognite_client.entity_matching._get_base_url_with_base_path()}{cognite_client.entity_matching._RESOURCE_PATH}/rules/\\d+"
+            f"{cognite_beta_client.entity_matching._get_base_url_with_base_path()}{cognite_beta_client.entity_matching._RESOURCE_PATH}/rules/\\d+"
         ),
         status=200,
         json=response_body,
@@ -80,10 +80,10 @@ def mock_status_rules_ok(rsps, cognite_client):
 
 
 class TestEntityMatching:
-    def test_fit(self, cognite_client, mock_fit, mock_status_ok):
+    def test_fit(self, cognite_beta_client, mock_fit, mock_status_ok):
         entities_from = [{"id": 1, "name": "xx"}]
         entities_to = [{"id": 2, "name": "yy"}]
-        model = cognite_client.entity_matching.fit(
+        model = cognite_beta_client.entity_matching.fit(
             sources=entities_from, targets=entities_to, true_matches=[(1, 2)], feature_type="bigram"
         )
         assert isinstance(model, EntityMatchingModel)
@@ -119,11 +119,11 @@ class TestEntityMatching:
         assert 1 == n_fit_calls
         assert 1 == n_status_calls
 
-    def test_ml_fit(self, cognite_client, mock_fit, mock_status_ok):
+    def test_ml_fit(self, cognite_beta_client, mock_fit, mock_status_ok):
         # fit_ml should produce the same output as fit. Will eventually be removed
         entities_from = [{"id": 1, "name": "xx"}]
         entities_to = [{"id": 2, "name": "yy"}]
-        model = cognite_client.entity_matching.fit(
+        model = cognite_beta_client.entity_matching.fit(
             sources=entities_from, targets=entities_to, true_matches=[(1, 2)], feature_type="bigram"
         )
         assert isinstance(model, EntityMatchingModel)
@@ -133,10 +133,10 @@ class TestEntityMatching:
         assert "Completed" == model.status
         assert 123 == model.id
 
-    def test_fit_cognite_resource(self, cognite_client, mock_fit):
+    def test_fit_cognite_resource(self, cognite_beta_client, mock_fit):
         entities_from = [TimeSeries(id=1, name="x", metadata={"ka": "va"})]
         entities_to = [Asset(id=1, external_id="abc", name="x")]
-        cognite_client.entity_matching.fit(
+        cognite_beta_client.entity_matching.fit(
             sources=entities_from, targets=entities_to, true_matches=[(1, "abc")], feature_type="bigram"
         )
         assert {
@@ -152,10 +152,10 @@ class TestEntityMatching:
             "classifier": None,
         } == jsgz_load(mock_fit.calls[0].request.body)
 
-    def test_fit_fails(self, cognite_client, mock_fit, mock_status_failed):
+    def test_fit_fails(self, cognite_beta_client, mock_fit, mock_status_failed):
         entities_from = [{"id": 1, "name": "xx"}]
         entities_to = [{"id": 2, "name": "yy"}]
-        model = cognite_client.entity_matching.fit(sources=entities_from, targets=entities_to)
+        model = cognite_beta_client.entity_matching.fit(sources=entities_from, targets=entities_to)
         with pytest.raises(ModelFailedException) as exc_info:
             model.wait_for_completion()
         assert exc_info.type is ModelFailedException
@@ -163,8 +163,8 @@ class TestEntityMatching:
         assert "error message" == exc_info.value.error_message
         assert "EntityMatchingModel 123 failed with error 'error message'" == str(exc_info.value)
 
-    def test_retrieve(self, cognite_client, mock_retrieve):
-        model = cognite_client.entity_matching.retrieve(id=123)
+    def test_retrieve(self, cognite_beta_client, mock_retrieve):
+        model = cognite_beta_client.entity_matching.retrieve(id=123)
         assert isinstance(model, EntityMatchingModel)
         assert "Completed" == model.status
         assert 123 == model.id


### PR DESCRIPTION
## Description
This work fixes the  tests for the entity matcher and the diagrams api. Many of the endpoints in the mentioned APIs are in beta and since the Context API now actually check for `cdf-version` in the header, an error will be returned if the corresponding header value is not `beta`. The fix is to therefore use the beta client in the EM and diagrams integration tests.

## Checklist:
- [x] Tests added/updated.
- [x] Documentation updated. Documentation is generated from docstrings - these must be updated according to your change. 
  If a new method has been added it should be referenced in [cognite.rst](https://github.com/cognitedata/cognite-sdk-python/blob/master/docs/source/cognite.rst) in order to generate docs based on its docstring. 
- [x] Changelog updated in [CHANGELOG.md](https://github.com/cognitedata/cognite-sdk-python/blob/master/CHANGELOG.md).
- [x] Version bumped. If triggering a new release is desired, bump the version number in [_version.py](https://github.com/cognitedata/cognite-sdk-python/blob/master/cognite/client/_version.py) per [semantic versioning](https://semver.org/).
