### PR TITLE
Make dev dependencies into a poetry group

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ sympy = ["sympy"]
 functions = ["pip"]
 all = ["pandas", "geopandas", "shapely", "sympy", "pip"]
 
-[tool.poetry.dev-dependencies]
+[tool.poetry.group.dev.dependencies]
 docutils = "==0.15.2"
 sphinx = "^5.0.1"
 sphinx-rtd-theme = ">=1.0.0"


### PR DESCRIPTION
## Description
As of poetry 1.2, (from docs):

The proper way to define a dev dependencies group since Poetry 1.2.0 is the following:

```
[tool.poetry.group.dev.dependencies]
pytest = "^6.0.0"
pytest-mock = "*"
```
This group notation is preferred since Poetry 1.2.0 and not usable in earlier versions. For backward compatibility with older versions of Poetry, any dependency declared in the dev-dependencies section will automatically be added to the dev group. 
(...)
_Poetry will slowly transition away from the dev-dependencies notation which will soon be **deprecated**, so it’s advised to migrate your existing development dependencies to the new group notation._

https://python-poetry.org/docs/managing-dependencies/

<img width="732" alt="image" src="https://user-images.githubusercontent.com/8521241/215477873-016ed042-e377-490c-9a74-0cf4c5618669.png">