### PR TITLE
Remove 'Examples' section from docs landing page

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -34,7 +34,3 @@ Contents
 ^^^^^^^^
 .. toctree::
    cognite
-
-Examples
-^^^^^^^^
-For a collection of scripts and Jupyter Notebooks that explain how to perform various tasks in Cognite Data Fusion (CDF) using Python, see the GitHub repository `here <https://github.com/  cognitedata/cognite-python-docs>`__.


### PR DESCRIPTION
The repo it links to is archived and only has very outdated examples.

## Description
Please describe the change you have made.

## Checklist:
- [ ] Tests added/updated.
- [ ] Documentation updated. Documentation is generated from docstrings - these must be updated according to your change. 
  If a new method has been added it should be referenced in [cognite.rst](https://github.com/cognitedata/cognite-sdk-python/blob/master/docs/source/cognite.rst) in order to generate docs based on its docstring. 
- [ ] Changelog updated in [CHANGELOG.md](https://github.com/cognitedata/cognite-sdk-python/blob/master/CHANGELOG.md).
- [ ] Version bumped. If triggering a new release is desired, bump the version number in [_version.py](https://github.com/cognitedata/cognite-sdk-python/blob/master/cognite/client/_version.py) per [semantic versioning](https://semver.org/).
