### PR TITLE
Improve user input validation of dicts in `DatapointsAPI`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ Changes are grouped as follows
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
+## [5.6.4] - 28-02-23
+### Added
+- Input validation on `DatapointsAPI.[insert, insert_multiple, delete_ranges]` now raise on missing keys, not just invalid keys.
+
 ## [5.6.3] - 23-02-23
 ### Added
 - Make the SDK compatible with `pandas` major version 2 ahead of release.
@@ -24,10 +28,6 @@ Changes are grouped as follows
 ## [5.6.2] - 21-02-23
 ### Fixed
 - Fixed an issue where `Content-Type` was not correctly set on file uploads to Azure.
-
-## [5.6.2] - 20-02-23
-### Added
-- Input validation on `DatapointsAPI.[insert, insert_multiple, delete_ranges]` now raise on missing keys, not just invalid keys.
 
 ## [5.6.1] - 20-02-23
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,10 @@ Changes are grouped as follows
 ### Fixed
 - Fixed an issue where `Content-Type` was not correctly set on file uploads to Azure.
 
+## [5.6.2] - 20-02-23
+### Added
+- Input validation on `DatapointsAPI.[insert, insert_multiple, delete_ranges]` now raise on missing keys, not just invalid keys.
+
 ## [5.6.1] - 20-02-23
 ### Fixed
 - Fixed an issue where `IndexError` was raised when a user queried `DatapointsAPI.retrieve_latest` for a single, non-existent time series while also passing `ignore_unknown_ids=True`. Changed to returning `None`, inline with other `retrieve` methods.

--- a/cognite/client/_api/datapoints.py
+++ b/cognite/client/_api/datapoints.py
@@ -9,8 +9,8 @@ import statistics
 import time
 import warnings
 from abc import ABC, abstractmethod
-from concurrent.futures import CancelledError
 from collections.abc import Mapping
+from concurrent.futures import CancelledError
 from copy import copy
 from datetime import datetime
 from itertools import chain

--- a/cognite/client/_constants.py
+++ b/cognite/client/_constants.py
@@ -2,3 +2,5 @@ from __future__ import annotations
 
 LIST_LIMIT_DEFAULT = 25
 LIST_LIMIT_CEILING = 10_000  # variable used to guarantee all items are returned when list(limit) is None, inf or -1.
+
+MAX_VALID_INTERNAL_ID = 9007199254740991

--- a/cognite/client/_constants.py
+++ b/cognite/client/_constants.py
@@ -2,5 +2,5 @@ from __future__ import annotations
 
 LIST_LIMIT_DEFAULT = 25
 LIST_LIMIT_CEILING = 10_000  # variable used to guarantee all items are returned when list(limit) is None, inf or -1.
-
+# Max JavaScript-safe integer 2^53 - 1
 MAX_VALID_INTERNAL_ID = 9007199254740991

--- a/cognite/client/_version.py
+++ b/cognite/client/_version.py
@@ -1,4 +1,4 @@
 from __future__ import annotations
 
-__version__ = "5.6.3"
+__version__ = "5.6.4"
 __api_subversion__ = "V20220125"

--- a/cognite/client/utils/_auxiliary.py
+++ b/cognite/client/utils/_auxiliary.py
@@ -138,7 +138,7 @@ def validate_user_input_dict_with_identifier(dct: Mapping, required_keys: Set[st
     invalid_keys = set(dct) - required_keys - {"id", "externalId", "external_id"}
     if missing_keys or invalid_keys:
         raise ValueError(
-            f"Given dictionary at failed validation. Invalid key(s): {sorted(invalid_keys)}, "
+            f"Given dictionary failed validation. Invalid key(s): {sorted(invalid_keys)}, "
             f"required key(s) missing: {sorted(missing_keys)}."
         )
     return id_dct

--- a/cognite/client/utils/_auxiliary.py
+++ b/cognite/client/utils/_auxiliary.py
@@ -128,7 +128,7 @@ def assert_type(var: Any, var_name: str, types: List[type], allow_none: bool = F
 
 def validate_user_input_dict_with_identifier(dct: Mapping, required_keys: Set[str]) -> Dict[str, T_ID]:
     if not isinstance(dct, Mapping):
-        raise TypeError(f"Expected list of dict-like objects, got {type(dct)}")
+        raise TypeError(f"Expected dict-like object, got {type(dct)}")
 
     # Verify that we have gotten exactly one identifier:
     xid = dct.get("externalId") or dct.get("external_id")

--- a/cognite/client/utils/_auxiliary.py
+++ b/cognite/client/utils/_auxiliary.py
@@ -16,6 +16,7 @@ import random
 import re
 import string
 import warnings
+from collections.abc import Mapping
 from decimal import Decimal
 from types import ModuleType
 from typing import (
@@ -37,6 +38,7 @@ from urllib.parse import quote
 
 import cognite.client
 from cognite.client.exceptions import CogniteImportError
+from cognite.client.utils._identifier import T_ID, Identifier
 from cognite.client.utils._version_checker import get_newest_version_in_major_release
 
 T = TypeVar("T")
@@ -122,6 +124,24 @@ def assert_type(var: Any, var_name: str, types: List[type], allow_none: bool = F
             raise TypeError(f"{var_name} cannot be None")
     elif not isinstance(var, tuple(types)):
         raise TypeError(f"{var_name} must be one of types {types}")
+
+
+def validate_user_input_dict_with_identifier(dct: Mapping, required_keys: Set[str]) -> Dict[str, T_ID]:
+    if not isinstance(dct, Mapping):
+        raise TypeError(f"Expected list of dict-like objects, got {type(dct)}")
+
+    # Verify that we have gotten exactly one identifier:
+    xid = dct.get("externalId") or dct.get("external_id")
+    id_dct = Identifier.of_either(dct.get("id"), xid).as_dict(camel_case=True)
+
+    missing_keys = required_keys.difference(dct)
+    invalid_keys = set(dct) - required_keys - {"id", "externalId", "external_id"}
+    if missing_keys or invalid_keys:
+        raise ValueError(
+            f"Given dictionary at failed validation. Invalid key(s): {sorted(invalid_keys)}, "
+            f"required key(s) missing: {sorted(missing_keys)}."
+        )
+    return id_dct
 
 
 def interpolate_and_url_encode(path: str, *args: Any) -> str:

--- a/cognite/client/utils/_identifier.py
+++ b/cognite/client/utils/_identifier.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import numbers
 from typing import Dict, Generic, Iterable, List, Optional, Sequence, Tuple, TypeVar, Union, cast, overload
 
+from cognite.client._constants import MAX_VALID_INTERNAL_ID
+
 T_ID = TypeVar("T_ID", int, str)
 
 
@@ -14,8 +16,11 @@ class Identifier(Generic[T_ID]):
     def of_either(cls, id: Optional[int], external_id: Optional[str]) -> Identifier:
         if id is external_id is None:
             raise ValueError("Exactly one of id or external id must be specified, got neither")
-        elif id is not None and external_id is not None:
-            raise ValueError("Exactly one of id or external id must be specified, got both")
+        elif id is not None:
+            if external_id is not None:
+                raise ValueError("Exactly one of id or external id must be specified, got both")
+            elif not 1 <= id <= MAX_VALID_INTERNAL_ID:
+                raise ValueError(f"Invalid id, must satisfy: 1 <= id <= {MAX_VALID_INTERNAL_ID}")
         return Identifier(id or external_id)
 
     @classmethod

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "cognite-sdk"
 
-version = "5.6.3"
+version = "5.6.4"
 
 description = "Cognite Python SDK"
 readme = "README.md"

--- a/tests/tests_unit/test_api/test_datapoints.py
+++ b/tests/tests_unit/test_api/test_datapoints.py
@@ -259,7 +259,7 @@ class TestInsertDatapoints:
     def test_insert_datapoints_in_multiple_time_series_invalid_key(self, cognite_client):
         dps = [{"timestamp": i * 1e11, "value": i} for i in range(1, 11)]
         dps_objects = [{"extId": "1", "datapoints": dps}]
-        with pytest.raises(ValueError, match="Invalid key 'extId'"):
+        with pytest.raises(ValueError, match="Exactly one of id or external id must be specified, got neither"):
             cognite_client.time_series.data.insert_multiple(dps_objects)
 
     def test_insert_datapoints_ts_does_not_exist(self, cognite_client, mock_post_datapoints_400):
@@ -268,11 +268,11 @@ class TestInsertDatapoints:
 
     def test_insert_multiple_ts__below_ts_and_dps_limit(self, cognite_client, mock_post_datapoints):
         dps = [{"timestamp": i * 1e11, "value": i} for i in range(1, 2)]
-        dps_objects = [{"id": i, "datapoints": dps} for i in range(100)]
+        dps_objects = [{"id": i, "datapoints": dps} for i in range(1, 101)]
         cognite_client.time_series.data.insert_multiple(dps_objects)
         assert 1 == len(mock_post_datapoints.calls)
         request_body = jsgz_load(mock_post_datapoints.calls[0].request.body)
-        for i, dps in enumerate(request_body["items"]):
+        for i, dps in enumerate(request_body["items"], 1):
             assert i == dps["id"]
 
     def test_insert_multiple_ts_single_call__below_dps_limit_above_ts_limit(self, cognite_client, mock_post_datapoints):
@@ -332,12 +332,17 @@ class TestDeleteDatapoints:
             ]
         } == jsgz_load(mock_delete_datapoints.calls[0].request.body)
 
-    def test_delete_ranges_invalid_ids(self, cognite_client):
-        ranges = [{"idz": 1, "start": 0, "end": 1}]
-        with pytest.raises(AssertionError, match="Invalid key 'idz'"):
-            cognite_client.time_series.data.delete_ranges(ranges)
-        ranges = [{"start": 0, "end": 1}]
-        with pytest.raises(ValueError, match="Exactly one of id or external id must be specified"):
+    @pytest.mark.parametrize(
+        "input_dct, err_suffix",
+        (
+            ({}, "neither"),
+            ({"id": 1, "external_id": "a"}, "both"),
+            ({"id": 1, "externalId": "a"}, "both"),
+        ),
+    )
+    def test_delete_ranges_invalid_ids(self, input_dct, err_suffix, cognite_client):
+        ranges = [{"start": 0, "end": 1, **input_dct}]
+        with pytest.raises(ValueError, match=f"Exactly one of id or external id must be specified, got {err_suffix}"):
             cognite_client.time_series.data.delete_ranges(ranges)
 
 

--- a/tests/tests_unit/test_api/test_datapoints.py
+++ b/tests/tests_unit/test_api/test_datapoints.py
@@ -278,13 +278,13 @@ class TestInsertDatapoints:
     def test_insert_multiple_ts_single_call__below_dps_limit_above_ts_limit(self, cognite_client, mock_post_datapoints):
         with patch(DATAPOINTS_API.format("POST_DPS_OBJECTS_LIMIT"), 100):
             dps = [{"timestamp": i * 1e11, "value": i} for i in range(1, 2)]
-            dps_objects = [{"id": i, "datapoints": dps} for i in range(101)]
+            dps_objects = [{"id": i, "datapoints": dps} for i in range(1, 102)]
             cognite_client.time_series.data.insert_multiple(dps_objects)
             assert 2 == len(mock_post_datapoints.calls)
 
     def test_insert_multiple_ts_single_call__above_dps_limit_below_ts_limit(self, cognite_client, mock_post_datapoints):
         dps = [{"timestamp": i * 1e11, "value": i} for i in range(1, 1002)]
-        dps_objects = [{"id": i, "datapoints": dps} for i in range(10)]
+        dps_objects = [{"id": i, "datapoints": dps} for i in range(1, 11)]
         cognite_client.time_series.data.insert_multiple(dps_objects)
         assert 2 == len(mock_post_datapoints.calls)
 

--- a/tests/tests_unit/test_api/test_datapoints_tasks.py
+++ b/tests/tests_unit/test_api/test_datapoints_tasks.py
@@ -103,14 +103,14 @@ class TestSingleTSQueryValidator:
 
     @pytest.mark.parametrize("limit, exp_limit", [(0, 0), (1, 1), (-1, None), (math.inf, None), (None, None)])
     def test_valid_limits(self, limit, exp_limit):
-        ts_query = _SingleTSQueryValidator(_DatapointsQuery(id=0, limit=limit)).validate_and_create_single_queries()
+        ts_query = _SingleTSQueryValidator(_DatapointsQuery(id=1, limit=limit)).validate_and_create_single_queries()
         assert len(ts_query) == 1
         assert ts_query[0].limit == exp_limit
 
     @pytest.mark.parametrize("limit", (-2, -math.inf, math.nan, ..., "5000"))
     def test_limits_not_allowed_values(self, limit):
         with pytest.raises(TypeError, match=re.escape("Parameter `limit` must be a non-negative integer -OR-")):
-            _SingleTSQueryValidator(_DatapointsQuery(id=0, limit=limit)).validate_and_create_single_queries()
+            _SingleTSQueryValidator(_DatapointsQuery(id=1, limit=limit)).validate_and_create_single_queries()
 
     @pytest.mark.parametrize(
         "granularity, aggregates, outside, exp_err, exp_err_msg_idx",
@@ -133,7 +133,7 @@ class TestSingleTSQueryValidator:
             "'Include outside points' is not supported for aggregates.",
         ]
         user_query = _DatapointsQuery(
-            id=0, granularity=granularity, aggregates=aggregates, include_outside_points=outside
+            id=1, granularity=granularity, aggregates=aggregates, include_outside_points=outside
         )
         with pytest.raises(exp_err, match=re.escape(err_msgs[exp_err_msg_idx])):
             _SingleTSQueryValidator(user_query).validate_and_create_single_queries()
@@ -153,7 +153,7 @@ class TestSingleTSQueryValidator:
     def test_function__verify_time_range__valid_inputs(self, start, end):
         gran_dct = {"granularity": random_granularity(), "aggregates": random_aggregates()}
         for kwargs in [{}, gran_dct]:
-            user_query = _DatapointsQuery(id=0, start=start, end=end, **kwargs)
+            user_query = _DatapointsQuery(id=1, start=start, end=end, **kwargs)
             ts_query = _SingleTSQueryValidator(user_query).validate_and_create_single_queries()
             assert isinstance(ts_query[0].start, int)
             assert isinstance(ts_query[0].end, int)
@@ -174,7 +174,7 @@ class TestSingleTSQueryValidator:
     def test_function__verify_time_range__raises(self, start, end):
         gran_dct = {"granularity": random_granularity(), "aggregates": random_aggregates()}
         for kwargs in [{}, gran_dct]:
-            user_query = _DatapointsQuery(id=0, start=start, end=end, **kwargs)
+            user_query = _DatapointsQuery(id=1, start=start, end=end, **kwargs)
             with pytest.raises(ValueError, match="Invalid time range"):
                 _SingleTSQueryValidator(user_query).validate_and_create_single_queries()
 

--- a/tests/tests_unit/test_utils/test_auxiliary.py
+++ b/tests/tests_unit/test_utils/test_auxiliary.py
@@ -19,6 +19,7 @@ from cognite.client.utils._auxiliary import (
     split_into_n_parts,
     to_camel_case,
     to_snake_case,
+    validate_user_input_dict_with_identifier,
 )
 
 
@@ -283,3 +284,43 @@ class TestExactlyOneIsNotNone:
     )
     def test_exactly_one_is_not_none(self, inp, expected):
         assert exactly_one_is_not_none(*inp) == expected
+
+
+class TestValidateUserInputDictWithIdentifier:
+    @pytest.mark.parametrize(
+        "dct, keys, expected",
+        (
+            ({"id": 123, "a": None, "b": 0}, {"a", "b"}, {"id": 123}),
+            ({"external_id": "foo", "c": None}, {"c"}, {"externalId": "foo"}),
+            ({"externalId": "foo"}, set(), {"externalId": "foo"}),
+        ),
+    )
+    def test_validate_normal_input(self, dct, keys, expected):
+        assert expected == validate_user_input_dict_with_identifier(dct, required_keys=keys)
+
+    @pytest.mark.parametrize(
+        "dct, keys, err, err_msg",
+        (
+            (["id", 123], set(), TypeError, "Expected list of dict-like objects, got <class 'list'>"),
+            ({}, set(), ValueError, "must be specified, got neither"),
+            ({"id": 123, "external_id": "foo"}, set(), ValueError, "must be specified, got both"),
+            ({"id": 123, "externalId": "foo"}, set(), ValueError, "must be specified, got both"),
+            ({"id": 123}, {"a"}, ValueError, re.escape("Invalid key(s): [], required key(s) missing: ['a'].")),
+            (
+                {"id": 123, "a": 0},
+                {"b"},
+                ValueError,
+                re.escape("Invalid key(s): ['a'], required key(s) missing: ['b']."),
+            ),
+            (
+                {"id": 123, "a": 0, "b": 1},
+                {"c", "d"},
+                ValueError,
+                re.escape("Invalid key(s): ['a', 'b'], required key(s) missing: ['c', 'd']."),
+            ),
+            ({"id": 123, "a": 0}, set(), ValueError, re.escape("Invalid key(s): ['a'], required key(s) missing: [].")),
+        ),
+    )
+    def test_validate_bad_input(self, dct, keys, err, err_msg):
+        with pytest.raises(err, match=err_msg):
+            validate_user_input_dict_with_identifier(dct, required_keys=keys)

--- a/tests/tests_unit/test_utils/test_auxiliary.py
+++ b/tests/tests_unit/test_utils/test_auxiliary.py
@@ -301,7 +301,7 @@ class TestValidateUserInputDictWithIdentifier:
     @pytest.mark.parametrize(
         "dct, keys, err, err_msg",
         (
-            (["id", 123], set(), TypeError, "Expected list of dict-like objects, got <class 'list'>"),
+            (["id", 123], set(), TypeError, "Expected dict-like object, got <class 'list'>"),
             ({}, set(), ValueError, "must be specified, got neither"),
             ({"id": 123, "external_id": "foo"}, set(), ValueError, "must be specified, got both"),
             ({"id": 123, "externalId": "foo"}, set(), ValueError, "must be specified, got both"),

--- a/tests/tests_unit/test_utils/test_identifier.py
+++ b/tests/tests_unit/test_utils/test_identifier.py
@@ -1,6 +1,33 @@
 import pytest
 
-from cognite.client.utils._identifier import IdentifierSequence
+from cognite.client._constants import MAX_VALID_INTERNAL_ID
+from cognite.client.utils._identifier import Identifier, IdentifierSequence
+
+
+class TestIdentifier:
+    @pytest.mark.parametrize(
+        "id, external_id, exp_tpl",
+        (
+            (1, None, ("id", 1)),
+            (MAX_VALID_INTERNAL_ID, None, ("id", MAX_VALID_INTERNAL_ID)),
+            (None, "foo", ("external_id", "foo")),
+        ),
+    )
+    def test_of_either__normal_input(self, id, external_id, exp_tpl):
+        assert exp_tpl == Identifier.of_either(id, external_id).as_tuple(camel_case=False)
+
+    @pytest.mark.parametrize(
+        "id, external_id, err_msg",
+        (
+            (None, None, "Exactly one of id or external id must be specified, got neither"),
+            (123, "foo", "Exactly one of id or external id must be specified, got both"),
+            (0, None, f"Invalid id, must satisfy: 1 <= id <= {MAX_VALID_INTERNAL_ID}"),
+            (MAX_VALID_INTERNAL_ID + 1, None, f"Invalid id, must satisfy: 1 <= id <= {MAX_VALID_INTERNAL_ID}"),
+        ),
+    )
+    def test_of_either__bad_input(self, id, external_id, err_msg):
+        with pytest.raises(ValueError, match=err_msg):
+            Identifier.of_either(id, external_id)
 
 
 class TestIdentifierSequence:

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -9,6 +9,7 @@ import os
 import random
 from contextlib import contextmanager
 
+from cognite.client._constants import MAX_VALID_INTERNAL_ID
 from cognite.client.data_classes.datapoints import ALL_SORTED_DP_AGGS
 from cognite.client.utils._auxiliary import random_string
 
@@ -50,7 +51,7 @@ def rng_context(seed: int):
 
 def random_cognite_ids(n):
     # Returns list of random, valid Cognite internal IDs:
-    return random.choices(range(1, 9007199254740992), k=n)
+    return random.choices(range(1, MAX_VALID_INTERNAL_ID + 1), k=n)
 
 
 def random_cognite_external_ids(n, str_len=50):


### PR DESCRIPTION
## Description
From the issue raised on slack: https://cognitedata.slack.com/archives/CEXTYVBMG/p1676104405912859 

Adds input validation on `DatapointsAPI.[insert, insert_multiple, delete_ranges]` that now raises also on _missing keys_, not just _invalid keys_.

With the new validation, I found tests failing due to `id` being passed as `0`, which, when given to `Identifier.of_either` returns `None` as the identifier (because zero is falsy):
```py
>>> # Before
>>> Identifier.of_either(0, None)
Identifier(None)
>>>
>>> # After
>>> Identifier.of_either(0, None)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/.../cognite-sdk-python/cognite/client/utils/_identifier.py", line 23, in of_either
    raise ValueError(f"Invalid id, must satisfy: 1 <= id <= {MAX_VALID_INTERNAL_ID}")
ValueError: Invalid id, must satisfy: 1 <= id <= 9007199254740991
```
Also added a few tests for `Identifier.of_either`.

## Checklist:
- [x] Tests added/updated.
- [x] Documentation updated. Documentation is generated from docstrings - these must be updated according to your change.
  If a new method has been added it should be referenced in [cognite.rst](https://github.com/cognitedata/cognite-sdk-python/blob/master/docs/source/cognite.rst) in order to generate docs based on its docstring.
- [x] Changelog updated in [CHANGELOG.md](https://github.com/cognitedata/cognite-sdk-python/blob/master/CHANGELOG.md).
- [x] Version bumped. If triggering a new release is desired, bump the version number in [_version.py](https://github.com/cognitedata/cognite-sdk-python/blob/master/cognite/client/_version.py) and [pyproject.toml](https://github.com/cognitedata/cognite-sdk-python/blob/master/pyproject.toml) per [semantic versioning](https://semver.org/).
