### PR TITLE
Two v5-bugfixes: `DatapointsArray.dump` and synthetic dps `to_pandas`

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -3,7 +3,7 @@ Please describe the change you have made.
 
 ## Checklist:
 - [ ] Tests added/updated.
-- [ ] Documentation updated. Documentation is generated from docstrings - these must be updated according to your change. 
-  If a new method has been added it should be referenced in [cognite.rst](https://github.com/cognitedata/cognite-sdk-python/blob/master/docs/source/cognite.rst) in order to generate docs based on its docstring. 
+- [ ] Documentation updated. Documentation is generated from docstrings - these must be updated according to your change.
+  If a new method has been added it should be referenced in [cognite.rst](https://github.com/cognitedata/cognite-sdk-python/blob/master/docs/source/cognite.rst) in order to generate docs based on its docstring.
 - [ ] Changelog updated in [CHANGELOG.md](https://github.com/cognitedata/cognite-sdk-python/blob/master/CHANGELOG.md).
-- [ ] Version bumped. If triggering a new release is desired, bump the version number in [_version.py](https://github.com/cognitedata/cognite-sdk-python/blob/master/cognite/client/_version.py) per [semantic versioning](https://semver.org/).
+- [ ] Version bumped. If triggering a new release is desired, bump the version number in [_version.py](https://github.com/cognitedata/cognite-sdk-python/blob/master/cognite/client/_version.py) and [pyproject.toml](https://github.com/cognitedata/cognite-sdk-python/blob/master/pyproject.toml) per [semantic versioning](https://semver.org/).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,12 @@ Changes are grouped as follows
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
+## [5.0.1] - 07-12-22
+### Fixed
+- `DatapointsArray.dump` would return timestamps in nanoseconds instead of milliseconds when `convert_timestamps=False`.
+- Converting a `Datapoints` object coming from a synthetic datapoints query to a `pandas.DataFrame` would, when passed `include_errors=True`, starting in version `5.0.0`, erroneously cast the `error` column to a numeric data type and sort it *before* the returned values. Both of these behaviours have been reverted.
+- Several documentation issues: Missing methods, wrong descriptions through inheritance and some pure visual/aesthetic.
+
 ## [5.0.0] - 06-12-22
 ### Improved
 - Greatly increased speed of datapoints fetching (new adaptable implementation and change from `JSON` to `protobuf`), especially when asking for... (measured in fetched `dps/sec` using the new `retrieve_arrays` method, with default settings for concurrency):
@@ -42,6 +48,8 @@ Changes are grouped as follows
 - New optional dependency, `numpy`.
 - A new datapoints fetching method, `retrieve_arrays`, that loads data directly into NumPy arrays for improved speed and *much* lower memory usage.
 - These arrays are stored in the new resource types `DatapointsArray` with corresponding container (list) type, `DatapointsArrayList` which offer much more efficient memory usage. `DatapointsArray` also offer zero-overhead pandas-conversion.
+- `DatapointsAPI.insert` now also accepts `DatapointsArray`. It also does basic error checking like making sure the number of datapoints match the number of timestamps, and that it contains raw datapoints (as opposed to aggregate data which raises an error). This also applies to `Datapoints` input.
+- `DatapointsAPI.insert_multiple` now accepts `Datapoints` and `DatapointsArray` as part of the (possibly) multiple inputs. Applies the same error checking as `insert`.
 
 ### Changed
 - Datapoints are no longer fetched using `JSON`: the age of `protobuf` has begun.

--- a/cognite/client/_api/datapoints.py
+++ b/cognite/client/_api/datapoints.py
@@ -553,10 +553,11 @@ class DatapointsAPI(APIClient):
     ) -> Union[None, Datapoints, DatapointsList]:
         """`Retrieve datapoints for one or more time series. <https://docs.cognite.com/api/v1/#operation/getMultiTimeSeriesDatapoints>`_
 
-        **Performance guide:**:
-            1. In order to retrieve millions of datapoints as efficiently as possible, with the least memory overhead, consider using `retrieve_arrays(...)` which instead uses `numpy.ndarrays` for data storage.
-            2. Try to avoid specifying a large finite `limit` (e.g. 1 million is bad) as the retrieve performance will (likely) take a hit.
-            3. Try to avoid specifying `start` and `end` to be very far from the actual data, e.g. if you have data from 2000 to 2015, don't set start=0 (1970).
+        **Performance guide**:
+            In order to retrieve millions of datapoints as efficiently as possible, here are a few guidelines:
+            1. For best speed, and significantly lower memory usage, consider using `retrieve_arrays(...)` which uses `numpy.ndarrays` for data storage.
+            2. Unlimited queries are fastest as they are trivial to parallelize. Thus, specifying a very large finite `limit`, e.g. 1 million, comes with a performance penalty.
+            3. Try to avoid specifying `start` and `end` to be very far from the actual data: If you have data from 2000 to 2015, don't set start=0 (1970).
 
         Args:
             start (Union[int, str, datetime, None]): Inclusive start. Default: 1970-01-01 UTC.
@@ -1033,14 +1034,15 @@ class DatapointsAPI(APIClient):
                 ...     {"timestamp": 150000000000, "value": 1000},
                 ...     {"timestamp": 160000000000, "value": 2000},
                 ... ]
-                >>> c.time_series.data.insert(datapoints, external_id="def")
+                >>> c.time_series.data.insert(datapoints, external_id="abcd")
 
             Or they can be a Datapoints or DatapointsArray object (with raw datapoints only). Note that the id or external_id
-            set on these objects are not inspected/used, and so you must explicitly pass the identifier of the time series
-            you want to insert into, which in this example is external_id="def"::
+            set on these objects are not inspected/used (as they belong to the "from-time-series", and not the "to-time-series"),
+            and so you must explicitly pass the identifier of the time series you want to insert into, which in this example is
+            `external_id="efgh"`::
 
                 >>> data = c.time_series.data.retrieve(external_id="abc", start="1w-ago", end="now")
-                >>> c.time_series.data.insert(data, external_id="def")
+                >>> c.time_series.data.insert(data, external_id="efgh")
         """
         post_dps_object = Identifier.of_either(id, external_id).as_dict()
         dps_to_post: Union[
@@ -1060,8 +1062,7 @@ class DatapointsAPI(APIClient):
         """`Insert datapoints into multiple time series <https://docs.cognite.com/api/v1/#operation/postMultiTimeSeriesDatapoints>`_
 
         Args:
-            datapoints (List[Dict]): The datapoints you wish to insert along with the ids of the time series.
-                See examples below.
+            datapoints (List[Dict]): The datapoints you wish to insert along with the ids of the time series. See examples below.
 
         Returns:
             None

--- a/cognite/client/_api/files.py
+++ b/cognite/client/_api/files.py
@@ -563,6 +563,7 @@ class FilesAPI(APIClient):
                 >>> res = c.files.upload("/path/to/file", name="my_file", labels=[Label(external_id="WELL LOG")])
 
             Upload a file with a geo_location::
+
                 >>> from cognite.client import CogniteClient
                 >>> from cognite.client.data_classes import GeoLocation, Geometry
                 >>> c = CogniteClient()

--- a/cognite/client/_api/templates.py
+++ b/cognite/client/_api/templates.py
@@ -343,7 +343,7 @@ class TemplateInstancesAPI(APIClient):
             Union[TemplateInstance, TemplateInstanceList]: Created template instance(s).
 
         Examples:
-            create new template instances for Covid-19 spread:
+            Create new template instances for Covid-19 spread:
 
                 >>> from cognite.client import CogniteClient
                 >>> from cognite.client.data_classes import TemplateInstance
@@ -378,15 +378,15 @@ class TemplateInstancesAPI(APIClient):
         Will overwrite existing instances.
 
         Args:
-         external_id (str): The external id of the template group.
-         version (int): The version of the template group to create instances for.
-         instances (Union[TemplateInstance, Sequence[TemplateInstance]]): The instances to create.
+            external_id (str): The external id of the template group.
+            version (int): The version of the template group to create instances for.
+            instances (Union[TemplateInstance, Sequence[TemplateInstance]]): The instances to create.
 
         Returns:
-         Union[TemplateInstance, TemplateInstanceList]: Created template instance(s).
+            Union[TemplateInstance, TemplateInstanceList]: Created template instance(s).
 
         Examples:
-         create new template instances for Covid-19 spread:
+            Create new template instances for Covid-19 spread:
 
              >>> from cognite.client import CogniteClient
              >>> from cognite.client.data_classes import TemplateInstance

--- a/cognite/client/_version.py
+++ b/cognite/client/_version.py
@@ -1,2 +1,2 @@
-__version__ = "5.0.0"
+__version__ = "5.0.1"
 __api_subversion__ = "V20220125"

--- a/cognite/client/data_classes/datapoints.py
+++ b/cognite/client/data_classes/datapoints.py
@@ -593,7 +593,8 @@ class Datapoints(CogniteResource):
         return truncated_datapoints
 
     def _repr_html_(self) -> str:
-        return self.to_pandas(include_errors=True)._repr_html_()
+        is_synthetic_dps = self.error is not None
+        return self.to_pandas(include_errors=is_synthetic_dps)._repr_html_()
 
 
 class DatapointsArrayList(CogniteResourceList):

--- a/cognite/client/data_classes/time_series.py
+++ b/cognite/client/data_classes/time_series.py
@@ -95,7 +95,7 @@ class TimeSeries(CogniteResource):
 
         identifier = Identifier.load(self.id, self.external_id).as_dict()
         dps = self._cognite_client.time_series.data.retrieve(
-            **identifier, start=MIN_TIMESTAMP_MS, end=MAX_TIMESTAMP_MS, aggregates=["count"], granularity="100d"
+            **identifier, start=MIN_TIMESTAMP_MS, end=MAX_TIMESTAMP_MS, aggregates="count", granularity="100d"
         )
         return sum(dps.count)
 

--- a/cognite/client/testing.py
+++ b/cognite/client/testing.py
@@ -118,7 +118,6 @@ class CogniteClientMock(MagicMock):
 
         self.sequences = MagicMock(spec=SequencesAPI)
         self.sequences.data = MagicMock(spec_set=SequencesDataAPI)
-        self.diagrams = MagicMock(spec_set=DiagramsAPI)
 
         self.templates = MagicMock(spec=TemplatesAPI)
         self.templates.groups = MagicMock(spec_set=TemplateGroupsAPI)

--- a/docs/source/cognite.rst
+++ b/docs/source/cognite.rst
@@ -1178,6 +1178,7 @@ Upsert Template instances
 .. automethod:: cognite.client._api.templates.TemplateInstancesAPI.upsert
 
 Update Template instances
+^^^^^^^^^^^^^^^^^^^^^^^^^
 .. automethod:: cognite.client._api.templates.TemplateInstancesAPI.update
 
 Retrieve Template instances

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "cognite-sdk"
 
-version = "5.0.0"
+version = "5.0.1"
 
 description = "Cognite Python SDK"
 readme = "README.md"


### PR DESCRIPTION
Invisible ninja bugs prior to v5 release 🥷 

1. Fix bug in DatapointsArray.dump that returned ns instead of ms.    
2. Fix bug that erroneously cast string error-column to float when converting synthetic dps to pandas.    
3. Fix merge error in `cognite/client/testing.py` (duplicate line)
4. Address several minor documentation issues.

## Checklist:
- [ ] Tests added/updated 👀 
- [x] Documentation updated. Documentation is generated from docstrings - these must be updated according to your change. 
  If a new method has been added it should be referenced in [cognite.rst](https://github.com/cognitedata/cognite-sdk-python/blob/master/docs/source/cognite.rst) in order to generate docs based on its docstring. 
- [x] Changelog updated in [CHANGELOG.md](https://github.com/cognitedata/cognite-sdk-python/blob/master/CHANGELOG.md).
- [x] Version bumped. If triggering a new release is desired, bump the version number in [_version.py](https://github.com/cognitedata/cognite-sdk-python/blob/master/cognite/client/_version.py) per [semantic versioning](https://semver.org/).
