### PR TITLE
Fix flaky tests: Make items-are-equal checks ignore ordering

### DIFF
--- a/tests/tests_unit/test_api_client.py
+++ b/tests/tests_unit/test_api_client.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import math
+import unittest
 from collections import namedtuple
 from typing import Any
 
@@ -419,9 +420,10 @@ class TestStandardRetrieveMultiple:
                 resource_path=URL_PATH,
                 identifiers=IdentifierSequence.of(1, 2),
             )
-
-        assert {"items": [{"id": 1}]} == jsgz_load(rsps.calls[0].request.body)
-        assert {"items": [{"id": 2}]} == jsgz_load(rsps.calls[1].request.body)
+        unittest.TestCase().assertCountEqual(
+            [{"items": [{"id": 1}]}, {"items": [{"id": 2}]}],
+            [jsgz_load(rsps.calls[0].request.body), jsgz_load(rsps.calls[1].request.body)],
+        )
 
 
 class TestStandardList:
@@ -868,7 +870,7 @@ class TestStandardDelete:
                     resource_path=URL_PATH, wrap_ids=False, identifiers=IdentifierSequence.of([1, 2, 3])
                 )
 
-        assert [{"id": 1}, {"id": 3}] == e.value.not_found
+        unittest.TestCase().assertCountEqual([{"id": 1}, {"id": 3}], e.value.not_found)
         assert [1, 2, 3] == e.value.failed
 
     def test_over_limit_concurrent(self, api_client_with_api_key, rsps):
@@ -879,8 +881,10 @@ class TestStandardDelete:
             api_client_with_api_key._delete_multiple(
                 resource_path=URL_PATH, identifiers=IdentifierSequence.of([1, 2, 3, 4]), wrap_ids=False
             )
-        assert {"items": [1, 2]} == jsgz_load(rsps.calls[0].request.body)
-        assert {"items": [3, 4]} == jsgz_load(rsps.calls[1].request.body)
+        unittest.TestCase().assertCountEqual(
+            [{"items": [1, 2]}, {"items": [3, 4]}],
+            [jsgz_load(rsps.calls[0].request.body), jsgz_load(rsps.calls[1].request.body)],
+        )
 
 
 class TestStandardUpdate:
@@ -1069,9 +1073,10 @@ class TestStandardUpdate:
                 resource_path=URL_PATH,
                 items=[SomeResource(1, 2, id=1), SomeResource(3, 4, id=2)],
             )
-
-        assert {"items": [{"id": 1, "update": {"y": {"set": 2}}}]} == jsgz_load(rsps.calls[0].request.body)
-        assert {"items": [{"id": 2, "update": {"y": {"set": 4}}}]} == jsgz_load(rsps.calls[1].request.body)
+        unittest.TestCase().assertCountEqual(
+            [{"items": [{"id": 1, "update": {"y": {"set": 2}}}]}, {"items": [{"id": 2, "update": {"y": {"set": 4}}}]}],
+            [jsgz_load(rsps.calls[0].request.body), jsgz_load(rsps.calls[1].request.body)],
+        )
 
 
 class TestStandardSearch:


### PR DESCRIPTION
## Description
Several tests in `tests/tests_unit/test_api_client.py` are flaky due to threading sometimes returning a different ordering of elements. This should not affect the check that verifies that the items of both sequences are equal. Pytest does not have such a feature, but built-in `unittest` have.
```
=========================== short test summary info ============================
FAILED tests/tests_unit/test_api_client.py::TestStandardDelete::test_standard_delete_multiple_fail_missing_ids - AssertionError: assert [{'id': 1}, {'id': 3}] == [{'id': 3}, {'id': 1}]
  At index 0 diff: {'id': 1} != {'id': 3}
  Full diff:
  - [{'id': 3}, {'id': 1}]
  ?         ^          ^
  + [{'id': 1}, {'id': 3}]
  ?         ^          ^


FAILED tests/tests_unit/test_api_client.py::TestStandardDelete::test_over_limit_concurrent - AssertionError: assert {'items': [1, 2]} == {'items': [3, 4]}
  Differing items:
  {'items': [1, 2]} != {'items': [3, 4]}
  Full diff:
  - {'items': [3, 4]}
  ?            ^  ^
  + {'items': [1, 2]}
  ?            ^  ^


FAILED tests/tests_unit/test_api_client.py::TestStandardUpdate::test_over_limit_concurrent - AssertionError: assert {'items': [{'...{'set': 2}}}]} == {'items': [{'...{'set': 4}}}]}
  Differing items:
  {'items': [{'id': 1, 'update': {'y': {'set': 2}}}]} != {'items': [{'id': 2, 'update': {'y': {'set': 4}}}]}
  Full diff:
  - {'items': [{'id': 2, 'update': {'y': {'set': 4}}}]}
  ?                   ^                          ^
  + {'items': [{'id': 1, 'update': {'y': {'set': 2}}}]}
  ?                   ^                          ^
```

## Checklist:
- [x] Tests added/updated.
- [ ] Documentation updated. Documentation is generated from docstrings - these must be updated according to your change.
  If a new method has been added it should be referenced in [cognite.rst](https://github.com/cognitedata/cognite-sdk-python/blob/master/docs/source/cognite.rst) in order to generate docs based on its docstring.
- [ ] Changelog updated in [CHANGELOG.md](https://github.com/cognitedata/cognite-sdk-python/blob/master/CHANGELOG.md).
- [ ] Version bumped. If triggering a new release is desired, bump the version number in [_version.py](https://github.com/cognitedata/cognite-sdk-python/blob/master/cognite/client/_version.py) and [pyproject.toml](https://github.com/cognitedata/cognite-sdk-python/blob/master/pyproject.toml) per [semantic versioning](https://semver.org/).
