### PR TITLE
Add sequences.retrieve_latest and support extended expiry on file dl links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ Changes are grouped as follows
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
+## [4.10.0] - 2022-10-11
+### Added
+- Add `retrieve_latest` method to `cognite.client.sequences`
+
 ## [4.9.0] - 2022-10-10
 ### Added
 - Add support for extraction pipeline configuration files

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Changes are grouped as follows
 ## [4.10.0] - 2022-10-11
 ### Added
 - Add `retrieve_latest` method to `cognite.client.sequences`
+- Add support for extending the expiration time of download links returned by `cognite.client.files.retrieve_download_urls()`
 
 ## [4.9.0] - 2022-10-10
 ### Added

--- a/cognite/client/_api/files.py
+++ b/cognite/client/_api/files.py
@@ -710,7 +710,7 @@ class FilesAPI(APIClient):
         Args:
             id (Union[int, Sequence[int]]): Id or list of ids.
             external_id (Union[str, Sequence[str]]): External id or list of external ids.
-            extended_expiration (optional, bool): Extend exipration time of download url to 1 hour.
+            extended_expiration (bool): Extend expiration time of download url to 1 hour. Defaults to false.
 
         Returns:
             Dict[Union[str, int], str]: Dictionary containing download urls.

--- a/cognite/client/_api/sequences.py
+++ b/cognite/client/_api/sequences.py
@@ -723,8 +723,9 @@ class SequencesDataAPI(APIClient):
         """`Retrieves the last row (i.e the row with the highest row number) in a sequence. <https://docs.cognite.com/api/v1/#operation/getLatestSequenceRow>`_
 
         Args:
-            id (Union[int, List[int]]: Id or list of ids.
-            external_id (Union[str, List[str]): External id or list of external ids.
+            id (optional, int): Id or list of ids.
+            external_id (optional, str): External id or list of external ids.
+            column_external_ids: (optional, SequenceType[str]): external ids of columns to include. Omitting wil return all columns.
             before: (optional, int): Get latest datapoint before this row number.
 
         Returns:
@@ -732,7 +733,7 @@ class SequencesDataAPI(APIClient):
 
         Examples:
 
-            Getting the latest row in a sequence before key 1000::
+            Getting the latest row in a sequence before row number 1000::
 
                 >>> from cognite.client import CogniteClient
                 >>> c = CogniteClient()

--- a/cognite/client/_api/sequences.py
+++ b/cognite/client/_api/sequences.py
@@ -713,6 +713,37 @@ class SequencesDataAPI(APIClient):
         else:
             return SequenceDataList(results)
 
+    def retrieve_latest(
+        self,
+        id: int = None,
+        external_id: str = None,
+        column_external_ids: Optional[SequenceType[str]] = None,
+        before: int = None,
+    ) -> SequenceData:
+        """`Retrieves the last row (i.e the row with the highest row number) in a sequence. <https://docs.cognite.com/api/v1/#operation/getLatestSequenceRow>`_
+
+        Args:
+            id (Union[int, List[int]]: Id or list of ids.
+            external_id (Union[str, List[str]): External id or list of external ids.
+            before: (optional, int): Get latest datapoint before this row number.
+
+        Returns:
+            SequenceData: A Datapoints object containing the requested data, or a list of such objects.
+
+        Examples:
+
+            Getting the latest row in a sequence before key 1000::
+
+                >>> from cognite.client import CogniteClient
+                >>> c = CogniteClient()
+                >>> res = c.sequences.data.retrieve_latest(id=1, before=1000)
+        """
+        identifier = Identifier.of_either(id, external_id).as_dict()
+        res = self._do_request(
+            "POST", self._DATA_PATH + "/latest", json={**identifier, "before": before, "columns": column_external_ids}
+        ).json()
+        return SequenceData(id=res["id"], external_id=res.get("external_id"), rows=res["rows"], columns=res["columns"])
+
     def retrieve_dataframe(
         self,
         start: int,

--- a/cognite/client/_version.py
+++ b/cognite/client/_version.py
@@ -1,2 +1,2 @@
-__version__ = "4.9.0"
+__version__ = "4.10.0"
 __api_subversion__ = "V20220125"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "cognite-sdk"
 
-version = "4.9.0"
+version = "4.10.0"
 
 description = "Cognite Python SDK"
 readme = "README.md"

--- a/tests/tests_integration/test_api/test_files.py
+++ b/tests/tests_integration/test_api/test_files.py
@@ -125,6 +125,17 @@ class TestFilesAPI:
         assert download_links[f1.id].startswith("http")
         assert download_links[f2.external_id].startswith("http")
 
+    def test_retrieve_download_urls_with_extended_expiration(self, cognite_client):
+        f1 = cognite_client.files.upload_bytes(b"f1", external_id=random_string(10), name="bla")
+        f2 = cognite_client.files.upload_bytes(b"f2", external_id=random_string(10), name="bla")
+        time.sleep(0.5)
+        download_links = cognite_client.files.retrieve_download_urls(
+            id=f1.id, external_id=f2.external_id, extended_expiration=True
+        )
+        assert len(download_links.values()) == 2
+        assert download_links[f1.id].startswith("http")
+        assert download_links[f2.external_id].startswith("http")
+
     def test_list(self, cognite_client):
         res = cognite_client.files.list(limit=4)
         assert 4 == len(res)

--- a/tests/tests_integration/test_api/test_sequences_data.py
+++ b/tests/tests_integration/test_api/test_sequences_data.py
@@ -79,6 +79,10 @@ class TestSequencesDataAPI:
         assert isinstance(dps, SequenceData)
         assert len(dps) > 0
 
+    def test_retrieve_latest(self, cognite_client, small_sequence):
+        dps = cognite_client.sequences.data.retrieve_latest(id=small_sequence.id)
+        assert len(dps) == 1
+
     def test_retrieve_multi(self, cognite_client, small_sequence, pretend_timeseries):
         dps = cognite_client.sequences.data.retrieve(
             id=[small_sequence.id], external_id=pretend_timeseries.external_id, start=0, end=None


### PR DESCRIPTION
- Add retrieve_latest method to SequencesDataAPI
- Add support for extending expiration time of file download links
- Bump version to 4.10.0

## Description
Please describe the change you have made.

## Checklist:
- [ ] Tests added/updated.
- [ ] Documentation updated. Documentation is generated from docstrings - these must be updated according to your change. 
  If a new method has been added it should be referenced in [cognite.rst](https://github.com/cognitedata/cognite-sdk-python/blob/master/docs/source/cognite.rst) in order to generate docs based on its docstring. 
- [ ] Changelog updated in [CHANGELOG.md](https://github.com/cognitedata/cognite-sdk-python/blob/master/CHANGELOG.md).
- [ ] Version bumped. If triggering a new release is desired, bump the version number in [_version.py](https://github.com/cognitedata/cognite-sdk-python/blob/master/cognite/client/_version.py) per [semantic versioning](https://semver.org/).
