### PR TITLE
remove `tool.poetry.source` from `pyproject.toml`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,10 +51,6 @@ mypy = "^0.961"
 types-urllib3 = "^1.26.16"
 types-requests = "^2.28.1"
 
-[[tool.poetry.source]]
-name = "snakepit"
-url = "https://cognite.jfrog.io/cognite/api/pypi/snakepit/simple"
-
 [build-system]
 requires = ["poetry>=1.0"]
 build-backend = "poetry.masonry.api"


### PR DESCRIPTION
## Afaik, we don't need this 😄 
@erlendvollset this is mostly a question to you! Let me know if I'm wrong (just close if so!)

## Why remove?
It slows down development and hinders contributions (jfrog accounts love being blocked for some reason... 🤷 )