### PR TITLE
Fix method dump of TransformationDestination

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ Changes are grouped as follows
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
+## [5.7.2] - 10-03-23
+### Fixed
+- Fix method dump in TransformationDestination to ignore None.
+
 ## [5.7.1] - 09-03-23
 ### Changed
 - Split `instances` destination type of Transformations to `nodes` and `edges`.

--- a/cognite/client/_version.py
+++ b/cognite/client/_version.py
@@ -1,4 +1,4 @@
 from __future__ import annotations
 
-__version__ = "5.7.1"
+__version__ = "5.7.2"
 __api_subversion__ = "V20220125"

--- a/cognite/client/data_classes/transformations/common.py
+++ b/cognite/client/data_classes/transformations/common.py
@@ -27,7 +27,8 @@ class TransformationDestination:
 
         needs_dump = set(iterable_to_case(("view", "edge_type"), camel_case))
         for k in needs_dump.intersection(ret):
-            ret[k] = ret[k].dump(camel_case=camel_case)
+            if ret[k] is not None:
+                ret[k] = ret[k].dump(camel_case=camel_case)
         return ret
 
     @staticmethod

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "cognite-sdk"
 
-version = "5.7.1"
+version = "5.7.2"
 
 description = "Cognite Python SDK"
 readme = "README.md"

--- a/tests/tests_integration/test_api/test_transformations/test_transformations.py
+++ b/tests/tests_integration/test_api/test_transformations/test_transformations.py
@@ -186,7 +186,7 @@ class TestTransformationsAPI:
 
         cognite_client.transformations.delete(id=ts.id)
 
-    def test_create_instance_edges_transformation(self, cognite_client):
+    def test_create_instance_edges_view_transformation(self, cognite_client):
         prefix = random_string(6, string.ascii_letters)
         instance_edges = TransformationDestination.instance_edges(
             view=ViewInfo(
@@ -195,10 +195,7 @@ class TestTransformationsAPI:
                 space="view-test-space",
             ),
             instance_space="test-instance-space",
-            edge_type=EdgeType(
-                space="edge_type-space",
-                external_id="edge_type-edge",
-            ),
+            edge_type=None,
         )
 
         transform = Transformation(
@@ -214,6 +211,33 @@ class TestTransformationsAPI:
         assert ts.destination.view.external_id == "view-testInstanceViewExternalId"
         assert ts.destination.view.version == "view-testInstanceViewVersion"
         assert ts.destination.view.space == "view-test-space"
+
+        assert ts.destination.instance_space == "test-instance-space"
+        assert ts.destination.edge_type is None
+
+        cognite_client.transformations.delete(id=ts.id)
+
+    def test_create_instance_edges_type_transformation(self, cognite_client):
+        prefix = random_string(6, string.ascii_letters)
+        instance_edges = TransformationDestination.instance_edges(
+            view=None,
+            instance_space="test-instance-space",
+            edge_type=EdgeType(
+                space="edge_type-space",
+                external_id="edge_type-edge",
+            ),
+        )
+
+        transform = Transformation(
+            name="any",
+            external_id=f"{prefix}-transformation",
+            destination=instance_edges,
+        )
+        ts = cognite_client.transformations.create(transform)
+        assert ts.destination.type == "edges"
+        assert isinstance(ts.destination, InstanceEdges)
+
+        assert ts.destination.view is None
 
         assert ts.destination.instance_space == "test-instance-space"
         assert isinstance(ts.destination.edge_type, EdgeType)


### PR DESCRIPTION
## Description
We should ignore None in the method dump of TransformationDestination to avoid the error
`Result AttributeError("'NoneType' object has no attribute 'dump'")`

## Checklist:
- [x] Tests added/updated.
- [x] Documentation updated. Documentation is generated from docstrings - these must be updated according to your change.
  If a new method has been added it should be referenced in [cognite.rst](https://github.com/cognitedata/cognite-sdk-python/blob/master/docs/source/cognite.rst) in order to generate docs based on its docstring.
- [x] Changelog updated in [CHANGELOG.md](https://github.com/cognitedata/cognite-sdk-python/blob/master/CHANGELOG.md).
- [x] Version bumped. If triggering a new release is desired, bump the version number in [_version.py](https://github.com/cognitedata/cognite-sdk-python/blob/master/cognite/client/_version.py) and [pyproject.toml](https://github.com/cognitedata/cognite-sdk-python/blob/master/pyproject.toml) per [semantic versioning](https://semver.org/).
