### PR TITLE
Fix thread shutdown on PY39+ (fix #1121)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,18 +17,22 @@ Changes are grouped as follows
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
-## [5.3.4] - 21-01-24
+## [5.3.5] - 25-01-23
 ### Fixed
 - Displaying Cognite resources like an `Asset` or a `TimeSeriesList` in a Jupyter notebook or similar environments depending on `._repr_html_`, no longer raises `CogniteImportError` stating that `pandas` is required. Instead, a warning is issued and `.dump()` is used as fallback.
 
-## [5.3.3] - 20-01-24
+## [5.3.4] - 25-01-23
+### Fixed
+- Displaying Cognite resources like an `Asset` or a `TimeSeriesList` in a Jupyter notebook or similar environments depending on `._repr_html_`, no longer raises `CogniteImportError` stating that `pandas` is required. Instead, a warning is issued and `.dump()` is used as fallback.
+
+## [5.3.3] - 24-01-23
 ### Added
 - New parameter `token_cache_path` now accepted by `OAuthInteractive` and `OAuthDeviceCode` to allow overriding location of token cache.
 
 ### Fixed
 - Platform dependent temp directory for the caching of the token in `OAuthInteractive` and `OAuthDeviceCode` (no longer crashes at exit on Windows).
 
-## [5.3.2] - 20-01-24
+## [5.3.2] - 24-01-23
 ### Changed
 - Update pytest and other dependencies to get rid of dependency on the `py` package.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ Changes are grouped as follows
 
 ## [5.3.5] - 25-01-23
 ### Fixed
-- Displaying Cognite resources like an `Asset` or a `TimeSeriesList` in a Jupyter notebook or similar environments depending on `._repr_html_`, no longer raises `CogniteImportError` stating that `pandas` is required. Instead, a warning is issued and `.dump()` is used as fallback.
+- Fixed an atexit-exception (`TypeError: '<' not supported between instances of 'tuple' and 'NoneType'`) that could be raised on PY39+ after fetching datapoints (which uses a custom thread pool implementation).
 
 ## [5.3.4] - 25-01-23
 ### Fixed

--- a/cognite/client/_api/datapoints.py
+++ b/cognite/client/_api/datapoints.py
@@ -275,6 +275,7 @@ class EagerDpsFetcher(DpsFetchStrategy):
         except CancelledError:
             return None
         except CogniteAPIError as e:
+            future._exception = None  # break ref cycle
             if not (e.code == 400 and e.missing and ts_task.query.ignore_unknown_ids):
                 # TODO: We only notify the user one the first occurrence of a missing time series, and we
                 #       should probably change that (add note to exception or await all ts have been checked)

--- a/cognite/client/_api/datapoints.py
+++ b/cognite/client/_api/datapoints.py
@@ -275,7 +275,8 @@ class EagerDpsFetcher(DpsFetchStrategy):
         except CancelledError:
             return None
         except CogniteAPIError as e:
-            future._exception = None  # break ref cycle
+            # Break ref cycle with the exception:
+            future._exception = None  # type: ignore [attr-defined]
             if not (e.code == 400 and e.missing and ts_task.query.ignore_unknown_ids):
                 # TODO: We only notify the user one the first occurrence of a missing time series, and we
                 #       should probably change that (add note to exception or await all ts have been checked)

--- a/cognite/client/_version.py
+++ b/cognite/client/_version.py
@@ -1,4 +1,4 @@
 from __future__ import annotations
 
-__version__ = "5.3.4"
+__version__ = "5.3.5"
 __api_subversion__ = "V20220125"

--- a/cognite/client/utils/_priority_tpe.py
+++ b/cognite/client/utils/_priority_tpe.py
@@ -65,7 +65,6 @@ else:
     # function hook very similar to atexit.register(), which gets called at 'threading' shutdown
     # instead of interpreter shutdown. Check out https://github.com/python/cpython/issues/83993
     for i, exit_fn in enumerate(_threading_atexits):
-        print(i, exit_fn, exit_fn.func, _python_exit)
         if exit_fn.func is _python_exit:
             # TODO: Does this have unwanted side effects? If not, why no threading._unregister_atexit?
             _threading_atexits.pop(i)  # Note: Remove inplace

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "cognite-sdk"
 
-version = "5.3.4"
+version = "5.3.5"
 
 description = "Cognite Python SDK"
 readme = "README.md"


### PR DESCRIPTION
## Description
Starting in 3.9, ThreadPoolExecutor no longer uses daemon threads, but instead, an internal function hook very similar to atexit.register(), which gets called at 'threading' shutdown instead of interpreter shutdown. Check out https://github.com/python/cpython/issues/83993

Some links:

- https://www.andy-pearce.com/blog/posts/2022/Nov/whats-new-in-python-39-library-changes/#concurrent-execution 
- https://github.com/python/cpython/issues/83993
- https://github.com/python/cpython/pull/19149

This sounds like an argument for testing multiple Python versions (with `tox` perhaps)? 🤔 

## Checklist:
- [ ] Tests added/updated.
- [x] Documentation updated. Documentation is generated from docstrings - these must be updated according to your change.
  If a new method has been added it should be referenced in [cognite.rst](https://github.com/cognitedata/cognite-sdk-python/blob/master/docs/source/cognite.rst) in order to generate docs based on its docstring.
- [x] Changelog updated in [CHANGELOG.md](https://github.com/cognitedata/cognite-sdk-python/blob/master/CHANGELOG.md).
- [x] Version bumped. If triggering a new release is desired, bump the version number in [_version.py](https://github.com/cognitedata/cognite-sdk-python/blob/master/cognite/client/_version.py) and [pyproject.toml](https://github.com/cognitedata/cognite-sdk-python/blob/master/pyproject.toml) per [semantic versioning](https://semver.org/).
