### PR TITLE
WIP: Add datapoints.delete method for improved dps delete support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ Changes are grouped as follows
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
+## [4.11.2] - 2022-11-08
+### Fixed
+- Add support for deleting single datapoint with datapoints.delete_point.
+
 ## [4.11.1] - 2022-11-08
 ### Changed
 - Update doc for Vision extract method

--- a/cognite/client/_version.py
+++ b/cognite/client/_version.py
@@ -1,2 +1,2 @@
-__version__ = "4.11.1"
+__version__ = "4.11.2"
 __api_subversion__ = "V20220125"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "cognite-sdk"
 
-version = "4.11.1"
+version = "4.11.2"
 
 description = "Cognite Python SDK"
 readme = "README.md"

--- a/tests/tests_unit/test_api/test_datapoints.py
+++ b/tests/tests_unit/test_api/test_datapoints.py
@@ -703,6 +703,25 @@ def mock_delete_datapoints(rsps, cognite_client):
 
 
 class TestDeleteDatapoints:
+    def test_delete_point(self, cognite_client, mock_delete_datapoints):
+        res = cognite_client.datapoints.delete_point({"id": 1, "timestamp": 1})
+        assert res is None
+        assert {"items": [{"id": 1, "inclusiveBegin": 1, "exclusiveEnd": 2}]} == jsgz_load(
+            mock_delete_datapoints.calls[0].request.body
+        )
+
+    def test_delete_points(self, cognite_client, mock_delete_datapoints):
+        res = cognite_client.datapoints.delete_point(
+            [{"id": 1, "timestamp": 1}, {"externalId": "abc", "timestamp": 10}]
+        )
+        assert res is None
+        assert {
+            "items": [
+                {"id": 1, "inclusiveBegin": 1, "exclusiveEnd": 2},
+                {"externalId": "abc", "inclusiveBegin": 10, "exclusiveEnd": 11},
+            ]
+        } == jsgz_load(mock_delete_datapoints.calls[0].request.body)
+
     def test_delete_range(self, cognite_client, mock_delete_datapoints):
         res = cognite_client.datapoints.delete_range(start=datetime(2018, 1, 1), end=datetime(2018, 1, 2), id=1)
         assert res is None


### PR DESCRIPTION
Wanna make this just datapoints.delete() instead. And that can accept timestamps and ranges, as well as Datapoint and Datapoints objects. Then we'll deprecate the other ones in V5 and remove in V6.