### PR TITLE
Fix bug in assets.create_hierarchy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ Changes are grouped as follows
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
+## [5.4.1] - 02-02-23
+### Fixed
+- Bug where create_hierarchy would stop progressing after encountering more than `config.max_workers` failures.
+
 ## [5.4.0] - 02-02-23
 ### Added
 - Support for aggregating metadata keys/values for assets

--- a/cognite/client/_version.py
+++ b/cognite/client/_version.py
@@ -1,4 +1,4 @@
 from __future__ import annotations
 
-__version__ = "5.4.0"
+__version__ = "5.4.1"
 __api_subversion__ = "V20220125"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "cognite-sdk"
 
-version = "5.4.0"
+version = "5.4.1"
 
 description = "Cognite Python SDK"
 readme = "README.md"

--- a/tests/tests_unit/test_api/test_assets.py
+++ b/tests/tests_unit/test_api/test_assets.py
@@ -322,7 +322,7 @@ class TestAssetPosterWorker:
         w = _AssetPosterWorker(request_queue=q_req, response_queue=q_res, client=cognite_client.assets)
         w.start()
         q_req.put([Asset()])
-        time.sleep(0.1)
+        time.sleep(1)
         w.stop = True
         assert [Asset._load(mock_assets_response.calls[0].response.json()["items"][0])] == q_res.get()
         assert 1 == len(mock_assets_response.calls)

--- a/tests/tests_unit/test_api/test_assets.py
+++ b/tests/tests_unit/test_api/test_assets.py
@@ -538,6 +538,14 @@ class TestAssetPoster:
         assert {a.external_id for a in e.value.failed} == {"02", "021", "0211", "031"}
         assert {a.external_id for a in e.value.successful} == {"0", "01"}
 
+    def test_post_with_all_failures_and_more_requests_than_workers(self, cognite_client, mock_post_assets_failures):
+        num_assets = cognite_client.config.max_workers * 10
+        assets = [Asset(name="400", external_id=str(i)) for i in range(num_assets)]
+        with pytest.raises(CogniteAPIError) as e:
+            cognite_client.assets.create_hierarchy(assets)
+
+        assert {a.external_id for a in e.value.failed} == {str(i) for i in range(num_assets)}
+
 
 @pytest.fixture
 def mock_assets_empty(rsps, cognite_client):


### PR DESCRIPTION
Fix bug where AssetPosterWorker stops doing work after encountering an exception.

When a worker encountered an exception, it would just stop doing work. This means that 1) the method becomes slower as it encounters errors and 2) if it encounters more errors than there are workers, it would just stop progressing entirely.
