### PR TITLE
do not be strict about number of detected tags in a diagram test

### DIFF
--- a/tests/tests_integration/test_api/test_diagrams.py
+++ b/tests/tests_integration/test_api/test_diagrams.py
@@ -16,7 +16,7 @@ class TestPNIDParsingIntegration:
         assert isinstance(job.items[0], DiagramDetectItem)
         assert isinstance(job[PNID_FILE_ID], DiagramDetectItem)
 
-        assert 2 == len(job[PNID_FILE_ID].annotations)
+        assert 1 < len(job[PNID_FILE_ID].annotations)
         for annotation in job[PNID_FILE_ID].annotations:
             assert 1 == annotation["region"]["page"]
 


### PR DESCRIPTION
## Description
An integration test is failing since the OCR cache was wiped. The test assumes 2 detections, but we now get 3. The test should not be asserting the exact number of tags detected by the algorithm, but that the sdk works. Asserting >1 detection now, since not detecting at least 2 would be a deterioration of the algorithm. Also, the third detection is only possible since the test searches for few entities, and YI-96122 is detected as YT-96122. Strictly not correct, but expected behaviour when YI-96122 is not searched for.



## Checklist:
- [x] Tests added/updated.
- [ ] ~~Documentation updated. Documentation is generated from docstrings - these must be updated according to your change.~~ 
  ~~If a new method has been added it should be referenced in [cognite.rst](https://github.com/cognitedata/cognite-sdk-python/blob/master/docs/source/cognite.rst) in order to generate docs based on its docstring.~~
- [ ] ~~Changelog updated in [CHANGELOG.md](https://github.com/cognitedata/cognite-sdk-python/blob/master/CHANGELOG.md).~~
- [ ] ~~Version bumped. If triggering a new release is desired, bump the version number in [_version.py](https://github.com/cognitedata/cognite-sdk-python/blob/master/cognite/client/_version.py) per [semantic versioning](https://semver.org/).~~