### PR TITLE
Fix: Use named arg in Vision extract doc + improve error message in `VisionExtractJob.save_annotations`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ Changes are grouped as follows
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
+## [4.11.1] - 2022-11-08
+### Changed
+- Update doc for Vision extract method
+
 ## [4.11.0] - 2022-10-17
 ### Added
 - Add `compute` method to `cognite.client.geospatial`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Changes are grouped as follows
 ## [4.11.1] - 2022-11-08
 ### Changed
 - Update doc for Vision extract method
+- Improve error message in `VisionExtractJob.save_annotations`
 
 ## [4.11.0] - 2022-10-17
 ### Added

--- a/cognite/client/_version.py
+++ b/cognite/client/_version.py
@@ -1,2 +1,2 @@
-__version__ = "4.11.0"
+__version__ = "4.11.1"
 __api_subversion__ = "V20220125"

--- a/cognite/client/data_classes/contextualization.py
+++ b/cognite/client/data_classes/contextualization.py
@@ -699,10 +699,14 @@ class VisionExtractJob(VisionJob):
             Union[Annotation, AnnotationList]: (suggested) annotation(s) stored in CDF.
 
         """
-        annotations = self._predictions_to_annotations(
-            creating_user=creating_user, creating_app=creating_app, creating_app_version=creating_app_version
+        if self.status == JobStatus.COMPLETED.value:
+            annotations = self._predictions_to_annotations(
+                creating_user=creating_user, creating_app=creating_app, creating_app_version=creating_app_version
+            )
+            if annotations:
+                return self._cognite_client.annotations.suggest(annotations=annotations)
+            raise CogniteException("Extract job does not contain any predictions.")
+
+        raise CogniteException(
+            "Extract job is not completed. If the job is queued or running, wait for completion and try again"
         )
-        if annotations:
-            return self._cognite_client.annotations.suggest(annotations=annotations)
-        else:
-            raise CogniteException("Extract job is not completed. Wait for completion and try again")

--- a/docs/source/cognite.rst
+++ b/docs/source/cognite.rst
@@ -1147,7 +1147,7 @@ Tweaking the parameters of a feature extractor:
     >>> extract_job = c.vision.extract(
     ...     features=VisionFeature.TEXT_DETECTION,
     ...     file_ids=[1, 2],
-    ...     parameters=FeatureParameters(TextDetectionParameters(threshold=0.9))
+    ...     parameters=FeatureParameters(text_detection_parameters=TextDetectionParameters(threshold=0.9))
     ... )
 
 Extract

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "cognite-sdk"
 
-version = "4.11.0"
+version = "4.11.1"
 
 description = "Cognite Python SDK"
 readme = "README.md"


### PR DESCRIPTION
## Description
* Use named arg in Vision extract doc
* Improve error message in save_predictions
* Add tests for `VisionExtractJob.save_annotations`

## Checklist:
- [x] Tests added/updated.
- [x] Documentation updated. Documentation is generated from docstrings - these must be updated according to your change. 
  If a new method has been added it should be referenced in [cognite.rst](https://github.com/cognitedata/cognite-sdk-python/blob/master/docs/source/cognite.rst) in order to generate docs based on its docstring. 
- [x] Changelog updated in [CHANGELOG.md](https://github.com/cognitedata/cognite-sdk-python/blob/master/CHANGELOG.md).
- [x] Version bumped. If triggering a new release is desired, bump the version number in [_version.py](https://github.com/cognitedata/cognite-sdk-python/blob/master/cognite/client/_version.py) per [semantic versioning](https://semver.org/).
