### PR TITLE
Pass `verify` parameter from `global_config.disable_ssl` to `PublicClientApplication`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ Changes are grouped as follows
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
+## [5.4.3] - 05-02-23
+### Fixed
+- `OAuthDeviceCode` and `OAuthInteractive` now respect `global_config.disable_ssl` setting.
+
 ## [5.4.2] - 03-02-23
 ### Changed
 - Improved error handling (propagate IDP error message) for `OAuthDeviceCode` and `OAuthInteractive` upon authentication failure.
@@ -53,8 +57,8 @@ Changes are grouped as follows
 - Platform dependent temp directory for the caching of the token in `OAuthInteractive` and `OAuthDeviceCode` (no longer crashes at exit on Windows).
 
 ## [5.3.2] - 24-01-23
-### Changed
-- Update pytest and other dependencies to get rid of dependency on the `py` package.
+### Security
+- Update `pytest` and other dependencies to get rid of dependency on the `py` package (CVE-2022-42969).
 
 ## [5.3.1] - 20-01-23
 ### Fixed

--- a/cognite/client/_version.py
+++ b/cognite/client/_version.py
@@ -1,4 +1,4 @@
 from __future__ import annotations
 
-__version__ = "5.4.2"
+__version__ = "5.4.3"
 __api_subversion__ = "V20220125"

--- a/cognite/client/credentials.py
+++ b/cognite/client/credentials.py
@@ -153,6 +153,8 @@ class OAuthDeviceCode(_OAuthCredentialProviderWithTokenRefresh, _WithMsalSeriali
         scopes: List[str],
         token_cache_path: Path = None,
     ) -> None:
+        from cognite.client.config import global_config
+
         super().__init__()
         self.__authority_url = authority_url
         self.__client_id = client_id
@@ -162,7 +164,10 @@ class OAuthDeviceCode(_OAuthCredentialProviderWithTokenRefresh, _WithMsalSeriali
         token_cache_path = token_cache_path or Path(tempfile.gettempdir()) / f"cognitetokencache.{self.__client_id}.bin"
         serializable_token_cache = self._create_serializable_token_cache(token_cache_path)
         self.__app = PublicClientApplication(
-            client_id=self.__client_id, authority=self.__authority_url, token_cache=serializable_token_cache
+            client_id=self.__client_id,
+            authority=self.__authority_url,
+            token_cache=serializable_token_cache,
+            verify=not global_config.disable_ssl,
         )
 
     @property
@@ -224,6 +229,8 @@ class OAuthInteractive(_OAuthCredentialProviderWithTokenRefresh, _WithMsalSerial
         redirect_port: int = 53000,
         token_cache_path: Path = None,
     ) -> None:
+        from cognite.client.config import global_config
+
         super().__init__()
         self.__authority_url = authority_url
         self.__client_id = client_id
@@ -234,7 +241,10 @@ class OAuthInteractive(_OAuthCredentialProviderWithTokenRefresh, _WithMsalSerial
         token_cache_path = token_cache_path or Path(tempfile.gettempdir()) / f"cognitetokencache.{self.__client_id}.bin"
         serializable_token_cache = self._create_serializable_token_cache(token_cache_path)
         self.__app = PublicClientApplication(
-            client_id=self.__client_id, authority=self.__authority_url, token_cache=serializable_token_cache
+            client_id=self.__client_id,
+            authority=self.__authority_url,
+            token_cache=serializable_token_cache,
+            verify=not global_config.disable_ssl,
         )
 
     @property

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "cognite-sdk"
 
-version = "5.4.2"
+version = "5.4.3"
 
 description = "Cognite Python SDK"
 readme = "README.md"


### PR DESCRIPTION
## Checklist:
- [ ] Tests added/updated.
- [ ] Documentation updated. Documentation is generated from docstrings - these must be updated according to your change.
  If a new method has been added it should be referenced in [cognite.rst](https://github.com/cognitedata/cognite-sdk-python/blob/master/docs/source/cognite.rst) in order to generate docs based on its docstring.
- [x] Changelog updated in [CHANGELOG.md](https://github.com/cognitedata/cognite-sdk-python/blob/master/CHANGELOG.md).
- [x] Version bumped. If triggering a new release is desired, bump the version number in [_version.py](https://github.com/cognitedata/cognite-sdk-python/blob/master/cognite/client/_version.py) and [pyproject.toml](https://github.com/cognitedata/cognite-sdk-python/blob/master/pyproject.toml) per [semantic versioning](https://semver.org/).
