### PR TITLE
Update schedules.py

### DIFF
--- a/cognite/client/_api/transformations/schedules.py
+++ b/cognite/client/_api/transformations/schedules.py
@@ -196,7 +196,7 @@ class TransformationSchedulesAPI(APIClient):
                 >>> c = CogniteClient()
                 >>> transformation_schedule = c.transformations.schedules.retrieve(id=1)
                 >>> transformation_schedule.is_paused = True
-                >>> res = c.transformations.update(transformation)
+                >>> res = c.transformations.schedules.update(transformation_schedule)
 
             Perform a partial update on a transformation schedule, updating the interval and unpausing it::
 


### PR DESCRIPTION

## Description
Updated the documentation of transformations schedules.
There is no such variable as 'transformation', so the code doesn't work.
Should I bump the version? It's only change to the docs.

## Checklist:
- [ ] Tests added/updated.
- [X] Documentation updated. Documentation is generated from docstrings - these must be updated according to your change.
  If a new method has been added it should be referenced in [cognite.rst](https://github.com/cognitedata/cognite-sdk-python/blob/master/docs/source/cognite.rst) in order to generate docs based on its docstring.
- [ ] Changelog updated in [CHANGELOG.md](https://github.com/cognitedata/cognite-sdk-python/blob/master/CHANGELOG.md).
- [ ] Version bumped. If triggering a new release is desired, bump the version number in [_version.py](https://github.com/cognitedata/cognite-sdk-python/blob/master/cognite/client/_version.py) and [pyproject.toml](https://github.com/cognitedata/cognite-sdk-python/blob/master/pyproject.toml) per [semantic versioning](https://semver.org/).
