### PR TITLE
Use thread lock when refreshing `Token` using given `callable`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,8 +19,8 @@ Changes are grouped as follows
 
 
 ## [5.5.1] - 10-02-23
-### Fixed
-- Fix `CredentialProvider` `Token` to be thread safe when given a callable that does token refresh.
+### Changed
+- Change `CredentialProvider` `Token` to be thread safe when given a callable that does token refresh.
 
 ## [5.5.0] - 10-02-23
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ Changes are grouped as follows
 - `Security` in case of vulnerabilities.
 
 
+## [5.5.1] - 10-02-23
+### Fixed
+- Fix `CredentialProvider` `Token` to be thread safe when given a callable that does token refresh.
+
 ## [5.5.0] - 10-02-23
 ### Added
 - support `instances` destination type on Transformations.

--- a/cognite/client/_version.py
+++ b/cognite/client/_version.py
@@ -1,4 +1,4 @@
 from __future__ import annotations
 
-__version__ = "5.5.0"
+__version__ = "5.5.1"
 __api_subversion__ = "V20220125"

--- a/cognite/client/credentials.py
+++ b/cognite/client/credentials.py
@@ -65,11 +65,11 @@ class Token(CredentialProvider):
             self.__token_factory = lambda: token
 
         elif callable(token):  # mypy flat out refuses variations of: isinstance(token, collections.abc.Callable)
-            self.__token_refresh_lock = threading.Lock()
+            token_refresh_lock = threading.Lock()
 
             def thread_safe_get_token() -> str:
                 assert not isinstance(token, str)  # unbelivable
-                with self.__token_refresh_lock:
+                with token_refresh_lock:
                     return token()
 
             self.__token_factory = thread_safe_get_token

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "cognite-sdk"
 
-version = "5.5.0"
+version = "5.5.1"
 
 description = "Cognite Python SDK"
 readme = "README.md"


### PR DESCRIPTION
## Description
The `CredentialProvder` `Token` accepts either a string or a callable function from the user, allowing for custom logic, e.g. to do token refresh. This process needs to be made thread-safe for concurrent scenarios.

## Checklist:
- [ ] Tests added/updated.
- [ ] Documentation updated. Documentation is generated from docstrings - these must be updated according to your change.
  If a new method has been added it should be referenced in [cognite.rst](https://github.com/cognitedata/cognite-sdk-python/blob/master/docs/source/cognite.rst) in order to generate docs based on its docstring.
- [x] Changelog updated in [CHANGELOG.md](https://github.com/cognitedata/cognite-sdk-python/blob/master/CHANGELOG.md).
- [x] Version bumped. If triggering a new release is desired, bump the version number in [_version.py](https://github.com/cognitedata/cognite-sdk-python/blob/master/cognite/client/_version.py) and [pyproject.toml](https://github.com/cognitedata/cognite-sdk-python/blob/master/pyproject.toml) per [semantic versioning](https://semver.org/).
