### PR TITLE
Enforce that all mocked APIs exactly match available APIs

### DIFF
--- a/cognite/client/testing.py
+++ b/cognite/client/testing.py
@@ -81,9 +81,6 @@ class CogniteClientMock(MagicMock):
         self.assets = MagicMock(spec_set=AssetsAPI)
         self.data_sets = MagicMock(spec_set=DataSetsAPI)
 
-        self.datapoints = MagicMock(spec=DatapointsAPI)  # TODO: In v6, remove and move to time_series.data
-        self.datapoints.synthetic = MagicMock(spec_set=SyntheticDatapointsAPI)
-
         self.diagrams = MagicMock(spec_set=DiagramsAPI)
         self.entity_matching = MagicMock(spec_set=EntityMatchingAPI)
         self.events = MagicMock(spec_set=EventsAPI)
@@ -134,7 +131,9 @@ class CogniteClientMock(MagicMock):
         self.three_d.revisions = MagicMock(spec_set=ThreeDRevisionsAPI)
 
         self.time_series = MagicMock(spec=TimeSeriesAPI)
-        self.time_series.data = self.datapoints
+        self.time_series.data = MagicMock(spec=DatapointsAPI)
+        self.time_series.data.synthetic = MagicMock(spec_set=SyntheticDatapointsAPI)
+        self.datapoints = self.time_series.data  # TODO: In v6, remove and move to time_series.data
 
         self.transformations = MagicMock(spec=TransformationsAPI)
         self.transformations.jobs = MagicMock(spec_set=TransformationJobsAPI)

--- a/tests/tests_unit/test_testing.py
+++ b/tests/tests_unit/test_testing.py
@@ -1,35 +1,31 @@
-from unittest.mock import MagicMock
-
 import pytest
 
 from cognite.client import ClientConfig, CogniteClient
+from cognite.client._api_client import APIClient
 from cognite.client.credentials import APIKey
 from cognite.client.testing import CogniteClientMock, monkeypatch_cognite_client
+from tests.utils import all_mock_children, all_subclasses
 
 
-def test_mock_cognite_client():
-    with monkeypatch_cognite_client() as c_mock:
-        c = CogniteClient(ClientConfig(client_name="bla", project="bla", credentials=APIKey("bla")))
-        assert isinstance(c_mock, MagicMock)
-        assert c_mock == c
+def test_ensure_all_apis_are_available_on_cognite_mock():
+    mocked_apis = all_mock_children(CogniteClientMock())
+    available = {v.__class__ for v in mocked_apis.values()}
+    expected = set(all_subclasses(APIClient))
+    # New APIs that have not been added to CogniteClientMock?
+    assert not expected.difference(available)
+    # Removed APIs still available on CogniteClientMock?
+    assert not available.difference(expected)
 
-        api_pairs = [
-            (c.time_series, c_mock.time_series),
-            (c.raw, c_mock.raw),
-            (c.assets, c_mock.assets),
-            (c.datapoints, c_mock.datapoints),
-            (c.events, c_mock.events),
-            (c.files, c_mock.files),
-            (c.iam, c_mock.iam),
-            (c.login, c_mock.login),
-            (c.three_d, c_mock.three_d),
-        ]
-        for api, mock_api in api_pairs:
-            assert isinstance(mock_api, MagicMock)
-            assert api == mock_api
 
-            with pytest.raises(AttributeError):
-                api.does_not_exist
+@pytest.mark.parametrize("api", list(all_mock_children(CogniteClientMock()).values()))
+def test_ensure_all_apis_are_specced_cognite_mock(api):
+    # All APIs raise when trying to access a non-existing attribute:
+    with pytest.raises(AttributeError):
+        api.does_not_exist
+    # ...but only APIs that do not contain other APIs have spec_set=True:
+    if api._spec_set is True:
+        with pytest.raises(AttributeError):
+            api.does_not_exist = 42
 
 
 def test_cognite_client_accepts_arguments_during_and_after_mock():

--- a/tests/tests_unit/test_testing.py
+++ b/tests/tests_unit/test_testing.py
@@ -11,21 +11,26 @@ def test_ensure_all_apis_are_available_on_cognite_mock():
     mocked_apis = all_mock_children(CogniteClientMock())
     available = {v.__class__ for v in mocked_apis.values()}
     expected = set(all_subclasses(APIClient))
-    # New APIs that have not been added to CogniteClientMock?
+    # Any new APIs that have not been added to CogniteClientMock?
     assert not expected.difference(available)
-    # Removed APIs still available on CogniteClientMock?
+    # Any removed APIs that are still available on CogniteClientMock?
     assert not available.difference(expected)
 
 
 @pytest.mark.parametrize("api", list(all_mock_children(CogniteClientMock()).values()))
-def test_ensure_all_apis_are_specced_cognite_mock(api):
+def test_ensure_all_apis_are_specced_on_cognite_mock(api):
     # All APIs raise when trying to access a non-existing attribute:
     with pytest.raises(AttributeError):
         api.does_not_exist
-    # ...but only APIs that do not contain other APIs have spec_set=True:
+
+    # ...but only APIs that do not contain other APIs have spec_set=True.
     if api._spec_set is True:
+        assert not api._mock_children
         with pytest.raises(AttributeError):
             api.does_not_exist = 42
+    else:
+        assert api._mock_children
+        api.does_not_exist = 42
 
 
 def test_cognite_client_accepts_arguments_during_and_after_mock():


### PR DESCRIPTION
## Description
In the past, the APIs available on `CogniteClientMock` has been a subset of the actual APIs available through the `CogniteClient`. This PR adds a test that enforces both that...

1. ...after a new API has been added to the SDK, the `CogniteClientMock` must be updated accordingly
2. ...once an API is removed from the SDK, the `CogniteClientMock` must be updated accordingly

## Checklist:
- [x] Tests added/updated.