### PR TITLE
Use Content-Type instead of `X-Upload-Content-Type` for file uploads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ Changes are grouped as follows
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
+## [5.6.2] - 21-02-23
+### Fixed
+- Fixed an issue where `Content-Type` was not correctly set on file uploads to Azure.
 
 ## [5.6.1] - 20-02-23
 ### Fixed

--- a/cognite/client/_api/files.py
+++ b/cognite/client/_api/files.py
@@ -696,7 +696,7 @@ class FilesAPI(APIClient):
         )
         returned_file_metadata = res.json()
         upload_url = returned_file_metadata["uploadUrl"]
-        headers = {"X-Upload-Content-Type": file_metadata.mime_type}
+        headers = {"Content-Type": file_metadata.mime_type}
         self._http_client_with_retry.request(
             "PUT", upload_url, data=content, timeout=self._config.file_transfer_timeout, headers=headers
         )

--- a/cognite/client/_version.py
+++ b/cognite/client/_version.py
@@ -1,4 +1,4 @@
 from __future__ import annotations
 
-__version__ = "5.6.1"
+__version__ = "5.6.2"
 __api_subversion__ = "V20220125"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "cognite-sdk"
 
-version = "5.6.1"
+version = "5.6.2"
 
 description = "Cognite Python SDK"
 readme = "README.md"


### PR DESCRIPTION
## Description
File uploads currently do not work correctly in azure and openshift because we don't set the content-type header. https://cognitedata.atlassian.net/browse/CDF-17727

https://cloud.google.com/storage/docs/json_api/v1/parameters#contenttype https://cloud.google.com/storage/docs/performing-resumable-uploads

`X-Upload-Content-Type` is an optional header used in resumable uploads in GCS. Let's replace this with the standard header `Content-Type`, not expected to break anything.

## Checklist:
- [ ] Tests added/updated.
- [ ] Documentation updated. Documentation is generated from docstrings - these must be updated according to your change.
  If a new method has been added it should be referenced in [cognite.rst](https://github.com/cognitedata/cognite-sdk-python/blob/master/docs/source/cognite.rst) in order to generate docs based on its docstring.
- [ ] Changelog updated in [CHANGELOG.md](https://github.com/cognitedata/cognite-sdk-python/blob/master/CHANGELOG.md).
- [ ] Version bumped. If triggering a new release is desired, bump the version number in [_version.py](https://github.com/cognitedata/cognite-sdk-python/blob/master/cognite/client/_version.py) and [pyproject.toml](https://github.com/cognitedata/cognite-sdk-python/blob/master/pyproject.toml) per [semantic versioning](https://semver.org/).
