### PR TITLE
Bugfixes for `AssetList._retrieve_related_resources` convenience method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ Changes are grouped as follows
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
+## [5.9.2] - 20-03-23
+### Fixed
+- After calling e.g. `.time_series()` or `.events()` on an `AssetList` instance, the resulting resource list would be missing the lookup tables that allow for quick lookups by ID or external ID through the `.get()` method. Additionally, for future-proofing, the resulting resource list now also correctly has a `CogniteClient` reference.
+
 ## [5.9.1] - 20-03-23
 ### Fixed
 - `FunctionsAPI.call` now also works for clients using auth flow `OAuthInteractive`, `OAuthDeviceCode`, and any user-made subclass of `CredentialProvider`.

--- a/cognite/client/_version.py
+++ b/cognite/client/_version.py
@@ -1,4 +1,4 @@
 from __future__ import annotations
 
-__version__ = "5.9.1"
+__version__ = "5.9.2"
 __api_subversion__ = "V20220125"

--- a/cognite/client/data_classes/_base.py
+++ b/cognite/client/data_classes/_base.py
@@ -2,7 +2,21 @@ from __future__ import annotations
 
 import json
 from collections import UserList
-from typing import TYPE_CHECKING, Any, Collection, Dict, Generic, List, Optional, Sequence, Type, TypeVar, Union, cast
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Collection,
+    Dict,
+    Generic,
+    Iterable,
+    List,
+    Optional,
+    Sequence,
+    Type,
+    TypeVar,
+    Union,
+    cast,
+)
 
 from cognite.client import utils
 from cognite.client.exceptions import CogniteMissingClientError
@@ -212,6 +226,10 @@ class CogniteResourceList(UserList):
     def __str__(self) -> str:
         item = convert_time_attributes_to_datetime(self.dump())
         return json.dumps(item, default=utils._auxiliary.json_dump_default, indent=4)
+
+    def extend(self, other: Iterable[T_CogniteResource]) -> None:
+        # TODO: We inherit a lot from UserList that we don't actually support...
+        raise NotImplementedError
 
     def dump(self, camel_case: bool = False) -> List[Dict[str, Any]]:
         """Dump the instance into a json serializable Python data type.

--- a/cognite/client/data_classes/_base.py
+++ b/cognite/client/data_classes/_base.py
@@ -2,21 +2,7 @@ from __future__ import annotations
 
 import json
 from collections import UserList
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    Collection,
-    Dict,
-    Generic,
-    Iterable,
-    List,
-    Optional,
-    Sequence,
-    Type,
-    TypeVar,
-    Union,
-    cast,
-)
+from typing import TYPE_CHECKING, Any, Collection, Dict, Generic, List, Optional, Sequence, Type, TypeVar, Union, cast
 
 from cognite.client import utils
 from cognite.client.exceptions import CogniteMissingClientError
@@ -227,9 +213,15 @@ class CogniteResourceList(UserList):
         item = convert_time_attributes_to_datetime(self.dump())
         return json.dumps(item, default=utils._auxiliary.json_dump_default, indent=4)
 
-    def extend(self, other: Iterable[T_CogniteResource]) -> None:
-        # TODO: We inherit a lot from UserList that we don't actually support...
-        raise NotImplementedError
+    # TODO: We inherit a lot from UserList that we don't actually support...
+    def extend(self, other: Collection[Any]) -> None:  # type: ignore [override]
+        other_res_list = type(self)(other)  # See if we can accept the types
+        if set(self._id_to_item).isdisjoint(other_res_list._id_to_item):
+            super().extend(other)
+            self._external_id_to_item.update(other_res_list._external_id_to_item)
+            self._id_to_item.update(other_res_list._id_to_item)
+        else:
+            raise ValueError("Unable to extend as this would introduce duplicates")
 
     def dump(self, camel_case: bool = False) -> List[Dict[str, Any]]:
         """Dump the instance into a json serializable Python data type.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "cognite-sdk"
 
-version = "5.9.1"
+version = "5.9.2"
 
 description = "Cognite Python SDK"
 readme = "README.md"

--- a/tests/tests_unit/test_api/test_datapoints.py
+++ b/tests/tests_unit/test_api/test_datapoints.py
@@ -432,7 +432,7 @@ class TestDatapointsObject:
         res = Datapoints(id=1, timestamp=[1, 2, 3])._slice(slice(None, 1))
         assert [1] == res.timestamp
 
-    def test_extend(self, cognite_client):
+    def test__extend(self, cognite_client):  # test _extend, not extend
         d0 = Datapoints()
         d1 = Datapoints(id=1, external_id="1", timestamp=[1, 2, 3], value=[1, 2, 3])
         d2 = Datapoints(id=1, external_id="1", timestamp=[4, 5, 6], value=[4, 5, 6])

--- a/tests/tests_unit/test_base.py
+++ b/tests/tests_unit/test_base.py
@@ -250,8 +250,8 @@ class TestCogniteResourceList:
 
         expected = MyResourceList([MyResource(1, 2), MyResource(2, 3), MyResource(4, 5), MyResource(6, 7)])
         assert expected == resource_list
-        assert expected._id_to_item == resource_list._id_to_item
-        assert expected._external_id_to_item == resource_list._external_id_to_item
+        assert resource_list._id_to_item == {}
+        assert resource_list._external_id_to_item == {}
 
     def test_extend__with_identifiers(self):
         resource_list = MyResourceList([MyResource(id=1, external_id="2"), MyResource(id=2, external_id="3")])

--- a/tests/tests_unit/test_base.py
+++ b/tests/tests_unit/test_base.py
@@ -243,11 +243,38 @@ class TestCogniteResourceList:
         rl_sliced = rl[:]
         assert rl._cognite_client == rl_sliced._cognite_client
 
-    def test_extend(self):
+    def test_extend__no_identifiers(self):
         resource_list = MyResourceList([MyResource(1, 2), MyResource(2, 3)])
         another_resource_list = MyResourceList([MyResource(4, 5), MyResource(6, 7)])
         resource_list.extend(another_resource_list)
-        assert MyResourceList([MyResource(1, 2), MyResource(2, 3), MyResource(4, 5), MyResource(6, 7)]) == resource_list
+
+        expected = MyResourceList([MyResource(1, 2), MyResource(2, 3), MyResource(4, 5), MyResource(6, 7)])
+        assert expected == resource_list
+        assert expected._id_to_item == resource_list._id_to_item
+        assert expected._external_id_to_item == resource_list._external_id_to_item
+
+    def test_extend__with_identifiers(self):
+        resource_list = MyResourceList([MyResource(id=1, external_id="2"), MyResource(id=2, external_id="3")])
+        another_resource_list = MyResourceList([MyResource(id=4, external_id="5"), MyResource(id=6, external_id="7")])
+        resource_list.extend(another_resource_list)
+
+        expected = MyResourceList(
+            [
+                MyResource(id=1, external_id="2"),
+                MyResource(id=2, external_id="3"),
+                MyResource(id=4, external_id="5"),
+                MyResource(id=6, external_id="7"),
+            ]
+        )
+        assert expected == resource_list
+        assert expected._id_to_item == resource_list._id_to_item
+        assert expected._external_id_to_item == resource_list._external_id_to_item
+
+    def test_extend__fails_with_overlapping_identifiers(self):
+        resource_list = MyResourceList([MyResource(id=1), MyResource(id=2)])
+        another_resource_list = MyResourceList([MyResource(id=2), MyResource(id=6)])
+        with pytest.raises(ValueError, match="^Unable to extend as this would introduce duplicates$"):
+            resource_list.extend(another_resource_list)
 
     def test_len(self):
         resource_list = MyResourceList([MyResource(1, 2), MyResource(2, 3)])


### PR DESCRIPTION
## Description
The resource list that was returned after calling `.[time_series / events / files / ... etc]()` on an instance of `AssetList` was...

1. ...missing a `CogniteClient` reference (not a big deal yet, since neither of these have their own convenience methods).
2. ...missing the ID- and external ID lookup table, so `.get(...)` did not work.

This PR also changes:

- Makes use of the `split_into_chunks` convenience function.
- Instantiate only a single `CogniteResourceList` at the very end to ensure all lookups are built.
- ~~Disables future use of `extend` - at least until someone provides a working implementation that also updates the lookup tables~~
- Implemented `extend`.

## Checklist:
- [ ] Tests added/updated.
- [ ] Documentation updated. Documentation is generated from docstrings - these must be updated according to your change.
  If a new method has been added it should be referenced in [cognite.rst](https://github.com/cognitedata/cognite-sdk-python/blob/master/docs/source/cognite.rst) in order to generate docs based on its docstring.
- [x] Changelog updated in [CHANGELOG.md](https://github.com/cognitedata/cognite-sdk-python/blob/master/CHANGELOG.md).
- [x] Version bumped. If triggering a new release is desired, bump the version number in [_version.py](https://github.com/cognitedata/cognite-sdk-python/blob/master/cognite/client/_version.py) and [pyproject.toml](https://github.com/cognitedata/cognite-sdk-python/blob/master/pyproject.toml) per [semantic versioning](https://semver.org/).
