### PR TITLE
Improve validation for `list()` endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ Changes are grouped as follows
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
+## [5.11.1] - 17-04-23
+### Fixed
+- List (and `__call__`) methods for assets, events, files, labels, relationships, sequences and time series now raise if given bad input for `data_set_ids` or `data_set_external_ids` instead of ignoring/returning everything.
+
 ## [5.11.0] - 17-11-23
 ### Added
 - The `DatapointsAPI` now supports time zones with the addition of a new method, `retrieve_dataframe_in_tz`. It does not support individual customization of query parameters (for good reasons, e.g. a DataFrame has a single index).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,10 @@ Changes are grouped as follows
 
 ## [5.11.1] - 17-04-23
 ### Fixed
-- List (and `__call__`) methods for assets, events, files, labels, relationships, sequences and time series now raise if given bad input for `data_set_ids` or `data_set_external_ids` instead of ignoring/returning everything.
+- List (and `__call__`) methods for assets, events, files, labels, relationships, sequences and time series now raise if given bad input for `data_set_ids`, `data_set_external_ids`, `asset_subtree_ids` and `asset_subtree_external_ids` instead of ignoring/returning everything.
+
+### Improved
+- The listed parameters above have silently accepted non-list input, i.e. single `int` (for `ids`) or single `str` (for `external_ids`). Function signatures and docstrings have now been updated to reflect this "hidden functionality".
 
 ## [5.11.0] - 17-11-23
 ### Added

--- a/cognite/client/_api/assets.py
+++ b/cognite/client/_api/assets.py
@@ -117,7 +117,7 @@ class AssetsAPI(APIClient):
             ).as_dicts()
 
         data_set_ids_processed = None
-        if data_set_ids or data_set_external_ids:
+        if data_set_ids is not None or data_set_external_ids is not None:
             data_set_ids_processed = IdentifierSequence.load(data_set_ids, data_set_external_ids).as_dicts()
 
         filter = AssetFilter(
@@ -306,7 +306,7 @@ class AssetsAPI(APIClient):
             ).as_dicts()
 
         data_set_ids_processed = None
-        if data_set_ids or data_set_external_ids:
+        if data_set_ids is not None or data_set_external_ids is not None:
             data_set_ids_processed = IdentifierSequence.load(data_set_ids, data_set_external_ids).as_dicts()
 
         filter = AssetFilter(

--- a/cognite/client/_api/assets.py
+++ b/cognite/client/_api/assets.py
@@ -64,11 +64,11 @@ class AssetsAPI(APIClient):
         name: str = None,
         parent_ids: Sequence[int] = None,
         parent_external_ids: Sequence[str] = None,
-        asset_subtree_ids: Sequence[int] = None,
-        asset_subtree_external_ids: Sequence[str] = None,
+        asset_subtree_ids: Union[int, Sequence[int]] = None,
+        asset_subtree_external_ids: Union[str, Sequence[str]] = None,
         metadata: Dict[str, str] = None,
-        data_set_ids: Sequence[int] = None,
-        data_set_external_ids: Sequence[str] = None,
+        data_set_ids: Union[int, Sequence[int]] = None,
+        data_set_external_ids: Union[str, Sequence[str]] = None,
         labels: LabelFilter = None,
         geo_location: GeoLocationFilter = None,
         source: str = None,
@@ -89,11 +89,11 @@ class AssetsAPI(APIClient):
             name (str): Name of asset. Often referred to as tag.
             parent_ids (Sequence[int]): Return only the direct descendants of the specified assets.
             parent_external_ids (Sequence[str]): Return only the direct descendants of the specified assets.
-            asset_subtree_ids (Sequence[int]): List of asset subtrees ids to filter on.
-            asset_subtree_external_ids (Sequence[str]): List of asset subtrees external ids to filter on.
+            asset_subtree_ids (Union[int, Sequence[int]]): Asset subtree id or list of asset subtree ids to filter on.
+            asset_subtree_external_ids (Union[str, Sequence[str]]): Asset subtree external id or list of asset subtree external ids to filter on.
             metadata (Dict[str, str]): Custom, application specific metadata. String key -> String value
-            data_set_ids (Sequence[int]): Return only assets in the specified data sets with these ids.
-            data_set_external_ids (Sequence[str]): Return only assets in the specified data sets with these external ids.
+            data_set_ids (Union[int, Sequence[int]]): Return only assets in the specified data set(s) with this id / these ids.
+            data_set_external_ids (Union[str, Sequence[str]]): Return only assets in the specified data set(s) with this external id / these external ids.
             labels (LabelFilter): Return only the assets matching the specified label.
             geo_location (GeoLocationFilter): Only include files matching the specified geographic relation.
             source (str): The source of this asset
@@ -106,7 +106,7 @@ class AssetsAPI(APIClient):
             partitions (int): Retrieve assets in parallel using this number of workers. Also requires `limit=None` to be passed.
 
         Yields:
-            Union[Asset, AssetList]: yields Asset one by one if chunk is not specified, else AssetList objects.
+            Union[Asset, AssetList]: yields Asset one by one if chunk_size is not specified, else AssetList objects.
         """
         if aggregated_properties:
             aggregated_properties = [to_camel_case(s) for s in aggregated_properties]
@@ -218,10 +218,10 @@ class AssetsAPI(APIClient):
         name: str = None,
         parent_ids: Sequence[int] = None,
         parent_external_ids: Sequence[str] = None,
-        asset_subtree_ids: Sequence[int] = None,
-        asset_subtree_external_ids: Sequence[str] = None,
-        data_set_ids: Sequence[int] = None,
-        data_set_external_ids: Sequence[str] = None,
+        asset_subtree_ids: Union[int, Sequence[int]] = None,
+        asset_subtree_external_ids: Union[str, Sequence[str]] = None,
+        data_set_ids: Union[int, Sequence[int]] = None,
+        data_set_external_ids: Union[str, Sequence[str]] = None,
         labels: LabelFilter = None,
         geo_location: GeoLocationFilter = None,
         metadata: Dict[str, str] = None,
@@ -240,10 +240,10 @@ class AssetsAPI(APIClient):
             name (str): Name of asset. Often referred to as tag.
             parent_ids (Sequence[int]): Return only the direct descendants of the specified assets.
             parent_external_ids (Sequence[str]): Return only the direct descendants of the specified assets.
-            asset_subtree_ids (Sequence[int]): List of asset subtrees ids to filter on.
-            asset_subtree_external_ids (Sequence[str]): List of asset subtrees external ids to filter on.
-            data_set_ids (Sequence[int]): Return only assets in the specified data sets with these ids.
-            data_set_external_ids (Sequence[str]): Return only assets in the specified data sets with these external ids.
+            asset_subtree_ids (Union[int, Sequence[int]]): Asset subtree id or list of asset subtree ids to filter on.
+            asset_subtree_external_ids (Union[str, Sequence[str]]): Asset subtree external id or list of asset subtree external ids to filter on.
+            data_set_ids (Union[int, Sequence[int]]): Return only assets in the specified data set(s) with this id / these ids.
+            data_set_external_ids (Union[str, Sequence[str]]): Return only assets in the specified data set(s) with this external id / these external ids.
             labels (LabelFilter): Return only the assets matching the specified label filter.
             geo_location (GeoLocationFilter): Only include files matching the specified geographic relation.
             metadata (Dict[str, str]): Custom, application specific metadata. String key -> String value.

--- a/cognite/client/_api/assets.py
+++ b/cognite/client/_api/assets.py
@@ -47,6 +47,7 @@ from cognite.client.utils._auxiliary import split_into_n_parts
 from cognite.client.utils._concurrency import classify_error, get_priority_executor
 from cognite.client.utils._identifier import IdentifierSequence
 from cognite.client.utils._text import to_camel_case
+from cognite.client.utils._validation import process_asset_subtree_ids, process_data_set_ids
 
 if TYPE_CHECKING:
     from concurrent.futures import Future
@@ -110,15 +111,8 @@ class AssetsAPI(APIClient):
         if aggregated_properties:
             aggregated_properties = [to_camel_case(s) for s in aggregated_properties]
 
-        asset_subtree_ids_processed = None
-        if asset_subtree_ids or asset_subtree_external_ids:
-            asset_subtree_ids_processed = IdentifierSequence.load(
-                asset_subtree_ids, asset_subtree_external_ids
-            ).as_dicts()
-
-        data_set_ids_processed = None
-        if data_set_ids is not None or data_set_external_ids is not None:
-            data_set_ids_processed = IdentifierSequence.load(data_set_ids, data_set_external_ids).as_dicts()
+        asset_subtree_ids_processed = process_asset_subtree_ids(asset_subtree_ids, asset_subtree_external_ids)
+        data_set_ids_processed = process_data_set_ids(data_set_ids, data_set_external_ids)
 
         filter = AssetFilter(
             name=name,
@@ -299,15 +293,8 @@ class AssetsAPI(APIClient):
         if aggregated_properties:
             aggregated_properties = [to_camel_case(s) for s in aggregated_properties]
 
-        asset_subtree_ids_processed = None
-        if asset_subtree_ids or asset_subtree_external_ids:
-            asset_subtree_ids_processed = IdentifierSequence.load(
-                asset_subtree_ids, asset_subtree_external_ids
-            ).as_dicts()
-
-        data_set_ids_processed = None
-        if data_set_ids is not None or data_set_external_ids is not None:
-            data_set_ids_processed = IdentifierSequence.load(data_set_ids, data_set_external_ids).as_dicts()
+        asset_subtree_ids_processed = process_asset_subtree_ids(asset_subtree_ids, asset_subtree_external_ids)
+        data_set_ids_processed = process_data_set_ids(data_set_ids, data_set_external_ids)
 
         filter = AssetFilter(
             name=name,

--- a/cognite/client/_api/datapoints.py
+++ b/cognite/client/_api/datapoints.py
@@ -62,7 +62,6 @@ from cognite.client.utils._auxiliary import (
     local_import,
     split_into_chunks,
     split_into_n_parts,
-    validate_user_input_dict_with_identifier,
 )
 from cognite.client.utils._concurrency import collect_exc_info_and_raise, execute_tasks, get_priority_executor
 from cognite.client.utils._identifier import Identifier, IdentifierSequence
@@ -77,6 +76,7 @@ from cognite.client.utils._time import (
     to_pandas_freq,
     validate_timezone,
 )
+from cognite.client.utils._validation import validate_user_input_dict_with_identifier
 
 if not import_legacy_protobuf():
     from cognite.client._proto.data_point_list_response_pb2 import DataPointListItem, DataPointListResponse

--- a/cognite/client/_api/events.py
+++ b/cognite/client/_api/events.py
@@ -15,6 +15,7 @@ from cognite.client.data_classes import (
     TimestampRange,
 )
 from cognite.client.utils._identifier import IdentifierSequence
+from cognite.client.utils._validation import process_asset_subtree_ids, process_data_set_ids
 
 
 class EventsAPI(APIClient):
@@ -72,15 +73,8 @@ class EventsAPI(APIClient):
         Yields:
             Union[Event, EventList]: yields Event one by one if chunk is not specified, else EventList objects.
         """
-        asset_subtree_ids_processed = None
-        if asset_subtree_ids or asset_subtree_external_ids:
-            asset_subtree_ids_processed = IdentifierSequence.load(
-                asset_subtree_ids, asset_subtree_external_ids
-            ).as_dicts()
-
-        data_set_ids_processed = None
-        if data_set_ids is not None or data_set_external_ids is not None:
-            data_set_ids_processed = IdentifierSequence.load(data_set_ids, data_set_external_ids).as_dicts()
+        asset_subtree_ids_processed = process_asset_subtree_ids(asset_subtree_ids, asset_subtree_external_ids)
+        data_set_ids_processed = process_data_set_ids(data_set_ids, data_set_external_ids)
 
         filter = EventFilter(
             start_time=start_time,
@@ -252,15 +246,8 @@ class EventsAPI(APIClient):
                 >>> for event_list in c.events(chunk_size=2500):
                 ...     event_list # do something with the events
         """
-        asset_subtree_ids_processed = None
-        if asset_subtree_ids or asset_subtree_external_ids:
-            asset_subtree_ids_processed = IdentifierSequence.load(
-                asset_subtree_ids, asset_subtree_external_ids
-            ).as_dicts()
-
-        data_set_ids_processed = None
-        if data_set_ids is not None or data_set_external_ids is not None:
-            data_set_ids_processed = IdentifierSequence.load(data_set_ids, data_set_external_ids).as_dicts()
+        asset_subtree_ids_processed = process_asset_subtree_ids(asset_subtree_ids, asset_subtree_external_ids)
+        data_set_ids_processed = process_data_set_ids(data_set_ids, data_set_external_ids)
 
         if end_time and ("max" in end_time or "min" in end_time) and "isNull" in end_time:
             raise ValueError("isNull cannot be used with min or max values")

--- a/cognite/client/_api/events.py
+++ b/cognite/client/_api/events.py
@@ -79,7 +79,7 @@ class EventsAPI(APIClient):
             ).as_dicts()
 
         data_set_ids_processed = None
-        if data_set_ids or data_set_external_ids:
+        if data_set_ids is not None or data_set_external_ids is not None:
             data_set_ids_processed = IdentifierSequence.load(data_set_ids, data_set_external_ids).as_dicts()
 
         filter = EventFilter(
@@ -259,7 +259,7 @@ class EventsAPI(APIClient):
             ).as_dicts()
 
         data_set_ids_processed = None
-        if data_set_ids or data_set_external_ids:
+        if data_set_ids is not None or data_set_external_ids is not None:
             data_set_ids_processed = IdentifierSequence.load(data_set_ids, data_set_external_ids).as_dicts()
 
         if end_time and ("max" in end_time or "min" in end_time) and "isNull" in end_time:

--- a/cognite/client/_api/events.py
+++ b/cognite/client/_api/events.py
@@ -32,10 +32,10 @@ class EventsAPI(APIClient):
         metadata: Dict[str, str] = None,
         asset_ids: Sequence[int] = None,
         asset_external_ids: Sequence[str] = None,
-        asset_subtree_ids: Sequence[int] = None,
-        asset_subtree_external_ids: Sequence[str] = None,
-        data_set_ids: Sequence[int] = None,
-        data_set_external_ids: Sequence[str] = None,
+        asset_subtree_ids: Union[int, Sequence[int]] = None,
+        asset_subtree_external_ids: Union[str, Sequence[str]] = None,
+        data_set_ids: Union[int, Sequence[int]] = None,
+        data_set_external_ids: Union[str, Sequence[str]] = None,
         source: str = None,
         created_time: Union[Dict[str, Any], TimestampRange] = None,
         last_updated_time: Union[Dict[str, Any], TimestampRange] = None,
@@ -58,10 +58,10 @@ class EventsAPI(APIClient):
             metadata (Dict[str, str]): Customizable extra data about the event. String key -> String value.
             asset_ids (Sequence[int]): Asset IDs of related equipments that this event relates to.
             asset_external_ids (Sequence[str]): Asset External IDs of related equipment that this event relates to.
-            asset_subtree_ids (Sequence[int]): List of asset subtrees ids to filter on.
-            asset_subtree_external_ids (Sequence[str]): List of asset subtrees external ids to filter on.
-            data_set_ids (Sequence[int]): Return only events in the specified data sets with these ids.
-            data_set_external_ids (Sequence[str]): Return only events in the specified data sets with these external ids.
+            asset_subtree_ids (Union[int, Sequence[int]]): Asset subtree id or list of asset subtree ids to filter on.
+            asset_subtree_external_ids (Union[str, Sequence[str]]): Asset subtree external id or list of asset subtree external ids to filter on.
+            data_set_ids (Union[int, Sequence[int]]): Return only events in the specified data set(s) with this id / these ids.
+            data_set_external_ids (Sequence[str]): Return only events in the specified data set(s) with this external id / these external ids.
             source (str): The source of this event.
             created_time (Union[Dict[str, int], TimestampRange]):  Range between two timestamps. Possible keys are `min` and `max`, with values given as time stamps in ms.
             last_updated_time (Union[Dict[str, int], TimestampRange]):  Range between two timestamps. Possible keys are `min` and `max`, with values given as time stamps in ms.
@@ -71,7 +71,7 @@ class EventsAPI(APIClient):
             partitions (int): Retrieve assets in parallel using this number of workers. Also requires `limit=None` to be passed.
 
         Yields:
-            Union[Event, EventList]: yields Event one by one if chunk is not specified, else EventList objects.
+            Union[Event, EventList]: yields Event one by one if chunk_size is not specified, else EventList objects.
         """
         asset_subtree_ids_processed = process_asset_subtree_ids(asset_subtree_ids, asset_subtree_external_ids)
         data_set_ids_processed = process_data_set_ids(data_set_ids, data_set_external_ids)
@@ -185,10 +185,10 @@ class EventsAPI(APIClient):
         metadata: Dict[str, str] = None,
         asset_ids: Sequence[int] = None,
         asset_external_ids: Sequence[str] = None,
-        asset_subtree_ids: Sequence[int] = None,
-        asset_subtree_external_ids: Sequence[str] = None,
-        data_set_ids: Sequence[int] = None,
-        data_set_external_ids: Sequence[str] = None,
+        asset_subtree_ids: Union[int, Sequence[int]] = None,
+        asset_subtree_external_ids: Union[str, Sequence[str]] = None,
+        data_set_ids: Union[int, Sequence[int]] = None,
+        data_set_external_ids: Union[str, Sequence[str]] = None,
         source: str = None,
         created_time: Union[Dict[str, Any], TimestampRange] = None,
         last_updated_time: Union[Dict[str, Any], TimestampRange] = None,
@@ -208,10 +208,10 @@ class EventsAPI(APIClient):
             metadata (Dict[str, str]): Customizable extra data about the event. String key -> String value.
             asset_ids (Sequence[int]): Asset IDs of related equipments that this event relates to.
             asset_external_ids (Sequence[str]): Asset External IDs of related equipment that this event relates to.
-            asset_subtree_ids (Sequence[int]): List of asset subtrees ids to filter on.
-            asset_subtree_external_ids (Sequence[str]): List of asset subtrees external ids to filter on.
-            data_set_ids (Sequence[int]): Return only events in the specified data sets with these ids.
-            data_set_external_ids (Sequence[str]): Return only events in the specified data sets with these external ids.
+            asset_subtree_ids (Union[int, Sequence[int]]): Asset subtree id or list of asset subtree ids to filter on.
+            asset_subtree_external_ids (Union[str, Sequence[str]]): Asset subtree external id or list of asset subtree external ids to filter on.
+            data_set_ids (Union[int, Sequence[int]]): Return only events in the specified data set(s) with this id / these ids.
+            data_set_external_ids (Sequence[str]): Return only events in the specified data set(s) with this external id / these external ids.
             source (str): The source of this event.
             created_time (Union[Dict[str, int], TimestampRange]):  Range between two timestamps. Possible keys are `min` and `max`, with values given as time stamps in ms.
             last_updated_time (Union[Dict[str, int], TimestampRange]):  Range between two timestamps. Possible keys are `min` and `max`, with values given as time stamps in ms.

--- a/cognite/client/_api/files.py
+++ b/cognite/client/_api/files.py
@@ -35,6 +35,7 @@ from cognite.client.data_classes import (
     TimestampRange,
 )
 from cognite.client.utils._identifier import Identifier, IdentifierSequence
+from cognite.client.utils._validation import process_asset_subtree_ids, process_data_set_ids
 
 if TYPE_CHECKING:
     from requests import Response
@@ -100,15 +101,8 @@ class FilesAPI(APIClient):
         Yields:
             Union[FileMetadata, FileMetadataList]: yields FileMetadata one by one if chunk is not specified, else FileMetadataList objects.
         """
-        asset_subtree_ids_processed = None
-        if asset_subtree_ids or asset_subtree_external_ids:
-            asset_subtree_ids_processed = IdentifierSequence.load(
-                asset_subtree_ids, asset_subtree_external_ids
-            ).as_dicts()
-
-        data_set_ids_processed = None
-        if data_set_ids is not None or data_set_external_ids is not None:
-            data_set_ids_processed = IdentifierSequence.load(data_set_ids, data_set_external_ids).as_dicts()
+        asset_subtree_ids_processed = process_asset_subtree_ids(asset_subtree_ids, asset_subtree_external_ids)
+        data_set_ids_processed = process_data_set_ids(data_set_ids, data_set_external_ids)
 
         filter = FileMetadataFilter(
             name=name,
@@ -339,15 +333,8 @@ class FilesAPI(APIClient):
                 >>> my_geo_location_filter = GeoLocationFilter(relation="intersects", shape=GeometryFilter(type="Point", coordinates=[35,10]))
                 >>> file_list = c.files.list(geo_location=my_geo_location_filter)
         """
-        asset_subtree_ids_processed = None
-        if asset_subtree_ids or asset_subtree_external_ids:
-            asset_subtree_ids_processed = IdentifierSequence.load(
-                asset_subtree_ids, asset_subtree_external_ids
-            ).as_dicts()
-
-        data_set_ids_processed = None
-        if data_set_ids is not None or data_set_external_ids is not None:
-            data_set_ids_processed = IdentifierSequence.load(data_set_ids, data_set_external_ids).as_dicts()
+        asset_subtree_ids_processed = process_asset_subtree_ids(asset_subtree_ids, asset_subtree_external_ids)
+        data_set_ids_processed = process_data_set_ids(data_set_ids, data_set_external_ids)
 
         filter = FileMetadataFilter(
             name=name,

--- a/cognite/client/_api/files.py
+++ b/cognite/client/_api/files.py
@@ -52,10 +52,10 @@ class FilesAPI(APIClient):
         metadata: Dict[str, str] = None,
         asset_ids: Sequence[int] = None,
         asset_external_ids: Sequence[str] = None,
-        asset_subtree_ids: Sequence[int] = None,
-        asset_subtree_external_ids: Sequence[str] = None,
-        data_set_ids: Sequence[int] = None,
-        data_set_external_ids: Sequence[str] = None,
+        asset_subtree_ids: Union[int, Sequence[int]] = None,
+        asset_subtree_external_ids: Union[str, Sequence[str]] = None,
+        data_set_ids: Union[int, Sequence[int]] = None,
+        data_set_external_ids: Union[str, Sequence[str]] = None,
         labels: LabelFilter = None,
         geo_location: GeoLocationFilter = None,
         source: str = None,
@@ -81,10 +81,10 @@ class FilesAPI(APIClient):
             asset_ids (Sequence[int]): Only include files that reference these specific asset IDs.
             asset_subtree_external_ids (Sequence[str]): Only include files that reference these specific asset external IDs.
             root_asset_external_ids (Sequence[str]): The external IDs of the root assets that the related assets should be children of.
-            asset_subtree_ids (Sequence[int]): List of asset subtrees ids to filter on.
-            asset_subtree_external_ids (Sequence[str]): List of asset subtrees external ids to filter on.
-            data_set_ids (Sequence[int]): Return only files in the specified data sets with these ids.
-            data_set_external_ids (Sequence[str]): Return only files in the specified data sets with these external ids.
+            asset_subtree_ids (Union[int, Sequence[int]]): Asset subtree id or list of asset subtree ids to filter on.
+            asset_subtree_external_ids (Union[str, Sequence[str]]): Asset subtree external id or list of asset subtree external ids to filter on.
+            data_set_ids (Union[int, Sequence[int]]): Return only files in the specified data set(s) with this id / these ids.
+            data_set_external_ids (Sequence[str]): Return only files in the specified data set(s) with this external id / these external ids.
             labels (LabelFilter): Return only the files matching the specified label(s).
             geo_location (GeoLocationFilter): Only include files matching the specified geographic relation.
             source (str): The source of this event.
@@ -99,7 +99,7 @@ class FilesAPI(APIClient):
             limit (int, optional): Maximum number of files to return. Defaults to return all items.
 
         Yields:
-            Union[FileMetadata, FileMetadataList]: yields FileMetadata one by one if chunk is not specified, else FileMetadataList objects.
+            Union[FileMetadata, FileMetadataList]: yields FileMetadata one by one if chunk_size is not specified, else FileMetadataList objects.
         """
         asset_subtree_ids_processed = process_asset_subtree_ids(asset_subtree_ids, asset_subtree_external_ids)
         data_set_ids_processed = process_data_set_ids(data_set_ids, data_set_external_ids)
@@ -249,10 +249,10 @@ class FilesAPI(APIClient):
         metadata: Dict[str, str] = None,
         asset_ids: Sequence[int] = None,
         asset_external_ids: Sequence[str] = None,
-        asset_subtree_ids: Sequence[int] = None,
-        asset_subtree_external_ids: Sequence[str] = None,
-        data_set_ids: Sequence[int] = None,
-        data_set_external_ids: Sequence[str] = None,
+        asset_subtree_ids: Union[int, Sequence[int]] = None,
+        asset_subtree_external_ids: Union[str, Sequence[str]] = None,
+        data_set_ids: Union[int, Sequence[int]] = None,
+        data_set_external_ids: Union[str, Sequence[str]] = None,
         labels: LabelFilter = None,
         geo_location: GeoLocationFilter = None,
         source: str = None,
@@ -274,10 +274,10 @@ class FilesAPI(APIClient):
             metadata (Dict[str, str]): Custom, application specific metadata. String key -> String value
             asset_ids (Sequence[int]): Only include files that reference these specific asset IDs.
             asset_subtree_external_ids (Sequence[str]): Only include files that reference these specific asset external IDs.
-            asset_subtree_ids (Sequence[int]): List of asset subtrees ids to filter on.
-            asset_subtree_external_ids (Sequence[str]): List of asset subtrees external ids to filter on.
-            data_set_ids (Sequence[int]): Return only files in the specified data sets with these ids.
-            data_set_external_ids (Sequence[str]): Return only files in the specified data sets with these external ids.
+            asset_subtree_ids (Union[int, Sequence[int]]): Asset subtree id or list of asset subtree ids to filter on.
+            asset_subtree_external_ids (Union[str, Sequence[str]]): Asset subtree external id or list of asset subtree external ids to filter on.
+            data_set_ids (Union[int, Sequence[int]]): Return only files in the specified data set(s) with this id / these ids.
+            data_set_external_ids (Sequence[str]): Return only files in the specified data set(s) with this external id / these external ids.
             labels (LabelFilter): Return only the files matching the specified label filter(s).
             geo_location (GeoLocationFilter): Only include files matching the specified geographic relation.
             source (str): The source of this event.

--- a/cognite/client/_api/files.py
+++ b/cognite/client/_api/files.py
@@ -107,7 +107,7 @@ class FilesAPI(APIClient):
             ).as_dicts()
 
         data_set_ids_processed = None
-        if data_set_ids or data_set_external_ids:
+        if data_set_ids is not None or data_set_external_ids is not None:
             data_set_ids_processed = IdentifierSequence.load(data_set_ids, data_set_external_ids).as_dicts()
 
         filter = FileMetadataFilter(
@@ -346,7 +346,7 @@ class FilesAPI(APIClient):
             ).as_dicts()
 
         data_set_ids_processed = None
-        if data_set_ids or data_set_external_ids:
+        if data_set_ids is not None or data_set_external_ids is not None:
             data_set_ids_processed = IdentifierSequence.load(data_set_ids, data_set_external_ids).as_dicts()
 
         filter = FileMetadataFilter(

--- a/cognite/client/_api/labels.py
+++ b/cognite/client/_api/labels.py
@@ -6,6 +6,7 @@ from cognite.client._api_client import APIClient
 from cognite.client._constants import LIST_LIMIT_DEFAULT
 from cognite.client.data_classes import LabelDefinition, LabelDefinitionFilter, LabelDefinitionList
 from cognite.client.utils._identifier import IdentifierSequence
+from cognite.client.utils._validation import process_data_set_ids
 
 
 class LabelsAPI(APIClient):
@@ -17,7 +18,7 @@ class LabelsAPI(APIClient):
         Fetches Labels as they are iterated over, so you keep a limited number of Labels in memory.
 
         Yields:
-            Type: yields Labels one by one.
+            LabelDefinition: yields Labels one by one.
         """
         return cast(Iterator[LabelDefinition], self())
 
@@ -30,9 +31,8 @@ class LabelsAPI(APIClient):
         data_set_ids: Sequence[int] = None,
         data_set_external_ids: Sequence[str] = None,
     ) -> Union[Iterator[LabelDefinition], Iterator[LabelDefinitionList]]:
-        data_set_ids_processed = None
-        if data_set_ids is not None or data_set_external_ids is not None:
-            data_set_ids_processed = IdentifierSequence.load(data_set_ids, data_set_external_ids).as_dicts()
+        data_set_ids_processed = process_data_set_ids(data_set_ids, data_set_external_ids)
+
         filter = LabelDefinitionFilter(
             name=name, external_id_prefix=external_id_prefix, data_set_ids=data_set_ids_processed
         ).dump(camel_case=True)
@@ -87,9 +87,8 @@ class LabelsAPI(APIClient):
                 >>> for label_list in c.labels(chunk_size=2500):
                 ...     label_list # do something with the type definitions
         """
-        data_set_ids_processed = None
-        if data_set_ids is not None or data_set_external_ids is not None:
-            data_set_ids_processed = IdentifierSequence.load(data_set_ids, data_set_external_ids).as_dicts()
+        data_set_ids_processed = process_data_set_ids(data_set_ids, data_set_external_ids)
+
         filter = LabelDefinitionFilter(
             name=name, external_id_prefix=external_id_prefix, data_set_ids=data_set_ids_processed
         ).dump(camel_case=True)

--- a/cognite/client/_api/labels.py
+++ b/cognite/client/_api/labels.py
@@ -31,7 +31,7 @@ class LabelsAPI(APIClient):
         data_set_external_ids: Sequence[str] = None,
     ) -> Union[Iterator[LabelDefinition], Iterator[LabelDefinitionList]]:
         data_set_ids_processed = None
-        if data_set_ids or data_set_external_ids:
+        if data_set_ids is not None or data_set_external_ids is not None:
             data_set_ids_processed = IdentifierSequence.load(data_set_ids, data_set_external_ids).as_dicts()
         filter = LabelDefinitionFilter(
             name=name, external_id_prefix=external_id_prefix, data_set_ids=data_set_ids_processed
@@ -88,7 +88,7 @@ class LabelsAPI(APIClient):
                 ...     label_list # do something with the type definitions
         """
         data_set_ids_processed = None
-        if data_set_ids or data_set_external_ids:
+        if data_set_ids is not None or data_set_external_ids is not None:
             data_set_ids_processed = IdentifierSequence.load(data_set_ids, data_set_external_ids).as_dicts()
         filter = LabelDefinitionFilter(
             name=name, external_id_prefix=external_id_prefix, data_set_ids=data_set_ids_processed

--- a/cognite/client/_api/labels.py
+++ b/cognite/client/_api/labels.py
@@ -28,8 +28,8 @@ class LabelsAPI(APIClient):
         external_id_prefix: str = None,
         limit: int = None,
         chunk_size: int = None,
-        data_set_ids: Sequence[int] = None,
-        data_set_external_ids: Sequence[str] = None,
+        data_set_ids: Union[int, Sequence[int]] = None,
+        data_set_external_ids: Union[str, Sequence[str]] = None,
     ) -> Union[Iterator[LabelDefinition], Iterator[LabelDefinitionList]]:
         data_set_ids_processed = process_data_set_ids(data_set_ids, data_set_external_ids)
 
@@ -49,16 +49,16 @@ class LabelsAPI(APIClient):
         self,
         name: str = None,
         external_id_prefix: str = None,
-        data_set_ids: Sequence[int] = None,
-        data_set_external_ids: Sequence[str] = None,
+        data_set_ids: Union[int, Sequence[int]] = None,
+        data_set_external_ids: Union[str, Sequence[str]] = None,
         limit: int = LIST_LIMIT_DEFAULT,
     ) -> LabelDefinitionList:
         """`List Labels <https://docs.cognite.com/api/v1/#operation/listLabels>`_
 
         Args:
             name (str): returns the label definitions matching that name
-            data_set_ids (Sequence[int]): return only labels in the data sets with these ids.
-            data_set_external_ids (Sequence[str]): return only labels in the data sets with these external ids.
+            data_set_ids (Union[int, Sequence[int]]): return only labels in the data sets with this id / these ids.
+            data_set_external_ids (Union[str, Sequence[str]]): return only labels in the data sets with this external id / these external ids.
             external_id_prefix (str): filter label definitions with external ids starting with the prefix specified
             limit (int, optional): Maximum number of label definitions to return.
 

--- a/cognite/client/_api/relationships.py
+++ b/cognite/client/_api/relationships.py
@@ -9,6 +9,7 @@ from cognite.client.data_classes import Relationship, RelationshipFilter, Relati
 from cognite.client.data_classes.labels import LabelFilter
 from cognite.client.utils._auxiliary import is_unlimited
 from cognite.client.utils._identifier import IdentifierSequence
+from cognite.client.utils._validation import process_data_set_ids
 
 if TYPE_CHECKING:
     from cognite.client import CogniteClient
@@ -96,9 +97,7 @@ class RelationshipsAPI(APIClient):
         Yields:
             Union[Relationship, RelationshipList]: yields Relationship one by one if chunk is not specified, else RelationshipList objects.
         """
-        data_set_ids_processed = None
-        if data_set_ids is not None or data_set_external_ids is not None:
-            data_set_ids_processed = IdentifierSequence.load(data_set_ids, data_set_external_ids).as_dicts()
+        data_set_ids_processed = process_data_set_ids(data_set_ids, data_set_external_ids)
 
         filter = self._create_filter(
             source_external_ids=source_external_ids,
@@ -257,9 +256,7 @@ class RelationshipsAPI(APIClient):
                 >>> for relationship in c.relationships:
                 ...     relationship # do something with the relationship
         """
-        data_set_ids_processed = None
-        if data_set_ids is not None or data_set_external_ids is not None:
-            data_set_ids_processed = IdentifierSequence.load(data_set_ids, data_set_external_ids).as_dicts()
+        data_set_ids_processed = process_data_set_ids(data_set_ids, data_set_external_ids)
 
         filter = self._create_filter(
             source_external_ids=source_external_ids,

--- a/cognite/client/_api/relationships.py
+++ b/cognite/client/_api/relationships.py
@@ -59,8 +59,8 @@ class RelationshipsAPI(APIClient):
         source_types: Sequence[str] = None,
         target_external_ids: Sequence[str] = None,
         target_types: Sequence[str] = None,
-        data_set_ids: Sequence[int] = None,
-        data_set_external_ids: Sequence[str] = None,
+        data_set_ids: Union[int, Sequence[int]] = None,
+        data_set_external_ids: Union[str, Sequence[str]] = None,
         start_time: Dict[str, int] = None,
         end_time: Dict[str, int] = None,
         confidence: Dict[str, int] = None,
@@ -82,8 +82,8 @@ class RelationshipsAPI(APIClient):
             source_types (Sequence[str]): Include relationships that have any of these values in their source Type field
             target_external_ids (Sequence[str]): Include relationships that have any of these values in their target External Id field
             target_types (Sequence[str]): Include relationships that have any of these values in their target Type field
-            data_set_ids (Sequence[int]): Return only relationships in the specified data sets with these ids.
-            data_set_external_ids (Sequence[str]): Return only relationships in the specified data sets with these external ids.
+            data_set_ids (Union[int, Sequence[int]]): Return only relationships in the specified data set(s) with this id / these ids.
+            data_set_external_ids (Union[str, Sequence[str]]): Return only relationships in the specified data set(s) with this external id / these external ids.
             start_time (Dict[str, int]): Range between two timestamps, minimum and maximum milli seconds (inclusive)
             end_time (Dict[str, int]): Range between two timestamps, minimum and maximum milli seconds (inclusive)
             confidence (Dict[str, int]): Range to filter the field for (inclusive).
@@ -95,7 +95,7 @@ class RelationshipsAPI(APIClient):
             partitions (int): Retrieve relationships in parallel using this number of workers. Also requires `limit=None` to be passed.
 
         Yields:
-            Union[Relationship, RelationshipList]: yields Relationship one by one if chunk is not specified, else RelationshipList objects.
+            Union[Relationship, RelationshipList]: yields Relationship one by one if chunk_size is not specified, else RelationshipList objects.
         """
         data_set_ids_processed = process_data_set_ids(data_set_ids, data_set_external_ids)
 
@@ -203,8 +203,8 @@ class RelationshipsAPI(APIClient):
         source_types: Sequence[str] = None,
         target_external_ids: Sequence[str] = None,
         target_types: Sequence[str] = None,
-        data_set_ids: Sequence[int] = None,
-        data_set_external_ids: Sequence[str] = None,
+        data_set_ids: Union[int, Sequence[int]] = None,
+        data_set_external_ids: Union[str, Sequence[str]] = None,
         start_time: Dict[str, int] = None,
         end_time: Dict[str, int] = None,
         confidence: Dict[str, int] = None,
@@ -223,8 +223,8 @@ class RelationshipsAPI(APIClient):
             source_types (Sequence[str]): Include relationships that have any of these values in their source Type field
             target_external_ids (Sequence[str]): Include relationships that have any of these values in their target External Id field
             target_types (Sequence[str]): Include relationships that have any of these values in their target Type field
-            data_set_ids (Sequence[int]): Return only relationships in the specified data sets with these ids.
-            data_set_external_ids (Sequence[str]): Return only relationships in the specified data sets with these external ids.
+            data_set_ids (Union[int, Sequence[int]]): Return only relationships in the specified data set(s) with this id / these ids.
+            data_set_external_ids (Union[str, Sequence[str]]): Return only relationships in the specified data set(s) with this external id / these external ids.
             start_time (Dict[str, int]): Range between two timestamps, minimum and maximum milli seconds (inclusive)
             end_time (Dict[str, int]): Range between two timestamps, minimum and maximum milli seconds (inclusive)
             confidence (Dict[str, int]): Range to filter the field for (inclusive).

--- a/cognite/client/_api/relationships.py
+++ b/cognite/client/_api/relationships.py
@@ -97,7 +97,7 @@ class RelationshipsAPI(APIClient):
             Union[Relationship, RelationshipList]: yields Relationship one by one if chunk is not specified, else RelationshipList objects.
         """
         data_set_ids_processed = None
-        if data_set_ids or data_set_external_ids:
+        if data_set_ids is not None or data_set_external_ids is not None:
             data_set_ids_processed = IdentifierSequence.load(data_set_ids, data_set_external_ids).as_dicts()
 
         filter = self._create_filter(
@@ -258,7 +258,7 @@ class RelationshipsAPI(APIClient):
                 ...     relationship # do something with the relationship
         """
         data_set_ids_processed = None
-        if data_set_ids or data_set_external_ids:
+        if data_set_ids is not None or data_set_external_ids is not None:
             data_set_ids_processed = IdentifierSequence.load(data_set_ids, data_set_external_ids).as_dicts()
 
         filter = self._create_filter(

--- a/cognite/client/_api/sequences.py
+++ b/cognite/client/_api/sequences.py
@@ -78,7 +78,7 @@ class SequencesAPI(APIClient):
             ).as_dicts()
 
         data_set_ids_processed = None
-        if data_set_ids or data_set_external_ids:
+        if data_set_ids is not None or data_set_external_ids is not None:
             data_set_ids_processed = IdentifierSequence.load(data_set_ids, data_set_external_ids).as_dicts()
 
         filter = SequenceFilter(
@@ -236,7 +236,7 @@ class SequencesAPI(APIClient):
             ).as_dicts()
 
         data_set_ids_processed = None
-        if data_set_ids or data_set_external_ids:
+        if data_set_ids is not None or data_set_external_ids is not None:
             data_set_ids_processed = IdentifierSequence.load(data_set_ids, data_set_external_ids).as_dicts()
 
         filter = SequenceFilter(

--- a/cognite/client/_api/sequences.py
+++ b/cognite/client/_api/sequences.py
@@ -43,10 +43,10 @@ class SequencesAPI(APIClient):
         external_id_prefix: str = None,
         metadata: Dict[str, str] = None,
         asset_ids: SequenceType[int] = None,
-        asset_subtree_ids: SequenceType[int] = None,
-        asset_subtree_external_ids: SequenceType[str] = None,
-        data_set_ids: SequenceType[int] = None,
-        data_set_external_ids: SequenceType[str] = None,
+        asset_subtree_ids: Union[int, SequenceType[int]] = None,
+        asset_subtree_external_ids: Union[str, SequenceType[str]] = None,
+        data_set_ids: Union[int, SequenceType[int]] = None,
+        data_set_external_ids: Union[str, SequenceType[str]] = None,
         created_time: Dict[str, Any] = None,
         last_updated_time: Dict[str, Any] = None,
         limit: int = None,
@@ -61,16 +61,16 @@ class SequencesAPI(APIClient):
             external_id_prefix (str): Filter out sequences that do not have this string as the start of the externalId
             metadata (Dict[str, Any]): Filter out sequences that do not match these metadata fields and values (case-sensitive). Format is {"key1":"value1","key2":"value2"}.
             asset_ids (SequenceType[int]): Filter out sequences that are not linked to any of these assets.
-            asset_subtree_ids (SequenceType[int]): List of asset subtrees ids to filter on.
-            asset_subtree_external_ids (SequenceType[str]): List of asset subtrees external ids to filter on.
-            data_set_ids (SequenceType[int]): Return only events in the specified data sets with these ids.
-            data_set_external_ids (SequenceType[str]): Return only events in the specified data sets with these external ids.
+            asset_subtree_ids (Union[int, SequenceType[int]]): Asset subtree id or list of asset subtree ids to filter on.
+            asset_subtree_external_ids (Union[str, SequenceType[str]]): Asset subtree external id or list of asset subtree external ids to filter on.
+            data_set_ids (Union[int, SequenceType[int]]): Return only sequences in the specified data set(s) with this id / these ids.
+            data_set_external_ids (SequenceType[str]): Return only sequences in the specified data set(s) with this external id / these external ids.
             created_time (Union[Dict[str, int], TimestampRange]):  Range between two timestamps. Possible keys are `min` and `max`, with values given as time stamps in ms.
             last_updated_time (Union[Dict[str, int], TimestampRange]):  Range between two timestamps. Possible keys are `min` and `max`, with values given as time stamps in ms.
             limit (int, optional): Max number of sequences to return. Defaults to return all items.
 
         Yields:
-            Union[Sequence, SequenceList]: yields Sequence one by one if chunk is not specified, else SequenceList objects.
+            Union[Sequence, SequenceList]: yields Sequence one by one if chunk_size is not specified, else SequenceList objects.
         """
         asset_subtree_ids_processed = process_asset_subtree_ids(asset_subtree_ids, asset_subtree_external_ids)
         data_set_ids_processed = process_data_set_ids(data_set_ids, data_set_external_ids)
@@ -172,10 +172,10 @@ class SequencesAPI(APIClient):
         external_id_prefix: str = None,
         metadata: Dict[str, str] = None,
         asset_ids: SequenceType[int] = None,
-        asset_subtree_ids: SequenceType[int] = None,
-        asset_subtree_external_ids: SequenceType[str] = None,
-        data_set_ids: SequenceType[int] = None,
-        data_set_external_ids: SequenceType[str] = None,
+        asset_subtree_ids: Union[int, SequenceType[int]] = None,
+        asset_subtree_external_ids: Union[str, SequenceType[str]] = None,
+        data_set_ids: Union[int, SequenceType[int]] = None,
+        data_set_external_ids: Union[str, SequenceType[str]] = None,
         created_time: (Union[Dict[str, Any], TimestampRange]) = None,
         last_updated_time: (Union[Dict[str, Any], TimestampRange]) = None,
         limit: Optional[int] = LIST_LIMIT_DEFAULT,
@@ -189,10 +189,10 @@ class SequencesAPI(APIClient):
             external_id_prefix (str): Filter out sequences that do not have this string as the start of the externalId
             metadata (Dict[str, Any]): Filter out sequences that do not match these metadata fields and values (case-sensitive). Format is {"key1":"value1","key2":"value2"}.
             asset_ids (SequenceType[int]): Filter out sequences that are not linked to any of these assets.
-            asset_subtree_ids (SequenceType[int]): List of asset subtrees ids to filter on.
-            asset_subtree_external_ids (SequenceType[str]): List of asset subtrees external ids to filter on.
-            data_set_ids (SequenceType[int]): Return only events in the specified data sets with these ids.
-            data_set_external_ids (SequenceType[str]): Return only events in the specified data sets with these external ids.
+            asset_subtree_ids (Union[int, SequenceType[int]]): Asset subtree id or list of asset subtree ids to filter on.
+            asset_subtree_external_ids (Union[str, SequenceType[str]]): Asset subtree external id or list of asset subtree external ids to filter on.
+            data_set_ids (Union[int, SequenceType[int]]): Return only sequences in the specified data set(s) with this id / these ids.
+            data_set_external_ids (SequenceType[str]): Return only sequences in the specified data set(s) with this external id / these external ids.
             created_time (Union[Dict[str, int], TimestampRange]):  Range between two timestamps. Possible keys are `min` and `max`, with values given as time stamps in ms.
             last_updated_time (Union[Dict[str, int], TimestampRange]):  Range between two timestamps. Possible keys are `min` and `max`, with values given as time stamps in ms.
             limit (int, optional): Max number of sequences to return. Defaults to 25. Set to -1, float("inf") or None

--- a/cognite/client/_api/sequences.py
+++ b/cognite/client/_api/sequences.py
@@ -20,6 +20,7 @@ from cognite.client.data_classes import (
 )
 from cognite.client.data_classes.shared import TimestampRange
 from cognite.client.utils._identifier import Identifier, IdentifierSequence
+from cognite.client.utils._validation import process_asset_subtree_ids, process_data_set_ids
 
 if TYPE_CHECKING:
     import pandas
@@ -71,15 +72,8 @@ class SequencesAPI(APIClient):
         Yields:
             Union[Sequence, SequenceList]: yields Sequence one by one if chunk is not specified, else SequenceList objects.
         """
-        asset_subtree_ids_processed = None
-        if asset_subtree_ids or asset_subtree_external_ids:
-            asset_subtree_ids_processed = IdentifierSequence.load(
-                asset_subtree_ids, asset_subtree_external_ids
-            ).as_dicts()
-
-        data_set_ids_processed = None
-        if data_set_ids is not None or data_set_external_ids is not None:
-            data_set_ids_processed = IdentifierSequence.load(data_set_ids, data_set_external_ids).as_dicts()
+        asset_subtree_ids_processed = process_asset_subtree_ids(asset_subtree_ids, asset_subtree_external_ids)
+        data_set_ids_processed = process_data_set_ids(data_set_ids, data_set_external_ids)
 
         filter = SequenceFilter(
             name=name,
@@ -229,15 +223,8 @@ class SequencesAPI(APIClient):
                 >>> for seq_list in c.sequences(chunk_size=2500):
                 ...     seq_list # do something with the sequences
         """
-        asset_subtree_ids_processed = None
-        if asset_subtree_ids or asset_subtree_external_ids:
-            asset_subtree_ids_processed = IdentifierSequence.load(
-                asset_subtree_ids, asset_subtree_external_ids
-            ).as_dicts()
-
-        data_set_ids_processed = None
-        if data_set_ids is not None or data_set_external_ids is not None:
-            data_set_ids_processed = IdentifierSequence.load(data_set_ids, data_set_external_ids).as_dicts()
+        asset_subtree_ids_processed = process_asset_subtree_ids(asset_subtree_ids, asset_subtree_external_ids)
+        data_set_ids_processed = process_data_set_ids(data_set_ids, data_set_external_ids)
 
         filter = SequenceFilter(
             name=name,

--- a/cognite/client/_api/time_series.py
+++ b/cognite/client/_api/time_series.py
@@ -36,10 +36,10 @@ class TimeSeriesAPI(APIClient):
         is_step: bool = None,
         asset_ids: Sequence[int] = None,
         asset_external_ids: Sequence[str] = None,
-        asset_subtree_ids: Sequence[int] = None,
-        asset_subtree_external_ids: Sequence[str] = None,
-        data_set_ids: Sequence[int] = None,
-        data_set_external_ids: Sequence[str] = None,
+        asset_subtree_ids: Union[int, Sequence[int]] = None,
+        asset_subtree_external_ids: Union[str, Sequence[str]] = None,
+        data_set_ids: Union[int, Sequence[int]] = None,
+        data_set_external_ids: Union[str, Sequence[str]] = None,
         metadata: Dict[str, Any] = None,
         external_id_prefix: str = None,
         created_time: Dict[str, Any] = None,
@@ -59,10 +59,10 @@ class TimeSeriesAPI(APIClient):
             is_step (bool): Whether the time series is a step (piecewise constant) time series.
             asset_ids (Sequence[int], optional): List time series related to these assets.
             asset_external_ids  (Sequence[str], optional): List time series related to these assets.
-            asset_subtree_ids (Sequence[int]): List of asset subtrees ids to filter on.
-            asset_subtree_external_ids (Sequence[str]): List of asset subtrees external ids to filter on.
-            data_set_ids (Sequence[int]): Return only time series in the specified data sets with these ids.
-            data_set_external_ids (Sequence[str]): Return only time series in the specified data sets with these external ids.
+            asset_subtree_ids (Union[int, Sequence[int]]): Asset subtree id or list of asset subtree ids to filter on.
+            asset_subtree_external_ids (Union[str, Sequence[str]]): Asset external id or list of asset subtree external ids to filter on.
+            data_set_ids (Union[int, Sequence[int]]): Return only time series in the specified data set(s) with this id / these ids.
+            data_set_external_ids (Union[str, Sequence[str]]): Return only time series in the specified data set(s) with this external id / these external ids.
             metadata (Dict[str, Any]): Custom, application specific metadata. String key -> String value
             created_time (Union[Dict[str, int], TimestampRange]):  Range between two timestamps. Possible keys are `min` and `max`, with values given as time stamps in ms.
             last_updated_time (Union[Dict[str, int], TimestampRange]):  Range between two timestamps. Possible keys are `min` and `max`, with values given as time stamps in ms.
@@ -71,7 +71,7 @@ class TimeSeriesAPI(APIClient):
             partitions (int): Retrieve assets in parallel using this number of workers. Also requires `limit=None` to be passed.
 
         Yields:
-            Union[TimeSeries, TimeSeriesList]: yields TimeSeries one by one if chunk is not specified, else TimeSeriesList objects.
+            Union[TimeSeries, TimeSeriesList]: yields TimeSeries one by one if chunk_size is not specified, else TimeSeriesList objects.
         """
         asset_subtree_ids_processed = process_asset_subtree_ids(asset_subtree_ids, asset_subtree_external_ids)
         data_set_ids_processed = process_data_set_ids(data_set_ids, data_set_external_ids)
@@ -183,10 +183,10 @@ class TimeSeriesAPI(APIClient):
         is_step: bool = None,
         asset_ids: Sequence[int] = None,
         asset_external_ids: Sequence[str] = None,
-        asset_subtree_ids: Sequence[int] = None,
-        asset_subtree_external_ids: Sequence[str] = None,
-        data_set_ids: Sequence[int] = None,
-        data_set_external_ids: Sequence[str] = None,
+        asset_subtree_ids: Union[int, Sequence[int]] = None,
+        asset_subtree_external_ids: Union[str, Sequence[str]] = None,
+        data_set_ids: Union[int, Sequence[int]] = None,
+        data_set_external_ids: Union[str, Sequence[str]] = None,
         metadata: Dict[str, Any] = None,
         external_id_prefix: str = None,
         created_time: Dict[str, Any] = None,
@@ -205,10 +205,10 @@ class TimeSeriesAPI(APIClient):
             is_step (bool): Whether the time series is a step (piecewise constant) time series.
             asset_ids (Sequence[int], optional): List time series related to these assets.
             asset_external_ids (Sequence[str], optional): List time series related to these assets.
-            asset_subtree_ids (Sequence[int]): List of asset subtrees ids to filter on.
-            asset_subtree_external_ids (Sequence[str]): List of asset subtrees external ids to filter on.
-            data_set_ids (Sequence[int]): Return only assets in the specified data sets with these ids.
-            data_set_external_ids (Sequence[str]): Return only assets in the specified data sets with these external ids.
+            asset_subtree_ids (Union[int, Sequence[int]]): Asset subtree id or list of asset subtree ids to filter on.
+            asset_subtree_external_ids (Union[str, Sequence[str]]): Asset external id or list of asset subtree external ids to filter on.
+            data_set_ids (Union[int, Sequence[int]]): Return only time series in the specified data set(s) with this id / these ids.
+            data_set_external_ids (Union[str, Sequence[str]]): Return only time series in the specified data set(s) with this external id / these external ids.
             metadata (Dict[str, Any]): Custom, application specific metadata. String key -> String value
             created_time (Union[Dict[str, int], TimestampRange]):  Range between two timestamps. Possible keys are `min` and `max`, with values given as time stamps in ms.
             last_updated_time (Union[Dict[str, int], TimestampRange]):  Range between two timestamps. Possible keys are `min` and `max`, with values given as time stamps in ms.

--- a/cognite/client/_api/time_series.py
+++ b/cognite/client/_api/time_series.py
@@ -13,6 +13,7 @@ from cognite.client.data_classes import (
     TimeSeriesUpdate,
 )
 from cognite.client.utils._identifier import IdentifierSequence
+from cognite.client.utils._validation import process_asset_subtree_ids, process_data_set_ids
 
 if TYPE_CHECKING:
     from cognite.client import CogniteClient
@@ -72,15 +73,9 @@ class TimeSeriesAPI(APIClient):
         Yields:
             Union[TimeSeries, TimeSeriesList]: yields TimeSeries one by one if chunk is not specified, else TimeSeriesList objects.
         """
-        asset_subtree_ids_processed = None
-        if asset_subtree_ids or asset_subtree_external_ids:
-            asset_subtree_ids_processed = IdentifierSequence.load(
-                asset_subtree_ids, asset_subtree_external_ids
-            ).as_dicts()
+        asset_subtree_ids_processed = process_asset_subtree_ids(asset_subtree_ids, asset_subtree_external_ids)
+        data_set_ids_processed = process_data_set_ids(data_set_ids, data_set_external_ids)
 
-        data_set_ids_processed = None
-        if data_set_ids is not None or data_set_external_ids is not None:
-            data_set_ids_processed = IdentifierSequence.load(data_set_ids, data_set_external_ids).as_dicts()
         filter = TimeSeriesFilter(
             name=name,
             unit=unit,
@@ -247,15 +242,9 @@ class TimeSeriesAPI(APIClient):
                 >>> for ts_list in c.time_series(chunk_size=2500):
                 ...     ts_list # do something with the time_series
         """
-        asset_subtree_ids_processed = None
-        if asset_subtree_ids or asset_subtree_external_ids:
-            asset_subtree_ids_processed = IdentifierSequence.load(
-                asset_subtree_ids, asset_subtree_external_ids
-            ).as_dicts()
+        asset_subtree_ids_processed = process_asset_subtree_ids(asset_subtree_ids, asset_subtree_external_ids)
+        data_set_ids_processed = process_data_set_ids(data_set_ids, data_set_external_ids)
 
-        data_set_ids_processed = None
-        if data_set_ids is not None or data_set_external_ids is not None:
-            data_set_ids_processed = IdentifierSequence.load(data_set_ids, data_set_external_ids).as_dicts()
         filter = TimeSeriesFilter(
             name=name,
             unit=unit,

--- a/cognite/client/_api/time_series.py
+++ b/cognite/client/_api/time_series.py
@@ -79,7 +79,7 @@ class TimeSeriesAPI(APIClient):
             ).as_dicts()
 
         data_set_ids_processed = None
-        if data_set_ids or data_set_external_ids:
+        if data_set_ids is not None or data_set_external_ids is not None:
             data_set_ids_processed = IdentifierSequence.load(data_set_ids, data_set_external_ids).as_dicts()
         filter = TimeSeriesFilter(
             name=name,
@@ -254,7 +254,7 @@ class TimeSeriesAPI(APIClient):
             ).as_dicts()
 
         data_set_ids_processed = None
-        if data_set_ids or data_set_external_ids:
+        if data_set_ids is not None or data_set_external_ids is not None:
             data_set_ids_processed = IdentifierSequence.load(data_set_ids, data_set_external_ids).as_dicts()
         filter = TimeSeriesFilter(
             name=name,

--- a/cognite/client/_version.py
+++ b/cognite/client/_version.py
@@ -1,4 +1,4 @@
 from __future__ import annotations
 
-__version__ = "5.11.0"
+__version__ = "5.11.1"
 __api_subversion__ = "V20220125"

--- a/cognite/client/utils/_auxiliary.py
+++ b/cognite/client/utils/_auxiliary.py
@@ -12,7 +12,6 @@ import math
 import numbers
 import platform
 import warnings
-from collections.abc import Mapping
 from decimal import Decimal
 from types import ModuleType
 from typing import (
@@ -34,7 +33,6 @@ from urllib.parse import quote
 
 import cognite.client
 from cognite.client.exceptions import CogniteImportError
-from cognite.client.utils._identifier import T_ID, Identifier
 from cognite.client.utils._text import convert_all_keys_to_camel_case, convert_all_keys_to_snake_case, to_snake_case
 from cognite.client.utils._version_checker import get_newest_version_in_major_release
 
@@ -127,24 +125,6 @@ def assert_type(var: Any, var_name: str, types: List[type], allow_none: bool = F
             raise TypeError(f"{var_name} cannot be None")
     elif not isinstance(var, tuple(types)):
         raise TypeError(f"{var_name!r} must be one of types {types}, not {type(var)}")
-
-
-def validate_user_input_dict_with_identifier(dct: Mapping, required_keys: Set[str]) -> Dict[str, T_ID]:
-    if not isinstance(dct, Mapping):
-        raise TypeError(f"Expected dict-like object, got {type(dct)}")
-
-    # Verify that we have gotten exactly one identifier:
-    xid = dct.get("externalId") or dct.get("external_id")
-    id_dct = Identifier.of_either(dct.get("id"), xid).as_dict(camel_case=True)
-
-    missing_keys = required_keys.difference(dct)
-    invalid_keys = set(dct) - required_keys - {"id", "externalId", "external_id"}
-    if missing_keys or invalid_keys:
-        raise ValueError(
-            f"Given dictionary failed validation. Invalid key(s): {sorted(invalid_keys)}, "
-            f"required key(s) missing: {sorted(missing_keys)}."
-        )
-    return id_dct
 
 
 def interpolate_and_url_encode(path: str, *args: Any) -> str:

--- a/cognite/client/utils/_identifier.py
+++ b/cognite/client/utils/_identifier.py
@@ -40,6 +40,14 @@ class Identifier(Generic[T_ID]):
     def as_primitive(self) -> T_ID:
         return self.__value
 
+    @property
+    def is_id(self) -> bool:
+        return isinstance(self.as_primitive(), int)
+
+    @property
+    def is_external_id(self) -> bool:
+        return isinstance(self.as_primitive(), str)
+
     def as_dict(self, camel_case: bool = True) -> Dict[str, T_ID]:
         return {self.name(camel_case): self.__value}
 

--- a/cognite/client/utils/_validation.py
+++ b/cognite/client/utils/_validation.py
@@ -39,6 +39,5 @@ def _process_identifiers(
     return IdentifierSequence.load(ids, external_ids, id_name=id_name).as_dicts()
 
 
-process_function_ids = functools.partial(_process_identifiers, id_name="function")
 process_data_set_ids = functools.partial(_process_identifiers, id_name="data_set")
 process_asset_subtree_ids = functools.partial(_process_identifiers, id_name="asset_subtree")

--- a/cognite/client/utils/_validation.py
+++ b/cognite/client/utils/_validation.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+import functools
+from typing import TYPE_CHECKING, Mapping, Sequence
+
+from cognite.client.utils._identifier import Identifier, IdentifierSequence
+
+if TYPE_CHECKING:
+    from cognite.client.utils._identifier import T_ID
+
+
+def validate_user_input_dict_with_identifier(dct: Mapping, required_keys: set[str]) -> dict[str, T_ID]:
+    if not isinstance(dct, Mapping):
+        raise TypeError(f"Expected dict-like object, got {type(dct)}")
+
+    # Verify that we have gotten exactly one identifier:
+    if (xid := dct.get("external_id")) is None:  # "" is valid ext.id
+        xid = dct.get("externalId")
+    id_dct = Identifier.of_either(dct.get("id"), xid).as_dict(camel_case=True)
+
+    missing_keys = required_keys.difference(dct)
+    invalid_keys = set(dct) - required_keys - {"id", "externalId", "external_id"}
+    if missing_keys or invalid_keys:
+        raise ValueError(
+            f"Given dictionary failed validation. Invalid key(s): {sorted(invalid_keys)}, "
+            f"required key(s) missing: {sorted(missing_keys)}."
+        )
+    return id_dct
+
+
+def _process_identifiers(
+    ids: int | Sequence[int] | None,
+    external_ids: str | Sequence[str] | None,
+    *,
+    id_name: str,
+) -> list[dict[str, int | str]] | None:
+    if ids is None and external_ids is None:
+        return None
+    return IdentifierSequence.load(ids, external_ids, id_name=id_name).as_dicts()
+
+
+process_function_ids = functools.partial(_process_identifiers, id_name="function")
+process_data_set_ids = functools.partial(_process_identifiers, id_name="data_set")
+process_asset_subtree_ids = functools.partial(_process_identifiers, id_name="asset_subtree")

--- a/cognite/client/utils/_validation.py
+++ b/cognite/client/utils/_validation.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import functools
-from typing import TYPE_CHECKING, Mapping, Sequence
+from typing import TYPE_CHECKING, Callable, Mapping, Sequence
 
 from cognite.client.utils._identifier import Identifier, IdentifierSequence
 
@@ -39,5 +39,9 @@ def _process_identifiers(
     return IdentifierSequence.load(ids, external_ids, id_name=id_name).as_dicts()
 
 
-process_data_set_ids = functools.partial(_process_identifiers, id_name="data_set")
-process_asset_subtree_ids = functools.partial(_process_identifiers, id_name="asset_subtree")
+process_data_set_ids: Callable[
+    [int | Sequence[int] | None, str | Sequence[str] | None], list[dict[str, int | str]] | None
+] = functools.partial(_process_identifiers, id_name="data_set")
+process_asset_subtree_ids: Callable[
+    [int | Sequence[int] | None, str | Sequence[str] | None], list[dict[str, int | str]] | None
+] = functools.partial(_process_identifiers, id_name="asset_subtree")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "cognite-sdk"
 
-version = "5.11.0"
+version = "5.11.1"
 
 description = "Cognite Python SDK"
 readme = "README.md"

--- a/tests/tests_unit/test_utils/test_auxiliary.py
+++ b/tests/tests_unit/test_utils/test_auxiliary.py
@@ -17,7 +17,6 @@ from cognite.client.utils._auxiliary import (
     local_import,
     split_into_chunks,
     split_into_n_parts,
-    validate_user_input_dict_with_identifier,
 )
 
 
@@ -270,43 +269,3 @@ class TestExactlyOneIsNotNone:
     )
     def test_exactly_one_is_not_none(self, inp, expected):
         assert exactly_one_is_not_none(*inp) == expected
-
-
-class TestValidateUserInputDictWithIdentifier:
-    @pytest.mark.parametrize(
-        "dct, keys, expected",
-        (
-            ({"id": 123, "a": None, "b": 0}, {"a", "b"}, {"id": 123}),
-            ({"external_id": "foo", "c": None}, {"c"}, {"externalId": "foo"}),
-            ({"externalId": "foo"}, set(), {"externalId": "foo"}),
-        ),
-    )
-    def test_validate_normal_input(self, dct, keys, expected):
-        assert expected == validate_user_input_dict_with_identifier(dct, required_keys=keys)
-
-    @pytest.mark.parametrize(
-        "dct, keys, err, err_msg",
-        (
-            (["id", 123], set(), TypeError, "Expected dict-like object, got <class 'list'>"),
-            ({}, set(), ValueError, "must be specified, got neither"),
-            ({"id": 123, "external_id": "foo"}, set(), ValueError, "must be specified, got both"),
-            ({"id": 123, "externalId": "foo"}, set(), ValueError, "must be specified, got both"),
-            ({"id": 123}, {"a"}, ValueError, re.escape("Invalid key(s): [], required key(s) missing: ['a'].")),
-            (
-                {"id": 123, "a": 0},
-                {"b"},
-                ValueError,
-                re.escape("Invalid key(s): ['a'], required key(s) missing: ['b']."),
-            ),
-            (
-                {"id": 123, "a": 0, "b": 1},
-                {"c", "d"},
-                ValueError,
-                re.escape("Invalid key(s): ['a', 'b'], required key(s) missing: ['c', 'd']."),
-            ),
-            ({"id": 123, "a": 0}, set(), ValueError, re.escape("Invalid key(s): ['a'], required key(s) missing: [].")),
-        ),
-    )
-    def test_validate_bad_input(self, dct, keys, err, err_msg):
-        with pytest.raises(err, match=err_msg):
-            validate_user_input_dict_with_identifier(dct, required_keys=keys)

--- a/tests/tests_unit/test_utils/test_validation.py
+++ b/tests/tests_unit/test_utils/test_validation.py
@@ -1,0 +1,79 @@
+import re
+
+import pytest
+
+from cognite.client.utils._validation import (
+    process_asset_subtree_ids,
+    process_data_set_ids,
+    process_function_ids,
+    validate_user_input_dict_with_identifier,
+)
+
+
+class TestValidateUserInputDictWithIdentifier:
+    @pytest.mark.parametrize(
+        "dct, keys, expected",
+        (
+            ({"id": 123, "a": None, "b": 0}, {"a", "b"}, {"id": 123}),
+            ({"external_id": "foo", "c": None}, {"c"}, {"externalId": "foo"}),
+            ({"externalId": "foo"}, set(), {"externalId": "foo"}),
+        ),
+    )
+    def test_validate_normal_input(self, dct, keys, expected):
+        assert expected == validate_user_input_dict_with_identifier(dct, required_keys=keys)
+
+    @pytest.mark.parametrize(
+        "dct, keys, err, err_msg",
+        (
+            (["id", 123], set(), TypeError, "Expected dict-like object, got <class 'list'>"),
+            ({}, set(), ValueError, "must be specified, got neither"),
+            ({"id": 123, "external_id": "foo"}, set(), ValueError, "must be specified, got both"),
+            ({"id": 123, "externalId": "foo"}, set(), ValueError, "must be specified, got both"),
+            ({"id": 123}, {"a"}, ValueError, re.escape("Invalid key(s): [], required key(s) missing: ['a'].")),
+            (
+                {"id": 123, "a": 0},
+                {"b"},
+                ValueError,
+                re.escape("Invalid key(s): ['a'], required key(s) missing: ['b']."),
+            ),
+            (
+                {"id": 123, "a": 0, "b": 1},
+                {"c", "d"},
+                ValueError,
+                re.escape("Invalid key(s): ['a', 'b'], required key(s) missing: ['c', 'd']."),
+            ),
+            ({"id": 123, "a": 0}, set(), ValueError, re.escape("Invalid key(s): ['a'], required key(s) missing: [].")),
+        ),
+    )
+    def test_validate_bad_input(self, dct, keys, err, err_msg):
+        with pytest.raises(err, match=err_msg):
+            validate_user_input_dict_with_identifier(dct, required_keys=keys)
+
+
+process_fns = process_function_ids, process_data_set_ids, process_asset_subtree_ids
+process_fns_names = "function", "data_set", "asset_subtree"
+
+
+class TestProcessIdentifiers:
+    @pytest.mark.parametrize("fn, name", zip(process_fns, process_fns_names))
+    def test_all_process_fns_bad_input(self, fn, name):
+        exp_match = rf"^{name}_ids must be of type int or Sequence\[int\]\. Found <class 'str'>$"
+        with pytest.raises(TypeError, match=exp_match):
+            fn("97", "a")
+
+        exp_match = rf"^{name}_external_ids must be of type str or Sequence\[str\]\. Found <class 'int'>$"
+        with pytest.raises(TypeError, match=exp_match):
+            fn(97, ord("a"))
+
+    @pytest.mark.parametrize("fn", process_fns)
+    def test_all_process_fns_normal_input(self, fn):
+        assert fn(None, None) is None
+        # As singletons:
+        assert fn(1, None) == [{"id": 1}]
+        assert fn(None, "a") == [{"externalId": "a"}]
+        assert fn(1, "a") == [{"id": 1}, {"externalId": "a"}]
+        # As lists:
+        assert fn([1], None) == [{"id": 1}]
+        assert fn(None, ["a"]) == [{"externalId": "a"}]
+        assert fn([1], ["a"]) == [{"id": 1}, {"externalId": "a"}]
+        assert fn([1, 2], ["a", "b"]) == [{"id": 1}, {"id": 2}, {"externalId": "a"}, {"externalId": "b"}]

--- a/tests/tests_unit/test_utils/test_validation.py
+++ b/tests/tests_unit/test_utils/test_validation.py
@@ -5,7 +5,6 @@ import pytest
 from cognite.client.utils._validation import (
     process_asset_subtree_ids,
     process_data_set_ids,
-    process_function_ids,
     validate_user_input_dict_with_identifier,
 )
 
@@ -50,8 +49,8 @@ class TestValidateUserInputDictWithIdentifier:
             validate_user_input_dict_with_identifier(dct, required_keys=keys)
 
 
-process_fns = process_function_ids, process_data_set_ids, process_asset_subtree_ids
-process_fns_names = "function", "data_set", "asset_subtree"
+process_fns = process_data_set_ids, process_asset_subtree_ids
+process_fns_names = "data_set", "asset_subtree"
 
 
 class TestProcessIdentifiers:


### PR DESCRIPTION
## Description
List (and `__call__`) methods for assets, events, files, labels, relationships, sequences, and time series now raise if given bad input for `data_set_ids` or `data_set_external_ids` instead of ignoring/returning everything.

Also adds the same validation for `asset_subtree_ids` and `asset_subtree_external_ids`.

Validation functions now reside in `utils/_validation.py`.

Used the same validation function in `FunctionsAPI` in order to give better-worded error messages (stating `function_id` instead of `id`)

Function signatures (for all above-mentioned endpoints) + their corresponding doc-strings have been updated to show that a single id or external id is accepted. This has been so for quite some time (except falsy: `0` / `""`), so this is just being open about what we accept.

- Fixes CDF-15492

## Checklist:
- [x] Tests added/updated.
- [x] Documentation updated. Documentation is generated from docstrings - these must be updated according to your change.
  If a new method has been added it should be referenced in [cognite.rst](https://github.com/cognitedata/cognite-sdk-python/blob/master/docs/source/cognite.rst) in order to generate docs based on its docstring.
- [x] Changelog updated in [CHANGELOG.md](https://github.com/cognitedata/cognite-sdk-python/blob/master/CHANGELOG.md).
- [x] Version bumped. If triggering a new release is desired, bump the version number in [_version.py](https://github.com/cognitedata/cognite-sdk-python/blob/master/cognite/client/_version.py) and [pyproject.toml](https://github.com/cognitedata/cognite-sdk-python/blob/master/pyproject.toml) per [semantic versioning](https://semver.org/).
