### PR TITLE
abstract out `limit`-checks

### DIFF
--- a/cognite/client/_api/datapoint_tasks.py
+++ b/cognite/client/_api/datapoint_tasks.py
@@ -38,6 +38,7 @@ from cognite.client.data_classes.datapoints import NUMPY_IS_AVAILABLE, Datapoint
 from cognite.client.utils._auxiliary import (
     convert_all_keys_to_snake_case,
     import_legacy_protobuf,
+    is_unlimited,
     to_camel_case,
     to_snake_case,
 )
@@ -324,7 +325,7 @@ class _SingleTSQueryValidator:
         return converted
 
     def _verify_limit(self, limit: Optional[int]) -> Optional[int]:
-        if limit in {None, -1, math.inf}:
+        if is_unlimited(limit):
             return None
         elif isinstance(limit, numbers.Integral) and limit >= 0:  # limit=0 is accepted by the API
             try:

--- a/cognite/client/_api/entity_matching.py
+++ b/cognite/client/_api/entity_matching.py
@@ -11,7 +11,7 @@ from cognite.client.data_classes.contextualization import (
     EntityMatchingModelList,
     EntityMatchingModelUpdate,
 )
-from cognite.client.utils._auxiliary import convert_true_match
+from cognite.client.utils._auxiliary import convert_true_match, is_unlimited
 from cognite.client.utils._identifier import IdentifierSequence
 
 T_ContextualizationJob = TypeVar("T_ContextualizationJob", bound=ContextualizationJob)
@@ -107,7 +107,7 @@ class EntityMatchingAPI(APIClient):
 
         Returns:
             EntityMatchingModelList: List of models."""
-        if limit in [None, -1, float("inf")]:
+        if is_unlimited(limit):
             limit = 1_000_000_000  # currently no pagination
         filter = {
             "originalId": original_id,

--- a/cognite/client/_api/functions.py
+++ b/cognite/client/_api/functions.py
@@ -32,6 +32,7 @@ from cognite.client.data_classes import (
 from cognite.client.data_classes.files import FileMetadata
 from cognite.client.data_classes.functions import FunctionCallsFilter, FunctionsStatus
 from cognite.client.exceptions import CogniteAPIError
+from cognite.client.utils._auxiliary import is_unlimited
 from cognite.client.utils._identifier import IdentifierSequence, SingletonIdentifierSequence
 
 if TYPE_CHECKING:
@@ -272,7 +273,7 @@ class FunctionsAPI(APIClient):
                 >>> c = CogniteClient()
                 >>> functions_list = c.functions.list()
         """
-        if limit in [float("inf"), -1, None]:
+        if is_unlimited(limit):
             limit = LIST_LIMIT_CEILING
 
         filter = FunctionFilter(
@@ -979,7 +980,7 @@ class FunctionSchedulesAPI(APIClient):
             except ValueError:
                 raise AssertionError("Only function_id or function_external_id allowed when listing schedules.")
 
-        if limit in [float("inf"), -1, None]:
+        if is_unlimited(limit):
             limit = LIST_LIMIT_CEILING
 
         filter = FunctionSchedulesFilter(

--- a/cognite/client/_api/raw.py
+++ b/cognite/client/_api/raw.py
@@ -6,7 +6,7 @@ from cognite.client import utils
 from cognite.client._api_client import APIClient
 from cognite.client.config import ClientConfig
 from cognite.client.data_classes import Database, DatabaseList, Row, RowList, Table, TableList
-from cognite.client.utils._auxiliary import local_import
+from cognite.client.utils._auxiliary import is_unlimited, local_import
 from cognite.client.utils._identifier import Identifier
 
 if TYPE_CHECKING:
@@ -535,7 +535,7 @@ class RawRowsAPI(APIClient):
                 >>> for row_list in c.raw.rows(db_name="db1", table_name="t1", chunk_size=2500):
                 ...     row_list # do something with the rows
         """
-        if limit in {None, -1, float("inf")}:
+        if is_unlimited(limit):
             cursors = self._get(
                 url_path=utils._auxiliary.interpolate_and_url_encode(
                     "/raw/dbs/{}/tables/{}/cursors", db_name, table_name

--- a/cognite/client/_api/relationships.py
+++ b/cognite/client/_api/relationships.py
@@ -7,6 +7,7 @@ from cognite.client import utils
 from cognite.client._api_client import APIClient
 from cognite.client.data_classes import Relationship, RelationshipFilter, RelationshipList, RelationshipUpdate
 from cognite.client.data_classes.labels import LabelFilter
+from cognite.client.utils._auxiliary import is_unlimited
 from cognite.client.utils._identifier import IdentifierSequence
 
 
@@ -277,7 +278,7 @@ class RelationshipsAPI(APIClient):
             len(target_external_id_list) > self._LIST_SUBQUERY_LIMIT
             or len(source_external_id_list) > self._LIST_SUBQUERY_LIMIT
         ):
-            if limit not in [-1, None, float("inf")]:
+            if not is_unlimited(limit):
                 raise ValueError(
                     f"Querying more than {self._LIST_SUBQUERY_LIMIT} source_external_ids/target_external_ids only "
                     f"supported for queries without limit (pass -1 / None / inf instead of {limit})"

--- a/cognite/client/_api_client.py
+++ b/cognite/client/_api_client.py
@@ -43,6 +43,7 @@ from cognite.client.data_classes._base import (
     T_CogniteResourceList,
 )
 from cognite.client.exceptions import CogniteAPIError, CogniteNotFoundError
+from cognite.client.utils._auxiliary import is_unlimited
 from cognite.client.utils._identifier import Identifier, IdentifierSequence, SingletonIdentifierSequence
 
 if TYPE_CHECKING:
@@ -349,7 +350,7 @@ class APIClient:
         headers: Optional[Dict[str, Any]] = None,
         initial_cursor: Optional[str] = None,
     ) -> Union[Iterator[T_CogniteResourceList], Iterator[T_CogniteResource]]:
-        if limit == -1 or limit == float("inf"):
+        if is_unlimited(limit):
             limit = None
         resource_path = resource_path or self._RESOURCE_PATH
 
@@ -471,7 +472,7 @@ class APIClient:
         initial_cursor: Optional[str] = None,
     ) -> T_CogniteResourceList:
         if partitions:
-            if limit not in [None, -1, float("inf")]:
+            if not is_unlimited(limit):
                 raise ValueError("When using partitions, limit should be `None`, `-1` or `inf`.")
             if sort is not None:
                 raise ValueError("When using sort, partitions is not supported.")

--- a/cognite/client/data_classes/functions.py
+++ b/cognite/client/data_classes/functions.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING, Dict, List, Optional, Union, cast
 from cognite.client._constants import LIST_LIMIT_CEILING, LIST_LIMIT_DEFAULT
 from cognite.client.data_classes._base import CogniteFilter, CogniteResource, CogniteResourceList, CogniteResponse
 from cognite.client.data_classes.shared import TimestampRange
+from cognite.client.utils._auxiliary import is_unlimited
 
 if TYPE_CHECKING:
     from cognite.client import CogniteClient
@@ -134,7 +135,7 @@ class Function(CogniteResource):
         )
         schedules_by_id = self._cognite_client.functions.schedules.list(function_id=self.id, limit=limit)
 
-        if limit in [float("inf"), -1, None]:
+        if is_unlimited(limit):
             limit = LIST_LIMIT_CEILING
 
         return (schedules_by_external_id + schedules_by_id)[:limit]

--- a/cognite/client/utils/_auxiliary.py
+++ b/cognite/client/utils/_auxiliary.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import functools
 import heapq
 import importlib
+import math
 import numbers
 import platform
 import random
@@ -26,6 +27,10 @@ from cognite.client.utils._version_checker import get_newest_version_in_major_re
 
 T = TypeVar("T")
 THashable = TypeVar("THashable", bound=Hashable)
+
+
+def is_unlimited(limit: Any) -> bool:
+    return limit in {None, -1, math.inf}
 
 
 @functools.lru_cache(maxsize=128)

--- a/cognite/client/utils/_auxiliary.py
+++ b/cognite/client/utils/_auxiliary.py
@@ -29,7 +29,7 @@ T = TypeVar("T")
 THashable = TypeVar("THashable", bound=Hashable)
 
 
-def is_unlimited(limit: Any) -> bool:
+def is_unlimited(limit: Optional[Union[float, int]]) -> bool:
     return limit in {None, -1, math.inf}
 
 

--- a/cognite/client/utils/_auxiliary.py
+++ b/cognite/client/utils/_auxiliary.py
@@ -18,7 +18,21 @@ import string
 import warnings
 from decimal import Decimal
 from types import ModuleType
-from typing import Any, Dict, Hashable, Iterable, Iterator, List, Sequence, Set, Tuple, TypeVar, Union, overload
+from typing import (
+    Any,
+    Dict,
+    Hashable,
+    Iterable,
+    Iterator,
+    List,
+    Optional,
+    Sequence,
+    Set,
+    Tuple,
+    TypeVar,
+    Union,
+    overload,
+)
 from urllib.parse import quote
 
 import cognite.client


### PR DESCRIPTION
## Description
8 variances of "is limit `None`, -1 or `math.inf`" replaced with a utility function.