### PR TITLE
Add example on how to fetch all data for time series

### DIFF
--- a/cognite/client/_api/datapoints.py
+++ b/cognite/client/_api/datapoints.py
@@ -709,10 +709,11 @@ class DatapointsAPI(APIClient):
                 ...     limit=1)
 
             To get *all* historic and future datapoints for a time series, e.g. to do a backup, you may want to import the two integer
-            constants: `MIN_TIMESTAMP_MS` and `MAX_TIMESTAMP_MS`, to make sure you do not miss any::
+            constants: `MIN_TIMESTAMP_MS` and `MAX_TIMESTAMP_MS`, to make sure you do not miss any. Performance warning: This pattern of
+            fetching datapoints from the entire valid time domain is slower and shouldn't be used for regular "day-to-day" queries::
 
                 >>> from cognite.client.utils import MIN_TIMESTAMP_MS, MAX_TIMESTAMP_MS
-                >>> dps = client.time_series.data.retrieve(
+                >>> dps_backup = client.time_series.data.retrieve(
                 ...     id=123,
                 ...     start=MIN_TIMESTAMP_MS,
                 ...     end=MAX_TIMESTAMP_MS + 1)  # end is exclusive

--- a/cognite/client/_api/datapoints.py
+++ b/cognite/client/_api/datapoints.py
@@ -708,6 +708,15 @@ class DatapointsAPI(APIClient):
                 ...     external_id=[{"external_id": "foo", "start": start} for start in month_starts],
                 ...     limit=1)
 
+            To get *all* historic and future datapoints for a time series, e.g. to do a backup, you may want to import the two integer
+            constants: `MIN_TIMESTAMP_MS` and `MAX_TIMESTAMP_MS`, to make sure you do not miss any::
+
+                >>> from cognite.client.utils import MIN_TIMESTAMP_MS, MAX_TIMESTAMP_MS
+                >>> dps = client.time_series.data.retrieve(
+                ...     id=123,
+                ...     start=MIN_TIMESTAMP_MS,
+                ...     end=MAX_TIMESTAMP_MS + 1)  # end is exclusive
+
             The last example here is just to showcase the great flexibility of the `retrieve` endpoint, with a very custom query::
 
                 >>> ts1 = 1337

--- a/cognite/client/utils/__init__.py
+++ b/cognite/client/utils/__init__.py
@@ -5,5 +5,10 @@ from cognite.client.utils import (  # isort: skip
     _time,
     _version_checker,
 )
-
-from cognite.client.utils._time import datetime_to_ms, ms_to_datetime, timestamp_to_ms  # isort: skip
+from cognite.client.utils._time import (  # isort: skip
+    MAX_TIMESTAMP_MS,
+    MIN_TIMESTAMP_MS,
+    datetime_to_ms,
+    ms_to_datetime,
+    timestamp_to_ms,
+)


### PR DESCRIPTION
## Description
Adds the integer constants `MIN_TIMESTAMP_MS` and `MAX_TIMESTAMP_MS` to the public API (importable: `from cognite.client.utils import ...`, other suggestions for locations very welcome) and adds a "how to backup" example to the docstring of `DatapointsAPI.retrieve`.

## Checklist:
- [ ] Tests added/updated.
- [x] Documentation updated. Documentation is generated from docstrings - these must be updated according to your change.
  If a new method has been added it should be referenced in [cognite.rst](https://github.com/cognitedata/cognite-sdk-python/blob/master/docs/source/cognite.rst) in order to generate docs based on its docstring.
- [ ] Changelog updated in [CHANGELOG.md](https://github.com/cognitedata/cognite-sdk-python/blob/master/CHANGELOG.md).
- [ ] Version bumped. If triggering a new release is desired, bump the version number in [_version.py](https://github.com/cognitedata/cognite-sdk-python/blob/master/cognite/client/_version.py) and [pyproject.toml](https://github.com/cognitedata/cognite-sdk-python/blob/master/pyproject.toml) per [semantic versioning](https://semver.org/).
