### PR TITLE
Data Model Centric destination type Tested and deployed

### DIFF
--- a/cognite/client/data_classes/transformations/__init__.py
+++ b/cognite/client/data_classes/transformations/__init__.py
@@ -102,6 +102,7 @@ class Transformation(CogniteResource):
         destination_nonce (NonceCredentials): Single use credentials to bind to a CDF session for writing.
         source_session (SessionDetails): Details for the session used to read from the source project.
         destination_session (SessionDetails): Details for the session used to write to the destination project.
+        dataModel: The data model centric destination type in transformation
     """
 
     def __init__(
@@ -137,6 +138,7 @@ class Transformation(CogniteResource):
         source_session: Optional[SessionDetails] = None,
         destination_session: Optional[SessionDetails] = None,
         tags: Optional[List[str]] = None,
+        dataModel: TransformationDestination = None,
     ):
         self.id = id
         self.external_id = external_id
@@ -171,6 +173,7 @@ class Transformation(CogniteResource):
         self.destination_session = destination_session
         self.tags = tags
         self._cognite_client = cast("CogniteClient", cognite_client)
+        self.dataModel =dataModel
 
     def copy(self) -> Transformation:
         return Transformation(
@@ -205,6 +208,7 @@ class Transformation(CogniteResource):
             self.source_session,
             self.destination_session,
             self.tags,
+            self.dataModel,
         )
 
     def _process_credentials(self, sessions_cache: Dict[str, NonceCredentials] = None, keep_none: bool = False) -> None:
@@ -400,6 +404,7 @@ class TransformationUpdate(CogniteUpdate):
     @property
     def tags(self) -> _ListTransformationUpdate:
         return TransformationUpdate._ListTransformationUpdate(self, "tags")
+
 
     def dump(self, camel_case: bool = True) -> Dict[str, Any]:
         obj = super().dump()

--- a/cognite/client/data_classes/transformations/common.py
+++ b/cognite/client/data_classes/transformations/common.py
@@ -163,6 +163,18 @@ class TransformationDestination:
         """
         return InstanceEdges(view=view, instance_space=instance_space, edge_type=edge_type)
 
+    @staticmethod
+    def instance_instances(dataModel: Optional[DataModelInfo] = None, instance_space: Optional[str] = None) -> InstanceInstances:
+        """To be used when the transformation is meant to produce data model's instances.
+            Flexible Data Models resource type is on `beta` version currently.
+
+        Args:
+            dataModel (DataModelInfo): information of the data model.
+            instance_space (str): space id of the instance.
+        Returns:
+            InstanceInstances: pointing to the target flexible data model.
+        """
+        return InstanceInstances(dataModel=dataModel, instance_space=instance_space)
 
 class RawTable(TransformationDestination):
     def __init__(self, database: str = None, table: str = None):
@@ -225,6 +237,19 @@ class EdgeType:
     def dump(self, camel_case: bool = False) -> Dict[str, Any]:
         return basic_obj_dump(self, camel_case)
 
+class DataModelInfo:
+    def __init__(self, space: str, external_id: str, version: str, destinationType: str, destinationRelationshipFromType: Optional[str]):
+        self.space = space
+        self.external_id = external_id
+        self.version = version
+        self.destinationType =destinationType
+        self.destinationRelationshipFromType =destinationRelationshipFromType
+
+    def __hash__(self) -> int:
+        return hash((self.space, self.external_id, self.version))
+
+    def dump(self, camel_case: bool = False) -> Dict[str, Any]:
+        return basic_obj_dump(self, camel_case)
 
 class InstanceNodes(TransformationDestination):
     def __init__(
@@ -275,6 +300,27 @@ class InstanceEdges(TransformationDestination):
             inst.edge_type = EdgeType(**convert_all_keys_to_snake_case(inst.edge_type))
         return inst
 
+class InstanceInstances(TransformationDestination):
+    def __init__(
+        self,
+        dataModel: Optional[DataModelInfo] = None,
+        instance_space: Optional[str] = None,
+    ):
+        warnings.warn(
+            "Feature DataModelStorage is in beta and still in development. "
+            "Breaking changes can happen in between patch versions.",
+            stacklevel=2,
+        )
+        super().__init__(type="instances")
+        self.dataModel = dataModel
+        self.instance_space = instance_space
+
+    @classmethod
+    def _load(cls, resource: Dict[str, Any]) -> InstanceInstances:
+        inst = cls(**resource)
+        if isinstance(inst.dataModel, dict):
+            inst.dataModel = DataModelInfo(**convert_all_keys_to_snake_case(inst.dataModel))
+        return inst
 
 class OidcCredentials:
     def __init__(
@@ -344,7 +390,7 @@ class TransformationBlockedInfo:
 
 def _load_destination_dct(
     dct: Dict[str, Any]
-) -> Union[RawTable, DataModelInstances, InstanceNodes, InstanceEdges, SequenceRows, TransformationDestination]:
+) -> Union[RawTable, DataModelInstances, InstanceNodes, InstanceEdges, InstanceInstances, SequenceRows, TransformationDestination]:
     """Helper function to load destination from dictionary"""
     snake_dict = convert_all_keys_to_snake_case(dct)
     destination_type = snake_dict.pop("type")
@@ -356,9 +402,10 @@ def _load_destination_dct(
     if destination_type in simple:
         return simple[destination_type](**snake_dict)
 
-    nested: Dict[str, Union[type[InstanceNodes], type[InstanceEdges]]] = {
+    nested: Dict[str, Union[type[InstanceNodes], type[InstanceEdges], type[InstanceInstances]]] = {
         "nodes": InstanceNodes,
         "edges": InstanceEdges,
+        "instances": InstanceInstances,
     }
     if destination_type in nested:
         return nested[destination_type]._load(snake_dict)

--- a/tests/tests_integration/test_api/test_transformations/test_transformations.py
+++ b/tests/tests_integration/test_api/test_transformations/test_transformations.py
@@ -16,12 +16,11 @@ from cognite.client.data_classes.transformations.common import (
     EdgeType,
     InstanceEdges,
     InstanceNodes,
-    InstanceInstances,
+    DataModelCentricDestination,
     NonceCredentials,
     OidcCredentials,
     SequenceRows,
     ViewInfo,
-    DataModelInfo,
 )
 from cognite.client.utils._text import random_string
 
@@ -228,33 +227,39 @@ class TestTransformationsAPI:
 
         cognite_client.transformations.delete(id=ts.id)
 
-    def test_create_instance_instances_transformation(self, cognite_client):
+    def test_create_datalmodel_centric_destination_transformation(self, cognite_client):
         prefix = random_string(6, string.ascii_letters)
-        instance_instances = TransformationDestination.instance_instances(
-            dataModel=DataModelInfo(
-                space="test-space", external_id="testInstanceDataModelExternalId", version="testInstanceDataModelVersion", destinationType="TestViewExternalId",  destinationRelationshipFromType="PropertyIdentiferIdDestinationType"
-            ),
-            instance_space="test-space",
+        destination  = DataModelCentricDestination(
+            space="DataModelSpace",
+            external_id="MyDataModel",
+            version="v1",
+            destination_type="Equipment",
+            destination_relationship_from_type ="Property Identifer in destinationType",
+            instance_space="MyInstanceSpace",
         )
         transform = Transformation(
             name="any",
             external_id=f"{prefix}-transformation",
-            destination=instance_instances,
+            dataModel=destination,
         )
+
         ts = cognite_client.transformations.create(transform)
-        assert isinstance(ts.destination, InstanceInstances)
-        assert ts.destination.type == "instances"
 
-        assert isinstance(ts.destination.dataModel, DataModelInfo)
-        assert ts.destination.dataModel.space == "test-space"
-        assert ts.destination.dataModel.external_id == "testInstanceDataModelExternalId"
-        assert ts.destination.dataModel.version == "testInstanceDataModelVersion"
-        assert ts.destination.dataModel.destinationType == "TestViewExternalId"
-        assert ts.destination.dataModel.destinationRelationshipFromType == "PropertyIdentiferIdDestinationType"
+        assert isinstance(destination, DataModelCentricDestination)
+        # Check if the type attribute is set correctly
+        assert destination.type == "instances"
 
-        assert ts.destination.instance_space == "test-space"
+        # Check if the dataModel attribute contains the expected values
+        assert destination.dataModel["space"] == "DataModelSpace"
+        assert destination.dataModel["externalId"] == "MyDataModel"
+        assert destination.dataModel["version"] == "v1"
+        assert destination.dataModel["destinationType"] == "Equipment"
+        assert destination.dataModel["destinationRelationshipFromType"] == "Property Identifer in destinationType"
 
+        # Check if the instanceSpace attribute is set correctly
+        assert destination.instanceSpace == "MyInstanceSpace"
         cognite_client.transformations.delete(id=ts.id)
+
 
     def test_create_sequence_rows_transformation(self, cognite_client):
         prefix = random_string(6, string.ascii_letters)
@@ -442,24 +447,6 @@ class TestTransformationsAPI:
             None,
             "test-space",
             EdgeType("edge-space2", "myEdge2"),
-        )
-
-    def test_update_instance_instances(self, cognite_client, new_transformation):
-        new_transformation.destination = TransformationDestination.instance_instances(
-            DataModelInfo("MyDataModelExternalId", "myDataModelVersion", "test-space", "MyyDestinationType", "MyDestinationTypeIdentifer"), "test-space"
-        )
-        partial_update = TransformationUpdate(id=new_transformation.id).destination.set(
-            TransformationDestination.instance_nodes(
-                DataModelInfo("MyDataModelExternalId", "myDataModelVersion2", "test-space", "MyyDestinationType", "MyDestinationTypeIdentifer"), "test-space"
-            )
-        )
-        updated_transformation = cognite_client.transformations.update(new_transformation)
-        assert updated_transformation.destination == TransformationDestination.instance_instances(
-            DataModelInfo("MyDataModelExternalId", "myDataModelVersion", "test-space", "MyyDestinationType", "MyDestinationTypeIdentifer"), "test-space"
-        )
-        partial_updated = cognite_client.transformations.update(partial_update)
-        assert partial_updated.destination == TransformationDestination.instance_instances(
-            DataModelInfo("MyDataModelExternalId", "myDataModelVersion2", "test-space", "MyyDestinationType", "MyDestinationTypeIdentifer"), "test-space"
         )
 
     def test_update_sequence_rows_update(self, cognite_client, new_transformation):


### PR DESCRIPTION
## Description
Data Model Centric destination type in transformations

## Checklist:
- defined dataModel resiource in thee Transformation class in the cognite/client/data_classes/transformations/__init__.py

Line 141
Line 176

```
class Transformation(CogniteResource):
        def __init__(
...
dataModel: TransformationDestination = None,
);
self.dataModel =dataModel

```
- Defined DataModelCentricDestination class in common.py

Line 228 -248
```
class DataModelCentricDestination(TransformationDestination):
    def __init__(self, space: str, external_id: str, version: str, destination_type: str, destination_relationship_from_type: str = None, instance_space: str = None):
        super().__init__()
        self.type = "instances"
        self.dataModel = {
            "space": space,
            "externalId": external_id,
            "version": version,
            "destinationType": destination_type,
        }
        if destination_relationship_from_type:
            self.dataModel["destinationRelationshipFromType"] = destination_relationship_from_type
        if instance_space:
            self.instanceSpace = instance_space


    def __hash__(self) -> int:
        return hash((self.space, self.external_id, self.version, self.destination_type, self.destination_relationship_from_type ))

    def dump(self, camel_case: bool = False) -> Dict[str, Any]:
        return basic_obj_dump(self, camel_case)
```
- Test/transformation.py

Line 230-261

```
    def test_create_datalmodel_centric_destination_transformation(self, cognite_client):
        prefix = random_string(6, string.ascii_letters)
        destination  = DataModelCentricDestination(
            space="DataModelSpace",
            external_id="MyDataModel",
            version="v1",
            destination_type="Equipment",
            destination_relationship_from_type ="Property Identifer in destinationType",
            instance_space="MyInstanceSpace",
        )
        transform = Transformation(
            name="any",
            external_id=f"{prefix}-transformation",
            dataModel=destination,
        )

        ts = cognite_client.transformations.create(transform)

        assert isinstance(destination, DataModelCentricDestination)
        # Check if the type attribute is set correctly
        assert destination.type == "instances"

        # Check if the dataModel attribute contains the expected values
        assert destination.dataModel["space"] == "DataModelSpace"
        assert destination.dataModel["externalId"] == "MyDataModel"
        assert destination.dataModel["version"] == "v1"
        assert destination.dataModel["destinationType"] == "Equipment"
        assert destination.dataModel["destinationRelationshipFromType"] == "Property Identifer in destinationType"

        # Check if the instanceSpace attribute is set correctly
        assert destination.instanceSpace == "MyInstanceSpace"
        cognite_client.transformations.delete(id=ts.id)
```

test_transformations.py::TestTransformationsAPI::test_create_datalmodel_centric_destination_transformation  Test Passed
