### PR TITLE
Improve error messages for `OAuthDeviceCode` and `OAuthInteractive`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ Changes are grouped as follows
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
+## [5.4.2] - 03-02-23
+### Changed
+- Improved error handling (propagate IDP error message) for `OAuthDeviceCode` and `OAuthInteractive` upon authentication failure.
+
 ## [5.4.1] - 02-02-23
 ### Fixed
 - Bug where create_hierarchy would stop progressing after encountering more than `config.max_workers` failures.

--- a/cognite/client/_version.py
+++ b/cognite/client/_version.py
@@ -1,4 +1,4 @@
 from __future__ import annotations
 
-__version__ = "5.4.1"
+__version__ = "5.4.2"
 __api_subversion__ = "V20220125"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "cognite-sdk"
 
-version = "5.4.1"
+version = "5.4.2"
 
 description = "Cognite Python SDK"
 readme = "README.md"


### PR DESCRIPTION
## Description
Because of how the `msal` library works, when auth fails, no error is raised, but a dictionary with different keys is returned. When we then try to grab the e.g. `"access_token"` key, this would fail with (surprise) `KeyError` and hide all the useful auth-IDP-debug information in the dictionary.

This PR adds a credential check to the superclass which also raises `CogniteAuthError` instead.

Example:
```py
# Before:
KeyError: 'access_token'

# After:
cognite.client.exceptions.CogniteAuthError: Error generating access token! Error: invalid_client,
  error description: AADSTS7000218: The request body must contain the following parameter:
  'client_assertion' or 'client_secret'. Trace ID: 776d585d-fed2-4264-8cbd-29aa0eb44e00
  Correlation ID: 240145fb-adf1-454a-bc07-0c1fafc528e8 Timestamp: 2023-02-03 10:43:49Z
```

Additional changes:

- Fixes a wrong import in the docstring example on how to use `OAuthDeviceCode`
- Simplifies datetime.timestamp to time.time

## Checklist:
- [ ] Tests added/updated.
- [ ] Documentation updated. Documentation is generated from docstrings - these must be updated according to your change.
  If a new method has been added it should be referenced in [cognite.rst](https://github.com/cognitedata/cognite-sdk-python/blob/master/docs/source/cognite.rst) in order to generate docs based on its docstring.
- [x] Changelog updated in [CHANGELOG.md](https://github.com/cognitedata/cognite-sdk-python/blob/master/CHANGELOG.md).
- [x] Version bumped. If triggering a new release is desired, bump the version number in [_version.py](https://github.com/cognitedata/cognite-sdk-python/blob/master/cognite/client/_version.py) and [pyproject.toml](https://github.com/cognitedata/cognite-sdk-python/blob/master/pyproject.toml) per [semantic versioning](https://semver.org/).
