### PR TITLE
Add X-Job-Token header support for contextualization jobs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ Changes are grouped as follows
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
+## [5.7.4] - 17-03-23
+### Added
+- Use `X-Job-Token` header for contextualization jobs to reduce required capabilities.
+
 ## [5.7.3] - 14-03-23
 ### Improved
 - For users unknowingly using a too old version of `numpy` (against the SDK dependency requirements), an exception could be raised (`NameError: name 'np' is not defined`). This has been fixed.

--- a/cognite/client/_api/diagrams.py
+++ b/cognite/client/_api/diagrams.py
@@ -52,8 +52,10 @@ class DiagramsAPI(APIClient):
     ) -> T_ContextualizationJob:
         if status_path is None:
             status_path = job_path + "/"
+        response = self._camel_post(job_path, json=kwargs, headers=headers).json()
         return job_cls._load_with_status(
-            self._camel_post(job_path, json=kwargs, headers=headers).json(),
+            response.json(),
+            response.headers,
             status_path=self._RESOURCE_PATH + status_path,
             cognite_client=self._cognite_client,
         )
@@ -76,7 +78,6 @@ class DiagramsAPI(APIClient):
         external_ids: Union[Sequence[str], str, None],
         file_references: Union[Sequence[FileReference], FileReference, None],
     ) -> List[Union[Dict[str, Union[int, str, Dict[str, int]]], Dict[str, str], Dict[str, int]]]:
-
         ids = DiagramsAPI._list_from_instance_or_list(ids, int, "ids must be int or list of int")
         external_ids = DiagramsAPI._list_from_instance_or_list(
             external_ids, str, "external_ids must be str or list of str"
@@ -148,7 +149,6 @@ class DiagramsAPI(APIClient):
         *,
         multiple_jobs: bool = False,
     ) -> Union[DiagramDetectResults, Tuple[Optional[DetectJobBundle], List[Dict[str, Any]]]]:
-
         """Detect entities in a PNID. The results are not written to CDF.
 
         Note:
@@ -237,7 +237,10 @@ class DiagramsAPI(APIClient):
         jobs = res.json()["items"]
         return [
             DiagramDetectResults._load_with_status(
-                data=job, cognite_client=self._cognite_client, status_path="/context/diagram/detect/"
+                data=job,
+                headers=res.headers,
+                cognite_client=self._cognite_client,
+                status_path="/context/diagram/detect/",
             )
             for job in jobs
         ]

--- a/cognite/client/_api/diagrams.py
+++ b/cognite/client/_api/diagrams.py
@@ -52,7 +52,7 @@ class DiagramsAPI(APIClient):
     ) -> T_ContextualizationJob:
         if status_path is None:
             status_path = job_path + "/"
-        response = self._camel_post(job_path, json=kwargs, headers=headers).json()
+        response = self._camel_post(job_path, json=kwargs, headers=headers)
         return job_cls._load_with_status(
             response.json(),
             response.headers,

--- a/cognite/client/_api/diagrams.py
+++ b/cognite/client/_api/diagrams.py
@@ -54,8 +54,8 @@ class DiagramsAPI(APIClient):
             status_path = job_path + "/"
         response = self._camel_post(job_path, json=kwargs, headers=headers)
         return job_cls._load_with_status(
-            response.json(),
-            response.headers,
+            data=response.json(),
+            headers=response.headers,
             status_path=self._RESOURCE_PATH + status_path,
             cognite_client=self._cognite_client,
         )

--- a/cognite/client/_api/entity_matching.py
+++ b/cognite/client/_api/entity_matching.py
@@ -33,8 +33,8 @@ class EntityMatchingAPI(APIClient):
         response = self._post(self._RESOURCE_PATH + job_path, json=json, headers=headers)
 
         return job_cls._load_with_status(
-            response.json(),
-            response.headers,
+            data=response.json(),
+            headers=response.headers,
             status_path=self._RESOURCE_PATH + status_path,
             cognite_client=self._cognite_client,
         )

--- a/cognite/client/_api/entity_matching.py
+++ b/cognite/client/_api/entity_matching.py
@@ -30,7 +30,7 @@ class EntityMatchingAPI(APIClient):
     ) -> T_ContextualizationJob:
         if status_path is None:
             status_path = job_path + "/"
-        response = self._post(self._RESOURCE_PATH + job_path, json=json, headers=headers).json()
+        response = self._post(self._RESOURCE_PATH + job_path, json=json, headers=headers)
 
         return job_cls._load_with_status(
             response.json(),

--- a/cognite/client/_api/entity_matching.py
+++ b/cognite/client/_api/entity_matching.py
@@ -30,8 +30,11 @@ class EntityMatchingAPI(APIClient):
     ) -> T_ContextualizationJob:
         if status_path is None:
             status_path = job_path + "/"
+        response = self._post(self._RESOURCE_PATH + job_path, json=json, headers=headers).json()
+
         return job_cls._load_with_status(
-            self._post(self._RESOURCE_PATH + job_path, json=json, headers=headers).json(),
+            response.json(),
+            response.headers,
             status_path=self._RESOURCE_PATH + status_path,
             cognite_client=self._cognite_client,
         )

--- a/cognite/client/_api/vision.py
+++ b/cognite/client/_api/vision.py
@@ -47,8 +47,8 @@ class VisionAPI(APIClient):
             headers=headers,
         )
         return job_cls._load_with_status(
-            res.json(),
-            res.headers,
+            data=res.json(),
+            headers=res.headers,
             status_path=self._RESOURCE_PATH + status_path,
             cognite_client=self._cognite_client,
         )

--- a/cognite/client/_api/vision.py
+++ b/cognite/client/_api/vision.py
@@ -48,6 +48,7 @@ class VisionAPI(APIClient):
         )
         return job_cls._load_with_status(
             res.json(),
+            res.headers,
             status_path=self._RESOURCE_PATH + status_path,
             cognite_client=self._cognite_client,
         )

--- a/cognite/client/_version.py
+++ b/cognite/client/_version.py
@@ -1,4 +1,4 @@
 from __future__ import annotations
 
-__version__ = "5.7.3"
+__version__ = "5.7.4"
 __api_subversion__ = "V20220125"

--- a/cognite/client/data_classes/contextualization.py
+++ b/cognite/client/data_classes/contextualization.py
@@ -83,6 +83,7 @@ class ContextualizationJob(CogniteResource):
         start_time: int = None,
         status_time: int = None,
         status_path: str = None,
+        job_token: str = None,
         cognite_client: CogniteClient = None,
     ):
         """Data class for the result of a contextualization job."""
@@ -93,13 +94,14 @@ class ContextualizationJob(CogniteResource):
         self.start_time = start_time
         self.status_time = status_time
         self.error_message = error_message
+        self.job_token = job_token
         self._cognite_client = cast("CogniteClient", cognite_client)
         self._result: Optional[Dict[str, Any]] = None
         self._status_path = status_path
 
     def update_status(self) -> str:
         """Updates the model status and returns it"""
-        headers = {"X-Job-Token": self.jobToken} if self.jobToken else {}
+        headers = {"X-Job-Token": self.job_token} if self.job_token else {}
         data = (
             getattr(self._cognite_client, self._JOB_TYPE.value)
             ._get(f"{self._status_path}{self.job_id}", headers=headers)

--- a/cognite/client/data_classes/contextualization.py
+++ b/cognite/client/data_classes/contextualization.py
@@ -99,7 +99,7 @@ class ContextualizationJob(CogniteResource):
 
     def update_status(self) -> str:
         """Updates the model status and returns it"""
-        headers = {"X-Job-Token": self.job_token} if self.job_token else {}
+        headers = {"X-Job-Token": self.jobToken} if self.jobToken else {}
         data = (
             getattr(self._cognite_client, self._JOB_TYPE.value)
             ._get(f"{self._status_path}{self.job_id}", headers=headers)

--- a/cognite/client/data_classes/contextualization.py
+++ b/cognite/client/data_classes/contextualization.py
@@ -147,6 +147,7 @@ class ContextualizationJob(CogniteResource):
     @classmethod
     def _load_with_status(
         cls: Type[T_ContextualizationJob],
+        *,
         data: Dict[str, Any],
         headers: CaseInsensitiveDict[str],
         status_path: str,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "cognite-sdk"
 
-version = "5.7.3"
+version = "5.7.4"
 
 description = "Cognite Python SDK"
 readme = "README.md"

--- a/tests/tests_integration/test_api/test_transformations/test_transformations.py
+++ b/tests/tests_integration/test_api/test_transformations/test_transformations.py
@@ -409,13 +409,12 @@ class TestTransformationsAPI:
 
     def test_update_instance_edges(self, cognite_client, new_transformation):
         new_transformation.destination = TransformationDestination.instance_edges(
-            ViewInfo("myViewExternalId", "myViewVersion", "test-space"), "test-space", EdgeType("edge-space", "myEdge")
+            instance_space="test-space", edge_type=EdgeType("edge-space", "myEdge")
         )
         partial_update = TransformationUpdate(id=new_transformation.id).destination.set(
             TransformationDestination.instance_edges(
-                ViewInfo("myViewExternalId", "myViewVersion2", "test-space"),
-                "test-space",
-                EdgeType("edge-space2", "myEdge2"),
+                instance_space="test-space",
+                edge_type=EdgeType("edge-space2", "myEdge2"),
             )
         )
         updated_transformation = cognite_client.transformations.update(new_transformation)


### PR DESCRIPTION
## Description
Several contextualization endpoints have been updated to return and accept a `X-Job-Token` header in order to reduce the capability requirements in a backwards compatible way. For the job endpoints that respond with such a header the user can request the result with the same header to avoid any capability requirements.

## Checklist:
- [x] Tests added/updated.
- [ ] Documentation updated. Documentation is generated from docstrings - these must be updated according to your change.
  If a new method has been added it should be referenced in [cognite.rst](https://github.com/cognitedata/cognite-sdk-python/blob/master/docs/source/cognite.rst) in order to generate docs based on its docstring.
- [x] Changelog updated in [CHANGELOG.md](https://github.com/cognitedata/cognite-sdk-python/blob/master/CHANGELOG.md).
- [x] Version bumped. If triggering a new release is desired, bump the version number in [_version.py](https://github.com/cognitedata/cognite-sdk-python/blob/master/cognite/client/_version.py) and [pyproject.toml](https://github.com/cognitedata/cognite-sdk-python/blob/master/pyproject.toml) per [semantic versioning](https://semver.org/).
