### PR TITLE
[MLOPS-1227] Avoid opening a file for writing twice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@ Changes are grouped as follows
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
+## [4.5.3] - 2022-09-15
+### Fixed
+- Fixes the OS specific issue where the `requirements.txt`-validation failed 
+  with `Permission Denied` on Windows.
+
 ## [4.5.2] - 2022-09-09
 ### Fixed
 - Fixes the issue when updating transformations with new nonce credentials

--- a/cognite/client/_api/functions.py
+++ b/cognite/client/_api/functions.py
@@ -7,7 +7,7 @@ from inspect import getdoc, getsource
 from numbers import Integral, Number
 from pathlib import Path
 from tempfile import NamedTemporaryFile, TemporaryDirectory
-from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Sequence, Union, cast, IO
+from typing import IO, TYPE_CHECKING, Any, Callable, Dict, List, Optional, Sequence, Union, cast
 from zipfile import ZipFile
 
 from cognite.client import utils
@@ -443,7 +443,7 @@ class FunctionsAPI(APIClient):
                             reqs = _extract_requirements_from_file(path)
                             # Validate and format requirements
                             parsed_reqs = _validate_and_parse_requirements(reqs)
-                            with NamedTemporaryFile(mode='w+') as nth:
+                            with NamedTemporaryFile(mode="w+") as nth:
                                 _write_requirements_to_file(nth, parsed_reqs)
                                 # NOTE: the actual file is not written.
                                 # A temporary formatted file is used instead
@@ -477,7 +477,7 @@ class FunctionsAPI(APIClient):
                 f.write(source)
 
             # Read and validate requirements
-            with NamedTemporaryFile(mode='w+') as named_temp_file:
+            with NamedTemporaryFile(mode="w+") as named_temp_file:
                 requirements_written = _write_fn_docstring_requirements_to_file(function_handle, named_temp_file)
 
                 zip_path = os.path.join(tmpdir, "function.zip")

--- a/cognite/client/_api/functions.py
+++ b/cognite/client/_api/functions.py
@@ -444,7 +444,7 @@ class FunctionsAPI(APIClient):
                             # Validate and format requirements
                             parsed_reqs = _validate_and_parse_requirements(reqs)
                             with NamedTemporaryFile(mode="w+") as nth:
-                                _write_requirements_to_file(nth, parsed_reqs)
+                                _write_requirements_to_named_temp_file(nth, parsed_reqs)
                                 # NOTE: the actual file is not written.
                                 # A temporary formatted file is used instead
                                 zf.write(nth.name, arcname=REQUIREMENTS_FILE_NAME)
@@ -729,7 +729,7 @@ def _validate_and_parse_requirements(requirements: List[str]) -> List[str]:
     return parsed_reqs
 
 
-def _write_requirements_to_file(file: IO, requirements: List[str]) -> None:
+def _write_requirements_to_named_temp_file(file: IO, requirements: List[str]) -> None:
     if not file.closed:
         file.write("\n".join(requirements))
 
@@ -750,7 +750,7 @@ def _write_fn_docstring_requirements_to_file(fn: Callable, file: IO) -> bool:
         reqs = _extract_requirements_from_doc_string(docstr)
         if reqs:
             parsed_reqs = _validate_and_parse_requirements(reqs)
-            _write_requirements_to_file(file, parsed_reqs)
+            _write_requirements_to_named_temp_file(file, parsed_reqs)
             return True
 
     return False

--- a/cognite/client/_api/functions.py
+++ b/cognite/client/_api/functions.py
@@ -730,8 +730,7 @@ def _validate_and_parse_requirements(requirements: List[str]) -> List[str]:
 
 
 def _write_requirements_to_named_temp_file(file: IO, requirements: List[str]) -> None:
-    if not file.closed:
-        file.write("\n".join(requirements))
+    file.write("\n".join(requirements))
 
 
 def _write_fn_docstring_requirements_to_file(fn: Callable, file: IO) -> bool:

--- a/cognite/client/_version.py
+++ b/cognite/client/_version.py
@@ -1,2 +1,2 @@
-__version__ = "4.5.2"
+__version__ = "4.5.3"
 __api_subversion__ = "V20220125"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "cognite-sdk"
 
-version = "4.5.2"
+version = "4.5.3"
 
 description = "Cognite Python SDK"
 readme = "README.md"

--- a/tests/tests_unit/test_api/test_functions.py
+++ b/tests/tests_unit/test_api/test_functions.py
@@ -688,14 +688,14 @@ class TestRequirementsParser:
             """
             return None
 
-        with NamedTemporaryFile(mode='w+') as ntf:
+        with NamedTemporaryFile(mode="w+") as ntf:
             assert _write_fn_docstring_requirements_to_file(fn, ntf) is True
 
     def test_get_requirements_handle_error(self):
         def fn():
             return None
 
-        with NamedTemporaryFile(mode='w+') as ntf:
+        with NamedTemporaryFile(mode="w+") as ntf:
             assert _write_fn_docstring_requirements_to_file(fn, ntf) is False
 
     def test_get_requirements_handle_no_docstr(self):
@@ -708,7 +708,7 @@ class TestRequirementsParser:
             return None
 
         with pytest.raises(Exception):
-            with NamedTemporaryFile(mode='w+') as ntf:
+            with NamedTemporaryFile(mode="w+") as ntf:
                 assert _write_fn_docstring_requirements_to_file(fn, ntf) is False
 
     def test_get_requirements_handle_no_reqs(self):
@@ -719,7 +719,7 @@ class TestRequirementsParser:
             """
             return None
 
-        with NamedTemporaryFile(mode='w+') as ntf:
+        with NamedTemporaryFile(mode="w+") as ntf:
             assert _write_fn_docstring_requirements_to_file(fn, ntf) is False
 
     def test_extract_requirements_from_file(self, tmpdir):

--- a/tests/tests_unit/test_api/test_functions.py
+++ b/tests/tests_unit/test_api/test_functions.py
@@ -688,15 +688,15 @@ class TestRequirementsParser:
             """
             return None
 
-        with NamedTemporaryFile() as ntf:
-            assert _write_fn_docstring_requirements_to_file(fn, ntf.name) is True
+        with NamedTemporaryFile(mode='w+') as ntf:
+            assert _write_fn_docstring_requirements_to_file(fn, ntf) is True
 
     def test_get_requirements_handle_error(self):
         def fn():
             return None
 
-        with NamedTemporaryFile() as ntf:
-            assert _write_fn_docstring_requirements_to_file(fn, ntf.name) is False
+        with NamedTemporaryFile(mode='w+') as ntf:
+            assert _write_fn_docstring_requirements_to_file(fn, ntf) is False
 
     def test_get_requirements_handle_no_docstr(self):
         def fn():
@@ -708,8 +708,8 @@ class TestRequirementsParser:
             return None
 
         with pytest.raises(Exception):
-            with NamedTemporaryFile() as ntf:
-                assert _write_fn_docstring_requirements_to_file(fn, ntf.name) is False
+            with NamedTemporaryFile(mode='w+') as ntf:
+                assert _write_fn_docstring_requirements_to_file(fn, ntf) is False
 
     def test_get_requirements_handle_no_reqs(self):
         def fn():
@@ -719,8 +719,8 @@ class TestRequirementsParser:
             """
             return None
 
-        with NamedTemporaryFile() as ntf:
-            assert _write_fn_docstring_requirements_to_file(fn, ntf.name) is False
+        with NamedTemporaryFile(mode='w+') as ntf:
+            assert _write_fn_docstring_requirements_to_file(fn, ntf) is False
 
     def test_extract_requirements_from_file(self, tmpdir):
         req = "somepackage == 3.8.1"


### PR DESCRIPTION
## Description

The FunctionsAPI had an issue whereby we opened a file twice. This works on UNIX, not on Windows. 
The change proposed here is to simply open it once, and pass the open file handler around instead.

From the `NamedTemporaryFile`-docs: 
> Whether the name can be used to open the file a second time, while the named temporary file is still open, varies across platforms (it can be so used on Unix; it cannot on Windows).

## Checklist:
- [x] Tests added/updated.
- [ ] Documentation updated. Documentation is generated from docstrings - these must be updated according to your change. 
  If a new method has been added it should be referenced in [cognite.rst](https://github.com/cognitedata/cognite-sdk-python/blob/master/docs/source/cognite.rst) in order to generate docs based on its docstring. 
- [x] Changelog updated in [CHANGELOG.md](https://github.com/cognitedata/cognite-sdk-python/blob/master/CHANGELOG.md).
- [x] Version bumped. If triggering a new release is desired, bump the version number in [_version.py](https://github.com/cognitedata/cognite-sdk-python/blob/master/cognite/client/_version.py) per [semantic versioning](https://semver.org/).
