### PR TITLE
Add missing nullable int columns in `to_pandas`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ Changes are grouped as follows
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
+## [5.10.4] - 13-04-23
+### Fixed
+- A lot of nullable integer attributes ended up as float after calling `.to_pandas`. These are now correctly converted to `dtype=Int64`.
+
 ## [5.10.3] - 13-04-23
 ### Fixed
 - When passing `CogniteResource` classes (like `Asset` or `Event`) to `update`, any labels were skipped in the update (passing `AssetUpdate` works). This has been fixed for all Cognite resource classes.

--- a/cognite/client/_version.py
+++ b/cognite/client/_version.py
@@ -1,4 +1,4 @@
 from __future__ import annotations
 
-__version__ = "5.10.3"
+__version__ = "5.10.4"
 __api_subversion__ = "V20220125"

--- a/cognite/client/data_classes/_base.py
+++ b/cognite/client/data_classes/_base.py
@@ -7,8 +7,8 @@ from typing import TYPE_CHECKING, Any, Collection, Dict, Generic, List, Optional
 from cognite.client import utils
 from cognite.client.exceptions import CogniteMissingClientError
 from cognite.client.utils._identifier import IdentifierSequence
-from cognite.client.utils._pandas_helpers import notebook_display_with_fallback
-from cognite.client.utils._text import convert_all_keys_to_camel_case, to_camel_case, to_snake_case
+from cognite.client.utils._pandas_helpers import convert_nullable_int_cols, notebook_display_with_fallback
+from cognite.client.utils._text import convert_all_keys_to_camel_case, to_snake_case
 from cognite.client.utils._time import convert_time_attributes_to_datetime
 
 if TYPE_CHECKING:
@@ -257,13 +257,7 @@ class CogniteResourceList(UserList):
         """
         pd = cast(Any, utils._auxiliary.local_import("pandas"))
         df = pd.DataFrame(self.dump(camel_case=camel_case))
-        nullable_int_cols = ["start_time", "end_time", "asset_id", "parent_id", "data_set_id"]
-        if camel_case:
-            nullable_int_cols = list(map(to_camel_case, nullable_int_cols))
-
-        to_convert = df.columns.intersection(nullable_int_cols)
-        df[to_convert] = df[to_convert].astype("Int64")
-        return df
+        return convert_nullable_int_cols(df, camel_case)
 
     def _repr_html_(self) -> str:
         return notebook_display_with_fallback(self)

--- a/cognite/client/data_classes/sequences.py
+++ b/cognite/client/data_classes/sequences.py
@@ -411,7 +411,7 @@ class SequenceData(CogniteResource):
             column_names.format(id=str(self.id), externalId=str(self.external_id), columnExternalId=eid)
             for eid in self.column_external_ids
         ]
-
+        # TODO: Optimization required (None/nan):
         return pd.DataFrame(  # type: ignore
             [[x if x is not None else math.nan for x in r] for r in self.values],
             index=self.row_numbers,

--- a/cognite/client/utils/_pandas_helpers.py
+++ b/cognite/client/utils/_pandas_helpers.py
@@ -17,7 +17,7 @@ if TYPE_CHECKING:
     from cognite.client.data_classes._base import T_CogniteResource, T_CogniteResourceList
 
 
-NULLABLE_INT_COLS = [
+NULLABLE_INT_COLS = {
     "start_time",
     "end_time",
     "asset_id",
@@ -32,8 +32,8 @@ NULLABLE_INT_COLS = [
     "last_seen",
     "last_seen_time",
     "last_updated_time",
-]
-NULLABLE_INT_COLS_CC = list(map(to_camel_case, NULLABLE_INT_COLS))
+}
+NULLABLE_INT_COLS_CC = set(map(to_camel_case, NULLABLE_INT_COLS))
 
 
 def pandas_major_version() -> int:

--- a/cognite/client/utils/_pandas_helpers.py
+++ b/cognite/client/utils/_pandas_helpers.py
@@ -33,7 +33,7 @@ NULLABLE_INT_COLS = {
     "last_seen_time",
     "last_updated_time",
 }
-NULLABLE_INT_COLS_CC = set(map(to_camel_case, NULLABLE_INT_COLS))
+NULLABLE_INT_COLS_CAMEL_CASE = set(map(to_camel_case, NULLABLE_INT_COLS))
 
 
 def pandas_major_version() -> int:
@@ -58,7 +58,7 @@ def notebook_display_with_fallback(inst: Union[T_CogniteResource, T_CogniteResou
 
 
 def convert_nullable_int_cols(df: pd.DataFrame, camel_case: bool) -> pd.DataFrame:
-    cols = {True: NULLABLE_INT_COLS_CC, False: NULLABLE_INT_COLS}[camel_case]
+    cols = {True: NULLABLE_INT_COLS_CAMEL_CASE, False: NULLABLE_INT_COLS}[camel_case]
     to_convert = df.columns.intersection(cols)
     df[to_convert] = df[to_convert].astype("Int64")
     return df

--- a/cognite/client/utils/_pandas_helpers.py
+++ b/cognite/client/utils/_pandas_helpers.py
@@ -9,11 +9,31 @@ from typing import TYPE_CHECKING, Any, Sequence, Union, cast
 
 from cognite.client.exceptions import CogniteImportError
 from cognite.client.utils._auxiliary import local_import
+from cognite.client.utils._text import to_camel_case
 
 if TYPE_CHECKING:
     import pandas as pd
 
     from cognite.client.data_classes._base import T_CogniteResource, T_CogniteResourceList
+
+
+NULLABLE_INT_COLS = [
+    "start_time",
+    "end_time",
+    "asset_id",
+    "parent_id",
+    "data_set_id",
+    "scheduled_time",
+    "schedule_id",
+    "session_id",
+    "deleted_time",
+    "last_success",
+    "last_failure",
+    "last_seen",
+    "last_seen_time",
+    "last_updated_time",
+]
+NULLABLE_INT_COLS_CC = list(map(to_camel_case, NULLABLE_INT_COLS))
 
 
 def pandas_major_version() -> int:
@@ -35,6 +55,13 @@ def notebook_display_with_fallback(inst: Union[T_CogniteResource, T_CogniteResou
             UserWarning,
         )
         return str(inst)
+
+
+def convert_nullable_int_cols(df: pd.DataFrame, camel_case: bool) -> pd.DataFrame:
+    cols = {True: NULLABLE_INT_COLS_CC, False: NULLABLE_INT_COLS}[camel_case]
+    to_convert = df.columns.intersection(cols)
+    df[to_convert] = df[to_convert].astype("Int64")
+    return df
 
 
 def concat_dataframes_with_nullable_int_cols(dfs: Sequence[pd.DataFrame]) -> pd.DataFrame:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "cognite-sdk"
 
-version = "5.10.3"
+version = "5.10.4"
 
 description = "Cognite Python SDK"
 readme = "README.md"


### PR DESCRIPTION
## Description
Quite a lot of nullable int columns were missing. This attempts to add all of them (while not touching ones like `id` which should always have a value (in the API response), except when the user instantiates them).

### Note
I'm not adding changelog entry & bumping version before this has been approved and is ready to merge to avoid the _never-ending merge conflicts with these three files_.