### PR TITLE
Add missing API attributes to CogniteClientMock

### DIFF
--- a/cognite/client/testing.py
+++ b/cognite/client/testing.py
@@ -3,17 +3,42 @@ from typing import Any, Iterator
 from unittest.mock import MagicMock
 
 from cognite.client import CogniteClient
+from cognite.client._api.annotations import AnnotationsAPI
 from cognite.client._api.assets import AssetsAPI
 from cognite.client._api.data_sets import DataSetsAPI
-from cognite.client._api.datapoints import DatapointsAPI
+from cognite.client._api.datapoints import DatapointsAPI, SyntheticDatapointsAPI
+from cognite.client._api.diagrams import DiagramsAPI
+from cognite.client._api.entity_matching import EntityMatchingAPI
 from cognite.client._api.events import EventsAPI
+from cognite.client._api.extractionpipelines import (
+    ExtractionPipelineConfigsAPI,
+    ExtractionPipelineRunsAPI,
+    ExtractionPipelinesAPI,
+)
 from cognite.client._api.files import FilesAPI
-from cognite.client._api.iam import IAMAPI, APIKeysAPI, GroupsAPI, SecurityCategoriesAPI, ServiceAccountsAPI
+from cognite.client._api.functions import FunctionCallsAPI, FunctionsAPI, FunctionSchedulesAPI
+from cognite.client._api.geospatial import GeospatialAPI
+from cognite.client._api.iam import (
+    IAMAPI,
+    APIKeysAPI,
+    GroupsAPI,
+    SecurityCategoriesAPI,
+    ServiceAccountsAPI,
+    SessionsAPI,
+    TokenAPI,
+)
 from cognite.client._api.labels import LabelsAPI
 from cognite.client._api.login import LoginAPI
 from cognite.client._api.raw import RawAPI, RawDatabasesAPI, RawRowsAPI, RawTablesAPI
 from cognite.client._api.relationships import RelationshipsAPI
 from cognite.client._api.sequences import SequencesAPI, SequencesDataAPI
+from cognite.client._api.templates import (
+    TemplateGroupsAPI,
+    TemplateGroupVersionsAPI,
+    TemplateInstancesAPI,
+    TemplatesAPI,
+    TemplateViewsAPI,
+)
 from cognite.client._api.three_d import (
     ThreeDAPI,
     ThreeDAssetMappingAPI,
@@ -22,6 +47,14 @@ from cognite.client._api.three_d import (
     ThreeDRevisionsAPI,
 )
 from cognite.client._api.time_series import TimeSeriesAPI
+from cognite.client._api.transformations import (
+    TransformationJobsAPI,
+    TransformationNotificationsAPI,
+    TransformationsAPI,
+    TransformationSchedulesAPI,
+    TransformationSchemaAPI,
+)
+from cognite.client._api.vision import VisionAPI
 
 
 class CogniteClientMock(MagicMock):
@@ -35,31 +68,55 @@ class CogniteClientMock(MagicMock):
             super().__init__(*args, **kwargs)
             return
         super().__init__(spec=CogniteClient, *args, **kwargs)
-        self.time_series = MagicMock(spec_set=TimeSeriesAPI)
-        self.datapoints = MagicMock(spec_set=DatapointsAPI)
+        self.annotations = MagicMock(spec_set=AnnotationsAPI)
         self.assets = MagicMock(spec_set=AssetsAPI)
-        self.events = MagicMock(spec_set=EventsAPI)
         self.data_sets = MagicMock(spec_set=DataSetsAPI)
+        self.datapoints = MagicMock(spec=DatapointsAPI)
+        self.datapoints.synthetic = MagicMock(spec_set=SyntheticDatapointsAPI)
+        self.diagrams = MagicMock(spec_set=DiagramsAPI)
+        self.entity_matching = MagicMock(spec_set=EntityMatchingAPI)
+        self.events = MagicMock(spec_set=EventsAPI)
+        self.extraction_pipelines = MagicMock(spec=ExtractionPipelinesAPI)
+        self.extraction_pipelines.config = MagicMock(spec_set=ExtractionPipelineConfigsAPI)
+        self.extraction_pipelines.runs = MagicMock(spec_set=ExtractionPipelineRunsAPI)
         self.files = MagicMock(spec_set=FilesAPI)
-        self.labels = MagicMock(spec_set=LabelsAPI)
-        self.login = MagicMock(spec_set=LoginAPI)
-        self.three_d = MagicMock(spec=ThreeDAPI)
-        self.three_d.models = MagicMock(spec_set=ThreeDModelsAPI)
-        self.three_d.revisions = MagicMock(spec_set=ThreeDRevisionsAPI)
-        self.three_d.files = MagicMock(spec_set=ThreeDFilesAPI)
-        self.three_d.asset_mappings = MagicMock(spec_set=ThreeDAssetMappingAPI)
+        self.functions = MagicMock(spec=FunctionsAPI)
+        self.functions.calls = MagicMock(spec_set=FunctionCallsAPI)
+        self.functions.schedules = MagicMock(spec_set=FunctionSchedulesAPI)
+        self.geospatial = MagicMock(spec_set=GeospatialAPI)
         self.iam = MagicMock(spec=IAMAPI)
-        self.iam.service_accounts = MagicMock(spec=ServiceAccountsAPI)
         self.iam.api_keys = MagicMock(spec_set=APIKeysAPI)
         self.iam.groups = MagicMock(spec_set=GroupsAPI)
         self.iam.security_categories = MagicMock(spec_set=SecurityCategoriesAPI)
+        self.iam.service_accounts = MagicMock(spec=ServiceAccountsAPI)
+        self.iam.sessions = MagicMock(spec_set=SessionsAPI)
+        self.iam.token = MagicMock(spec_set=TokenAPI)
+        self.labels = MagicMock(spec_set=LabelsAPI)
+        self.login = MagicMock(spec_set=LoginAPI)
         self.raw = MagicMock(spec=RawAPI)
         self.raw.databases = MagicMock(spec_set=RawDatabasesAPI)
-        self.raw.tables = MagicMock(spec_set=RawTablesAPI)
         self.raw.rows = MagicMock(spec_set=RawRowsAPI)
+        self.raw.tables = MagicMock(spec_set=RawTablesAPI)
         self.relationships = MagicMock(spec_set=RelationshipsAPI)
         self.sequences = MagicMock(spec=SequencesAPI)
         self.sequences.data = MagicMock(spec_set=SequencesDataAPI)
+        self.templates = MagicMock(spec=TemplatesAPI)
+        self.templates.groups = MagicMock(spec_set=TemplateGroupsAPI)
+        self.templates.instances = MagicMock(spec_set=TemplateInstancesAPI)
+        self.templates.versions = MagicMock(spec_set=TemplateGroupVersionsAPI)
+        self.templates.views = MagicMock(spec_set=TemplateViewsAPI)
+        self.three_d = MagicMock(spec=ThreeDAPI)
+        self.three_d.asset_mappings = MagicMock(spec_set=ThreeDAssetMappingAPI)
+        self.three_d.files = MagicMock(spec_set=ThreeDFilesAPI)
+        self.three_d.models = MagicMock(spec_set=ThreeDModelsAPI)
+        self.three_d.revisions = MagicMock(spec_set=ThreeDRevisionsAPI)
+        self.time_series = MagicMock(spec_set=TimeSeriesAPI)
+        self.transformations = MagicMock(spec=TransformationsAPI)
+        self.transformations.jobs = MagicMock(spec_set=TransformationJobsAPI)
+        self.transformations.notifications = MagicMock(spec_set=TransformationNotificationsAPI)
+        self.transformations.schedules = MagicMock(spec_set=TransformationSchedulesAPI)
+        self.transformations.schema = MagicMock(spec_set=TransformationSchemaAPI)
+        self.vision = MagicMock(spec_set=VisionAPI)
 
 
 @contextmanager


### PR DESCRIPTION
## Description
When working with the extraction pipelines, we discovered that not all APIs were setup for mocking in the CogniteClientMock.

This adds the missing ones, and also re-sorts the list again to easier spot which are missing.
