### PR TITLE
Geospatial - Partially stabilize compute endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ Changes are grouped as follows
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
+## [4.11.0] - 2022-10-17
+### Added
+- Add `compute` method to `cognite.client.geospatial`
+
 ## [4.10.0] - 2022-10-11
 ### Added
 - Add `retrieve_latest` method to `cognite.client.sequences`

--- a/cognite/client/_api/geospatial.py
+++ b/cognite/client/_api/geospatial.py
@@ -1176,6 +1176,6 @@ class GeospatialAPI(APIClient):
             "POST",
             url_path,
             timeout=self._config.timeout,
-            json={"output": output},
+            json={"output": {k: v.to_json_payload() for k, v in output.items()}},
         )
         return GeospatialComputedItemList._load(res.json())

--- a/cognite/client/_api/geospatial.py
+++ b/cognite/client/_api/geospatial.py
@@ -18,6 +18,7 @@ from cognite.client.data_classes.geospatial import (
     FeatureTypePatch,
     FeatureTypeUpdate,
     GeospatialComputedItemList,
+    GeospatialComputedResponse,
     GeospatialComputeFunction,
     OrderSpec,
     RasterMetadata,
@@ -1150,7 +1151,7 @@ class GeospatialAPI(APIClient):
     def compute(
         self,
         output: Dict[str, GeospatialComputeFunction],
-    ) -> GeospatialComputedItemList:
+    ) -> GeospatialComputedResponse:
         """`Compute`
         <https://docs.cognite.com/api/v1/#tag/Geospatial/operation/compute>
 
@@ -1178,4 +1179,5 @@ class GeospatialAPI(APIClient):
             timeout=self._config.timeout,
             json={"output": {k: v.to_json_payload() for k, v in output.items()}},
         )
-        return GeospatialComputedItemList._load(res.json())
+        json = res.json()
+        return GeospatialComputedResponse._load(json)

--- a/cognite/client/_api/geospatial.py
+++ b/cognite/client/_api/geospatial.py
@@ -1179,4 +1179,4 @@ class GeospatialAPI(APIClient):
             json={"output": {k: v.to_json_payload() for k, v in output.items()}},
         )
         json = res.json()
-        return GeospatialComputedResponse._load(json)
+        return GeospatialComputedResponse._load(json, cognite_client=self._cognite_client)

--- a/cognite/client/_api/geospatial.py
+++ b/cognite/client/_api/geospatial.py
@@ -17,6 +17,8 @@ from cognite.client.data_classes.geospatial import (
     FeatureTypeList,
     FeatureTypePatch,
     FeatureTypeUpdate,
+    GeospatialComputedItemList,
+    GeospatialComputeFunction,
     OrderSpec,
     RasterMetadata,
 )
@@ -41,6 +43,10 @@ class GeospatialAPI(APIClient):
             GeospatialAPI._feature_resource_path(feature_type_external_id)
             + f"/{encoded_feature_external_id}/rasters/{encoded_raster_property_name}"
         )
+
+    @staticmethod
+    def _compute_path() -> str:
+        return f"{GeospatialAPI._RESOURCE_PATH}/compute"
 
     @overload
     def create_feature_types(self, feature_type: FeatureType) -> FeatureType:
@@ -1140,3 +1146,36 @@ class GeospatialAPI(APIClient):
             },
         )
         return res.content
+
+    def compute(
+        self,
+        output: Dict[str, GeospatialComputeFunction],
+    ) -> GeospatialComputedItemList:
+        """`Compute`
+        <https://docs.cognite.com/api/v1/#tag/Geospatial/operation/compute>
+
+        Args:
+            output : Mapping of keys to compute functions.
+
+        Returns:
+            dict: Mapping of keys to computed items.
+
+        Examples:
+
+            Compute the transformation of an ewkt geometry from one SRID to another:
+
+                >>> from cognite.client import CogniteClient
+                >>> from cognite.client.data_classes.geospatial import GeospatialGeometryTransformComputeFunction, GeospatialGeometryValueComputeFunction
+                >>> c = CogniteClient()
+                >>> compute_function = GeospatialGeometryTransformComputeFunction(GeospatialGeometryValueComputeFunction("SRID=4326;POLYGON((0 0,10 0,10 10,0 10,0 0))"), srid=23031)
+                >>> compute_result = c.geospatial.compute(output = {"output": compute_function})
+        """
+        url_path = self._compute_path()
+
+        res = self._do_request(
+            "POST",
+            url_path,
+            timeout=self._config.timeout,
+            json={"output": output},
+        )
+        return GeospatialComputedItemList._load(res.json())

--- a/cognite/client/_api/geospatial.py
+++ b/cognite/client/_api/geospatial.py
@@ -17,7 +17,6 @@ from cognite.client.data_classes.geospatial import (
     FeatureTypeList,
     FeatureTypePatch,
     FeatureTypeUpdate,
-    GeospatialComputedItemList,
     GeospatialComputedResponse,
     GeospatialComputeFunction,
     OrderSpec,

--- a/cognite/client/_version.py
+++ b/cognite/client/_version.py
@@ -1,2 +1,2 @@
-__version__ = "4.10.0"
+__version__ = "4.11.0"
 __api_subversion__ = "V20220125"

--- a/docs/source/cognite.rst
+++ b/docs/source/cognite.rst
@@ -939,6 +939,10 @@ Get raster data
 ^^^^^^^^^^^^^^^
 .. automethod:: cognite.client._api.geospatial.GeospatialAPI.get_raster
 
+Compute
+^^^^^^^
+.. automethod:: cognite.client._api.geospatial.GeospatialAPI.compute
+
 Data classes
 ^^^^^^^^^^^^
 .. automodule:: cognite.client.data_classes.geospatial

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "cognite-sdk"
 
-version = "4.10.0"
+version = "4.11.0"
 
 description = "Cognite Python SDK"
 readme = "README.md"

--- a/tests/tests_integration/test_api/test_geospatial.py
+++ b/tests/tests_integration/test_api/test_geospatial.py
@@ -14,6 +14,8 @@ from cognite.client.data_classes.geospatial import (
     FeatureType,
     FeatureTypePatch,
     FeatureTypeUpdate,
+    GeospatialGeometryTransformComputeFunction,
+    GeospatialGeometryValueComputeFunction,
     OrderSpec,
     Patches,
     PropertyAndSearchSpec,
@@ -750,3 +752,16 @@ class TestGeospatialAPI:
         )
         assert res[0].external_id == test_feature_with_raster.external_id
         assert hasattr(res[0], "raster") is False
+
+    def test_compute_st_transform_geometry_value(self, cognite_client, test_crs):
+        compute_st_transform = GeospatialGeometryTransformComputeFunction(
+            GeospatialGeometryValueComputeFunction("SRID=4326;POLYGON((0 0,10 0,10 10,0 10,0 0))"), srid=test_crs.srid
+        )
+        res = cognite_client.geospatial.compute(
+            output={
+                "output": compute_st_transform,
+            }
+        )
+        assert len(res["items"]) == 1
+        assert res["items"][0]["output"]["srid"] == test_crs.srid
+        assert res["items"][0]["output"]["wkt"] == "POLYGON((0 0,10.5 0,10.5 10.5,0 10.5,0 0))"

--- a/tests/tests_integration/test_api/test_geospatial.py
+++ b/tests/tests_integration/test_api/test_geospatial.py
@@ -762,6 +762,7 @@ class TestGeospatialAPI:
                 "output": compute_st_transform,
             }
         )
-        assert len(res["items"]) == 1
-        assert res["items"][0]["output"]["srid"] == test_crs.srid
-        assert res["items"][0]["output"]["wkt"] == "POLYGON((0 0,10.5 0,10.5 10.5,0 10.5,0 0))"
+        items = res.items
+        assert len(items) == 1
+        assert items[0]["output"]["srid"] == test_crs.srid
+        assert items[0]["output"]["wkt"] == "POLYGON((0 0,10 0,10 10,0 10,0 0))"


### PR DESCRIPTION
## Description
Added a `compute` function to the geospatial part of the client, accepting a subset of available compute functions for output.

Tests will fail until https://github.com/cognitedata/coregis/pull/1893 is merged

## Checklist:
- [x] Tests added/updated.
- [x] Documentation updated. Documentation is generated from docstrings - these must be updated according to your change. 
  If a new method has been added it should be referenced in [cognite.rst](https://github.com/cognitedata/cognite-sdk-python/blob/master/docs/source/cognite.rst) in order to generate docs based on its docstring. 
- [x] Changelog updated in [CHANGELOG.md](https://github.com/cognitedata/cognite-sdk-python/blob/master/CHANGELOG.md).
- [x] Version bumped. If triggering a new release is desired, bump the version number in [_version.py](https://github.com/cognitedata/cognite-sdk-python/blob/master/cognite/client/_version.py) per [semantic versioning](https://semver.org/).
