### PR TITLE
Two bugfixes: `FunctionSchedulesAPI.[create, get_input_data]`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,18 +17,23 @@ Changes are grouped as follows
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
-## [5.9.2] - 20-03-23
+## [5.9.3] - 27-03-23
+### Fixed
+- After creating a schedule for a function, the returned `FunctionSchedule` was missing a reference to the `CogniteClient`, meaning later calls to `.get_input_data()` would fail and raise `CogniteMissingClientError`.
+- When calling `.get_input_data()` on a `FunctionSchedule` instance, it would fail and raise `KeyError` if no input data was specified for the schedule. This now returns `None`.
+
+## [5.9.2] - 27-03-23
 ### Fixed
 - After calling e.g. `.time_series()` or `.events()` on an `AssetList` instance, the resulting resource list would be missing the lookup tables that allow for quick lookups by ID or external ID through the `.get()` method. Additionally, for future-proofing, the resulting resource list now also correctly has a `CogniteClient` reference.
 
-## [5.9.1] - 20-03-23
+## [5.9.1] - 23-03-23
 ### Fixed
 - `FunctionsAPI.call` now also works for clients using auth flow `OAuthInteractive`, `OAuthDeviceCode`, and any user-made subclass of `CredentialProvider`.
 
 ### Improved
 - `FunctionSchedulesAPI.create` now also accepts an instance of `ClientCredentials` (used to be dictionary only).
 
-## [5.9.0] - 20-03-23
+## [5.9.0] - 21-03-23
 ### Added
 - New class `AssetHierarchy` for easy verification and reporting on asset hierarchy issues without explicitly trying to insert them.
 - Orphan assets can now be reported on (orphan is an asset whose parent is not part of the given assets). Also, `AssetHierarchy` accepts an `ignore_orphans` argument to mimic the old behaviour where all orphans were assumed to be valid.
@@ -48,7 +53,7 @@ Changes are grouped as follows
 ### Added
 - Support for client certificate authentication to Azure AD.
 
-## [5.7.4] - 17-03-23
+## [5.7.4] - 20-03-23
 ### Added
 - Use `X-Job-Token` header for contextualization jobs to reduce required capabilities.
 
@@ -60,7 +65,7 @@ Changes are grouped as follows
 ### Fixed
 - Fix method dump in TransformationDestination to ignore None.
 
-## [5.7.1] - 09-03-23
+## [5.7.1] - 10-03-23
 ### Changed
 - Split `instances` destination type of Transformations to `nodes` and `edges`.
 

--- a/cognite/client/_api/functions.py
+++ b/cognite/client/_api/functions.py
@@ -1003,8 +1003,7 @@ class FunctionSchedulesAPI(APIClient):
         if data:
             body["items"][0]["data"] = data
 
-        url = "/functions/schedules"
-        res = self._post(url, json=body)
+        res = self._post(self._RESOURCE_PATH, json=body)
         return FunctionSchedule._load(res.json()["items"][0], cognite_client=self._cognite_client)
 
     def delete(self, id: int) -> None:
@@ -1026,7 +1025,7 @@ class FunctionSchedulesAPI(APIClient):
 
         """
         body = {"items": [{"id": id}]}
-        url = "/functions/schedules/delete"
+        url = f"{self._RESOURCE_PATH}/delete"
         self._post(url, json=body)
 
     def get_input_data(self, id: int) -> Optional[Dict]:
@@ -1044,9 +1043,9 @@ class FunctionSchedulesAPI(APIClient):
 
                 >>> from cognite.client import CogniteClient
                 >>> c = CogniteClient()
-                >>> c.functions.schedules.get_input_data(id = 123)
+                >>> c.functions.schedules.get_input_data(id=123)
         """
-        url = f"/functions/schedules/{id}/input_data"
+        url = f"{self._RESOURCE_PATH}/{id}/input_data"
         res = self._get(url)
 
         return res.json().get("data")

--- a/cognite/client/_api/functions.py
+++ b/cognite/client/_api/functions.py
@@ -1005,7 +1005,7 @@ class FunctionSchedulesAPI(APIClient):
 
         url = "/functions/schedules"
         res = self._post(url, json=body)
-        return FunctionSchedule._load(res.json()["items"][0])
+        return FunctionSchedule._load(res.json()["items"][0], cognite_client=self._cognite_client)
 
     def delete(self, id: int) -> None:
         """`Delete a schedule associated with a specific project. <https://docs.cognite.com/api/v1/#operation/deleteFunctionSchedules>`_

--- a/cognite/client/_api/functions.py
+++ b/cognite/client/_api/functions.py
@@ -1034,7 +1034,7 @@ class FunctionSchedulesAPI(APIClient):
             id (int): Id of the schedule
 
         Returns:
-            Input data to the associated function or None if not set. This data is passed
+            Optional[Dict]: Input data to the associated function or None if not set. This data is passed
             deserialized into the function through the data argument.
 
         Examples:

--- a/cognite/client/_api/functions.py
+++ b/cognite/client/_api/functions.py
@@ -1029,14 +1029,15 @@ class FunctionSchedulesAPI(APIClient):
         url = "/functions/schedules/delete"
         self._post(url, json=body)
 
-    def get_input_data(self, id: int) -> Dict:
+    def get_input_data(self, id: int) -> Optional[Dict]:
         """`Retrieve the input data to the associated function. <https://docs.cognite.com/api/v1/#operation/getFunctionScheduleInputData>`_
         Args:
             id (int): Id of the schedule
 
         Returns:
-            Input data to the associated function. This data is passed
+            Input data to the associated function or None if not set. This data is passed
             deserialized into the function through the data argument.
+
         Examples:
 
             Get schedule input data::
@@ -1048,4 +1049,4 @@ class FunctionSchedulesAPI(APIClient):
         url = f"/functions/schedules/{id}/input_data"
         res = self._get(url)
 
-        return res.json()["data"]
+        return res.json().get("data")

--- a/cognite/client/_version.py
+++ b/cognite/client/_version.py
@@ -1,4 +1,4 @@
 from __future__ import annotations
 
-__version__ = "5.9.2"
+__version__ = "5.9.3"
 __api_subversion__ = "V20220125"

--- a/cognite/client/data_classes/functions.py
+++ b/cognite/client/data_classes/functions.py
@@ -237,12 +237,12 @@ class FunctionSchedule(CogniteResource):
         self.session_id = session_id
         self._cognite_client = cast("CogniteClient", cognite_client)
 
-    def get_input_data(self) -> dict:
+    def get_input_data(self) -> Optional[dict]:
         """
         Retrieve the input data to the associated function.
 
         Returns:
-            Input data to the associated function. This data is passed
+            Input data to the associated function or None if not set. This data is passed
             deserialized into the function through the data argument.
         """
         return self._cognite_client.functions.schedules.get_input_data(id=self.id)

--- a/cognite/client/data_classes/functions.py
+++ b/cognite/client/data_classes/functions.py
@@ -242,7 +242,7 @@ class FunctionSchedule(CogniteResource):
         Retrieve the input data to the associated function.
 
         Returns:
-            Input data to the associated function or None if not set. This data is passed
+            Optional[Dict]: Input data to the associated function or None if not set. This data is passed
             deserialized into the function through the data argument.
         """
         return self._cognite_client.functions.schedules.get_input_data(id=self.id)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "cognite-sdk"
 
-version = "5.9.2"
+version = "5.9.3"
 
 description = "Cognite Python SDK"
 readme = "README.md"


### PR DESCRIPTION
## Description
From changelog:

## [5.9.2] - 26-03-23
### Fixed
- After creating a schedule for a function, the returned `FunctionSchedule` was missing a reference to the `CogniteClient`, meaning later calls to `.get_input_data()` would fail and raise `CogniteMissingClientError`.
- When calling `.get_input_data()` on a `FunctionSchedule` instance, it would fail and raise `KeyError` if no input data was specified for the schedule. This now returns `None`.

Also changes some URLs to actually use `_RESOURCE_PATH`.

Btw, weird that `data` can be missing when it is listed as required in the response on the official docs:

<img width="801" alt="image" src="https://user-images.githubusercontent.com/8521241/227749720-b132656c-bf5d-4585-9ee6-2474582ba235.png">


## Checklist:
- [ ] Tests added/updated.
- [x] Documentation updated. Documentation is generated from docstrings - these must be updated according to your change.
  If a new method has been added it should be referenced in [cognite.rst](https://github.com/cognitedata/cognite-sdk-python/blob/master/docs/source/cognite.rst) in order to generate docs based on its docstring.
- [x] Changelog updated in [CHANGELOG.md](https://github.com/cognitedata/cognite-sdk-python/blob/master/CHANGELOG.md).
- [x] Version bumped. If triggering a new release is desired, bump the version number in [_version.py](https://github.com/cognitedata/cognite-sdk-python/blob/master/cognite/client/_version.py) and [pyproject.toml](https://github.com/cognitedata/cognite-sdk-python/blob/master/pyproject.toml) per [semantic versioning](https://semver.org/).
