### PR TITLE
File Not Found OAuthInteractive Windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,8 @@ test-report.xml
 # tox
 .tox/
 .python-version
+
+.benchmarks
+cache.bin
+local_cog_client.py
+tests/tests_integration/test_benchmarks/

--- a/.gitignore
+++ b/.gitignore
@@ -49,8 +49,3 @@ test-report.xml
 # tox
 .tox/
 .python-version
-
-.benchmarks
-cache.bin
-local_cog_client.py
-tests/tests_integration/test_benchmarks/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ Changes are grouped as follows
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
+## [5.3.3] - 20-01-24
+### Changed
+- Allowed to pass in `token_cache_path` in `OAuthInteractive`.
+
 ## [5.3.2] - 20-01-24
 ### Changed
 - Update pytest and other dependencies

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ Changes are grouped as follows
 
 ## [5.3.3] - 20-01-24
 ### Changed
-- Allowed to pass in `token_cache_path` in `OAuthInteractive`.
+- Allowed to pass in `token_cache_path` in `OAuthInteractive` and `OAuthDeviceCode`.
 
 ## [5.3.2] - 20-01-24
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@ Changes are grouped as follows
 ### Changed
 - Allowed to pass in `token_cache_path` in `OAuthInteractive` and `OAuthDeviceCode`.
 
+### Fixed
+- Platform independent temp directory.
+
 ## [5.3.2] - 20-01-24
 ### Changed
 - Update pytest and other dependencies

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ Changes are grouped as follows
 - Allowed to pass in `token_cache_path` in `OAuthInteractive` and `OAuthDeviceCode`.
 
 ### Fixed
-- Platform independent temp directory.
+- Platform independent temp directory for the caching of the token in `OAuthInteractive` and `OAuthDeviceCode`.
 
 ## [5.3.2] - 20-01-24
 ### Changed

--- a/cognite/client/_version.py
+++ b/cognite/client/_version.py
@@ -1,4 +1,4 @@
 from __future__ import annotations
 
-__version__ = "5.3.2"
+__version__ = "5.3.3"
 __api_subversion__ = "V20220125"

--- a/cognite/client/credentials.py
+++ b/cognite/client/credentials.py
@@ -107,7 +107,7 @@ class _WithMsalSerializableTokenCache:
 
         def __at_exit() -> None:
             if token_cache.has_state_changed:
-                with open(cache_path, "w") as fh:
+                with open(cache_path, "w+") as fh:
                     fh.write(token_cache.serialize())
 
         atexit.register(__at_exit)
@@ -121,6 +121,7 @@ class OAuthDeviceCode(_OAuthCredentialProviderWithTokenRefresh, _WithMsalSeriali
         authority_url (str): OAuth authority url
         client_id (str): Your application's client id.
         scopes (List[str]): A list of scopes.
+        token_cache_path (Path): Location to store token cache, defaults to /tmp/cognitetokencache.{client_id}.bin.
 
     Examples:
 
@@ -132,14 +133,20 @@ class OAuthDeviceCode(_OAuthCredentialProviderWithTokenRefresh, _WithMsalSeriali
             ... )
     """
 
-    def __init__(self, authority_url: str, client_id: str, scopes: List[str]) -> None:
+    def __init__(
+        self,
+        authority_url: str,
+        client_id: str,
+        scopes: List[str],
+        token_cache_path: Path = None,
+    ) -> None:
         super().__init__()
         self.__authority_url = authority_url
         self.__client_id = client_id
         self.__scopes = scopes
 
         # In addition to caching in memory, we also cache the token on disk so it can be reused across processes.
-        token_cache_path = Path(f"/tmp/cognitetokencache.{self.__client_id}.bin")
+        token_cache_path = token_cache_path or Path(f"/tmp/cognitetokencache.{self.__client_id}.bin")
         serializable_token_cache = self._create_serializable_token_cache(token_cache_path)
         self.__app = PublicClientApplication(
             client_id=self.__client_id, authority=self.__authority_url, token_cache=serializable_token_cache

--- a/cognite/client/credentials.py
+++ b/cognite/client/credentials.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import atexit
+import tempfile
 import threading
 from abc import abstractmethod
 from datetime import datetime
@@ -121,7 +122,8 @@ class OAuthDeviceCode(_OAuthCredentialProviderWithTokenRefresh, _WithMsalSeriali
         authority_url (str): OAuth authority url
         client_id (str): Your application's client id.
         scopes (List[str]): A list of scopes.
-        token_cache_path (Path): Location to store token cache, defaults to /tmp/cognitetokencache.{client_id}.bin.
+        token_cache_path (Path): Location to store token cache, defaults to
+                                 os temp directory/cognitetokencache.{client_id}.bin.
 
     Examples:
 
@@ -146,7 +148,7 @@ class OAuthDeviceCode(_OAuthCredentialProviderWithTokenRefresh, _WithMsalSeriali
         self.__scopes = scopes
 
         # In addition to caching in memory, we also cache the token on disk so it can be reused across processes.
-        token_cache_path = token_cache_path or Path(f"/tmp/cognitetokencache.{self.__client_id}.bin")
+        token_cache_path = token_cache_path or Path(tempfile.gettempdir()) / f"cognitetokencache.{self.__client_id}.bin"
         serializable_token_cache = self._create_serializable_token_cache(token_cache_path)
         self.__app = PublicClientApplication(
             client_id=self.__client_id, authority=self.__authority_url, token_cache=serializable_token_cache
@@ -189,7 +191,8 @@ class OAuthInteractive(_OAuthCredentialProviderWithTokenRefresh, _WithMsalSerial
         client_id (str): Your application's client id.
         scopes (List[str]): A list of scopes.
         redirect_port (List[str]): Redirect port defaults to 53000.
-        token_cache_path (Path): Location to store token cache, defaults to /tmp/cognitetokencache.{client_id}.bin.
+        token_cache_path (Path): Location to store token cache, defaults to
+                                 os temp directory/cognitetokencache.{client_id}.bin.
 
     Examples:
 
@@ -216,7 +219,7 @@ class OAuthInteractive(_OAuthCredentialProviderWithTokenRefresh, _WithMsalSerial
         self.__redirect_port = redirect_port
 
         # In addition to caching in memory, we also cache the token on disk so it can be reused across processes.
-        token_cache_path = token_cache_path or Path(f"/tmp/cognitetokencache.{self.__client_id}.bin")
+        token_cache_path = token_cache_path or Path(tempfile.gettempdir()) / f"cognitetokencache.{self.__client_id}.bin"
         serializable_token_cache = self._create_serializable_token_cache(token_cache_path)
         self.__app = PublicClientApplication(
             client_id=self.__client_id, authority=self.__authority_url, token_cache=serializable_token_cache

--- a/cognite/client/credentials.py
+++ b/cognite/client/credentials.py
@@ -182,6 +182,7 @@ class OAuthInteractive(_OAuthCredentialProviderWithTokenRefresh, _WithMsalSerial
         client_id (str): Your application's client id.
         scopes (List[str]): A list of scopes.
         redirect_port (List[str]): Redirect port defaults to 53000.
+        token_cache_path (Path): Location to store token cache, defaults to /tmp/cognitetokencache.{client_id}.bin.
 
     Examples:
 
@@ -193,7 +194,14 @@ class OAuthInteractive(_OAuthCredentialProviderWithTokenRefresh, _WithMsalSerial
             ... )
     """
 
-    def __init__(self, authority_url: str, client_id: str, scopes: List[str], redirect_port: int = 53000) -> None:
+    def __init__(
+        self,
+        authority_url: str,
+        client_id: str,
+        scopes: List[str],
+        redirect_port: int = 53000,
+        token_cache_path: Path = None,
+    ) -> None:
         super().__init__()
         self.__authority_url = authority_url
         self.__client_id = client_id
@@ -201,7 +209,7 @@ class OAuthInteractive(_OAuthCredentialProviderWithTokenRefresh, _WithMsalSerial
         self.__redirect_port = redirect_port
 
         # In addition to caching in memory, we also cache the token on disk so it can be reused across processes.
-        token_cache_path = Path(f"/tmp/cognitetokencache.{self.__client_id}.bin")
+        token_cache_path = token_cache_path or Path(f"/tmp/cognitetokencache.{self.__client_id}.bin")
         serializable_token_cache = self._create_serializable_token_cache(token_cache_path)
         self.__app = PublicClientApplication(
             client_id=self.__client_id, authority=self.__authority_url, token_cache=serializable_token_cache

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "cognite-sdk"
 
-version = "5.3.2"
+version = "5.3.3"
 
 description = "Cognite Python SDK"
 readme = "README.md"


### PR DESCRIPTION
## Description  
closes #1116 

**Problem**
When running the interactive login workflow on windows I get the following exception

```python
Exception ignored in atexit callback: <function _WithMsalSerializableTokenCache._create_serializable_token_cache.<locals>.__at_exit at 0x0000014A704B4D60>
Traceback (most recent call last):
  File "...\.venv\Lib\site-packages\cognite\client\credentials.py", line 108, in __at_exit
    with open(cache_path, "w") as fh:
         ^^^^^^^^^^^^^^^^^^^^^
FileNotFoundError: [Errno 2] No such file or directory: '\\tmp\\cognitetokencache.123456789.bin'
```
**Solution**  
By allowing to pass in the path for the token cache, I can ensure that the folder exists.


## Checklist:
- [ ] Tests added/updated.
- [x] Documentation updated. Documentation is generated from docstrings - these must be updated according to your change.
  If a new method has been added it should be referenced in [cognite.rst](https://github.com/cognitedata/cognite-sdk-python/blob/master/docs/source/cognite.rst) in order to generate docs based on its docstring.
- [x] Changelog updated in [CHANGELOG.md](https://github.com/cognitedata/cognite-sdk-python/blob/master/CHANGELOG.md).
- [x] Version bumped. If triggering a new release is desired, bump the version number in [_version.py](https://github.com/cognitedata/cognite-sdk-python/blob/master/cognite/client/_version.py) and [pyproject.toml](https://github.com/cognitedata/cognite-sdk-python/blob/master/pyproject.toml) per [semantic versioning](https://semver.org/).
