### PR TITLE
Fix identifier trouble in `ExtractionPipelineRun`s

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,12 +17,15 @@ Changes are grouped as follows
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
-## [5.6.5] - 08-03-23
+## [5.7.0] - 08-03-23
 ### Removed
 - `ExtractionPipelineRunUpdate` was removed as runs are immutable.
 
 ### Fixed
-- `ExtractionPipelinesRunsAPI` was hiding `id` of runs because `ExtractionPipelineRun` only defined `external_id` (which doesn't exist for the resource), it only has `id` (and "parent" ext.pipe external ID is not returned by the API).
+- `ExtractionPipelinesRunsAPI` was hiding `id` of runs because `ExtractionPipelineRun` only defined `external_id` which doesn't exist for the "run resource", only for the "parent" ext.pipe (but this is not returned by the API; only used to query).
+
+### Changed
+- Rename and deprecate `external_id` in `ExtractionPipelinesRunsAPI` in favour of the more descriptive `extpipe_external_id`. The change is backwards-compatible, but will issue a `UserWarning` for the old usage pattern.
 
 ## [5.6.4] - 28-02-23
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,13 @@ Changes are grouped as follows
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
+## [5.6.5] - 08-03-23
+### Removed
+- `ExtractionPipelineRunUpdate` was removed as runs are immutable.
+
+### Fixed
+- `ExtractionPipelinesRunsAPI` was hiding `id` of runs because `ExtractionPipelineRun` only defined `external_id` (which doesn't exist for the resource), it only has `id` (and "parent" ext.pipe external ID is not returned by the API).
+
 ## [5.6.4] - 28-02-23
 ### Added
 - Input validation on `DatapointsAPI.[insert, insert_multiple, delete_ranges]` now raise on missing keys, not just invalid keys.

--- a/cognite/client/_api/extractionpipelines.py
+++ b/cognite/client/_api/extractionpipelines.py
@@ -313,7 +313,8 @@ class ExtractionPipelineRunsAPI(APIClient):
                 >>> from cognite.client import CogniteClient
                 >>> from cognite.client.data_classes import ExtractionPipelineRun
                 >>> c = CogniteClient()
-                >>> res = c.extraction_pipelines.runs.create(ExtractionPipelineRun(status="success", external_id="extId"))
+                >>> res = c.extraction_pipelines.runs.create(
+                ...     ExtractionPipelineRun(status="success", extpipe_external_id="extId"))
         """
         utils._auxiliary.assert_type(run, "run", [ExtractionPipelineRun, Sequence])
         return self._create_multiple(list_cls=ExtractionPipelineRunList, resource_cls=ExtractionPipelineRun, items=run)

--- a/cognite/client/_version.py
+++ b/cognite/client/_version.py
@@ -1,4 +1,4 @@
 from __future__ import annotations
 
-__version__ = "5.6.5"
+__version__ = "5.7.0"
 __api_subversion__ = "V20220125"

--- a/cognite/client/_version.py
+++ b/cognite/client/_version.py
@@ -1,4 +1,4 @@
 from __future__ import annotations
 
-__version__ = "5.6.4"
+__version__ = "5.6.5"
 __api_subversion__ = "V20220125"

--- a/cognite/client/data_classes/__init__.py
+++ b/cognite/client/data_classes/__init__.py
@@ -31,7 +31,6 @@ from cognite.client.data_classes.extractionpipelines import (
     ExtractionPipelineRun,
     ExtractionPipelineRunFilter,
     ExtractionPipelineRunList,
-    ExtractionPipelineRunUpdate,
     ExtractionPipelineUpdate,
 )
 from cognite.client.data_classes.files import (

--- a/cognite/client/data_classes/extractionpipelines.py
+++ b/cognite/client/data_classes/extractionpipelines.py
@@ -201,7 +201,7 @@ class ExtractionPipelineRun(CogniteResource):
     """A representation of an extraction pipeline run.
 
     Args:
-        external_id (str): The external ID of the extraction pipeline.
+        id (int): A server-generated ID for the object.
         status (str): success/failure/seen.
         message (str): Optional status message.
         created_time (int): The number of milliseconds since 00:00:00 Thursday, 1 January 1970, Coordinated Universal Time (UTC), minus leap seconds.
@@ -210,13 +210,13 @@ class ExtractionPipelineRun(CogniteResource):
 
     def __init__(
         self,
-        external_id: str = None,
+        id: int = None,
         status: str = None,
         message: str = None,
         created_time: int = None,
         cognite_client: CogniteClient = None,
     ):
-        self.external_id = external_id
+        self.id = id
         self.status = status
         self.message = message
         self.created_time = created_time
@@ -299,7 +299,7 @@ class ExtractionPipelineConfigRevision(CogniteResource):
 
 
 class ExtractionPipelineConfig(ExtractionPipelineConfigRevision):
-    """An extraction pipeline config revision
+    """An extraction pipeline config
 
     Args:
         external_id (str): The external ID of the associated extraction pipeline.

--- a/cognite/client/data_classes/extractionpipelines.py
+++ b/cognite/client/data_classes/extractionpipelines.py
@@ -223,12 +223,6 @@ class ExtractionPipelineRun(CogniteResource):
         self._cognite_client = cast("CogniteClient", cognite_client)
 
 
-class ExtractionPipelineRunUpdate(CogniteUpdate):
-    class _PrimitiveExtractionPipelineRunUpdate(CognitePrimitiveUpdate):
-        def set(self, value: Any) -> ExtractionPipelineRunUpdate:
-            return self._set(value)
-
-
 class ExtractionPipelineRunList(CogniteResourceList):
     _RESOURCE = ExtractionPipelineRun
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "cognite-sdk"
 
-version = "5.6.5"
+version = "5.7.0"
 
 description = "Cognite Python SDK"
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "cognite-sdk"
 
-version = "5.6.4"
+version = "5.6.5"
 
 description = "Cognite Python SDK"
 readme = "README.md"

--- a/tests/tests_integration/test_api/test_extraction_pipelines.py
+++ b/tests/tests_integration/test_api/test_extraction_pipelines.py
@@ -68,7 +68,7 @@ class TestExtractionPipelinesAPI:
         intial_message = cognite_client.extraction_pipelines.retrieve(new_extpipe.id).last_message
         assert intial_message is None
 
-        cognite_client.extraction_pipeline_runs.create(ExtractionPipelineRun(status="failure", message="Oh no!"))
+        cognite_client.extraction_pipelines.runs.create(ExtractionPipelineRun(status="failure", message="Oh no!"))
         new_message = cognite_client.extraction_pipelines.retrieve(new_extpipe.id).last_message
         assert new_message == "Oh no!"
 
@@ -80,7 +80,7 @@ class TestExtractionPipelinesAPI:
         assert extpipe.last_seen == 0
 
         # IDEA: Add convenience method to update an ext.pipe? (inspiration, see: FunctionsAPI)
-        new_run = cognite_client.extraction_pipeline_runs.create
+        new_run = cognite_client.extraction_pipelines.runs.create
         new_run(ExtractionPipelineRun(extpipe_external_id=new_extpipe.external_id, status="seen"))
         extpipe = retrieve(external_id=new_extpipe.external_id)
         assert extpipe.last_failure == 0

--- a/tests/tests_integration/test_api/test_extraction_pipelines.py
+++ b/tests/tests_integration/test_api/test_extraction_pipelines.py
@@ -68,7 +68,9 @@ class TestExtractionPipelinesAPI:
         intial_message = cognite_client.extraction_pipelines.retrieve(new_extpipe.id).last_message
         assert intial_message is None
 
-        cognite_client.extraction_pipelines.runs.create(ExtractionPipelineRun(status="failure", message="Oh no!"))
+        cognite_client.extraction_pipelines.runs.create(
+            ExtractionPipelineRun(status="failure", message="Oh no!", extpipe_external_id=new_extpipe.external_id)
+        )
         new_message = cognite_client.extraction_pipelines.retrieve(new_extpipe.id).last_message
         assert new_message == "Oh no!"
 

--- a/tests/tests_integration/test_api/test_extraction_pipelines.py
+++ b/tests/tests_integration/test_api/test_extraction_pipelines.py
@@ -68,38 +68,33 @@ class TestExtractionPipelinesAPI:
         intial_message = cognite_client.extraction_pipelines.retrieve(new_extpipe.id).last_message
         assert intial_message is None
 
-        cognite_client.extraction_pipeline_runs.create(
-            ExtractionPipelineRun(external_id=new_extpipe.external_id, status="failure", message="Oh no!")
-        )
+        cognite_client.extraction_pipeline_runs.create(ExtractionPipelineRun(status="failure", message="Oh no!"))
         new_message = cognite_client.extraction_pipelines.retrieve(new_extpipe.id).last_message
         assert new_message == "Oh no!"
 
     def test_last_run_times(self, cognite_client, new_extpipe: ExtractionPipeline):
-        extpipe = cognite_client.extraction_pipelines.retrieve(external_id=new_extpipe.external_id)
+        retrieve = cognite_client.extraction_pipelines.retrieve
+        extpipe = retrieve(external_id=new_extpipe.external_id)
         assert extpipe.last_failure == 0
         assert extpipe.last_success == 0
         assert extpipe.last_seen == 0
 
-        cognite_client.extraction_pipeline_runs.create(
-            ExtractionPipelineRun(external_id=new_extpipe.external_id, status="seen")
-        )
-        extpipe = cognite_client.extraction_pipelines.retrieve(external_id=new_extpipe.external_id)
+        # IDEA: Add convenience method to update an ext.pipe? (inspiration, see: FunctionsAPI)
+        new_run = cognite_client.extraction_pipeline_runs.create
+        new_run(ExtractionPipelineRun(extpipe_external_id=new_extpipe.external_id, status="seen"))
+        extpipe = retrieve(external_id=new_extpipe.external_id)
         assert extpipe.last_failure == 0
         assert extpipe.last_success == 0
         assert extpipe.last_seen != 0
 
-        cognite_client.extraction_pipeline_runs.create(
-            ExtractionPipelineRun(external_id=new_extpipe.external_id, status="success")
-        )
-        extpipe = cognite_client.extraction_pipelines.retrieve(external_id=new_extpipe.external_id)
+        new_run(ExtractionPipelineRun(extpipe_external_id=new_extpipe.external_id, status="success"))
+        extpipe = retrieve(external_id=new_extpipe.external_id)
         assert extpipe.last_failure == 0
         assert extpipe.last_success != 0
         assert extpipe.last_seen != 0
 
-        cognite_client.extraction_pipeline_runs.create(
-            ExtractionPipelineRun(external_id=new_extpipe.external_id, status="failure")
-        )
-        extpipe = cognite_client.extraction_pipelines.retrieve(external_id=new_extpipe.external_id)
+        new_run(ExtractionPipelineRun(extpipe_external_id=new_extpipe.external_id, status="failure"))
+        extpipe = retrieve(external_id=new_extpipe.external_id)
         assert extpipe.last_failure != 0
         assert extpipe.last_success != 0
         assert extpipe.last_seen != 0


### PR DESCRIPTION
## Description
As discovered by @spex66 , `id` of ext. pipe runs was returned from the API, but hidden from users of the Python SDK.

Due to how the SDK is implemented (or more correctly, how the ext-pipe-API is inconsistent 😉 ), we can't make this change work without "sacrificing something". Here's a copy of note from the PR:
```
# Note: No way to make this id/xid API mixup completely correct. Either:
# 1. We use id / external_id for respecively "self id" / "ext.pipe external id"
#   - Problem: Only dataclass in the SDK where id and external_id does not point to same object...
# 2. We rename external_id to extpipe_external_id in the SDK only
#   - Problem: This dump method might be surprising to the user - if used (its public)...
# ...and 2 was chosen:
```

Slack discussion:
https://cognitedata.slack.com/archives/CG10VQPFX/p1677665680493719

## Checklist:
- [x] Tests added/updated.
- [x] Documentation updated. Documentation is generated from docstrings - these must be updated according to your change.
  If a new method has been added it should be referenced in [cognite.rst](https://github.com/cognitedata/cognite-sdk-python/blob/master/docs/source/cognite.rst) in order to generate docs based on its docstring.
- [x] Changelog updated in [CHANGELOG.md](https://github.com/cognitedata/cognite-sdk-python/blob/master/CHANGELOG.md).
- [x] Version bumped. If triggering a new release is desired, bump the version number in [_version.py](https://github.com/cognitedata/cognite-sdk-python/blob/master/cognite/client/_version.py) and [pyproject.toml](https://github.com/cognitedata/cognite-sdk-python/blob/master/pyproject.toml) per [semantic versioning](https://semver.org/).
