### PR TITLE
Fix exc raised when user erroneously had too old `numpy` version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ Changes are grouped as follows
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
+## [5.7.3] - 14-03-23
+### Improved
+- For users unknowingly using a too old version of `numpy` (against the SDK dependency requirements), an exception could be raised (`NameError: name 'np' is not defined`). This has been fixed.
+
 ## [5.7.2] - 10-03-23
 ### Fixed
 - Fix method dump in TransformationDestination to ignore None.

--- a/cognite/client/_api/datapoint_tasks.py
+++ b/cognite/client/_api/datapoint_tasks.py
@@ -65,10 +65,10 @@ else:
 if NUMPY_IS_AVAILABLE:
     import numpy as np
 
-    from cognite.client.data_classes.datapoints import NumpyFloat64Array, NumpyInt64Array, NumpyObjArray
-
 if TYPE_CHECKING:
     import numpy.typing as npt
+
+    from cognite.client.data_classes.datapoints import NumpyFloat64Array, NumpyInt64Array, NumpyObjArray
 
 DPS_LIMIT_AGG = 10_000
 DPS_LIMIT = 100_000

--- a/cognite/client/_version.py
+++ b/cognite/client/_version.py
@@ -1,4 +1,4 @@
 from __future__ import annotations
 
-__version__ = "5.7.2"
+__version__ = "5.7.3"
 __api_subversion__ = "V20220125"

--- a/cognite/client/data_classes/datapoints.py
+++ b/cognite/client/data_classes/datapoints.py
@@ -55,23 +55,24 @@ ALL_SORTED_DP_AGGS = sorted(
     ]
 )
 
+try:
+    import numpy as np
+
+    NUMPY_IS_AVAILABLE = True
+
+except ImportError:  # pragma no cover
+    NUMPY_IS_AVAILABLE = False
+
 if TYPE_CHECKING:
+    import numpy.typing as npt
     import pandas
 
     from cognite.client import CogniteClient
-
-try:
-    import numpy as np
-    import numpy.typing as npt
 
     NumpyDatetime64NSArray = npt.NDArray[np.datetime64]
     NumpyInt64Array = npt.NDArray[np.int64]
     NumpyFloat64Array = npt.NDArray[np.float64]
     NumpyObjArray = npt.NDArray[np.object_]
-    NUMPY_IS_AVAILABLE = True
-
-except ImportError:  # pragma no cover
-    NUMPY_IS_AVAILABLE = False
 
 
 @dataclass(frozen=True)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "cognite-sdk"
 
-version = "5.7.2"
+version = "5.7.3"
 
 description = "Cognite Python SDK"
 readme = "README.md"


### PR DESCRIPTION
## Description
- For users unknowingly using a too old version of `numpy` (against the SDK dependency requirements), an exception could be raised (`NameError: name 'np' is not defined`). This has been fixed.

https://cognitedata.slack.com/archives/CDJUS0FAB/p1678801763640389?thread_ts=1678800656.935999&cid=CDJUS0FAB