### PR TITLE
Support new max timestamp (end of 2099)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ Changes are grouped as follows
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
+## [5.0.2] - 15-12-22
+### Changed
+- The valid time range for datapoints has been increased to support timestamps up to end of the year 2099 in the TimeSeriesAPI. The utility function `ms_to_datetime` has been updated accordingly.
+
 ## [5.0.1] - 07-12-22
 ### Fixed
 - `DatapointsArray.dump` would return timestamps in nanoseconds instead of milliseconds when `convert_timestamps=False`.

--- a/cognite/client/_version.py
+++ b/cognite/client/_version.py
@@ -1,2 +1,2 @@
-__version__ = "5.0.1"
+__version__ = "5.0.2"
 __api_subversion__ = "V20220125"

--- a/cognite/client/utils/_time.py
+++ b/cognite/client/utils/_time.py
@@ -7,8 +7,8 @@ from typing import Dict, List, Optional, Tuple, Union
 UNIT_IN_MS_WITHOUT_WEEK = {"s": 1000, "m": 60000, "h": 3600000, "d": 86400000}
 UNIT_IN_MS = {**UNIT_IN_MS_WITHOUT_WEEK, "w": 604800000}
 
-MIN_TIMESTAMP_MS = -2208988800000
-MAX_TIMESTAMP_MS = 2556143999999
+MIN_TIMESTAMP_MS = -2208988800000  # 1900-01-01 00:00:00.000
+MAX_TIMESTAMP_MS = 4102444799999  # 2099-12-31 23:59:59.999
 
 
 def datetime_to_ms(dt: datetime) -> int:
@@ -24,10 +24,13 @@ def datetime_to_ms(dt: datetime) -> int:
 
 
 def ms_to_datetime(ms: Union[int, float]) -> datetime:
-    """Converts milliseconds since epoch to datetime object.
+    """Converts valid Cognite timestamps, i.e. milliseconds since epoch, to datetime object.
 
     Args:
         ms (Union[int, float]): Milliseconds since epoch.
+
+    Raises:
+        ValueError: On invalid Cognite timestamps.
 
     Returns:
         datetime: Aware datetime object in UTC.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "cognite-sdk"
 
-version = "5.0.1"
+version = "5.0.2"
 
 description = "Cognite Python SDK"
 readme = "README.md"

--- a/tests/tests_integration/test_api/test_datapoints.py
+++ b/tests/tests_integration/test_api/test_datapoints.py
@@ -676,7 +676,7 @@ class TestRetrieveAggregateDatapointsAPI:
             end = random.randint(start, -31536000000)  # start -> 1969
         else:  # after last dp
             start = random.randint(31536000000, 2524608000000)  # 1971 -> 2050
-            end = random.randint(start, MAX_TIMESTAMP_MS)  # start -> (2051 minus 1ms)
+            end = random.randint(start, MAX_TIMESTAMP_MS)  # start -> (2100 minus 1ms)
         granularities = (
             f"{random.randint(1, 15)}d",
             f"{random.randint(1, 50)}h",

--- a/tests/tests_unit/test_utils/test_time.py
+++ b/tests/tests_unit/test_utils/test_time.py
@@ -46,19 +46,22 @@ class TestDatetimeToMs:
         assert datetime_to_ms(datetime(2018, 1, 31, 11, 11, 11, tzinfo=utc)) == 1517397071000
         assert datetime_to_ms(datetime(100, 1, 31, tzinfo=utc)) == -59008867200000
 
-    def test_ms_to_datetime(self):
+    def test_ms_to_datetime__valid_input(self):  # TODO: Many tests here could benefit from parametrize
         utc = timezone.utc
         assert ms_to_datetime(1517356800000) == datetime(2018, 1, 31, tzinfo=utc)
         assert ms_to_datetime(1517397071000) == datetime(2018, 1, 31, 11, 11, 11, tzinfo=utc)
         assert ms_to_datetime(MIN_TIMESTAMP_MS) == datetime(1900, 1, 1, 0, 0, tzinfo=utc)
-        assert ms_to_datetime(MAX_TIMESTAMP_MS) == datetime(2050, 12, 31, 23, 59, 59, 999000, tzinfo=utc)
-        with pytest.raises(
-            ValueError,
-            match=re.escape("Input ms=-59008867200000 does not satisfy: -2208988800000 <= ms <= 2556143999999"),
-        ):
-            ms_to_datetime(-59008867200000)
+        assert ms_to_datetime(MAX_TIMESTAMP_MS) == datetime(2099, 12, 31, 23, 59, 59, 999000, tzinfo=utc)
+
+    def test_ms_to_datetime__bad_input(self):
         with pytest.raises(TypeError):
             ms_to_datetime(None)
+        err_msg = "Input ms={} does not satisfy: -2208988800000 <= ms <= 4102444799999"
+        too_low, too_high = MIN_TIMESTAMP_MS - 1, MAX_TIMESTAMP_MS + 1
+        with pytest.raises(ValueError, match=re.escape(err_msg.format(too_low))):
+            ms_to_datetime(too_low)
+        with pytest.raises(ValueError, match=re.escape(err_msg.format(too_high))):
+            ms_to_datetime(too_high)
 
 
 class TestTimestampToMs:
@@ -80,7 +83,7 @@ class TestTimestampToMs:
             assert 1514764800000 == timestamp_to_ms(datetime(2018, 1, 1))
             assert 1546300800000 == timestamp_to_ms(datetime(2019, 1, 1))
             assert MIN_TIMESTAMP_MS == timestamp_to_ms(datetime(1900, 1, 1))
-            assert MAX_TIMESTAMP_MS == timestamp_to_ms(datetime(2051, 1, 1)) - 1
+            assert MAX_TIMESTAMP_MS == timestamp_to_ms(datetime(2100, 1, 1)) - 1
 
     def test_float(self):
         assert 1514760000000 == timestamp_to_ms(1514760000000.0)


### PR DESCRIPTION
<img width="568" alt="Screenshot 2022-12-15 at 13 43 45" src="https://user-images.githubusercontent.com/8521241/207862388-06bf8c1c-c33d-49fe-8019-8a77d2823471.png">

Issue: https://cognitedata.atlassian.net/browse/CDF-17290

## Checklist:
- [x] Tests added/updated.
- [x] Documentation updated. Documentation is generated from docstrings - these must be updated according to your change.
  If a new method has been added it should be referenced in [cognite.rst](https://github.com/cognitedata/cognite-sdk-python/blob/master/docs/source/cognite.rst) in order to generate docs based on its docstring.
- [x] Changelog updated in [CHANGELOG.md](https://github.com/cognitedata/cognite-sdk-python/blob/master/CHANGELOG.md).
- [x] Version bumped. If triggering a new release is desired, bump the version number in [_version.py](https://github.com/cognitedata/cognite-sdk-python/blob/master/cognite/client/_version.py) and [pyproject.toml](https://github.com/cognitedata/cognite-sdk-python/blob/master/pyproject.toml) per [semantic versioning](https://semver.org/).
