### PR TITLE
QoL changes in `data_classes/contextualization.py`

### DIFF
--- a/cognite/client/_api/vision.py
+++ b/cognite/client/_api/vision.py
@@ -109,6 +109,7 @@ class VisionAPI(APIClient):
 
         Args:
             job_id (int): ID of an existing feature extraction job.
+
         Returns:
             VisionExtractJob: Vision extract job, which can be used to retrieve the status of the job or the prediction results if the job is finished. Note that .result property of this job will wait for the job to finish and returns the results.
 

--- a/cognite/client/_api/vision.py
+++ b/cognite/client/_api/vision.py
@@ -6,7 +6,6 @@ from typing import Any, Dict, List, Optional, Type, Union
 from cognite.client._api_client import APIClient
 from cognite.client.data_classes.contextualization import (
     FeatureParameters,
-    InternalId,
     T_ContextualizationJob,
     VisionExtractJob,
     VisionFeature,
@@ -105,11 +104,11 @@ class VisionAPI(APIClient):
             headers={"cdf-version": "beta"} if len(beta_features) > 0 else None,
         )
 
-    def get_extract_job(self, job_id: InternalId) -> VisionExtractJob:
+    def get_extract_job(self, job_id: int) -> VisionExtractJob:
         """Retrieve an existing extract job by ID.
 
         Args:
-            job_id (InternalId): ID of an existing feature extraction job.
+            job_id (int): ID of an existing feature extraction job.
         Returns:
             VisionExtractJob: Vision extract job, which can be used to retrieve the status of the job or the prediction results if the job is finished. Note that .result property of this job will wait for the job to finish and returns the results.
 

--- a/cognite/client/data_classes/annotation_types/primitives.py
+++ b/cognite/client/data_classes/annotation_types/primitives.py
@@ -70,7 +70,7 @@ def _process_vertices(vertices: Union[List[PointDict], List[Point]]) -> List[Poi
     for v in vertices:
         if isinstance(v, Point):
             processed_vertices.append(v)
-        elif isinstance(v, Dict) and v.keys() == ["x", "y"]:
+        elif isinstance(v, dict) and set(v) == set("xy"):
             processed_vertices.append(Point(**v))
         else:
             raise ValueError(f"{v} is an invalid point.")

--- a/cognite/client/data_classes/contextualization.py
+++ b/cognite/client/data_classes/contextualization.py
@@ -533,6 +533,15 @@ class VisionFeature(str, Enum):
         return {cls.INDUSTRIAL_OBJECT_DETECTION, cls.PERSONAL_PROTECTIVE_EQUIPMENT_DETECTION}
 
 
+@dataclass
+class VisionExtractPredictions(VisionResource):
+    text_predictions: Optional[List[TextRegion]] = None
+    asset_tag_predictions: Optional[List[AssetLink]] = None
+    industrial_object_predictions: Optional[List[ObjectDetection]] = None
+    people_predictions: Optional[List[ObjectDetection]] = None
+    personal_protective_equipment_predictions: Optional[List[ObjectDetection]] = None
+
+
 VISION_FEATURE_MAP: Dict[str, Any] = {
     "text_predictions": TextRegion,
     "asset_tag_predictions": AssetLink,
@@ -540,14 +549,6 @@ VISION_FEATURE_MAP: Dict[str, Any] = {
     "people_predictions": ObjectDetection,
     "personal_protective_equipment_predictions": ObjectDetection,
 }
-
-
-# Auto-generate the dataclass from the mapping VISION_FEATURE_MAP:
-@dataclass
-class VisionExtractPredictions(VisionResource):
-    __annotations__ = {param: f"Optional[List[{cls.__name__}]]" for param, cls in VISION_FEATURE_MAP.items()}
-    for attr in VISION_FEATURE_MAP:
-        locals()[attr] = None
 
 
 VISION_ANNOTATION_TYPE_MAP: Dict[str, str] = {

--- a/cognite/client/data_classes/contextualization.py
+++ b/cognite/client/data_classes/contextualization.py
@@ -104,9 +104,7 @@ class ContextualizationJob(CogniteResource):
 
     def update_status(self) -> str:
         """Updates the model status and returns it"""
-        data = (
-            self._cognite_client.__getattribute__(self._JOB_TYPE.value)._get(f"{self._status_path}{self.job_id}").json()
-        )
+        data = getattr(self._cognite_client, self._JOB_TYPE.value)._get(f"{self._status_path}{self.job_id}").json()
         self.status = data["status"]
         self.status_time = data.get("statusTime")
         self.start_time = data.get("startTime")
@@ -697,9 +695,7 @@ class VisionJob(ContextualizationJob):
     def update_status(self) -> str:
         # Override update_status since we need to handle the vision-specific
         # edge case where we also record failed items per batch
-        data = (
-            self._cognite_client.__getattribute__(self._JOB_TYPE.value)._get(f"{self._status_path}{self.job_id}").json()
-        )
+        data = getattr(self._cognite_client, self._JOB_TYPE.value)._get(f"{self._status_path}{self.job_id}").json()
         self.status = data["status"]
         self.status_time = data.get("statusTime")
         self.start_time = data.get("startTime")

--- a/cognite/client/data_classes/contextualization.py
+++ b/cognite/client/data_classes/contextualization.py
@@ -122,11 +122,14 @@ class ContextualizationJob(CogniteResource):
         return self.status
 
     def wait_for_completion(self, timeout: int = None, interval: int = 1) -> None:
-        """Waits for job completion, raising ModelFailedException if fit failed - generally not needed to call as it is called by result.
+        """Waits for job completion. This is generally not needed to call directly, as `.result` will do so automatically.
 
         Args:
             timeout (int): Time out after this many seconds. (None means wait indefinitely)
             interval (int): Poll status every this many seconds.
+
+        Raises:
+            ModelFailedException: The model fit failed.
         """
         start = time.time()
         while timeout is None or time.time() < start + timeout:
@@ -216,11 +219,14 @@ class EntityMatchingModel(CogniteResource):
         return self.status
 
     def wait_for_completion(self, timeout: int = None, interval: int = 1) -> None:
-        """Waits for model completion, raising ModelFailedException if fit failed - generally not needed to call as it is called by predict
+        """Waits for model completion. This is generally not needed to call directly, as `.result` will do so automatically.
 
         Args:
             timeout: Time out after this many seconds. (None means wait indefinitely)
             interval: Poll status every this many seconds.
+
+        Raises:
+            ModelFailedException: The model fit failed.
         """
         start = time.time()
         while timeout is None or time.time() < start + timeout:

--- a/cognite/client/data_classes/contextualization.py
+++ b/cognite/client/data_classes/contextualization.py
@@ -505,8 +505,6 @@ class DiagramDetectResults(ContextualizationJob):
 
 # Vision dataclasses
 FeatureClass = Union[Type[TextRegion], Type[AssetLink], Type[ObjectDetection]]
-ExternalId = str
-InternalId = int
 
 
 class VisionFeature(str, Enum):
@@ -775,7 +773,7 @@ class VisionExtractJob(VisionJob):
         super().__init__(*args, **kwargs)
         self._items: Optional[List[VisionExtractItem]] = None
 
-    def __getitem__(self, file_id: InternalId) -> VisionExtractItem:
+    def __getitem__(self, file_id: int) -> VisionExtractItem:
         """Retrieves the results for a file by id"""
         found = [item for item in self.result["items"] if item.get("fileId") == file_id]
         if not found:

--- a/cognite/client/data_classes/contextualization.py
+++ b/cognite/client/data_classes/contextualization.py
@@ -118,6 +118,7 @@ class ContextualizationJob(CogniteResource):
 
     def wait_for_completion(self, timeout: int = None, interval: int = 1) -> None:
         """Waits for job completion, raising ModelFailedException if fit failed - generally not needed to call as it is called by result.
+
         Args:
             timeout (int): Time out after this many seconds. (None means wait indefinitely)
             interval (int): Poll status every this many seconds.
@@ -128,7 +129,7 @@ class ContextualizationJob(CogniteResource):
             if not JobStatus(self.status).is_not_finished():
                 break
             time.sleep(interval)
-        if JobStatus(self.status) == JobStatus.FAILED:
+        if JobStatus(self.status) is JobStatus.FAILED:
             raise ModelFailedException(self.__class__.__name__, cast(int, self.job_id), cast(str, self.error_message))
 
     @property
@@ -222,7 +223,7 @@ class EntityMatchingModel(CogniteResource):
             if JobStatus(self.status) not in [JobStatus.QUEUED, JobStatus.RUNNING]:
                 break
             time.sleep(interval)
-        if JobStatus(self.status) == JobStatus.FAILED:
+        if JobStatus(self.status) is JobStatus.FAILED:
             assert self.id is not None
             assert self.error_message is not None
             raise ModelFailedException(self.__class__.__name__, self.id, self.error_message)
@@ -418,7 +419,7 @@ class DiagramConvertResults(ContextualizationJob):
     @property
     def items(self) -> Optional[List[DiagramConvertItem]]:
         """returns a list of all results by file"""
-        if self.status == "Completed":
+        if JobStatus(self.status) is JobStatus.COMPLETED:
             self._items = [
                 DiagramConvertItem._load(item, cognite_client=self._cognite_client) for item in self.result["items"]
             ]
@@ -482,8 +483,8 @@ class DiagramDetectResults(ContextualizationJob):
 
     @property
     def items(self) -> Optional[List[DiagramDetectItem]]:
-        """returns a list of all results by file"""
-        if self.status == "Completed":
+        """Returns a list of all results by file"""
+        if JobStatus(self.status) is JobStatus.COMPLETED:
             self._items = [
                 DiagramDetectItem._load(item, cognite_client=self._cognite_client) for item in self.result["items"]
             ]
@@ -495,7 +496,7 @@ class DiagramDetectResults(ContextualizationJob):
 
     @property
     def errors(self) -> List[str]:
-        """returns a list of all error messages across files"""
+        """Returns a list of all error messages across files"""
         return [item["errorMessage"] for item in self.result["items"] if "errorMessage" in item]
 
     def convert(self) -> DiagramConvertResults:
@@ -631,6 +632,7 @@ class DetectJobBundle:
 
     def wait_for_completion(self, timeout: int = None) -> None:
         """Waits for all jobs to complete, generally not needed to call as it is called by result.
+
         Args:
             timeout (int): Time out after this many seconds. (None means wait indefinitely)
             interval (int): Poll status every this many seconds.
@@ -783,7 +785,7 @@ class VisionExtractJob(VisionJob):
     @property
     def items(self) -> Optional[List[VisionExtractItem]]:
         """Returns a list of all predictions by file"""
-        if self.status == JobStatus.COMPLETED.value:
+        if JobStatus(self.status) is JobStatus.COMPLETED:
             self._items = [
                 VisionExtractItem._load(item, cognite_client=self._cognite_client) for item in self.result["items"]
             ]
@@ -840,7 +842,7 @@ class VisionExtractJob(VisionJob):
             Union[Annotation, AnnotationList]: (suggested) annotation(s) stored in CDF.
 
         """
-        if self.status == JobStatus.COMPLETED.value:
+        if JobStatus(self.status) is JobStatus.COMPLETED:
             annotations = self._predictions_to_annotations(
                 creating_user=creating_user, creating_app=creating_app, creating_app_version=creating_app_version
             )

--- a/cognite/client/data_classes/contextualization.py
+++ b/cognite/client/data_classes/contextualization.py
@@ -4,22 +4,7 @@ import time
 import warnings
 from dataclasses import dataclass
 from enum import Enum
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    Dict,
-    List,
-    Optional,
-    Sequence,
-    Set,
-    Tuple,
-    Type,
-    TypeVar,
-    Union,
-    cast,
-    get_args,
-    get_type_hints,
-)
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Sequence, Set, Tuple, Type, TypeVar, Union, cast
 
 from cognite.client.data_classes import Annotation
 from cognite.client.data_classes._base import (

--- a/cognite/client/data_classes/contextualization.py
+++ b/cognite/client/data_classes/contextualization.py
@@ -533,30 +533,21 @@ class VisionFeature(str, Enum):
         return {cls.INDUSTRIAL_OBJECT_DETECTION, cls.PERSONAL_PROTECTIVE_EQUIPMENT_DETECTION}
 
 
+VISION_FEATURE_MAP: Dict[str, Any] = {
+    "text_predictions": TextRegion,
+    "asset_tag_predictions": AssetLink,
+    "industrial_object_predictions": ObjectDetection,
+    "people_predictions": ObjectDetection,
+    "personal_protective_equipment_predictions": ObjectDetection,
+}
+
+
+# Auto-generate the dataclass from the mapping VISION_FEATURE_MAP:
 @dataclass
 class VisionExtractPredictions(VisionResource):
-    text_predictions: Optional[List[TextRegion]] = None
-    asset_tag_predictions: Optional[List[AssetLink]] = None
-    industrial_object_predictions: Optional[List[ObjectDetection]] = None
-    people_predictions: Optional[List[ObjectDetection]] = None
-    personal_protective_equipment_predictions: Optional[List[ObjectDetection]] = None
-
-    @staticmethod
-    def _get_feature_class(type_hint: Type[Optional[List[FeatureClass]]]) -> FeatureClass:
-        # Unwrap the first level of type hints (i.e., the Optional[...])
-        # NOTE: outer type hint MUST be an Optional, since Optional[X] == Union[X, None]
-        list_type_hint, _ = get_args(type_hint)
-        # Unwrap the second level of type hint (i.e., the List[...])
-        (class_type,) = get_args(list_type_hint)
-        return class_type
-
-
-# Auto-generate the annotation-to-dataclass mapping based on the type hints of VisionExtractPredictions
-VISION_FEATURE_MAP: Dict[str, FeatureClass] = {
-    key: VisionExtractPredictions._get_feature_class(value)
-    for key, value in get_type_hints(VisionExtractPredictions).items()
-    if not key == "_cognite_client"
-}
+    __annotations__ = {param: f"Optional[List[{cls.__name__}]]" for param, cls in VISION_FEATURE_MAP.items()}
+    for attr in VISION_FEATURE_MAP:
+        locals()[attr] = None
 
 
 VISION_ANNOTATION_TYPE_MAP: Dict[str, str] = {

--- a/cognite/client/data_classes/contextualization.py
+++ b/cognite/client/data_classes/contextualization.py
@@ -337,9 +337,9 @@ class FileReference:
         self.last_page = last_page
 
         if not exactly_one_is_not_none(file_id, file_external_id):
-            raise Exception("Exactly one of file_id and file_external_id must be set for a file reference")
+            raise ValueError("Exactly one of file_id and file_external_id must be set for a file reference")
         if exactly_one_is_not_none(first_page, last_page):
-            raise Exception("If the page range feature is used, both first page and last page must be set")
+            raise ValueError("If the page range feature is used, both first page and last page must be set")
 
     def to_api_item(self) -> Dict[str, Union[str, int, Dict[str, int]]]:
         if self.file_id is None and self.file_external_id is not None:

--- a/tests/tests_unit/test_api/test_entity_matching.py
+++ b/tests/tests_unit/test_api/test_entity_matching.py
@@ -87,7 +87,7 @@ class TestEntityMatching:
             sources=entities_from, targets=entities_to, true_matches=[(1, 2)], feature_type="bigram"
         )
         assert isinstance(model, EntityMatchingModel)
-        assert "EntityMatchingModel(id: 123,status: Queued,error: None)" == str(model)
+        assert "EntityMatchingModel(id=123, status=Queued, error=None)" == str(model)
         assert 42 == model.created_time
         model.wait_for_completion()
         assert "Completed" == model.status
@@ -127,7 +127,7 @@ class TestEntityMatching:
             sources=entities_from, targets=entities_to, true_matches=[(1, 2)], feature_type="bigram"
         )
         assert isinstance(model, EntityMatchingModel)
-        assert "EntityMatchingModel(id: 123,status: Queued,error: None)" == str(model)
+        assert "EntityMatchingModel(id=123, status=Queued, error=None)" == str(model)
         assert 42 == model.created_time
         model.wait_for_completion()
         assert "Completed" == model.status

--- a/tests/tests_unit/test_api/test_vision_extract.py
+++ b/tests/tests_unit/test_api/test_vision_extract.py
@@ -106,6 +106,14 @@ def mock_get_extract_empty_predictions(rsps: RequestsMock, mock_get_response_bod
     yield rsps
 
 
+class TestJobStatusEnum:
+    @pytest.mark.parametrize("job_status", list(JobStatus))
+    def test_job_status_methods(self, job_status):
+        v1 = job_status.is_finished()
+        v2 = job_status.is_not_finished()
+        assert sorted([v1, v2]) == [False, True]
+
+
 class TestVisionExtract:
     @pytest.mark.parametrize(
         "features, parameters, error_message",
@@ -183,7 +191,7 @@ class TestVisionExtract:
             expected_job_id = 1
             job.wait_for_completion(interval=0)
             assert "items" in job.result
-            assert JobStatus.COMPLETED == JobStatus(job.status)
+            assert JobStatus.COMPLETED is JobStatus(job.status)
             assert expected_job_id == job.job_id
 
             num_post_requests, num_get_requests = 0, 0

--- a/tests/tests_unit/test_data_classes/test_contextualization.py
+++ b/tests/tests_unit/test_data_classes/test_contextualization.py
@@ -1,12 +1,12 @@
 from __future__ import annotations
 
-from typing import Any, Dict
+from typing import Any, Dict, get_args
 from unittest.mock import Mock, patch
 
 import pytest
 
 from cognite.client.data_classes import ContextualizationJob
-from cognite.client.data_classes.contextualization import DetectJobBundle
+from cognite.client.data_classes.contextualization import VISION_FEATURE_MAP, DetectJobBundle, VisionExtractPredictions
 from cognite.client.testing import monkeypatch_cognite_client
 
 
@@ -34,6 +34,18 @@ def mock_update_status_running(self):
 def mock_update_status_completed(self):
     self.status = "Completed"
     return self.status
+
+
+class TestVisionExtractPredictions:
+    def test_visionextractpredictions_in_sync_with_vision_feature_map(self) -> None:
+        """This test ensures that the mapping and VisionExtractPredictions class is 'in sync'"""
+        map_as_set = set(VISION_FEATURE_MAP.items())
+        # Unwrap the first level of type hints, (MUST be an Optional), since Optional[X] == Union[X, None].
+        # Unwrap the second level of type hint (i.e., the List[...]):
+        annots_as_set = set(
+            [(key, get_args(get_args(annot)[0])[0]) for key, annot in VisionExtractPredictions.__annotations__.items()]
+        )
+        assert map_as_set == annots_as_set
 
 
 class TestContextualizationJob:

--- a/tests/tests_unit/test_data_classes/test_contextualization.py
+++ b/tests/tests_unit/test_data_classes/test_contextualization.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any, Dict, get_args
+from typing import Any, Dict, get_args, get_type_hints
 from unittest.mock import Mock, patch
 
 import pytest
@@ -39,13 +39,12 @@ def mock_update_status_completed(self):
 class TestVisionExtractPredictions:
     def test_visionextractpredictions_in_sync_with_vision_feature_map(self) -> None:
         """This test ensures that the mapping and VisionExtractPredictions class is 'in sync'"""
-        map_as_set = set(VISION_FEATURE_MAP.items())
+        mapping_as_set = set(VISION_FEATURE_MAP.items())
+        (annot_dct := get_type_hints(VisionExtractPredictions)).pop("_cognite_client")
         # Unwrap the first level of type hints, (MUST be an Optional), since Optional[X] == Union[X, None].
         # Unwrap the second level of type hint (i.e., the List[...]):
-        annots_as_set = set(
-            [(key, get_args(get_args(annot)[0])[0]) for key, annot in VisionExtractPredictions.__annotations__.items()]
-        )
-        assert map_as_set == annots_as_set
+        annots_as_set = set([(k, get_args(get_args(a)[0])[0]) for k, a in annot_dct.items()])
+        assert mapping_as_set == annots_as_set
 
 
 class TestContextualizationJob:

--- a/tests/tests_unit/test_data_classes/test_vision.py
+++ b/tests/tests_unit/test_data_classes/test_vision.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, List, Optional
 from unittest.mock import MagicMock, PropertyMock, patch
 
 import pytest
@@ -33,21 +33,6 @@ mock_vision_extract_predictions = VisionExtractPredictions(
         )
     ]
 )
-
-
-class TestVisionExtractPredictions:
-    def test_get_feature_class(self) -> None:
-        assert VisionExtractPredictions._get_feature_class(Optional[List[str]]) == str
-        assert VisionExtractPredictions._get_feature_class(Optional[List[List[str]]]) == List[str]
-        assert VisionExtractPredictions._get_feature_class(Optional[List[float]]) == float
-        assert VisionExtractPredictions._get_feature_class(Optional[List[Union[int, str]]]) == Union[int, str]
-        assert (
-            VisionExtractPredictions._get_feature_class(Optional[List[VisionExtractPredictions]])
-            == VisionExtractPredictions
-        )
-        assert (
-            VisionExtractPredictions._get_feature_class(Optional[List[Dict[str, TextRegion]]]) == Dict[str, TextRegion]
-        )
 
 
 class TestVisionResource:


### PR DESCRIPTION
## Description

1. Remove duplicate-but-different definitions of `ExternalId` and `InternalId` that are not subclasses of `Identifier`.
2. Use singleton property of enums
3. Change two uses of `__getattribute__` to `getattr`
4. Remove code that has been abstracted out but still left in (forgotten about I guess)
5. Write `@dataclass`-like `__str__` methods
6. Improve / fix docstrings
7. Narrowed two raised 'Exception's to 'ValueError's
8. Move information about what the function might raise to a proper Spinhx parseable "block"
9. Fix bug in function `_process_vertices` (correct dict with different insertion order than `x`-then-`y` would raise ValueError)

## Controversial? 😅 
10. Future-proofing (looking at you #1107 ): Change the dataclass `VisionExtractPredictions` to be made dynamically from `VISION_FEATURE_MAP` and not the other way around. Used to depend on type annotations being on an exact correct format, which isn't compatible with preferred annotations syntax in newer versions (or older, with `from __future__ import annotations`).

One way to do this:
```py
VISION_FEATURE_MAP: Dict[str, Any] = {
    "text_predictions": TextRegion,
    "asset_tag_predictions": AssetLink,
    "industrial_object_predictions": ObjectDetection,
    "people_predictions": ObjectDetection,
    "personal_protective_equipment_predictions": ObjectDetection,
}


class VisionExtractPredictions(VisionResource):
    __annotations__ = {param: f"Optional[List[{cls.__name__}]]" for param, cls in VISION_FEATURE_MAP.items()}


# Auto-generate the dataclass from the mapping VISION_FEATURE_MAP:
for attr in VISION_FEATURE_MAP:
    setattr(VisionExtractPredictions, attr, None)
VisionExtractPredictions = dataclass(VisionExtractPredictions)  # type: ignore [misc]
```

...and another:
```py
VISION_FEATURE_MAP: Dict[str, Any] = {
    "text_predictions": TextRegion,
    "asset_tag_predictions": AssetLink,
    "industrial_object_predictions": ObjectDetection,
    "people_predictions": ObjectDetection,
    "personal_protective_equipment_predictions": ObjectDetection,
}

# Auto-generate the dataclass from the mapping VISION_FEATURE_MAP:
@dataclass
class VisionExtractPredictions(VisionResource):
    __annotations__ = {param: f"Optional[List[{cls.__name__}]]" for param, cls in VISION_FEATURE_MAP.items()}
    for attr in VISION_FEATURE_MAP:
        locals()[attr] = None
```

## Checklist:
- [x] Tests added/updated.
- [ ] Documentation updated. Documentation is generated from docstrings - these must be updated according to your change.
  If a new method has been added it should be referenced in [cognite.rst](https://github.com/cognitedata/cognite-sdk-python/blob/master/docs/source/cognite.rst) in order to generate docs based on its docstring.
- [ ] Changelog updated in [CHANGELOG.md](https://github.com/cognitedata/cognite-sdk-python/blob/master/CHANGELOG.md).
- [ ] Version bumped. If triggering a new release is desired, bump the version number in [_version.py](https://github.com/cognitedata/cognite-sdk-python/blob/master/cognite/client/_version.py) and [pyproject.toml](https://github.com/cognitedata/cognite-sdk-python/blob/master/pyproject.toml) per [semantic versioning](https://semver.org/).
