### PR TITLE
Function schedule add missing field `when`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ Changes are grouped as follows
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
+## [5.10.1] - 04-04-23
+### Fixed
+- Add missing field `when` (human readable version of the CRON expression) to `FunctionSchedule` class.
+
 ## [5.10.0] - 03-04-23
 ### Fixed
 - Implemented automatic retries for connection errors by default, improving the reliability of the connection to the Cognite API.

--- a/cognite/client/_version.py
+++ b/cognite/client/_version.py
@@ -1,4 +1,4 @@
 from __future__ import annotations
 
-__version__ = "5.10.0"
+__version__ = "5.10.1"
 __api_subversion__ = "V20220125"

--- a/cognite/client/data_classes/functions.py
+++ b/cognite/client/data_classes/functions.py
@@ -212,6 +212,7 @@ class FunctionSchedule(CogniteResource):
         cron_expression (str): Cron expression
         created_time (int): The number of milliseconds since 00:00:00 Thursday, 1 January 1970, Coordinated Universal Time (UTC), minus leap seconds.
         session_id (int): ID of the session running with the schedule.
+        when (str): When the schedule will trigger, in human readable text (server generated from cron_expression).
         cognite_client (CogniteClient): An optional CogniteClient to associate with this data class.
     """
 
@@ -225,6 +226,7 @@ class FunctionSchedule(CogniteResource):
         created_time: int = None,
         cron_expression: str = None,
         session_id: int = None,
+        when: str = None,
         cognite_client: CogniteClient = None,
     ) -> None:
         self.id = id
@@ -235,6 +237,7 @@ class FunctionSchedule(CogniteResource):
         self.cron_expression = cron_expression
         self.created_time = created_time
         self.session_id = session_id
+        self.when = when
         self._cognite_client = cast("CogniteClient", cognite_client)
 
     def get_input_data(self) -> Optional[dict]:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "cognite-sdk"
 
-version = "5.10.0"
+version = "5.10.1"
 
 description = "Cognite Python SDK"
 readme = "README.md"

--- a/tests/tests_unit/test_api/test_functions.py
+++ b/tests/tests_unit/test_api/test_functions.py
@@ -884,7 +884,6 @@ class TestFunctionSchedulesAPI:
         assert isinstance(res, FunctionSchedule)
         assert res._cognite_client is cognite_client  # make sure the created schedule has client ref
         expected = mock_function_schedules_response.calls[0].response.json()["items"][0]
-        expected.pop("when")
         assert expected == res.dump(camel_case=True)
 
     def test_create_schedules_with_function_id_and_client_credentials(
@@ -900,7 +899,6 @@ class TestFunctionSchedulesAPI:
 
         assert isinstance(res, FunctionSchedule)
         expected = mock_function_schedules_response_oidc_client_credentials.calls[1].response.json()["items"][0]
-        expected.pop("when")
         assert expected == res.dump(camel_case=True)
 
     def test_create_schedules_with_function_external_id_and_client_credentials_raises(self, cognite_client):
@@ -935,7 +933,6 @@ class TestFunctionSchedulesAPI:
         )
         assert isinstance(res, FunctionSchedule)
         expected = mock_function_schedules_response.calls[0].response.json()["items"][0]
-        expected.pop("when")
         assert expected == res.dump(camel_case=True)
 
     def test_delete_schedules(self, mock_function_schedules_delete_response, cognite_client):

--- a/tests/tests_unit/test_api/test_functions.py
+++ b/tests/tests_unit/test_api/test_functions.py
@@ -855,14 +855,12 @@ class TestFunctionSchedulesAPI:
         res = cognite_client.functions.schedules.retrieve(id=SCHEDULE_WITH_FUNCTION_EXTERNAL_ID["id"])
         assert isinstance(res, FunctionSchedule)
         expected = mock_function_schedules_retrieve_response.calls[0].response.json()["items"][0]
-        expected.pop("when")
         assert expected == res.dump(camel_case=True)
 
     def test_list_schedules(self, mock_filter_function_schedules_response, cognite_client):
         res = cognite_client.functions.schedules.list()
         assert isinstance(res, FunctionSchedulesList)
         expected = mock_filter_function_schedules_response.calls[0].response.json()["items"]
-        expected[0].pop("when")
         assert expected == res.dump(camel_case=True)
 
     def test_list_schedules_with_limit(self, mock_filter_function_schedules_response, cognite_client):


### PR DESCRIPTION
## Description
- Add missing field `when` (human readable version of the CRON expression) to `FunctionSchedule` class.

## Checklist:
- [x] Tests added/updated.
- [x] Documentation updated. Documentation is generated from docstrings - these must be updated according to your change.
  If a new method has been added it should be referenced in [cognite.rst](https://github.com/cognitedata/cognite-sdk-python/blob/master/docs/source/cognite.rst) in order to generate docs based on its docstring.
- [x] Changelog updated in [CHANGELOG.md](https://github.com/cognitedata/cognite-sdk-python/blob/master/CHANGELOG.md).
- [x] Version bumped. If triggering a new release is desired, bump the version number in [_version.py](https://github.com/cognitedata/cognite-sdk-python/blob/master/cognite/client/_version.py) and [pyproject.toml](https://github.com/cognitedata/cognite-sdk-python/blob/master/pyproject.toml) per [semantic versioning](https://semver.org/).
