### PR TITLE
Make `before` param customisable in `retrieve_latest`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,10 @@ Changes are grouped as follows
 ### Changed
 - Change RAW rows insert chunk size to make individual requests faster.
 
+## [5.1.0] - 08-01-23
+### Added
+- `DatapointsAPI.retrieve_latest` now support customising the `before` argument, by passing one or more objects of the newly added `LatestDatapointQuery` class.
+
 ## [5.1.0] - 03-01-23
 ### Added
 - The diagram detect function can take file reference objects that contain file (external) id as well as a page range. This is an alternative to the lists of file ids or file external ids that are still possible to use. Page ranges were not possible to specify before.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ Changes are grouped as follows
 ### Changed
 - Change RAW rows insert chunk size to make individual requests faster.
 
-## [5.1.0] - 08-01-23
+## [5.2.0] - 08-01-23
 ### Added
 - `DatapointsAPI.retrieve_latest` now support customising the `before` argument, by passing one or more objects of the newly added `LatestDatapointQuery` class.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ Changes are grouped as follows
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
+## [5.3.0] - 20-01-23
+### Added
+- `DatapointsAPI.retrieve_latest` now support customising the `before` argument, by passing one or more objects of the newly added `LatestDatapointQuery` class.
+
 ## [5.2.0] - 19-01-23
 ### Changed
 - The SDK has been refactored to support `protobuf>=3.16.0` (no longer requires v4 or higher). This was done to fix dependency conflicts with several popular Python packages like `tensorflow` and `streamlit` - and also Azure Functions - that required major version 3.x of `protobuf`.
@@ -24,10 +28,6 @@ Changes are grouped as follows
 ## [5.1.1] - 19-01-23
 ### Changed
 - Change RAW rows insert chunk size to make individual requests faster.
-
-## [5.2.0] - 08-01-23
-### Added
-- `DatapointsAPI.retrieve_latest` now support customising the `before` argument, by passing one or more objects of the newly added `LatestDatapointQuery` class.
 
 ## [5.1.0] - 03-01-23
 ### Added

--- a/cognite/client/_api/datapoints.py
+++ b/cognite/client/_api/datapoints.py
@@ -1429,8 +1429,11 @@ class RetrieveLatestDpsFetcher:
     def _prepare_requests(
         self, parsed_ids: Union[None, int, Sequence[int]], parsed_xids: Union[None, str, Sequence[str]]
     ) -> List[Dict]:
-        id_seq, xid_seq = IdentifierSequence.load(parsed_ids, None), IdentifierSequence.load(None, parsed_xids)
-        all_ids, all_xids = id_seq.as_dicts(), xid_seq.as_dicts()
+        all_ids, all_xids = [], []
+        if parsed_ids is not None:
+            all_ids = IdentifierSequence.load(parsed_ids, None).as_dicts()
+        if parsed_xids is not None:
+            all_xids = IdentifierSequence.load(None, parsed_xids).as_dicts()
 
         # In the API, missing 'before' defaults to 'now'. As we want to get the most up-to-date datapoint, we don't
         # specify a particular timestamp for 'now' in order to possibly get a datapoint a few hundred ms fresher:

--- a/cognite/client/_api/datapoints.py
+++ b/cognite/client/_api/datapoints.py
@@ -1419,6 +1419,7 @@ class RetrieveLatestDpsFetcher:
             self.before_settings[(identifier_type, 0)] = user_input.before
             return as_primitive
         elif isinstance(user_input, MutableSequence):
+            user_input = user_input[:]  # Modify a shallow copy to avoid side effects
             for i, inp in enumerate(user_input):
                 if isinstance(inp, LatestDatapointQuery):
                     as_primitive = self._get_and_check_identifier(inp, identifier_type)

--- a/cognite/client/_api/datapoints.py
+++ b/cognite/client/_api/datapoints.py
@@ -46,7 +46,13 @@ from cognite.client._api.datapoint_tasks import (
 )
 from cognite.client._api.synthetic_time_series import SyntheticDatapointsAPI
 from cognite.client._api_client import APIClient
-from cognite.client.data_classes.datapoints import Datapoints, DatapointsArray, DatapointsArrayList, DatapointsList
+from cognite.client.data_classes.datapoints import (
+    Datapoints,
+    DatapointsArray,
+    DatapointsArrayList,
+    DatapointsList,
+    LatestDatapointQuery,
+)
 from cognite.client.exceptions import CogniteAPIError, CogniteNotFoundError
 from cognite.client.utils._auxiliary import (
     assert_type,
@@ -952,21 +958,21 @@ class DatapointsAPI(APIClient):
 
     def retrieve_latest(
         self,
-        id: Union[int, List[int]] = None,
-        external_id: Union[str, List[str]] = None,
+        id: Union[int, LatestDatapointQuery, List[Union[int, LatestDatapointQuery]]] = None,
+        external_id: Union[str, LatestDatapointQuery, List[Union[str, LatestDatapointQuery]]] = None,
         before: Union[int, str, datetime] = None,
         ignore_unknown_ids: bool = False,
     ) -> Union[Datapoints, DatapointsList]:
         """`Get the latest datapoint for one or more time series <https://docs.cognite.com/api/v1/#operation/getLatest>`_
 
         Args:
-            id (Union[int, List[int]]): Id or list of ids.
-            external_id (Union[str, List[str]): External id or list of external ids.
-            before: (Union[int, str, datetime]): Get latest datapoint before this time.
+            id (Union[int, LatestDatapointQuery, List[Union[int, LatestDatapointQuery]]]): Id or list of ids.
+            external_id (Union[str, LatestDatapointQuery, List[Union[str, LatestDatapointQuery]]]): External id or list of external ids.
+            before: (Union[int, str, datetime]): Get latest datapoint before this time. Not used when passing 'LatestDatapointQuery'.
             ignore_unknown_ids (bool): Ignore IDs and external IDs that are not found rather than throw an exception.
 
         Returns:
-            Union[Datapoints, DatapointsList]: A Datapoints object containing the requested data, or a list of such objects.
+            Union[Datapoints, DatapointsList]: A Datapoints object containing the requested data, or a DatapointsList if multiple were requested.
 
         Examples:
 
@@ -979,38 +985,35 @@ class DatapointsAPI(APIClient):
 
             You can also get the first datapoint before a specific time::
 
-                >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
                 >>> res = c.time_series.data.retrieve_latest(id=1, before="2d-ago")[0]
 
-            If you need the latest datapoint for multiple time series simply give a list of ids. Note that we are
+            You may also pass an instance of LatestDatapointQuery:
+
+                >>> from cognite.client.data_classes import LatestDatapointQuery
+                >>> res = c.time_series.data.retrieve_latest(id=LatestDatapointQuery(id=1, before=60_000))[0]
+
+            If you need the latest datapoint for multiple time series, simply give a list of ids. Note that we are
             using external ids here, but either will work::
 
-                >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
                 >>> res = c.time_series.data.retrieve_latest(external_id=["abc", "def"])
                 >>> latest_abc = res[0][0]
                 >>> latest_def = res[1][0]
-        """
-        id_seq = IdentifierSequence.load(id, external_id)
-        all_ids = id_seq.as_dicts()
-        if before is not None:
-            before = timestamp_to_ms(before)
-            for id_ in all_ids:
-                id_["before"] = timestamp_to_ms(before)
 
-        tasks = [
-            {
-                "url_path": self._RESOURCE_PATH + "/latest",
-                "json": {"items": chunk, "ignoreUnknownIds": ignore_unknown_ids},
-            }
-            for chunk in split_into_chunks(all_ids, RETRIEVE_LATEST_LIMIT)
-        ]
-        tasks_summary = execute_tasks_concurrently(self._post, tasks, max_workers=self._config.max_workers)
-        if tasks_summary.exceptions:
-            raise tasks_summary.exceptions[0]
-        res = tasks_summary.joined_results(lambda res: res.json()["items"])
-        if id_seq.is_singleton():
+            If you need to specify a different value of 'before' for each time series, you may pass several
+            LatestDatapointQuery objects::
+
+                >>> from datetime import datetime, timezone
+                >>> id_queries = [
+                ...     123,
+                ...     LatestDatapointQuery(id=456, before="1w-ago"),
+                ...     LatestDatapointQuery(id=789, before=datetime(2018,1,1, tzinfo=timezone.utc))]
+                >>> res = c.time_series.data.retrieve_latest(
+                ...     id=id_queries,
+                ...     external_id=LatestDatapointQuery(external_id="abc", before="3h-ago"))
+        """
+        fetcher = RetrieveLatestDpsFetcher(id, external_id, before, ignore_unknown_ids, self)
+        res = fetcher.fetch_datapoints()
+        if fetcher.input_is_singleton:
             return Datapoints._load(res[0], cognite_client=self._cognite_client)
         return DatapointsList._load(res, cognite_client=self._cognite_client)
 
@@ -1367,3 +1370,70 @@ class DatapointsPoster:
         self.client._post(url_path=self.client._RESOURCE_PATH, json={"items": post_dps_objects})
         for it in post_dps_objects:
             del it["datapoints"]
+
+
+class RetrieveLatestDpsFetcher:
+    def __init__(self, id, external_id, before, ignore_unknown_ids, client: DatapointsAPI) -> None:
+        self.before_settings = {}
+        self.default_before = before
+        self.ignore_unknown_ids = ignore_unknown_ids
+        self.client = client
+
+        parsed_ids = self._parse_user_input(id, "id")
+        parsed_xids = self._parse_user_input(external_id, "external_id")
+        self._is_singleton = IdentifierSequence.load(parsed_ids, parsed_xids).is_singleton()
+        self._all_identifiers = self._prepare_requests(parsed_ids, parsed_xids)
+
+    @property
+    def input_is_singleton(self) -> bool:
+        return self._is_singleton
+
+    @staticmethod
+    def _get_identifier(query: LatestDatapointQuery, identifier_type: str) -> Union[int, str]:
+        if (as_primitive := getattr(query, identifier_type)) is None:
+            raise ValueError(f"Missing '{identifier_type}' from: '{query}'")
+        return as_primitive
+
+    def _parse_user_input(self, user_input, identifier_type: str) -> List[Union[str, int]]:
+        if user_input is None:
+            return []
+        if isinstance(user_input, LatestDatapointQuery):
+            as_primitive = self._get_identifier(user_input, identifier_type)
+            self.before_settings[(identifier_type, 0)] = user_input.before
+            return as_primitive
+        if isinstance(user_input, list):
+            for i, inp in enumerate(user_input):
+                if isinstance(inp, LatestDatapointQuery):
+                    as_primitive = self._get_identifier(inp, identifier_type)
+                    self.before_settings[(identifier_type, i)] = inp.before
+                    user_input[i] = as_primitive  # mutating while iterating like a boss
+        return user_input
+
+    def _prepare_requests(self, parsed_ids, parsed_xids) -> List[Dict]:
+        id_seq, xid_seq = IdentifierSequence.load(parsed_ids, None), IdentifierSequence.load(None, parsed_xids)
+        all_ids, all_xids = id_seq.as_dicts(), xid_seq.as_dicts()
+
+        # In the API, missing 'before' defaults to 'now'. As we want to get the most up-to-date datapoint, we don't
+        # specify a particular timestamp for 'now' in order to possibly get a datapoint a few hundred ms fresher:
+        for identifiers, identifier_type in zip([all_ids, all_xids], ["id", "external_id"]):
+            for i, dct in enumerate(identifiers):
+                i_before = self.before_settings.get((identifier_type, i), self.default_before)
+                if i_before not in {"now", None}:
+                    dct["before"] = timestamp_to_ms(i_before)
+        all_ids.extend(all_xids)
+        return all_ids
+
+    def fetch_datapoints(self):
+        tasks = [
+            {
+                "url_path": self.client._RESOURCE_PATH + "/latest",
+                "json": {"items": chunk, "ignoreUnknownIds": self.ignore_unknown_ids},
+            }
+            for chunk in split_into_chunks(self._all_identifiers, RETRIEVE_LATEST_LIMIT)
+        ]
+        tasks_summary = execute_tasks_concurrently(
+            self.client._post, tasks, max_workers=self.client._config.max_workers
+        )
+        if tasks_summary.exceptions:
+            raise tasks_summary.exceptions[0]
+        return tasks_summary.joined_results(lambda res: res.json()["items"])

--- a/cognite/client/_version.py
+++ b/cognite/client/_version.py
@@ -1,2 +1,2 @@
-__version__ = "5.2.0"
+__version__ = "5.3.0"
 __api_subversion__ = "V20220125"

--- a/cognite/client/data_classes/__init__.py
+++ b/cognite/client/data_classes/__init__.py
@@ -170,6 +170,7 @@ from cognite.client.data_classes.datapoints import (  # isort: skip
     DatapointsList,
     DatapointsArray,
     DatapointsArrayList,
+    LatestDatapointQuery,
 )
 from cognite.client.data_classes.events import EndTimeFilter, Event, EventFilter, EventList, EventUpdate  # isort: skip
 from cognite.client.data_classes.login import LoginStatus  # isort: skip

--- a/cognite/client/data_classes/datapoints.py
+++ b/cognite/client/data_classes/datapoints.py
@@ -73,9 +73,9 @@ except ImportError:  # pragma no cover
 
 @dataclass(frozen=True)
 class LatestDatapointQuery:
-    id: int = None
-    external_id: str = None
-    before: Union[int, str, datetime] = None
+    id: Optional[int] = None
+    external_id: Optional[str] = None
+    before: Union[None, int, str, datetime] = None
 
     def __post_init__(self) -> None:
         # Ensure user have just specified one of id/xid:

--- a/cognite/client/data_classes/datapoints.py
+++ b/cognite/client/data_classes/datapoints.py
@@ -81,7 +81,7 @@ class LatestDatapointQuery:
     Args:
         id (Optional[int]): The internal ID of the time series to query.
         external_id (Optional[str]): The external ID of the time series to query.
-        before (Union[None, int, str, datetime]): before: (Union[int, str, datetime]): Get latest datapoint before this time. None means 'now'.
+        before (Union[None, int, str, datetime]): Get latest datapoint before this time. None means 'now'.
     """
 
     id: Optional[int] = None

--- a/cognite/client/data_classes/datapoints.py
+++ b/cognite/client/data_classes/datapoints.py
@@ -73,6 +73,17 @@ except ImportError:  # pragma no cover
 
 @dataclass(frozen=True)
 class LatestDatapointQuery:
+    """Parameters describing a query for the latest datapoint from a time series.
+
+    Note:
+        Pass either ID or external ID.
+
+    Args:
+        id (Optional[int]): The internal ID of the time series to query.
+        external_id (Optional[str]): The external ID of the time series to query.
+        before (Union[None, int, str, datetime]): before: (Union[int, str, datetime]): Get latest datapoint before this time. None means 'now'.
+    """
+
     id: Optional[int] = None
     external_id: Optional[str] = None
     before: Union[None, int, str, datetime] = None

--- a/cognite/client/data_classes/datapoints.py
+++ b/cognite/client/data_classes/datapoints.py
@@ -4,6 +4,7 @@ import json
 import operator as op
 import warnings
 from collections import defaultdict
+from dataclasses import dataclass
 from datetime import datetime
 from functools import cached_property
 from typing import (
@@ -33,6 +34,7 @@ from cognite.client.utils._auxiliary import (
     local_import,
     to_camel_case,
 )
+from cognite.client.utils._identifier import Identifier
 from cognite.client.utils._pandas_helpers import concat_dataframes_with_nullable_int_cols
 
 ALL_SORTED_DP_AGGS = sorted(
@@ -67,6 +69,17 @@ try:
 
 except ImportError:  # pragma no cover
     NUMPY_IS_AVAILABLE = False
+
+
+@dataclass(frozen=True)
+class LatestDatapointQuery:
+    id: int = None
+    external_id: str = None
+    before: Union[int, str, datetime] = None
+
+    def __post_init__(self) -> None:
+        # Ensure user have just specified one of id/xid:
+        Identifier.of_either(self.id, self.external_id)
 
 
 class Datapoint(CogniteResource):

--- a/cognite/client/utils/_identifier.py
+++ b/cognite/client/utils/_identifier.py
@@ -119,7 +119,7 @@ class IdentifierSequence:
         all_identifiers: List[Union[int, str]] = []
 
         if ids is not None:
-            if isinstance(ids, (int, numbers.Integral)):
+            if isinstance(ids, numbers.Integral):
                 value_passed_as_primitive = True
                 all_identifiers.append(ids)
             elif isinstance(ids, Sequence) and not isinstance(ids, str):
@@ -134,7 +134,7 @@ class IdentifierSequence:
             elif isinstance(external_ids, Sequence):
                 all_identifiers.extend([str(extid) for extid in external_ids])
             else:
-                raise TypeError(f"ids must be of type str or Sequence[str]. Found {type(external_ids)}")
+                raise TypeError(f"external_ids must be of type str or Sequence[str]. Found {type(external_ids)}")
 
         is_singleton = value_passed_as_primitive and len(all_identifiers) == 1
         return cls(identifiers=[Identifier(val) for val in all_identifiers], is_singleton=is_singleton)

--- a/cognite/client/utils/_identifier.py
+++ b/cognite/client/utils/_identifier.py
@@ -121,7 +121,7 @@ class IdentifierSequence:
         if ids is not None:
             if isinstance(ids, numbers.Integral):
                 value_passed_as_primitive = True
-                all_identifiers.append(ids)
+                all_identifiers.append(int(ids))
             elif isinstance(ids, Sequence) and not isinstance(ids, str):
                 all_identifiers.extend([int(id_) for id_ in ids])
             else:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "cognite-sdk"
 
-version = "5.2.0"
+version = "5.3.0"
 
 description = "Cognite Python SDK"
 readme = "README.md"

--- a/tests/tests_unit/test_api/test_datapoints.py
+++ b/tests/tests_unit/test_api/test_datapoints.py
@@ -8,7 +8,7 @@ from unittest.mock import patch
 import pytest
 
 from cognite.client._api.datapoints import DatapointsBin
-from cognite.client.data_classes import Datapoint, Datapoints, DatapointsList
+from cognite.client.data_classes import Datapoint, Datapoints, DatapointsList, LatestDatapointQuery
 from cognite.client.exceptions import CogniteAPIError, CogniteNotFoundError
 from cognite.client.utils._time import granularity_to_ms
 from tests.utils import jsgz_load
@@ -146,6 +146,24 @@ class TestGetLatest:
             with pytest.raises(CogniteAPIError) as e:
                 cognite_client.time_series.data.retrieve_latest(id=[1, 2, 3])
             assert e.value.code == 500
+
+    @pytest.mark.parametrize(
+        "id, external_id, pass_as, err_msg",
+        (
+            (None, None, "id", "Exactly one of id or external id must be specified, got neither"),
+            (None, None, "external_id", "Exactly one of id or external id must be specified, got neither"),
+            (None, "foo", "id", "Missing 'id' from: 'LatestDatapointQuery"),
+            (123, None, "external_id", "Missing 'external_id' from: 'LatestDatapointQuery"),
+            (123, "foo", "id", "Exactly one of id or external id must be specified, got both"),
+            (123, "foo", "external_id", "Exactly one of id or external id must be specified, got both"),
+        ),
+    )
+    def test_using_latest_datapoint_query__fails_wrong_ident_type(
+        self, cognite_client, id, external_id, pass_as, err_msg
+    ):
+        with pytest.raises(ValueError, match=err_msg):
+            query = {pass_as: LatestDatapointQuery(id=id, external_id=external_id)}
+            cognite_client.time_series.data.retrieve_latest(**query)
 
 
 @pytest.fixture

--- a/tests/tests_unit/test_api/test_datapoints.py
+++ b/tests/tests_unit/test_api/test_datapoints.py
@@ -158,12 +158,17 @@ class TestGetLatest:
             (123, "foo", "external_id", "Exactly one of id or external id must be specified, got both"),
         ),
     )
-    def test_using_latest_datapoint_query__fails_wrong_ident_type(
-        self, cognite_client, id, external_id, pass_as, err_msg
-    ):
+    def test_using_latest_datapoint_query__fails_wrong_ident(self, cognite_client, id, external_id, pass_as, err_msg):
+        # Pass directly
         with pytest.raises(ValueError, match=err_msg):
-            query = {pass_as: LatestDatapointQuery(id=id, external_id=external_id)}
-            cognite_client.time_series.data.retrieve_latest(**query)
+            ldq = LatestDatapointQuery(id, external_id)
+            cognite_client.time_series.data.retrieve_latest(**{pass_as: ldq})
+
+        # Pass as a part of a list
+        with pytest.raises(ValueError, match=err_msg):
+            ldq = LatestDatapointQuery(id, external_id)
+            valid = 123 if pass_as == "id" else "foo"
+            cognite_client.time_series.data.retrieve_latest(**{pass_as: [valid, ldq, ldq, valid]})
 
 
 @pytest.fixture

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -112,8 +112,6 @@ def set_request_limit(client, limit):
         "_UPDATE_LIMIT",
         "_DELETE_LIMIT",
         "_DPS_LIMIT",
-        "_POST_DPS_OBJECTS_LIMIT",
-        "_RETRIEVE_LATEST_LIMIT",
     ]
 
     tmp = {lim: 0 for lim in limits}


### PR DESCRIPTION
## Description
- Adresses #1104 
- The time series API supports `before` argument to be individually specified. This PR adds similar support in the Python SDK by introducing a `LatestDatapointQuery` dataclass which can be passed to the `DatapointsAPI.retrieve_latest` method interchangably with basic/primitive identifiers to make it fully backwards compatible.

## Checklist:
- [x] Tests added/updated.
- [x] Documentation updated. Documentation is generated from docstrings - these must be updated according to your change.
  If a new method has been added it should be referenced in [cognite.rst](https://github.com/cognitedata/cognite-sdk-python/blob/master/docs/source/cognite.rst) in order to generate docs based on its docstring.
- [x] Changelog updated in [CHANGELOG.md](https://github.com/cognitedata/cognite-sdk-python/blob/master/CHANGELOG.md).
- [x] Version bumped. If triggering a new release is desired, bump the version number in [_version.py](https://github.com/cognitedata/cognite-sdk-python/blob/master/cognite/client/_version.py) and [pyproject.toml](https://github.com/cognitedata/cognite-sdk-python/blob/master/pyproject.toml) per [semantic versioning](https://semver.org/).
