### PR TITLE
[Bugfix: functions] Remove validation of `requirements`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,12 @@ Changes are grouped as follows
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
+## [4.7.1] - 2022-09-29
+
+### Fixed
+- Fixed the `FunctionsAPI.create` method for Windows-users by removing 
+  validation of `requirements.txt`.
+
 ## [4.7.0] - 2022-09-28
 ### Added
 - Support `tags` on `transformations`.

--- a/cognite/client/_api/functions.py
+++ b/cognite/client/_api/functions.py
@@ -456,15 +456,25 @@ class FunctionsAPI(APIClient):
         # / is not allowed in file names
         name = name.replace("/", "-")
 
+        docstr_requirements = _get_fn_docstring_requirements(function_handle)
+
         with TemporaryDirectory() as tmpdir:
             handle_path = os.path.join(tmpdir, HANDLER_FILE_NAME)
             with open(handle_path, "w") as f:
                 source = getsource(function_handle)
                 f.write(source)
 
+            if docstr_requirements:
+                requirements_path = os.path.join(tmpdir, REQUIREMENTS_FILE_NAME)
+                with open(requirements_path, "w") as f:
+                    for req in docstr_requirements:
+                        f.write(f"{req}\n")
+
             zip_path = os.path.join(tmpdir, "function.zip")
             with ZipFile(zip_path, "w") as zf:
                 zf.write(handle_path, arcname=HANDLER_FILE_NAME)
+                if docstr_requirements:
+                    zf.write(requirements_path, arcname=REQUIREMENTS_FILE_NAME)
 
             overwrite = True if external_id else False
             file = cast(
@@ -711,15 +721,15 @@ def _write_requirements_to_named_temp_file(file: IO, requirements: List[str]) ->
     file.write("\n".join(requirements))
 
 
-def _write_fn_docstring_requirements_to_file(fn: Callable, file: IO) -> bool:
-    """Read requirements from a function docstring, validate them, and write contents to the provided file path
+def _get_fn_docstring_requirements(fn: Callable) -> List[str]:
+    """Read requirements from a function docstring, validate them and return.
 
     Args:
         fn (Callable): the function to read requirements from
         file_path (str): Path of file to write requirements to
 
     Returns:
-        bool: whether or not anything was written to the file
+        List[str]: A (possibly empty) list of requirements.
     """
     docstr = getdoc(fn)
 
@@ -727,10 +737,9 @@ def _write_fn_docstring_requirements_to_file(fn: Callable, file: IO) -> bool:
         reqs = _extract_requirements_from_doc_string(docstr)
         if reqs:
             parsed_reqs = _validate_and_parse_requirements(reqs)
-            _write_requirements_to_named_temp_file(file, parsed_reqs)
-            return True
+            return parsed_reqs
 
-    return False
+    return []
 
 
 class FunctionCallsAPI(APIClient):

--- a/cognite/client/_version.py
+++ b/cognite/client/_version.py
@@ -1,2 +1,2 @@
-__version__ = "4.7.0"
+__version__ = "4.7.1"
 __api_subversion__ = "V20220125"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "cognite-sdk"
 
-version = "4.7.0"
+version = "4.7.1"
 
 description = "Cognite Python SDK"
 readme = "README.md"

--- a/tests/tests_unit/test_api/test_functions.py
+++ b/tests/tests_unit/test_api/test_functions.py
@@ -9,9 +9,9 @@ from cognite.client import ClientConfig, CogniteClient
 from cognite.client._api.functions import (
     _extract_requirements_from_doc_string,
     _extract_requirements_from_file,
+    _get_fn_docstring_requirements,
     _using_client_credential_flow,
     _validate_and_parse_requirements,
-    _write_fn_docstring_requirements_to_file,
     validate_function_folder,
 )
 from cognite.client.credentials import APIKey, OAuthClientCredentials, Token
@@ -656,6 +656,83 @@ class TestFunctionsAPI:
         res = cognite_client.functions.status()
         assert isinstance(res, FunctionsStatus)
         assert mock_functions_status_response.calls[1].response.json() == res.dump(camel_case=True)
+
+
+class TestRequirementsParser:
+    """Test extraction of requirements.txt from docstring in handle-function"""
+
+    def test_validate_requirements(self):
+        parsed = _validate_and_parse_requirements(["asyncio==3.4.3", "numpy==1.23.0", "pandas==1.4.3"])
+        assert parsed == ["asyncio==3.4.3", "numpy==1.23.0", "pandas==1.4.3"]
+
+    def test_validate_requirements_error(self):
+        reqs = [["asyncio=3.4.3"], ["num py==1.23.0"], ["pandas==1.4.3 python_version=='3.8'"]]
+        for req in reqs:
+            with pytest.raises(Exception):
+                _validate_and_parse_requirements(req)
+
+    def test_get_requirements_handle(self):
+        def fn():
+            """
+            [requirements]
+            asyncio
+            [/requirements]
+            """
+            return None
+
+        assert _get_fn_docstring_requirements(fn) == ["asyncio"]
+
+    def test_get_requirements_handle_error(self):
+        def fn():
+            return None
+
+        assert _get_fn_docstring_requirements(fn) == []
+
+    def test_get_requirements_handle_no_docstr(self):
+        def fn():
+            """
+            [requirements]
+            asyncio=3.4.3
+            [/requirements]
+            """
+            return None
+
+        with pytest.raises(Exception):
+            _get_fn_docstring_requirements(fn)
+
+    def test_get_requirements_handle_no_reqs(self):
+        def fn():
+            """
+            [requirements]
+            [/requirements]
+            """
+            return None
+
+        assert _get_fn_docstring_requirements(fn) == []
+
+    def test_extract_requirements_from_file(self, tmpdir):
+        req = "somepackage == 3.8.1"
+        file = os.path.join(tmpdir, "requirements.txt")
+        with open(file, "w+") as f:
+            f.writelines("\n".join(["# this should not be included", "     " + req]))
+        reqs = _extract_requirements_from_file(file_name=file)
+        assert type(reqs) == list
+        assert len(reqs) == 1
+        assert req in reqs
+
+    def test_extract_requirements_from_doc_string(self):
+        req_mock = '[requirements]\nSomePackage==3.4.3, >3.4.1; python_version=="3.7"\nSomePackage==21.4.0; python_version=="3.7" and python_full_version<"3.0.0" or python_full_version>="3.5.0" and python_version>="3.7"\nSomePackage==2022.6.15; python_version>="3.8" and python_version<"4"\ncSomePackage==1.15.0; python_version>="3.6"\n[/requirements]\n'
+        doc_string_mock = "this should not be included\n" + req_mock + "neither should this\n"
+        expected = req_mock.splitlines()[1:-1]
+        assert _extract_requirements_from_doc_string(doc_string_mock) == expected
+
+    def test_extract_requirements_from_doc_string_empty(self):
+        doc_string = "[requirements]\n[/requirements]\n"
+        assert _extract_requirements_from_doc_string(doc_string) == []
+
+    def test_extract_requirements_from_doc_string_no_defined(self):
+        doc_string = "no requirements here"
+        assert _extract_requirements_from_doc_string(doc_string) is None
 
 
 @pytest.fixture


### PR DESCRIPTION
## Description

This validation code was, unfortunately, introducing OS-specific bugs for our users. Windows users were having issues with permissions when we were using `NamedTemporaryFiles` behind the scenes.

## Checklist:
- [x] Tests added/updated.
- [x] Documentation updated. Documentation is generated from docstrings - these must be updated according to your change. 
  If a new method has been added it should be referenced in [cognite.rst](https://github.com/cognitedata/cognite-sdk-python/blob/master/docs/source/cognite.rst) in order to generate docs based on its docstring. 
- [x] Changelog updated in [CHANGELOG.md](https://github.com/cognitedata/cognite-sdk-python/blob/master/CHANGELOG.md).
- [x] Version bumped. If triggering a new release is desired, bump the version number in [_version.py](https://github.com/cognitedata/cognite-sdk-python/blob/master/cognite/client/_version.py) per [semantic versioning](https://semver.org/).
