### PR TITLE
Add flake8 plugin `pep8-naming`

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -10,3 +10,5 @@ ignore =
     E501,
     # Line break before binary operator
     W503,
+    # Error suffix in exception names (exceptions)
+    N818,

--- a/cognite/client/_api/extractionpipelines.py
+++ b/cognite/client/_api/extractionpipelines.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any, Dict, Optional, Sequence, Union, overload
+from typing import Any, Dict, Optional, Sequence, Union, cast, overload
 
 from cognite.client import utils
 from cognite.client._api_client import APIClient
@@ -153,7 +153,10 @@ class ExtractionPipelinesAPI(APIClient):
                 >>> res = c.extraction_pipelines.create(extpipes)
         """
         # TODO: Remove support for old argument name in major version 6
-        extraction_pipeline = handle_deprecated_camel_case_argument(extraction_pipeline, "extractionPipeline", "create", kwargs)
+        extraction_pipeline = cast(
+            Union[ExtractionPipeline, Sequence[ExtractionPipeline]],
+            handle_deprecated_camel_case_argument(extraction_pipeline, "extractionPipeline", "create", kwargs),
+        )
         utils._auxiliary.assert_type(extraction_pipeline, "extraction_pipeline", [ExtractionPipeline, Sequence])
         return self._create_multiple(
             list_cls=ExtractionPipelineList, resource_cls=ExtractionPipeline, items=extraction_pipeline

--- a/cognite/client/_api/extractionpipelines.py
+++ b/cognite/client/_api/extractionpipelines.py
@@ -16,6 +16,7 @@ from cognite.client.data_classes import (
     TimestampRange,
 )
 from cognite.client.data_classes.extractionpipelines import StringFilter
+from cognite.client.utils._auxiliary import handle_deprecated_camel_case_argument
 from cognite.client.utils._identifier import IdentifierSequence
 
 
@@ -117,22 +118,26 @@ class ExtractionPipelinesAPI(APIClient):
         return self._list(list_cls=ExtractionPipelineList, resource_cls=ExtractionPipeline, method="GET", limit=limit)
 
     @overload
-    def create(self, extractionPipeline: ExtractionPipeline) -> ExtractionPipeline:
+    def create(self, extraction_pipeline: ExtractionPipeline, **kwargs: Dict[str, Any]) -> ExtractionPipeline:
         ...
 
     @overload
-    def create(self, extractionPipeline: Sequence[ExtractionPipeline]) -> ExtractionPipelineList:
+    def create(
+        self, extraction_pipeline: Sequence[ExtractionPipeline], **kwargs: Dict[str, Any]
+    ) -> ExtractionPipelineList:
         ...
 
     def create(
-        self, extractionPipeline: Union[ExtractionPipeline, Sequence[ExtractionPipeline]]
+        self,
+        extraction_pipeline: Union[ExtractionPipeline, Sequence[ExtractionPipeline]] = None,
+        **kwargs: Dict[str, Any],
     ) -> Union[ExtractionPipeline, ExtractionPipelineList]:
         """`Create one or more extraction pipelines. <https://docs.cognite.com/api/v1/#operation/createExtPipes>`_
 
-        You can create an arbitrary number of extraction pipeline, and the SDK will split the request into multiple requests if necessary.
+        You can create an arbitrary number of extraction pipelines, and the SDK will split the request into multiple requests if necessary.
 
         Args:
-            extractionPipeline (Union[ExtractionPipeline, List[ExtractionPipeline]]): Extraction pipeline or list of extraction pipelines to create.
+            extraction_pipeline (Union[ExtractionPipeline, List[ExtractionPipeline]]): Extraction pipeline or list of extraction pipelines to create.
 
         Returns:
             Union[ExtractionPipeline, ExtractionPipelineList]: Created extraction pipeline(s)
@@ -147,9 +152,11 @@ class ExtractionPipelinesAPI(APIClient):
                 >>> extpipes = [ExtractionPipeline(name="extPipe1",...), ExtractionPipeline(name="extPipe2",...)]
                 >>> res = c.extraction_pipelines.create(extpipes)
         """
-        utils._auxiliary.assert_type(extractionPipeline, "extraction_pipeline", [ExtractionPipeline, Sequence])
+        # TODO: Remove support for old argument name in major version 6
+        extraction_pipeline = handle_deprecated_camel_case_argument(extraction_pipeline, "extractionPipeline", "create", kwargs)
+        utils._auxiliary.assert_type(extraction_pipeline, "extraction_pipeline", [ExtractionPipeline, Sequence])
         return self._create_multiple(
-            list_cls=ExtractionPipelineList, resource_cls=ExtractionPipeline, items=extractionPipeline
+            list_cls=ExtractionPipelineList, resource_cls=ExtractionPipeline, items=extraction_pipeline
         )
 
     def delete(self, id: Union[int, Sequence[int]] = None, external_id: Union[str, Sequence[str]] = None) -> None:

--- a/cognite/client/_api_client.py
+++ b/cognite/client/_api_client.py
@@ -178,7 +178,7 @@ class APIClient:
             res = self._http_client.request(method=method, url=full_url, **kwargs)
 
         if not self._status_ok(res.status_code):
-            self._raise_API_error(res, payload=json_payload)
+            self._raise_api_error(res, payload=json_payload)
         stream = kwargs.get("stream")
         self._log_request(res, payload=json_payload, stream=stream)
         return res
@@ -813,7 +813,7 @@ class APIClient:
         return status_code in {200, 201, 202, 204}
 
     @classmethod
-    def _raise_API_error(cls, res: Response, payload: Dict) -> NoReturn:
+    def _raise_api_error(cls, res: Response, payload: Dict) -> NoReturn:
         x_request_id = res.headers.get("X-Request-Id")
         code = res.status_code
         missing = None

--- a/cognite/client/_http_client.py
+++ b/cognite/client/_http_client.py
@@ -155,13 +155,13 @@ class HTTPClient:
 
     @classmethod
     def _any_exception_in_context_isinstance(
-        cls, exc: BaseException, T: Union[Tuple[Type[BaseException], ...], Type[BaseException]]
+        cls, exc: BaseException, exc_types: Union[Tuple[Type[BaseException], ...], Type[BaseException]]
     ) -> bool:
         """requests does not use the "raise ... from ..." syntax, so we need to access the underlying exceptions using
         the __context__ attribute.
         """
-        if isinstance(exc, T):
+        if isinstance(exc, exc_types):
             return True
         if exc.__context__ is None:
             return False
-        return cls._any_exception_in_context_isinstance(exc.__context__, T)
+        return cls._any_exception_in_context_isinstance(exc.__context__, exc_types)

--- a/cognite/client/data_classes/_base.py
+++ b/cognite/client/data_classes/_base.py
@@ -443,8 +443,8 @@ class CogniteFilter:
     @classmethod
     def _load(cls: Type[T_CogniteFilter], resource: Union[Dict, str]) -> T_CogniteFilter:
         if isinstance(resource, str):
-            return cls._load(json.loads(resource))
-        elif isinstance(resource, Dict):
+            resource = json.loads(resource)
+        if isinstance(resource, Dict):
             instance = cls()
             for key, value in resource.items():
                 snake_case_key = to_snake_case(key)

--- a/cognite/client/data_classes/_base.py
+++ b/cognite/client/data_classes/_base.py
@@ -443,8 +443,8 @@ class CogniteFilter:
     @classmethod
     def _load(cls: Type[T_CogniteFilter], resource: Union[Dict, str]) -> T_CogniteFilter:
         if isinstance(resource, str):
-            resource = json.loads(resource)
-        if isinstance(resource, Dict):
+            return cls._load(json.loads(resource))
+        elif isinstance(resource, Dict):
             instance = cls()
             for key, value in resource.items():
                 snake_case_key = to_snake_case(key)

--- a/cognite/client/data_classes/labels.py
+++ b/cognite/client/data_classes/labels.py
@@ -102,8 +102,8 @@ class Label(dict):
         return [convert_label(label) for label in labels]
 
     @classmethod
-    def _load(self, raw_label: Dict[str, Any]) -> Label:
-        return Label(external_id=raw_label["externalId"])
+    def _load(cls, raw_label: Dict[str, Any]) -> Label:
+        return cls(external_id=raw_label["externalId"])
 
     def dump(self, camel_case: bool = False) -> Dict[str, Any]:
         return convert_all_keys_to_camel_case(self) if camel_case else dict(self)

--- a/cognite/client/data_classes/relationships.py
+++ b/cognite/client/data_classes/relationships.py
@@ -45,6 +45,8 @@ class Relationship(CogniteResource):
         cognite_client (CogniteClient): The client to associate with this object.
     """
 
+    _RESOURCE_TYPES = frozenset({"asset", "timeseries", "file", "event", "sequence"})
+
     def __init__(
         self,
         external_id: str = None,
@@ -85,10 +87,8 @@ class Relationship(CogniteResource):
         self._validate_resource_type(rel.target_type)
         return rel
 
-    @staticmethod
-    def _validate_resource_type(resource_type: Optional[str]) -> None:
-        _RESOURCE_TYPES = {"asset", "timeseries", "file", "event", "sequence"}
-        if resource_type is None or resource_type.lower() not in _RESOURCE_TYPES:
+    def _validate_resource_type(self, resource_type: Optional[str]) -> None:
+        if resource_type is None or resource_type.lower() not in self._RESOURCE_TYPES:
             raise TypeError(f"Invalid source or target '{resource_type}' in relationship")
 
     @classmethod

--- a/cognite/client/data_classes/shared.py
+++ b/cognite/client/data_classes/shared.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
-from typing import Any, Dict, List, Union
+from typing import Any, Dict, List, Literal, Union
 
 from cognite.client.data_classes._base import CognitePropertyClassUtil
-from cognite.client.utils._auxiliary import convert_all_keys_to_camel_case
+from cognite.client.utils._auxiliary import convert_all_keys_to_camel_case, handle_deprecated_camel_case_argument
 
 
 class TimestampRange(dict):
@@ -101,9 +101,6 @@ class Geometry(dict):
                 Each Point is defined as an array of 2 numbers, representing coordinates of a point in 2D space.
 
                 Example: `[[[[30, 20], [45, 40], [10, 40], [30, 20]]], [[[15, 5], [40, 10], [10, 20], [5, 10], [15, 5]]]]`
-
-
-
     """
 
     def __init__(self, type: str, coordinates: List):
@@ -117,8 +114,8 @@ class Geometry(dict):
     coordinates = CognitePropertyClassUtil.declare_property("coordinates")
 
     @classmethod
-    def _load(self, raw_geometry: Dict[str, Any]) -> Geometry:
-        return Geometry(type=raw_geometry["type"], coordinates=raw_geometry["coordinates"])
+    def _load(cls, raw_geometry: Dict[str, Any]) -> Geometry:
+        return cls(type=raw_geometry["type"], coordinates=raw_geometry["coordinates"])
 
     def dump(self, camel_case: bool = False) -> Dict[str, Any]:
         return convert_all_keys_to_camel_case(self) if camel_case else dict(self)
@@ -131,8 +128,12 @@ class GeometryFilter(dict):
           coordinates (List): An array of the coordinates of the geometry. The structure of the elements in this array is determined by the type of geometry.
     """
 
-    def __init__(self, type: str, coordinates: List):
-        valid_types = ["Point", "LineString", "MultiLineString", "Polygon", "MultiPolygon"]
+    def __init__(
+        self,
+        type: Literal["Point", "LineString", "MultiLineString", "Polygon", "MultiPolygon"],
+        coordinates: List,
+    ):
+        valid_types = {"Point", "LineString", "MultiLineString", "Polygon", "MultiPolygon"}
         if type not in valid_types:
             raise ValueError("type must be one of " + str(valid_types))
         self.type = type
@@ -150,7 +151,7 @@ class GeoLocation(dict):
           properties (object): Optional additional properties in a String key -> Object value format.
     """
 
-    def __init__(self, type: str, geometry: Geometry, properties: dict = None):
+    def __init__(self, type: Literal["Feature"], geometry: Geometry, properties: dict = None):
         if type != "Feature":
             raise ValueError("Only the 'Feature' type is supported.")
         self.type = type
@@ -162,11 +163,13 @@ class GeoLocation(dict):
     properties = CognitePropertyClassUtil.declare_property("properties")
 
     @classmethod
-    def _load(self, raw_geoLocation: Dict[str, Any]) -> GeoLocation:
-        return GeoLocation(
-            type=raw_geoLocation.get("type", "Feature"),
-            geometry=raw_geoLocation["geometry"],
-            properties=raw_geoLocation.get("properties"),
+    def _load(cls, raw_geo_location: Dict[str, Any] = None, **kwargs: Dict[str, Any]) -> GeoLocation:
+        # TODO: Remove support for old argument name in major version 6
+        raw_geo_location = handle_deprecated_camel_case_argument(raw_geo_location, "raw_geoLocation", "_load", kwargs)
+        return cls(
+            type=raw_geo_location.get("type", "Feature"),
+            geometry=raw_geo_location["geometry"],
+            properties=raw_geo_location.get("properties"),
         )
 
     def dump(self, camel_case: bool = False) -> Dict[str, Any]:
@@ -188,8 +191,12 @@ class GeoLocationFilter(dict):
     shape = CognitePropertyClassUtil.declare_property("shape")
 
     @classmethod
-    def _load(self, raw_geoLocation_filter: Dict[str, Any]) -> GeoLocationFilter:
-        return GeoLocationFilter(relation=raw_geoLocation_filter["relation"], shape=raw_geoLocation_filter["shape"])
+    def _load(cls, raw_geo_location_filter: Dict[str, Any] = None, **kwargs: Dict[str, Any]) -> GeoLocationFilter:
+        # TODO: Remove support for old argument name in major version 6
+        raw_geo_location_filter = handle_deprecated_camel_case_argument(
+            raw_geo_location_filter, "raw_geoLocation_filter", "_load", kwargs
+        )
+        return cls(relation=raw_geo_location_filter["relation"], shape=raw_geo_location_filter["shape"])
 
     def dump(self, camel_case: bool = False) -> Dict[str, Any]:
         return convert_all_keys_to_camel_case(self) if camel_case else dict(self)

--- a/cognite/client/data_classes/transformations/__init__.py
+++ b/cognite/client/data_classes/transformations/__init__.py
@@ -487,7 +487,7 @@ class TransformationFilter(CogniteFilter):
         self.tags = tags
 
     @classmethod
-    def _load(self, resource: Union[Dict, str]) -> TransformationFilter:
+    def _load(cls, resource: Union[Dict, str]) -> TransformationFilter:
         instance = super()._load(resource)
         if isinstance(resource, Dict):
             if instance.created_time is not None:

--- a/cognite/client/data_classes/transformations/jobs.py
+++ b/cognite/client/data_classes/transformations/jobs.py
@@ -177,8 +177,8 @@ class TransformationJob(CogniteResource):
             TransformationJobStatus.FAILED,
             TransformationJobStatus.COMPLETED,
         ]:
-            toWait = min(timeout - waited, polling_interval)
-            time.sleep(toWait)
+            to_wait = min(timeout - waited, polling_interval)
+            time.sleep(to_wait)
             self.update()
             waited += polling_interval
 
@@ -238,8 +238,8 @@ class TransformationJob(CogniteResource):
             TransformationJobStatus.FAILED,
             TransformationJobStatus.COMPLETED,
         ]:
-            toWait = min(timeout - waited, polling_interval)
-            await asyncio.sleep(toWait)
+            to_wait = min(timeout - waited, polling_interval)
+            await asyncio.sleep(to_wait)
             self.update()
             waited += polling_interval
 

--- a/cognite/client/utils/_auxiliary.py
+++ b/cognite/client/utils/_auxiliary.py
@@ -54,14 +54,17 @@ def basic_obj_dump(obj: Any, camel_case: bool) -> Dict[str, Any]:
     return convert_all_keys_to_snake_case(vars(obj))
 
 
-def handle_deprecated_camel_case_argument(new_arg: T, old_arg_name: str, kw_dct: Dict[str, Any]) -> T:
+def handle_deprecated_camel_case_argument(new_arg: T, old_arg_name: str, fn_name: str, kw_dct: Dict[str, Any]) -> T:
     old_arg = kw_dct.pop(old_arg_name, None)
     if kw_dct:
         raise TypeError(f"Got unexpected keyword argument(s): {list(kw_dct)}")
-    if old_arg is None:
-        return new_arg
 
     new_arg_name = to_snake_case(old_arg_name)
+    if old_arg is None:
+        if new_arg is None:
+            raise TypeError(f"{fn_name}() missing 1 required positional argument: '{new_arg_name}'")
+        return new_arg
+
     warnings.warn(
         f"Argument '{old_arg_name}' have been changed to '{new_arg_name}', but the old is still supported until "
         "the next major version. Consider updating your code.",

--- a/cognite/client/utils/_time.py
+++ b/cognite/client/utils/_time.py
@@ -108,17 +108,19 @@ def timestamp_to_ms(timestamp: Union[int, float, str, datetime]) -> int:
     return ms
 
 
+TIME_ATTRIBUTES = {
+    "start_time",
+    "end_time",
+    "last_updated_time",
+    "created_time",
+    "timestamp",
+    "scheduled_execution_time",
+    "source_created_time",
+    "source_modified_time",
+}
+
+
 def _convert_time_attributes_in_dict(item: Dict) -> Dict:
-    TIME_ATTRIBUTES = {
-        "start_time",
-        "end_time",
-        "last_updated_time",
-        "created_time",
-        "timestamp",
-        "scheduled_execution_time",
-        "source_created_time",
-        "source_modified_time",
-    }
     new_item = {}
     for k, v in item.items():
         if k in TIME_ATTRIBUTES:

--- a/poetry.lock
+++ b/poetry.lock
@@ -48,14 +48,14 @@ pytz = ">=2015.7"
 
 [[package]]
 name = "bleach"
-version = "5.0.1"
+version = "6.0.0"
 description = "An easy safelist-based HTML-sanitizing tool."
 category = "dev"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "bleach-5.0.1-py3-none-any.whl", hash = "sha256:085f7f33c15bd408dd9b17a4ad77c577db66d76203e5984b1bd59baeee948b2a"},
-    {file = "bleach-5.0.1.tar.gz", hash = "sha256:0d03255c47eb9bd2f26aa9bb7f2107732e7e8fe195ca2f64709fcf3b0a4a085c"},
+    {file = "bleach-6.0.0-py3-none-any.whl", hash = "sha256:33c16e3353dbd13028ab4799a0f89a83f113405c766e9c122df8a06f5b85b3f4"},
+    {file = "bleach-6.0.0.tar.gz", hash = "sha256:1a1a85c1595e07d8db14c5f09f09e6433502c51c595970edc090551f0db99414"},
 ]
 
 [package.dependencies]
@@ -64,7 +64,6 @@ webencodings = "*"
 
 [package.extras]
 css = ["tinycss2 (>=1.1.0,<1.2)"]
-dev = ["Sphinx (==4.3.2)", "black (==22.3.0)", "build (==0.8.0)", "flake8 (==4.0.1)", "hashin (==0.17.0)", "mypy (==0.961)", "pip-tools (==6.6.2)", "pytest (==7.1.2)", "tox (==3.25.0)", "twine (==4.0.1)", "wheel (==0.37.1)"]
 
 [[package]]
 name = "certifi"
@@ -330,63 +329,63 @@ files = [
 
 [[package]]
 name = "coverage"
-version = "7.0.5"
+version = "7.1.0"
 description = "Code coverage measurement for Python"
 category = "dev"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "coverage-7.0.5-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:2a7f23bbaeb2a87f90f607730b45564076d870f1fb07b9318d0c21f36871932b"},
-    {file = "coverage-7.0.5-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:c18d47f314b950dbf24a41787ced1474e01ca816011925976d90a88b27c22b89"},
-    {file = "coverage-7.0.5-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ef14d75d86f104f03dea66c13188487151760ef25dd6b2dbd541885185f05f40"},
-    {file = "coverage-7.0.5-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:66e50680e888840c0995f2ad766e726ce71ca682e3c5f4eee82272c7671d38a2"},
-    {file = "coverage-7.0.5-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a9fed35ca8c6e946e877893bbac022e8563b94404a605af1d1e6accc7eb73289"},
-    {file = "coverage-7.0.5-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:d8d04e755934195bdc1db45ba9e040b8d20d046d04d6d77e71b3b34a8cc002d0"},
-    {file = "coverage-7.0.5-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:7e109f1c9a3ece676597831874126555997c48f62bddbcace6ed17be3e372de8"},
-    {file = "coverage-7.0.5-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:0a1890fca2962c4f1ad16551d660b46ea77291fba2cc21c024cd527b9d9c8809"},
-    {file = "coverage-7.0.5-cp310-cp310-win32.whl", hash = "sha256:be9fcf32c010da0ba40bf4ee01889d6c737658f4ddff160bd7eb9cac8f094b21"},
-    {file = "coverage-7.0.5-cp310-cp310-win_amd64.whl", hash = "sha256:cbfcba14a3225b055a28b3199c3d81cd0ab37d2353ffd7f6fd64844cebab31ad"},
-    {file = "coverage-7.0.5-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:30b5fec1d34cc932c1bc04017b538ce16bf84e239378b8f75220478645d11fca"},
-    {file = "coverage-7.0.5-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:1caed2367b32cc80a2b7f58a9f46658218a19c6cfe5bc234021966dc3daa01f0"},
-    {file = "coverage-7.0.5-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d254666d29540a72d17cc0175746cfb03d5123db33e67d1020e42dae611dc196"},
-    {file = "coverage-7.0.5-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:19245c249aa711d954623d94f23cc94c0fd65865661f20b7781210cb97c471c0"},
-    {file = "coverage-7.0.5-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7b05ed4b35bf6ee790832f68932baf1f00caa32283d66cc4d455c9e9d115aafc"},
-    {file = "coverage-7.0.5-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:29de916ba1099ba2aab76aca101580006adfac5646de9b7c010a0f13867cba45"},
-    {file = "coverage-7.0.5-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:e057e74e53db78122a3979f908973e171909a58ac20df05c33998d52e6d35757"},
-    {file = "coverage-7.0.5-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:411d4ff9d041be08fdfc02adf62e89c735b9468f6d8f6427f8a14b6bb0a85095"},
-    {file = "coverage-7.0.5-cp311-cp311-win32.whl", hash = "sha256:52ab14b9e09ce052237dfe12d6892dd39b0401690856bcfe75d5baba4bfe2831"},
-    {file = "coverage-7.0.5-cp311-cp311-win_amd64.whl", hash = "sha256:1f66862d3a41674ebd8d1a7b6f5387fe5ce353f8719040a986551a545d7d83ea"},
-    {file = "coverage-7.0.5-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:b69522b168a6b64edf0c33ba53eac491c0a8f5cc94fa4337f9c6f4c8f2f5296c"},
-    {file = "coverage-7.0.5-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:436e103950d05b7d7f55e39beeb4d5be298ca3e119e0589c0227e6d0b01ee8c7"},
-    {file = "coverage-7.0.5-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b8c56bec53d6e3154eaff6ea941226e7bd7cc0d99f9b3756c2520fc7a94e6d96"},
-    {file = "coverage-7.0.5-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7a38362528a9115a4e276e65eeabf67dcfaf57698e17ae388599568a78dcb029"},
-    {file = "coverage-7.0.5-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:f67472c09a0c7486e27f3275f617c964d25e35727af952869dd496b9b5b7f6a3"},
-    {file = "coverage-7.0.5-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:220e3fa77d14c8a507b2d951e463b57a1f7810a6443a26f9b7591ef39047b1b2"},
-    {file = "coverage-7.0.5-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:ecb0f73954892f98611e183f50acdc9e21a4653f294dfbe079da73c6378a6f47"},
-    {file = "coverage-7.0.5-cp37-cp37m-win32.whl", hash = "sha256:d8f3e2e0a1d6777e58e834fd5a04657f66affa615dae61dd67c35d1568c38882"},
-    {file = "coverage-7.0.5-cp37-cp37m-win_amd64.whl", hash = "sha256:9e662e6fc4f513b79da5d10a23edd2b87685815b337b1a30cd11307a6679148d"},
-    {file = "coverage-7.0.5-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:790e4433962c9f454e213b21b0fd4b42310ade9c077e8edcb5113db0818450cb"},
-    {file = "coverage-7.0.5-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:49640bda9bda35b057b0e65b7c43ba706fa2335c9a9896652aebe0fa399e80e6"},
-    {file = "coverage-7.0.5-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d66187792bfe56f8c18ba986a0e4ae44856b1c645336bd2c776e3386da91e1dd"},
-    {file = "coverage-7.0.5-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:276f4cd0001cd83b00817c8db76730938b1ee40f4993b6a905f40a7278103b3a"},
-    {file = "coverage-7.0.5-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:95304068686545aa368b35dfda1cdfbbdbe2f6fe43de4a2e9baa8ebd71be46e2"},
-    {file = "coverage-7.0.5-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:17e01dd8666c445025c29684d4aabf5a90dc6ef1ab25328aa52bedaa95b65ad7"},
-    {file = "coverage-7.0.5-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:ea76dbcad0b7b0deb265d8c36e0801abcddf6cc1395940a24e3595288b405ca0"},
-    {file = "coverage-7.0.5-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:50a6adc2be8edd7ee67d1abc3cd20678987c7b9d79cd265de55941e3d0d56499"},
-    {file = "coverage-7.0.5-cp38-cp38-win32.whl", hash = "sha256:e4ce984133b888cc3a46867c8b4372c7dee9cee300335e2925e197bcd45b9e16"},
-    {file = "coverage-7.0.5-cp38-cp38-win_amd64.whl", hash = "sha256:4a950f83fd3f9bca23b77442f3a2b2ea4ac900944d8af9993743774c4fdc57af"},
-    {file = "coverage-7.0.5-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:3c2155943896ac78b9b0fd910fb381186d0c345911f5333ee46ac44c8f0e43ab"},
-    {file = "coverage-7.0.5-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:54f7e9705e14b2c9f6abdeb127c390f679f6dbe64ba732788d3015f7f76ef637"},
-    {file = "coverage-7.0.5-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0ee30375b409d9a7ea0f30c50645d436b6f5dfee254edffd27e45a980ad2c7f4"},
-    {file = "coverage-7.0.5-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b78729038abea6a5df0d2708dce21e82073463b2d79d10884d7d591e0f385ded"},
-    {file = "coverage-7.0.5-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:13250b1f0bd023e0c9f11838bdeb60214dd5b6aaf8e8d2f110c7e232a1bff83b"},
-    {file = "coverage-7.0.5-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:2c407b1950b2d2ffa091f4e225ca19a66a9bd81222f27c56bd12658fc5ca1209"},
-    {file = "coverage-7.0.5-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:c76a3075e96b9c9ff00df8b5f7f560f5634dffd1658bafb79eb2682867e94f78"},
-    {file = "coverage-7.0.5-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:f26648e1b3b03b6022b48a9b910d0ae209e2d51f50441db5dce5b530fad6d9b1"},
-    {file = "coverage-7.0.5-cp39-cp39-win32.whl", hash = "sha256:ba3027deb7abf02859aca49c865ece538aee56dcb4871b4cced23ba4d5088904"},
-    {file = "coverage-7.0.5-cp39-cp39-win_amd64.whl", hash = "sha256:949844af60ee96a376aac1ded2a27e134b8c8d35cc006a52903fc06c24a3296f"},
-    {file = "coverage-7.0.5-pp37.pp38.pp39-none-any.whl", hash = "sha256:b9727ac4f5cf2cbf87880a63870b5b9730a8ae3a4a360241a0fdaa2f71240ff0"},
-    {file = "coverage-7.0.5.tar.gz", hash = "sha256:051afcbd6d2ac39298d62d340f94dbb6a1f31de06dfaf6fcef7b759dd3860c45"},
+    {file = "coverage-7.1.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:3b946bbcd5a8231383450b195cfb58cb01cbe7f8949f5758566b881df4b33baf"},
+    {file = "coverage-7.1.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:ec8e767f13be637d056f7e07e61d089e555f719b387a7070154ad80a0ff31801"},
+    {file = "coverage-7.1.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d4a5a5879a939cb84959d86869132b00176197ca561c664fc21478c1eee60d75"},
+    {file = "coverage-7.1.0-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b643cb30821e7570c0aaf54feaf0bfb630b79059f85741843e9dc23f33aaca2c"},
+    {file = "coverage-7.1.0-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:32df215215f3af2c1617a55dbdfb403b772d463d54d219985ac7cd3bf124cada"},
+    {file = "coverage-7.1.0-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:33d1ae9d4079e05ac4cc1ef9e20c648f5afabf1a92adfaf2ccf509c50b85717f"},
+    {file = "coverage-7.1.0-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:29571503c37f2ef2138a306d23e7270687c0efb9cab4bd8038d609b5c2393a3a"},
+    {file = "coverage-7.1.0-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:63ffd21aa133ff48c4dff7adcc46b7ec8b565491bfc371212122dd999812ea1c"},
+    {file = "coverage-7.1.0-cp310-cp310-win32.whl", hash = "sha256:4b14d5e09c656de5038a3f9bfe5228f53439282abcab87317c9f7f1acb280352"},
+    {file = "coverage-7.1.0-cp310-cp310-win_amd64.whl", hash = "sha256:8361be1c2c073919500b6601220a6f2f98ea0b6d2fec5014c1d9cfa23dd07038"},
+    {file = "coverage-7.1.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:da9b41d4539eefd408c46725fb76ecba3a50a3367cafb7dea5f250d0653c1040"},
+    {file = "coverage-7.1.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:c5b15ed7644ae4bee0ecf74fee95808dcc34ba6ace87e8dfbf5cb0dc20eab45a"},
+    {file = "coverage-7.1.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d12d076582507ea460ea2a89a8c85cb558f83406c8a41dd641d7be9a32e1274f"},
+    {file = "coverage-7.1.0-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:e2617759031dae1bf183c16cef8fcfb3de7617f394c813fa5e8e46e9b82d4222"},
+    {file = "coverage-7.1.0-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c4e4881fa9e9667afcc742f0c244d9364d197490fbc91d12ac3b5de0bf2df146"},
+    {file = "coverage-7.1.0-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:9d58885215094ab4a86a6aef044e42994a2bd76a446dc59b352622655ba6621b"},
+    {file = "coverage-7.1.0-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:ffeeb38ee4a80a30a6877c5c4c359e5498eec095878f1581453202bfacc8fbc2"},
+    {file = "coverage-7.1.0-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:3baf5f126f30781b5e93dbefcc8271cb2491647f8283f20ac54d12161dff080e"},
+    {file = "coverage-7.1.0-cp311-cp311-win32.whl", hash = "sha256:ded59300d6330be27bc6cf0b74b89ada58069ced87c48eaf9344e5e84b0072f7"},
+    {file = "coverage-7.1.0-cp311-cp311-win_amd64.whl", hash = "sha256:6a43c7823cd7427b4ed763aa7fb63901ca8288591323b58c9cd6ec31ad910f3c"},
+    {file = "coverage-7.1.0-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:7a726d742816cb3a8973c8c9a97539c734b3a309345236cd533c4883dda05b8d"},
+    {file = "coverage-7.1.0-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:bc7c85a150501286f8b56bd8ed3aa4093f4b88fb68c0843d21ff9656f0009d6a"},
+    {file = "coverage-7.1.0-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f5b4198d85a3755d27e64c52f8c95d6333119e49fd001ae5798dac872c95e0f8"},
+    {file = "coverage-7.1.0-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ddb726cb861c3117a553f940372a495fe1078249ff5f8a5478c0576c7be12050"},
+    {file = "coverage-7.1.0-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:51b236e764840a6df0661b67e50697aaa0e7d4124ca95e5058fa3d7cbc240b7c"},
+    {file = "coverage-7.1.0-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:7ee5c9bb51695f80878faaa5598040dd6c9e172ddcf490382e8aedb8ec3fec8d"},
+    {file = "coverage-7.1.0-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:c31b75ae466c053a98bf26843563b3b3517b8f37da4d47b1c582fdc703112bc3"},
+    {file = "coverage-7.1.0-cp37-cp37m-win32.whl", hash = "sha256:3b155caf3760408d1cb903b21e6a97ad4e2bdad43cbc265e3ce0afb8e0057e73"},
+    {file = "coverage-7.1.0-cp37-cp37m-win_amd64.whl", hash = "sha256:2a60d6513781e87047c3e630b33b4d1e89f39836dac6e069ffee28c4786715f5"},
+    {file = "coverage-7.1.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:f2cba5c6db29ce991029b5e4ac51eb36774458f0a3b8d3137241b32d1bb91f06"},
+    {file = "coverage-7.1.0-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:beeb129cacea34490ffd4d6153af70509aa3cda20fdda2ea1a2be870dfec8d52"},
+    {file = "coverage-7.1.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0c45948f613d5d18c9ec5eaa203ce06a653334cf1bd47c783a12d0dd4fd9c851"},
+    {file = "coverage-7.1.0-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:ef382417db92ba23dfb5864a3fc9be27ea4894e86620d342a116b243ade5d35d"},
+    {file = "coverage-7.1.0-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7c7c0d0827e853315c9bbd43c1162c006dd808dbbe297db7ae66cd17b07830f0"},
+    {file = "coverage-7.1.0-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:e5cdbb5cafcedea04924568d990e20ce7f1945a1dd54b560f879ee2d57226912"},
+    {file = "coverage-7.1.0-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:9817733f0d3ea91bea80de0f79ef971ae94f81ca52f9b66500c6a2fea8e4b4f8"},
+    {file = "coverage-7.1.0-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:218fe982371ac7387304153ecd51205f14e9d731b34fb0568181abaf7b443ba0"},
+    {file = "coverage-7.1.0-cp38-cp38-win32.whl", hash = "sha256:04481245ef966fbd24ae9b9e537ce899ae584d521dfbe78f89cad003c38ca2ab"},
+    {file = "coverage-7.1.0-cp38-cp38-win_amd64.whl", hash = "sha256:8ae125d1134bf236acba8b83e74c603d1b30e207266121e76484562bc816344c"},
+    {file = "coverage-7.1.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:2bf1d5f2084c3932b56b962a683074a3692bce7cabd3aa023c987a2a8e7612f6"},
+    {file = "coverage-7.1.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:98b85dd86514d889a2e3dd22ab3c18c9d0019e696478391d86708b805f4ea0fa"},
+    {file = "coverage-7.1.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:38da2db80cc505a611938d8624801158e409928b136c8916cd2e203970dde4dc"},
+    {file = "coverage-7.1.0-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:3164d31078fa9efe406e198aecd2a02d32a62fecbdef74f76dad6a46c7e48311"},
+    {file = "coverage-7.1.0-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:db61a79c07331e88b9a9974815c075fbd812bc9dbc4dc44b366b5368a2936063"},
+    {file = "coverage-7.1.0-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:9ccb092c9ede70b2517a57382a601619d20981f56f440eae7e4d7eaafd1d1d09"},
+    {file = "coverage-7.1.0-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:33ff26d0f6cc3ca8de13d14fde1ff8efe1456b53e3f0273e63cc8b3c84a063d8"},
+    {file = "coverage-7.1.0-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:d47dd659a4ee952e90dc56c97d78132573dc5c7b09d61b416a9deef4ebe01a0c"},
+    {file = "coverage-7.1.0-cp39-cp39-win32.whl", hash = "sha256:d248cd4a92065a4d4543b8331660121b31c4148dd00a691bfb7a5cdc7483cfa4"},
+    {file = "coverage-7.1.0-cp39-cp39-win_amd64.whl", hash = "sha256:7ed681b0f8e8bcbbffa58ba26fcf5dbc8f79e7997595bf071ed5430d8c08d6f3"},
+    {file = "coverage-7.1.0-pp37.pp38.pp39-none-any.whl", hash = "sha256:755e89e32376c850f826c425ece2c35a4fc266c081490eb0a841e7c1cb0d3bda"},
+    {file = "coverage-7.1.0.tar.gz", hash = "sha256:10188fe543560ec4874f974b5305cd1a8bdcfa885ee00ea3a03733464c4ca265"},
 ]
 
 [package.dependencies]
@@ -556,6 +555,23 @@ s3 = ["boto3 (>=1.2.4)"]
 test = ["boto3 (>=1.2.4)", "mock", "pytest (>=3)", "pytest-cov"]
 
 [[package]]
+name = "flake8"
+version = "5.0.4"
+description = "the modular source code checker: pep8 pyflakes and co"
+category = "dev"
+optional = false
+python-versions = ">=3.6.1"
+files = [
+    {file = "flake8-5.0.4-py2.py3-none-any.whl", hash = "sha256:7a1cf6b73744f5806ab95e526f6f0d8c01c66d7bbe349562d22dfca20610b248"},
+    {file = "flake8-5.0.4.tar.gz", hash = "sha256:6fbe320aad8d6b95cec8b8e47bc933004678dc63095be98528b7bdd2a9f510db"},
+]
+
+[package.dependencies]
+mccabe = ">=0.7.0,<0.8.0"
+pycodestyle = ">=2.9.0,<2.10.0"
+pyflakes = ">=2.5.0,<2.6.0"
+
+[[package]]
 name = "geopandas"
 version = "0.12.2"
 description = "Geographic pandas extensions"
@@ -576,14 +592,14 @@ shapely = ">=1.7"
 
 [[package]]
 name = "identify"
-version = "2.5.13"
+version = "2.5.15"
 description = "File identification library for Python"
 category = "dev"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "identify-2.5.13-py2.py3-none-any.whl", hash = "sha256:8aa48ce56e38c28b6faa9f261075dea0a942dfbb42b341b4e711896cbb40f3f7"},
-    {file = "identify-2.5.13.tar.gz", hash = "sha256:abb546bca6f470228785338a01b539de8a85bbf46491250ae03363956d8ebb10"},
+    {file = "identify-2.5.15-py2.py3-none-any.whl", hash = "sha256:1f4b36c5f50f3f950864b2a047308743f064eaa6f6645da5e5c780d1c7125487"},
+    {file = "identify-2.5.15.tar.gz", hash = "sha256:c22aa206f47cc40486ecf585d27ad5f40adbfc494a3fa41dc3ed0499a23b123f"},
 ]
 
 [package.extras]
@@ -825,6 +841,18 @@ files = [
     {file = "MarkupSafe-2.1.2-cp39-cp39-win32.whl", hash = "sha256:137678c63c977754abe9086a3ec011e8fd985ab90631145dfb9294ad09c102a7"},
     {file = "MarkupSafe-2.1.2-cp39-cp39-win_amd64.whl", hash = "sha256:0576fe974b40a400449768941d5d0858cc624e3249dfd1e0c33674e5c7ca7aed"},
     {file = "MarkupSafe-2.1.2.tar.gz", hash = "sha256:abcabc8c2b26036d62d4c746381a6f7cf60aafcc653198ad678306986b09450d"},
+]
+
+[[package]]
+name = "mccabe"
+version = "0.7.0"
+description = "McCabe checker, plugin for flake8"
+category = "dev"
+optional = false
+python-versions = ">=3.6"
+files = [
+    {file = "mccabe-0.7.0-py2.py3-none-any.whl", hash = "sha256:6c2d30ab6be0e4a46919781807b4f0d834ebdd6c6e3dca0bda5a15f863427b6e"},
+    {file = "mccabe-0.7.0.tar.gz", hash = "sha256:348e0240c33b60bbdf4e523192ef919f28cb2c3d7d5c7794f74009290f236325"},
 ]
 
 [[package]]
@@ -1093,6 +1121,21 @@ pytz = ">=2020.1"
 test = ["hypothesis (>=5.5.3)", "pytest (>=6.0)", "pytest-xdist (>=1.31)"]
 
 [[package]]
+name = "pep8-naming"
+version = "0.13.3"
+description = "Check PEP-8 naming conventions, plugin for flake8"
+category = "dev"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "pep8-naming-0.13.3.tar.gz", hash = "sha256:1705f046dfcd851378aac3be1cd1551c7c1e5ff363bacad707d43007877fa971"},
+    {file = "pep8_naming-0.13.3-py3-none-any.whl", hash = "sha256:1a86b8c71a03337c97181917e2b472f0f5e4ccb06844a0d6f0a33522549e7a80"},
+]
+
+[package.dependencies]
+flake8 = ">=5.0.0"
+
+[[package]]
 name = "pip"
 version = "22.3.1"
 description = "The PyPA recommended tool for installing Python packages."
@@ -1195,6 +1238,18 @@ files = [
 ]
 
 [[package]]
+name = "pycodestyle"
+version = "2.9.1"
+description = "Python style guide checker"
+category = "dev"
+optional = false
+python-versions = ">=3.6"
+files = [
+    {file = "pycodestyle-2.9.1-py2.py3-none-any.whl", hash = "sha256:d1735fc58b418fd7c5f658d28d943854f8a849b01a5d0a1e6f3f3fdd0166804b"},
+    {file = "pycodestyle-2.9.1.tar.gz", hash = "sha256:2c9607871d58c76354b697b42f5d57e1ada7d261c261efac224b664affdc5785"},
+]
+
+[[package]]
 name = "pycparser"
 version = "2.21"
 description = "C parser in Python"
@@ -1204,6 +1259,18 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 files = [
     {file = "pycparser-2.21-py2.py3-none-any.whl", hash = "sha256:8ee45429555515e1f6b185e78100aea234072576aa43ab53aefcae078162fca9"},
     {file = "pycparser-2.21.tar.gz", hash = "sha256:e644fdec12f7872f86c58ff790da456218b10f863970249516d60a5eaca77206"},
+]
+
+[[package]]
+name = "pyflakes"
+version = "2.5.0"
+description = "passive checker of Python programs"
+category = "dev"
+optional = false
+python-versions = ">=3.6"
+files = [
+    {file = "pyflakes-2.5.0-py2.py3-none-any.whl", hash = "sha256:4579f67d887f804e67edb544428f264b7b24f435b263c4614f384135cea553d2"},
+    {file = "pyflakes-2.5.0.tar.gz", hash = "sha256:491feb020dca48ccc562a8c0cbe8df07ee13078df59813b83959cbdada312ea3"},
 ]
 
 [[package]]
@@ -1804,14 +1871,14 @@ dev = ["bump2version", "sphinxcontrib-httpdomain", "transifex-client", "wheel"]
 
 [[package]]
 name = "sphinxcontrib-applehelp"
-version = "1.0.3"
+version = "1.0.4"
 description = "sphinxcontrib-applehelp is a Sphinx extension which outputs Apple help books"
 category = "dev"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "sphinxcontrib.applehelp-1.0.3-py3-none-any.whl", hash = "sha256:ba0f2a22e6eeada8da6428d0d520215ee8864253f32facf958cca81e426f661d"},
-    {file = "sphinxcontrib.applehelp-1.0.3.tar.gz", hash = "sha256:83749f09f6ac843b8cb685277dbc818a8bf2d76cc19602699094fe9a74db529e"},
+    {file = "sphinxcontrib-applehelp-1.0.4.tar.gz", hash = "sha256:828f867945bbe39817c210a1abfd1bc4895c8b73fcaade56d45357a348a07d7e"},
+    {file = "sphinxcontrib_applehelp-1.0.4-py3-none-any.whl", hash = "sha256:29d341f67fb0f6f586b23ad80e072c8e6ad0b48417db2bde114a4c9746feb228"},
 ]
 
 [package.extras]
@@ -2075,4 +2142,4 @@ sympy = ["sympy"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8"
-content-hash = "24cec6787a45d3db6fd853e18d742c85f1bc3ae159418f796243a566d6d339b7"
+content-hash = "9aa9845378d187d033c7e5abd14feccccee5de13178ef7b88ed9088b6f165df4"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,7 @@ python-dotenv = "^0.20.0"
 mypy = "^0.961"
 types-urllib3 = "^1.26.16"
 types-requests = "^2.28.1"
+pep8-naming = "^0"
 
 [build-system]
 requires = ["poetry>=1.0"]

--- a/tests/tests_unit/test_utils/test_auxiliary.py
+++ b/tests/tests_unit/test_utils/test_auxiliary.py
@@ -1,5 +1,6 @@
 import json
 import math
+import re
 from decimal import Decimal
 from itertools import zip_longest
 
@@ -10,6 +11,7 @@ from cognite.client.utils._auxiliary import (
     assert_type,
     exactly_one_is_not_none,
     find_duplicates,
+    handle_deprecated_camel_case_argument,
     interpolate_and_url_encode,
     json_dump_default,
     local_import,
@@ -30,6 +32,51 @@ class TestCaseConversion:
         assert "snake_case" == to_snake_case("snakeCase")
         assert "snake_case" == to_snake_case("snake_case")
         assert "a" == to_snake_case("a")
+
+
+@pytest.mark.parametrize(
+    "new_arg, old_arg_name, fn_name, kw_dct, expected",
+    (
+        ("Ceci n'est pas une pipe", "extractionPipeline", "f", {}, "Ceci n'est pas une pipe"),
+        (None, "extractionPipeline", "f", {"extractionPipeline": "Ceci n'est pas une pipe"}, "Ceci n'est pas une pipe"),
+        (42, "raw_geoLocation", "f", {}, 42),
+        (None, "raw_geoLocation", "f", {"raw_geoLocation": 42}, 42),
+    ),
+)
+def test_handle_deprecated_camel_case_argument__expected(new_arg, old_arg_name, fn_name, kw_dct, expected):
+    value = handle_deprecated_camel_case_argument(new_arg, old_arg_name, fn_name, kw_dct)
+    assert value == expected
+
+
+@pytest.mark.parametrize(
+    "new_arg, old_arg_name, fn_name, kw_dct, err_msg",
+    (
+        (
+            "Ceci n'est pas une pipe",
+            "extractionPipeline",
+            "f",
+            {"owner": "René Magritte"},
+            "Got unexpected keyword argument(s): ['owner']",
+        ),
+        (
+            None,
+            "extractionPipeline",
+            "fun_func",
+            {"extractionPipeline": None},
+            "fun_func() missing 1 required positional argument: 'extraction_pipeline'",
+        ),
+        (
+            "what",
+            "extractionPipeline",
+            "f",
+            {"extractionPipeline": "what"},
+            "Pass either 'extraction_pipeline' or 'extractionPipeline' (deprecated), not both",
+        ),
+    ),
+)
+def test_handle_deprecated_camel_case_argument__raises(new_arg, old_arg_name, fn_name, kw_dct, err_msg):
+    with pytest.raises(TypeError, match=re.escape(err_msg)):
+        handle_deprecated_camel_case_argument(new_arg, old_arg_name, fn_name, kw_dct)
 
 
 class TestLocalImport:


### PR DESCRIPTION
## Description
Adds `pep8-naming` which extends flake8 with quite some nice rules for better consistency across the SDK: https://pypi.org/project/pep8-naming/

Only one was added to the ignore-list: N818, as too many existing exceptions violated it (and are not going to change): `CogniteException`, `CogniteConnectionRefused`, `CogniteReadTimeout`, `CogniteMultiException`, `ModelFailedException`

Copy of rule list:

Code | Sample message
-- | --
N801 | class names should use CapWords convention (class names)
N802 | function name should be lowercase (function names)
N803 | argument name should be lowercase (function arguments)
N804 | first argument of a classmethod should be named ‘cls’ (function arguments)
N805 | first argument of a method should be named ‘self’ (function arguments)
N806 | variable in function should be lowercase
N807 | function name should not start and end with ‘__’
N811 | constant imported as non constant (constants)
N812 | lowercase imported as non-lowercase
N813 | camelcase imported as lowercase
N814 | camelcase imported as constant (distinct from N817 for selective enforcement)
N815 | mixedCase variable in class scope (constants, method names)
N816 | mixedCase variable in global scope (constants)
N817 | camelcase imported as acronym (distinct from N814 for selective enforcement)
N818 | error suffix in exception names (exceptions)