### PR TITLE
`SessionsAPI`: Fix docs mistakes, remove unused class `CreatedSessionList`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ Changes are grouped as follows
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
+## [5.3.7] - 31-01-23
+### Improved
+- Issues with the SessionsAPI documentation have been addressed, and the `.create()` have been further clarified.
+
 ## [5.3.6] - 30-01-23
 ### Changed
 - A file-not-found error has been changed from `TypeError` to `FileNotFoundError` as part of the validation in FunctionsAPI.

--- a/cognite/client/_version.py
+++ b/cognite/client/_version.py
@@ -1,4 +1,4 @@
 from __future__ import annotations
 
-__version__ = "5.3.6"
+__version__ = "5.3.7"
 __api_subversion__ = "V20220125"

--- a/cognite/client/data_classes/__init__.py
+++ b/cognite/client/data_classes/__init__.py
@@ -46,7 +46,6 @@ from cognite.client.data_classes.iam import (
     APIKeyList,
     ClientCredentials,
     CreatedSession,
-    CreatedSessionList,
     Group,
     GroupList,
     SecurityCategory,

--- a/cognite/client/data_classes/iam.py
+++ b/cognite/client/data_classes/iam.py
@@ -207,11 +207,6 @@ class CreatedSession(CogniteResource):
         self.client_id = client_id
 
 
-class CreatedSessionList(CogniteResourceList):
-    _RESOURCE = CreatedSession
-    _ASSERT_CLASSES = False
-
-
 class Session(CogniteResource):
     """Session status
 
@@ -244,7 +239,6 @@ class Session(CogniteResource):
 
 class SessionList(CogniteResourceList):
     _RESOURCE = Session
-    _ASSERT_CLASSES = False
 
 
 class ClientCredentials(CogniteResource):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "cognite-sdk"
 
-version = "5.3.6"
+version = "5.3.7"
 
 description = "Cognite Python SDK"
 readme = "README.md"


### PR DESCRIPTION
## Description
I wanted to move internal usage of the sessions API to actually use `client.iam.sessions`, however, some fixes were required first.