### PR TITLE
Flake8 cleanup: Remove E401, E731, F401, W291, W504, W605. Prettify config

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,3 +1,8 @@
 [flake8]
-ignore = E731, W503, W504, E203, E501, W291, W605, E401, F401
 max-line-length = 121
+# Ignore F401 "Module imported but unused" only for __init__ files:
+per-file-ignores = __init__.py:F401
+ignore =
+    E203,  # Whitespace before ':'
+    E501,  # Line too long
+    W503,  # Line break before binary operator

--- a/.flake8
+++ b/.flake8
@@ -4,6 +4,9 @@ per-file-ignores =
     # Ignore F401 "Module imported but unused" only for __init__ files
     __init__.py:F401
 ignore =
-    E203,  # Whitespace before ':'
-    E501,  # Line too long
-    W503,  # Line break before binary operator
+    # Whitespace before ':'
+    E203,
+    # Line too long
+    E501,
+    # Line break before binary operator
+    W503,

--- a/.flake8
+++ b/.flake8
@@ -1,7 +1,8 @@
 [flake8]
 max-line-length = 121
-# Ignore F401 "Module imported but unused" only for __init__ files:
-per-file-ignores = __init__.py:F401
+per-file-ignores =
+    # Ignore F401 "Module imported but unused" only for __init__ files
+    __init__.py:F401
 ignore =
     E203,  # Whitespace before ':'
     E501,  # Line too long

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,6 +5,7 @@ repos:
         exclude: ^cognite/client/_proto.*$
         args:
           - --remove-all-unused-imports
+          - --ignore-init-module-imports
           - --in-place
     repo: https://github.com/humitos/mirrors-autoflake
     rev: v1.1
@@ -22,6 +23,8 @@ repos:
           - --skip-glob
           - ^((?!py$).)*$
           - --float-to-top
+          - --skip
+          - __init__.py
     repo: https://github.com/timothycrosley/isort
     rev: 5.11.4
   - hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,17 +1,18 @@
 ---
 repos:
-  - hooks:
+  - repo: https://github.com/PyCQA/autoflake
+    rev: v2.0.0
+    hooks:
       - id: autoflake
         exclude: ^cognite/client/_proto.*$
         args:
           - --remove-all-unused-imports
           - --ignore-init-module-imports
+          - --remove-unused-variables
           - --in-place
-    repo: https://github.com/humitos/mirrors-autoflake
-    rev: v1.1
   - hooks:
       - id: isort
-        exclude: ^cognite/client/_proto.*$
+        exclude: ^cognite/client/(_proto.*|.*__init__.py)
         args:
           - --profile
           - black
@@ -23,8 +24,6 @@ repos:
           - --skip-glob
           - ^((?!py$).)*$
           - --float-to-top
-          - --skip
-          - __init__.py
     repo: https://github.com/timothycrosley/isort
     rev: 5.11.4
   - hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,7 +23,7 @@ repos:
           - ^((?!py$).)*$
           - --float-to-top
     repo: https://github.com/timothycrosley/isort
-    rev: 5.10.1
+    rev: 5.11.4
   - hooks:
       - id: black
         exclude: ^cognite/client/_proto.*$
@@ -35,7 +35,7 @@ repos:
           - --include
           - \.py$
     repo: https://github.com/psf/black
-    rev: 22.3.0
+    rev: 22.12.0
   - hooks:
       - id: mypy
         name: mypy
@@ -51,7 +51,7 @@ repos:
 #            additional_dependencies:
 #              - flake8-builtins
     repo: https://github.com/pycqa/flake8
-    rev: 3.9.2
+    rev: 6.0.0
   - hooks:
       - id: version-match-check
         name: version-match-check

--- a/cognite/client/__init__.py
+++ b/cognite/client/__init__.py
@@ -1,3 +1,5 @@
-from cognite.client._cognite_client import CogniteClient  # isort: skip
-from cognite.client.config import ClientConfig, global_config  # isort: skip
-from cognite.client._version import __version__  # isort: skip
+from __future__ import annotations
+
+from cognite.client._cognite_client import CogniteClient
+from cognite.client.config import ClientConfig, global_config
+from cognite.client._version import __version__

--- a/cognite/client/data_classes/__init__.py
+++ b/cognite/client/data_classes/__init__.py
@@ -1,4 +1,4 @@
-from cognite.client.data_classes.annotations import (  # isort: skip
+from cognite.client.data_classes.annotations import (
     Annotation,
     AnnotationFilter,
     AnnotationList,
@@ -141,12 +141,12 @@ from cognite.client.data_classes.transformations.schedules import (
     TransformationScheduleUpdate,
 )
 
-from cognite.client.data_classes.transformations.schema import (  # isort: skip
+from cognite.client.data_classes.transformations.schema import (
     TransformationSchemaColumn,
     TransformationSchemaColumnList,
 )
 
-from cognite.client.data_classes.data_sets import (  # isort: skip
+from cognite.client.data_classes.data_sets import (
     DataSet,
     DataSetAggregate,
     DataSetFilter,
@@ -154,7 +154,7 @@ from cognite.client.data_classes.data_sets import (  # isort: skip
     DataSetUpdate,
 )
 
-from cognite.client.data_classes.shared import (  # isort: skip
+from cognite.client.data_classes.shared import (
     AggregateResult,
     AggregateUniqueValuesResult,
     GeoLocation,
@@ -164,7 +164,7 @@ from cognite.client.data_classes.shared import (  # isort: skip
     TimestampRange,
 )
 
-from cognite.client.data_classes.datapoints import (  # isort: skip
+from cognite.client.data_classes.datapoints import (
     Datapoint,
     Datapoints,
     DatapointsList,
@@ -172,10 +172,10 @@ from cognite.client.data_classes.datapoints import (  # isort: skip
     DatapointsArrayList,
     LatestDatapointQuery,
 )
-from cognite.client.data_classes.events import EndTimeFilter, Event, EventFilter, EventList, EventUpdate  # isort: skip
-from cognite.client.data_classes.login import LoginStatus  # isort: skip
-from cognite.client.data_classes.raw import Database, DatabaseList, Row, RowList, Table, TableList  # isort: skip
-from cognite.client.data_classes.functions import (  # isort: skip
+from cognite.client.data_classes.events import EndTimeFilter, Event, EventFilter, EventList, EventUpdate
+from cognite.client.data_classes.login import LoginStatus
+from cognite.client.data_classes.raw import Database, DatabaseList, Row, RowList, Table, TableList
+from cognite.client.data_classes.functions import (
     Function,
     FunctionFilter,
     FunctionSchedule,
@@ -188,7 +188,7 @@ from cognite.client.data_classes.functions import (  # isort: skip
     FunctionCallLog,
     FunctionsLimits,
 )
-from cognite.client.data_classes.geospatial import (  # isort: skip
+from cognite.client.data_classes.geospatial import (
     Feature,
     FeatureList,
     FeatureType,

--- a/cognite/client/data_classes/extractionpipelines.py
+++ b/cognite/client/data_classes/extractionpipelines.py
@@ -1,6 +1,5 @@
 from typing import TYPE_CHECKING, Any, Dict, List, Sequence, Union, cast
 
-from cognite.client import utils
 from cognite.client.data_classes._base import (
     CogniteFilter,
     CogniteListUpdate,
@@ -12,6 +11,7 @@ from cognite.client.data_classes._base import (
     CogniteUpdate,
 )
 from cognite.client.data_classes.shared import TimestampRange
+from cognite.client.utils._auxiliary import convert_all_keys_to_camel_case
 
 if TYPE_CHECKING:
     from cognite.client import CogniteClient
@@ -39,8 +39,7 @@ class ExtractionPipelineContact(dict):
     send_notification = CognitePropertyClassUtil.declare_property("sendNotification")
 
     def dump(self, camel_case: bool = False) -> Dict[str, Any]:
-        dump_key = lambda key: key if not camel_case else utils._auxiliary.to_camel_case(key)
-        return {dump_key(key): value for key, value in self.items()}
+        return convert_all_keys_to_camel_case(self) if camel_case else dict(self)
 
 
 class ExtractionPipeline(CogniteResource):

--- a/cognite/client/data_classes/shared.py
+++ b/cognite/client/data_classes/shared.py
@@ -1,7 +1,7 @@
 from typing import Any, Dict, List, Union
 
-from cognite.client import utils
 from cognite.client.data_classes._base import CognitePropertyClassUtil
+from cognite.client.utils._auxiliary import convert_all_keys_to_camel_case
 
 
 class TimestampRange(dict):
@@ -119,8 +119,7 @@ class Geometry(dict):
         return Geometry(type=raw_geometry["type"], coordinates=raw_geometry["coordinates"])
 
     def dump(self, camel_case: bool = False) -> Dict[str, Any]:
-        dump_key = lambda key: key if not camel_case else utils._auxiliary.to_camel_case(key)
-        return {dump_key(key): value for key, value in self.items()}
+        return convert_all_keys_to_camel_case(self) if camel_case else dict(self)
 
 
 class GeometryFilter(dict):
@@ -169,8 +168,7 @@ class GeoLocation(dict):
         )
 
     def dump(self, camel_case: bool = False) -> Dict[str, Any]:
-        dump_key = lambda key: key if not camel_case else utils._auxiliary.to_camel_case(key)
-        return {dump_key(key): value for key, value in self.items()}
+        return convert_all_keys_to_camel_case(self) if camel_case else dict(self)
 
 
 class GeoLocationFilter(dict):
@@ -192,5 +190,4 @@ class GeoLocationFilter(dict):
         return GeoLocationFilter(relation=raw_geoLocation_filter["relation"], shape=raw_geoLocation_filter["shape"])
 
     def dump(self, camel_case: bool = False) -> Dict[str, Any]:
-        dump_key = lambda key: key if not camel_case else utils._auxiliary.to_camel_case(key)
-        return {dump_key(key): value for key, value in self.items()}
+        return convert_all_keys_to_camel_case(self) if camel_case else dict(self)

--- a/cognite/client/data_classes/transformations/jobs.py
+++ b/cognite/client/data_classes/transformations/jobs.py
@@ -4,13 +4,7 @@ from enum import Enum
 from typing import TYPE_CHECKING, Dict, Optional, Union, cast
 
 from cognite.client.data_classes._base import CogniteFilter, CogniteResource, CogniteResourceList
-from cognite.client.data_classes.transformations.common import (
-    DataModelInstances,
-    RawTable,
-    SequenceRows,
-    TransformationDestination,
-    _load_destination_dct,
-)
+from cognite.client.data_classes.transformations.common import TransformationDestination, _load_destination_dct
 
 if TYPE_CHECKING:
     from cognite.client import CogniteClient

--- a/cognite/client/utils/__init__.py
+++ b/cognite/client/utils/__init__.py
@@ -1,11 +1,13 @@
-from cognite.client.utils import (  # isort: skip
+from __future__ import annotations
+
+from cognite.client.utils import (
     _auxiliary,
     _concurrency,
     _logging,
     _time,
     _version_checker,
 )
-from cognite.client.utils._time import (  # isort: skip
+from cognite.client.utils._time import (
     MAX_TIMESTAMP_MS,
     MIN_TIMESTAMP_MS,
     datetime_to_ms,

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -52,7 +52,7 @@ author = "Erlend Vollset"
 # built documents.
 #
 # The short X.Y version.
-version = re.search('^__version__\s*=\s*"(.*)"', open("../../cognite/client/_version.py").read(), re.M).group(1)
+version = re.search(r'^__version__\s*=\s*"(.*)"', open("../../cognite/client/_version.py").read(), re.M).group(1)
 # The full version, including alpha/beta/rc tags.
 release = version
 


### PR DESCRIPTION
## Description
- Made `.flake8` configuration file more human-readable
- Made `F401` only apply ignore rule for `__init__.py` files
- Minor updates to accompany the removal of ignore-rules, i.e. refactored `lambda`s
- Ran `pre-commit autoupdate`; pretty uneventful except for...
- ...upgrading `flake8` from `3.9.2` to major version `6` 😮 
- Get rid of all # isort: skip comments by adding __init__-files to exclude regex pattern in .pre-commit-config.yaml

## Checklist:
- [ ] Tests added/updated.
- [ ] Documentation updated. Documentation is generated from docstrings - these must be updated according to your change.
  If a new method has been added it should be referenced in [cognite.rst](https://github.com/cognitedata/cognite-sdk-python/blob/master/docs/source/cognite.rst) in order to generate docs based on its docstring.
- [ ] Changelog updated in [CHANGELOG.md](https://github.com/cognitedata/cognite-sdk-python/blob/master/CHANGELOG.md).
- [ ] Version bumped. If triggering a new release is desired, bump the version number in [_version.py](https://github.com/cognitedata/cognite-sdk-python/blob/master/cognite/client/_version.py) and [pyproject.toml](https://github.com/cognitedata/cognite-sdk-python/blob/master/pyproject.toml) per [semantic versioning](https://semver.org/).
