### PR TITLE
Make `CogniteClient` private to avoid `JSON.dumps()` error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ Changes are grouped as follows
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
-## [5.5.1] - 10-02-23
+## [5.5.2] - 15-02-23
 ### Fixed
 - Fixed JSON dumps serialization error of instances of `ExtractionPipelineConfigRevision` and all subclasses (`ExtractionPipelineConfig`) as they stored a reference to the CogniteClient as a non-private attribute.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ Changes are grouped as follows
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
+## [5.5.1] - 10-02-23
+### Fixed
+- Fixed JSON dumps serialization error of instances of `ExtractionPipelineConfigRevision` and all subclasses (`ExtractionPipelineConfig`) as they stored a reference to the CogniteClient as a non-private attribute.
 
 ## [5.5.1] - 10-02-23
 ### Changed
@@ -24,7 +27,7 @@ Changes are grouped as follows
 
 ## [5.5.0] - 10-02-23
 ### Added
-- support `instances` destination type on Transformations.
+- Support `instances` destination type on Transformations.
 
 ## [5.4.4] - 06-02-23
 ### Added

--- a/cognite/client/_version.py
+++ b/cognite/client/_version.py
@@ -1,4 +1,4 @@
 from __future__ import annotations
 
-__version__ = "5.5.1"
+__version__ = "5.5.2"
 __api_subversion__ = "V20220125"

--- a/cognite/client/data_classes/_base.py
+++ b/cognite/client/data_classes/_base.py
@@ -54,6 +54,7 @@ class CogniteResponse:
         Returns:
             Dict[str, Any]: A dictionary representation of the instance.
         """
+        assert not hasattr(self, "cognite_client")
         return basic_instance_dump(self, camel_case=camel_case)
 
     @classmethod
@@ -100,6 +101,7 @@ class CogniteResource:
         Returns:
             Dict[str, Any]: A dictionary representation of the instance.
         """
+        assert not hasattr(self, "cognite_client")
         return basic_instance_dump(self, camel_case=camel_case)
 
     @classmethod
@@ -462,6 +464,7 @@ class CogniteFilter:
         Returns:
             Dict[str, Any]: A dictionary representation of the instance.
         """
+        assert not hasattr(self, "cognite_client")
         return basic_instance_dump(self, camel_case=camel_case)
 
 

--- a/cognite/client/data_classes/_base.py
+++ b/cognite/client/data_classes/_base.py
@@ -54,7 +54,6 @@ class CogniteResponse:
         Returns:
             Dict[str, Any]: A dictionary representation of the instance.
         """
-        assert not hasattr(self, "cognite_client")
         return basic_instance_dump(self, camel_case=camel_case)
 
     @classmethod
@@ -101,7 +100,6 @@ class CogniteResource:
         Returns:
             Dict[str, Any]: A dictionary representation of the instance.
         """
-        assert not hasattr(self, "cognite_client")
         return basic_instance_dump(self, camel_case=camel_case)
 
     @classmethod
@@ -464,7 +462,6 @@ class CogniteFilter:
         Returns:
             Dict[str, Any]: A dictionary representation of the instance.
         """
-        assert not hasattr(self, "cognite_client")
         return basic_instance_dump(self, camel_case=camel_case)
 
 

--- a/cognite/client/data_classes/extractionpipelines.py
+++ b/cognite/client/data_classes/extractionpipelines.py
@@ -301,7 +301,7 @@ class ExtractionPipelineConfigRevision(CogniteResource):
         self.revision = revision
         self.description = description
         self.created_time = created_time
-        self.cognite_client = cognite_client
+        self._cognite_client = cognite_client
 
 
 class ExtractionPipelineConfig(ExtractionPipelineConfigRevision):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "cognite-sdk"
 
-version = "5.5.1"
+version = "5.5.2"
 
 description = "Cognite Python SDK"
 readme = "README.md"

--- a/tests/tests_unit/test_api/test_extractionpipelines.py
+++ b/tests/tests_unit/test_api/test_extractionpipelines.py
@@ -82,13 +82,11 @@ def mock_revert_config_response(rsps, cognite_client):
 class TestExtractionPipelines:
     def test_retrieve_config(self, cognite_client, mock_config_response):
         res = cognite_client.extraction_pipelines.config.retrieve(external_id="int-123")
-        res.cognite_client = None
         assert isinstance(res, ExtractionPipelineConfig)
         assert mock_config_response.calls[0].response.json() == res.dump(camel_case=True)
 
     def test_retrieve_config_revision(self, cognite_client, mock_config_response_with_revision):
         res = cognite_client.extraction_pipelines.config.retrieve(external_id="int-123", revision=4)
-        res.cognite_client = None
         assert isinstance(res, ExtractionPipelineConfig)
         assert mock_config_response_with_revision.calls[0].response.json() == res.dump(camel_case=True)
 
@@ -96,20 +94,15 @@ class TestExtractionPipelines:
         res = cognite_client.extraction_pipelines.config.create(
             ExtractionPipelineConfig(external_id="int-123", config="config abc 123", description="description")
         )
-        res.cognite_client = None
         assert isinstance(res, ExtractionPipelineConfig)
         assert mock_config_response.calls[0].response.json() == res.dump(camel_case=True)
 
     def test_revert_config(self, cognite_client, mock_revert_config_response):
         res = cognite_client.extraction_pipelines.config.revert(external_id="int-123", revision=3)
-        res.cognite_client = None
         assert isinstance(res, ExtractionPipelineConfig)
         assert mock_revert_config_response.calls[0].response.json() == res.dump(camel_case=True)
 
     def test_list_revisions(self, cognite_client, mock_config_list_response):
         res = cognite_client.extraction_pipelines.config.list(external_id="int-123")
-        res.cognite_client = None
-        for r in res:
-            r.cognite_client = None
         assert isinstance(res, ExtractionPipelineConfigRevisionList)
         assert mock_config_list_response.calls[0].response.json() == {"items": res.dump(camel_case=True)}


### PR DESCRIPTION
## Description
Resource class `ExtractionPipelineConfigRevision` and all subclasses (`ExtractionPipelineConfig`) fails when printing (calls dump) and dumping. Found by @janne123456789 

Bug was introduced in #1057 which added the classes.

Code to reproduce error:
```py
>>> pipe_config = client.extraction_pipelines.config.retrieve(external_id="yo")
>>> print(pipe_config)  # or >>> pipe_config.dump()
TypeError: Object <unlocked _thread.lock object at 0x7fbd080b5420> of type <class '_thread.lock'> can't be serialized by the JSON encoder
```

## Checklist:
- [ ] Tests added/updated.
- [ ] Documentation updated. Documentation is generated from docstrings - these must be updated according to your change.
  If a new method has been added it should be referenced in [cognite.rst](https://github.com/cognitedata/cognite-sdk-python/blob/master/docs/source/cognite.rst) in order to generate docs based on its docstring.
- [x] Changelog updated in [CHANGELOG.md](https://github.com/cognitedata/cognite-sdk-python/blob/master/CHANGELOG.md).
- [x] Version bumped. If triggering a new release is desired, bump the version number in [_version.py](https://github.com/cognitedata/cognite-sdk-python/blob/master/cognite/client/_version.py) and [pyproject.toml](https://github.com/cognitedata/cognite-sdk-python/blob/master/pyproject.toml) per [semantic versioning](https://semver.org/).
