### PR TITLE
Add `_repr_html_` fallback (fix #1083). Remove redundant subclass methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,16 +17,20 @@ Changes are grouped as follows
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
+## [5.3.4] - 21-01-24
+### Fixed
+- Displaying Cognite resources like an `Asset` or a `TimeSeriesList` in a Jupyter notebook or similar environments depending on `._repr_html_`, no longer raises `CogniteImportError` stating that `pandas` is required. Instead, a warning is issued and `.dump()` is used as fallback.
+
 ## [5.3.3] - 20-01-24
-### Changed
-- Allowed to pass in `token_cache_path` in `OAuthInteractive` and `OAuthDeviceCode`.
+### Added
+- New parameter `token_cache_path` now accepted by `OAuthInteractive` and `OAuthDeviceCode` to allow overriding location of token cache.
 
 ### Fixed
-- Platform independent temp directory for the caching of the token in `OAuthInteractive` and `OAuthDeviceCode`.
+- Platform dependent temp directory for the caching of the token in `OAuthInteractive` and `OAuthDeviceCode` (no longer crashes at exit on Windows).
 
 ## [5.3.2] - 20-01-24
 ### Changed
-- Update pytest and other dependencies
+- Update pytest and other dependencies to get rid of dependency on the `py` package.
 
 ## [5.3.1] - 20-01-23
 ### Fixed

--- a/cognite/client/_version.py
+++ b/cognite/client/_version.py
@@ -1,4 +1,4 @@
 from __future__ import annotations
 
-__version__ = "5.3.3"
+__version__ = "5.3.4"
 __api_subversion__ = "V20220125"

--- a/cognite/client/data_classes/_base.py
+++ b/cognite/client/data_classes/_base.py
@@ -8,6 +8,7 @@ from cognite.client import utils
 from cognite.client.exceptions import CogniteMissingClientError
 from cognite.client.utils._auxiliary import convert_all_keys_to_camel_case, to_camel_case, to_snake_case
 from cognite.client.utils._identifier import IdentifierSequence
+from cognite.client.utils._pandas_helpers import notebook_display_with_fallback
 from cognite.client.utils._time import convert_time_attributes_to_datetime
 
 if TYPE_CHECKING:
@@ -149,7 +150,7 @@ class CogniteResource:
         return df
 
     def _repr_html_(self) -> str:
-        return self.to_pandas(camel_case=False)._repr_html_()
+        return notebook_display_with_fallback(self)
 
 
 T_CogniteResource = TypeVar("T_CogniteResource", bound=CogniteResource)
@@ -255,7 +256,7 @@ class CogniteResourceList(UserList):
         return df
 
     def _repr_html_(self) -> str:
-        return self.to_pandas(camel_case=False)._repr_html_()
+        return notebook_display_with_fallback(self)
 
     @classmethod
     def _load(

--- a/cognite/client/data_classes/annotation_types/primitives.py
+++ b/cognite/client/data_classes/annotation_types/primitives.py
@@ -55,9 +55,6 @@ class VisionResource(CogniteResource):
 
         return df
 
-    def _repr_html_(self) -> str:
-        return self.to_pandas(camel_case=False)._repr_html_()
-
 
 @dataclass
 class Point(VisionResource):

--- a/cognite/client/data_classes/datapoints.py
+++ b/cognite/client/data_classes/datapoints.py
@@ -35,7 +35,10 @@ from cognite.client.utils._auxiliary import (
     to_camel_case,
 )
 from cognite.client.utils._identifier import Identifier
-from cognite.client.utils._pandas_helpers import concat_dataframes_with_nullable_int_cols
+from cognite.client.utils._pandas_helpers import (
+    concat_dataframes_with_nullable_int_cols,
+    notebook_display_with_fallback,
+)
 
 ALL_SORTED_DP_AGGS = sorted(
     [
@@ -231,9 +234,6 @@ class DatapointsArray(CogniteResource):
 
     def __str__(self) -> str:
         return json.dumps(self.dump(convert_timestamps=True), indent=4)
-
-    def _repr_html_(self) -> str:
-        return self.to_pandas()._repr_html_()
 
     @overload
     def __getitem__(self, item: int) -> Datapoint:
@@ -618,7 +618,7 @@ class Datapoints(CogniteResource):
 
     def _repr_html_(self) -> str:
         is_synthetic_dps = self.error is not None
-        return self.to_pandas(include_errors=is_synthetic_dps)._repr_html_()
+        return notebook_display_with_fallback(self, include_errors=is_synthetic_dps)
 
 
 class DatapointsArrayList(CogniteResourceList):
@@ -663,9 +663,6 @@ class DatapointsArrayList(CogniteResourceList):
 
     def __str__(self) -> str:
         return json.dumps(self.dump(convert_timestamps=True), indent=4)
-
-    def _repr_html_(self) -> str:
-        return self.to_pandas()._repr_html_()
 
     def to_pandas(  # type: ignore [override]
         self,
@@ -771,6 +768,3 @@ class DatapointsList(CogniteResourceList):
             return pd.DataFrame(index=pd.to_datetime([]))
 
         return concat_dataframes_with_nullable_int_cols(dfs)
-
-    def _repr_html_(self) -> str:
-        return self.to_pandas()._repr_html_()

--- a/cognite/client/data_classes/raw.py
+++ b/cognite/client/data_classes/raw.py
@@ -43,9 +43,6 @@ class Row(CogniteResource):
         pd = cast(Any, utils._auxiliary.local_import("pandas"))
         return pd.DataFrame([self.columns], [self.key])
 
-    def _repr_html_(self) -> str:
-        return self.to_pandas()._repr_html_()
-
 
 class RowList(CogniteResourceList):
     _RESOURCE = Row
@@ -58,9 +55,6 @@ class RowList(CogniteResourceList):
         """
         pd = cast(Any, utils._auxiliary.local_import("pandas"))
         return pd.DataFrame.from_dict(OrderedDict(((d.key, d.columns) for d in self.data)), orient="index")
-
-    def _repr_html_(self) -> str:
-        return self.to_pandas()._repr_html_()
 
 
 class Table(CogniteResource):

--- a/cognite/client/data_classes/sequences.py
+++ b/cognite/client/data_classes/sequences.py
@@ -327,9 +327,6 @@ class SequenceData(CogniteResource):
     def __str__(self) -> str:
         return json.dumps(self.dump(), indent=4)
 
-    def _repr_html_(self) -> str:
-        return self.to_pandas()._repr_html_()
-
     def __len__(self) -> int:
         return len(self.row_numbers)
 
@@ -459,6 +456,3 @@ class SequenceDataList(CogniteResourceList):
         """
         pd = utils._auxiliary.local_import("pandas")
         return pd.concat([seq_data.to_pandas(column_names=column_names) for seq_data in self.data], axis=1)  # type: ignore
-
-    def _repr_html_(self) -> str:
-        return self.to_pandas()._repr_html_()

--- a/cognite/client/utils/_pandas_helpers.py
+++ b/cognite/client/utils/_pandas_helpers.py
@@ -2,14 +2,33 @@ from __future__ import annotations
 
 import re
 import warnings
+from inspect import signature
 from itertools import chain
 from numbers import Integral
-from typing import TYPE_CHECKING, Any, Sequence, cast
+from typing import TYPE_CHECKING, Any, Sequence, Union, cast
 
+from cognite.client.exceptions import CogniteImportError
 from cognite.client.utils._auxiliary import local_import
 
 if TYPE_CHECKING:
     import pandas as pd
+
+    from cognite.client.data_classes._base import T_CogniteResource, T_CogniteResourceList
+
+
+def notebook_display_with_fallback(inst: Union[T_CogniteResource, T_CogniteResourceList], **kwargs: Any) -> str:
+    if "camel_case" in signature(inst.to_pandas).parameters:
+        # Default of False enforced (when accepted by method):
+        kwargs["camel_case"] = False
+    try:
+        return inst.to_pandas(**kwargs)._repr_html_()
+    except CogniteImportError:
+        warnings.warn(
+            "The 'cognite-sdk' depends on 'pandas' for pretty-printing objects like 'Asset' or 'DatapointsList' in "
+            "(Jupyter) notebooks and similar environments. Consider installing it! Using fallback method.",
+            UserWarning,
+        )
+        return str(inst)
 
 
 def concat_dataframes_with_nullable_int_cols(dfs: Sequence[pd.DataFrame]) -> pd.DataFrame:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "cognite-sdk"
 
-version = "5.3.3"
+version = "5.3.4"
 
 description = "Cognite Python SDK"
 readme = "README.md"


### PR DESCRIPTION
## Description
Addresses issue #1083 by adding a fallback method to `_repr_html_` which uses `str` (which in turns call dump/json.dumps).

Also removed 8 unnecessary `_repr_html_` subclass methods.

...also abstracted out the base function to `cognite/client/utils/_pandas_helpers.py:notebook_display_with_fallback`

## Checklist:
- [ ] Tests added/updated.
- [ ] Documentation updated. Documentation is generated from docstrings - these must be updated according to your change.
  If a new method has been added it should be referenced in [cognite.rst](https://github.com/cognitedata/cognite-sdk-python/blob/master/docs/source/cognite.rst) in order to generate docs based on its docstring.
- [ ] Changelog updated in [CHANGELOG.md](https://github.com/cognitedata/cognite-sdk-python/blob/master/CHANGELOG.md).
- [ ] Version bumped. If triggering a new release is desired, bump the version number in [_version.py](https://github.com/cognitedata/cognite-sdk-python/blob/master/cognite/client/_version.py) and [pyproject.toml](https://github.com/cognitedata/cognite-sdk-python/blob/master/pyproject.toml) per [semantic versioning](https://semver.org/).
