### PR TITLE
Fix failed test when update Transformation with edge as destination

### DIFF
--- a/tests/tests_integration/test_api/test_transformations/test_transformations.py
+++ b/tests/tests_integration/test_api/test_transformations/test_transformations.py
@@ -140,7 +140,6 @@ class TestTransformationsAPI:
         assert {"vu", "hai"} == set(ts.tags)
         cognite_client.transformations.delete(id=ts.id)
 
-
     def test_create_instance_nodes_transformation(self, cognite_client):
         prefix = random_string(6, string.ascii_letters)
         instance_nodes = TransformationDestination.instance_nodes(

--- a/tests/tests_integration/test_api/test_transformations/test_transformations.py
+++ b/tests/tests_integration/test_api/test_transformations/test_transformations.py
@@ -414,9 +414,6 @@ class TestTransformationsAPI:
             ViewInfo("myViewExternalId", "myViewVersion2", "test-space"), "test-space"
         )
 
-    @pytest.mark.xfail(
-        reason="This test currently fails for both certificate and secret auth. Probably due to recent changes to the API. Non-GA."
-    )
     def test_update_instance_edges(self, cognite_client, new_transformation):
         new_transformation.destination = TransformationDestination.instance_edges(
             instance_space="test-space", edge_type=EdgeType("edge-space", "myEdge")
@@ -429,11 +426,11 @@ class TestTransformationsAPI:
         )
         updated_transformation = cognite_client.transformations.update(new_transformation)
         assert updated_transformation.destination == TransformationDestination.instance_edges(
-            ViewInfo("myViewExternalId", "myViewVersion", "test-space"), "test-space", EdgeType("edge-space", "myEdge")
+            None, "test-space", EdgeType("edge-space", "myEdge")
         )
         partial_updated = cognite_client.transformations.update(partial_update)
         assert partial_updated.destination == TransformationDestination.instance_edges(
-            ViewInfo("myViewExternalId", "myViewVersion2", "test-space"),
+            None,
             "test-space",
             EdgeType("edge-space2", "myEdge2"),
         )

--- a/tests/tests_integration/test_api/test_transformations/test_transformations.py
+++ b/tests/tests_integration/test_api/test_transformations/test_transformations.py
@@ -140,26 +140,6 @@ class TestTransformationsAPI:
         assert {"vu", "hai"} == set(ts.tags)
         cognite_client.transformations.delete(id=ts.id)
 
-    @pytest.mark.skip
-    def test_create_dmi_transformation(self, cognite_client):
-        prefix = random_string(6, string.ascii_letters)
-        transform = Transformation(
-            name="any",
-            external_id=f"{prefix}-transformation",
-            destination=TransformationDestination.data_model_instances(
-                model_external_id="testInstance",
-                space_external_id="test-space",
-                instance_space_external_id="test-space",
-            ),
-        )
-        ts = cognite_client.transformations.create(transform)
-        assert (
-            ts.destination.type == "data_model_instances"
-            and ts.destination.model_external_id == "testInstance"
-            and ts.destination.space_external_id == "test-space"
-            and ts.destination.instance_space_external_id == "test-space"
-        )
-        cognite_client.transformations.delete(id=ts.id)
 
     def test_create_instance_nodes_transformation(self, cognite_client):
         prefix = random_string(6, string.ascii_letters)


### PR DESCRIPTION
## Description
Fix `test_update_instance_edges`, since we deployed a recent change from the backend to reject in case edge contains both View and EdgeType information 

## Checklist:
- [x] Tests added/updated.
- [x] Documentation updated. Documentation is generated from docstrings - these must be updated according to your change.
  If a new method has been added it should be referenced in [cognite.rst](https://github.com/cognitedata/cognite-sdk-python/blob/master/docs/source/cognite.rst) in order to generate docs based on its docstring.
- [x] Changelog updated in [CHANGELOG.md](https://github.com/cognitedata/cognite-sdk-python/blob/master/CHANGELOG.md).
- [x] Version bumped. If triggering a new release is desired, bump the version number in [_version.py](https://github.com/cognitedata/cognite-sdk-python/blob/master/cognite/client/_version.py) and [pyproject.toml](https://github.com/cognitedata/cognite-sdk-python/blob/master/pyproject.toml) per [semantic versioning](https://semver.org/).
