### PR TITLE
[DEGR-1898] Remove API-key support for cognite functions

### DIFF
--- a/cognite/client/_api/functions.py
+++ b/cognite/client/_api/functions.py
@@ -91,7 +91,6 @@ class FunctionsAPI(APIClient):
         external_id: Optional[str] = None,
         description: Optional[str] = "",
         owner: Optional[str] = "",
-        api_key: Optional[str] = None,
         secrets: Optional[Dict] = None,
         env_vars: Optional[Dict] = None,
         cpu: Optional[Number] = None,
@@ -109,7 +108,6 @@ class FunctionsAPI(APIClient):
 
         The function named `handle` is the entrypoint of the created function. Valid arguments to `handle` are `data`, `client`, `secrets` and `function_call_info`:\n
         - If the user calls the function with input data, this is passed through the `data` argument.\n
-        - If the user gives an `api_key` when creating the function, a pre instantiated CogniteClient is passed through the `client` argument.\n
         - If the user gives one or more secrets when creating the function, these are passed through the `secrets` argument. The API key can be access through `secrets["apikey"]`.\n
         - Data about the function call can be accessed via the argument `function_call_info`, which is a dictionary with keys `function_id` and, if the call is scheduled, `schedule_id` and `scheduled_time`.\n
 
@@ -122,7 +120,6 @@ class FunctionsAPI(APIClient):
             external_id (str, optional):             External id of the function.
             description (str, optional):             Description of the function.
             owner (str, optional):                   Owner of this function. Typically used to know who created it.
-            api_key (str, optional):                 API key that can be used inside the function to access data in CDF.
             secrets (Dict[str, str]):                Additional secrets as key/value pairs. These can e.g. password to simulators or other data sources. Keys must be lowercase characters, numbers or dashes (-) and at most 15 characters. You can create at most 30 secrets, all keys must be unique, and cannot be apikey.
             env_vars (Dict[str, str]):               Environment variables as key/value pairs. Keys can contain only letters, numbers or the underscore character. You can create at most 100 environment variables.
             cpu (Number, optional):                  Number of CPU cores per function. Allowed values are in the range [0.1, 0.6], and None translates to the API default which is 0.25 in GCP. The argument is unavailable in Azure.
@@ -212,8 +209,6 @@ class FunctionsAPI(APIClient):
             function["runtime"] = runtime
         if external_id:
             function["externalId"] = external_id
-        if api_key:
-            function["apiKey"] = api_key
         if secrets:
             function["secrets"] = secrets
         if extra_index_urls:

--- a/cognite/client/data_classes/functions.py
+++ b/cognite/client/data_classes/functions.py
@@ -26,7 +26,6 @@ class Function(CogniteResource):
         file_id (int): File id of the code represented by this object.
         function_path (str): Relative path from the root folder to the file containing the `handle` function. Defaults to `handler.py`. Must be on posix path format.
         created_time (int): Created time in UNIX.
-        api_key (str): Api key attached to the function.
         secrets (Dict[str, str]): Secrets attached to the function ((key, value) pairs).
         env_vars (Dict[str, str]): User specified environment variables on the function ((key, value) pairs).
         cpu (Number): Number of CPU cores per function. Defaults to 0.25. Allowed values are in the range [0.1, 0.6].
@@ -49,7 +48,6 @@ class Function(CogniteResource):
         file_id: int = None,
         function_path: str = None,
         created_time: int = None,
-        api_key: str = None,
         secrets: Dict = None,
         env_vars: Dict = None,
         cpu: Number = None,
@@ -69,7 +67,6 @@ class Function(CogniteResource):
         self.file_id = file_id
         self.function_path = function_path
         self.created_time = created_time
-        self.api_key = api_key
         self.secrets = secrets
         self.env_vars = env_vars
         self.cpu = cpu

--- a/tests/tests_unit/test_api/test_functions.py
+++ b/tests/tests_unit/test_api/test_functions.py
@@ -68,7 +68,6 @@ EXAMPLE_FUNCTION = {
     "fileId": 1234,
     "functionPath": "handler.py",
     "createdTime": 1585662507939,
-    "apiKey": "***",
     "secrets": {"key1": "***", "key2": "***"},
     "envVars": {"env1": "foo", "env2": "bar"},
     "cpu": 0.25,
@@ -119,7 +118,8 @@ CALL_SCHEDULED = {
 
 @pytest.fixture
 def mock_sessions_with_client_credentials(rsps, cognite_client_with_client_credentials_flow):
-    url = full_url(cognite_client_with_client_credentials_flow, "/sessions", api="iam.sessions")
+    url = full_url(cognite_client_with_client_credentials_flow,
+                   "/sessions", api="iam.sessions")
 
     creds = cognite_client_with_client_credentials_flow.config.credentials
     assert isinstance(creds, OAuthClientCredentials)
@@ -129,7 +129,8 @@ def mock_sessions_with_client_credentials(rsps, cognite_client_with_client_crede
         url=url,
         status=200,
         json={"items": [{"nonce": "aabbccdd"}]},
-        match=[post_body_matcher({"items": [{"clientId": creds.client_id, "clientSecret": creds.client_secret}]})],
+        match=[post_body_matcher(
+            {"items": [{"clientId": creds.client_id, "clientSecret": creds.client_secret}]})],
     )
 
     return rsps
@@ -188,9 +189,11 @@ def mock_functions_create_response(rsps, cognite_client):
 
     rsps.add(rsps.POST, files_url, status=201, json=files_response_body)
     rsps.add(rsps.PUT, "https://upload.here", status=201)
-    rsps.add(rsps.POST, files_byids_url, status=201, json={"items": [files_response_body]})
+    rsps.add(rsps.POST, files_byids_url, status=201,
+             json={"items": [files_response_body]})
     functions_url = full_url(cognite_client, "/functions")
-    rsps.add(rsps.POST, functions_url, status=201, json={"items": [EXAMPLE_FUNCTION]})
+    rsps.add(rsps.POST, functions_url, status=201,
+             json={"items": [EXAMPLE_FUNCTION]})
 
     yield rsps
 
@@ -208,7 +211,8 @@ def mock_file_not_uploaded(rsps, cognite_client):
 
     files_byids_url = full_url(cognite_client, "/files/byids", api="files")
 
-    rsps.add(rsps.POST, files_byids_url, status=201, json={"items": [files_response_body]})
+    rsps.add(rsps.POST, files_byids_url, status=201,
+             json={"items": [files_response_body]})
     yield rsps
 
 
@@ -308,7 +312,8 @@ def cognite_client_with_client_credentials_flow(rsps):
         rsps.POST,
         "https://bla",
         status=200,
-        json={"access_token": "abc", "expires_at": datetime.now().timestamp() + 1000},
+        json={"access_token": "abc",
+              "expires_at": datetime.now().timestamp() + 1000},
     )
     return CogniteClient(
         ClientConfig(
@@ -382,7 +387,8 @@ def mock_file_create_response(rsps, cognite_client):
         "lastUpdatedTime": 0,
         "uploadUrl": "https://upload.here",
     }
-    rsps.add(rsps.POST, full_url(cognite_client, "/files", api="files"), status=200, json=response_body)
+    rsps.add(rsps.POST, full_url(cognite_client, "/files",
+             api="files"), status=200, json=response_body)
     rsps.add(rsps.PUT, "https://upload.here", status=200, json=response_body)
     yield rsps
 
@@ -396,13 +402,15 @@ class TestFunctionsAPI:
             ("bad_function_code", "handler.py", FileNotFoundError),
             ("bad_function_code2", "handler.py", TypeError),
             ("./good_absolute_import/", "my_functions/handler.py", None),
-            ("bad_absolute_import", "extra_root_folder/my_functions/handler.py", ModuleNotFoundError),
+            ("bad_absolute_import",
+             "extra_root_folder/my_functions/handler.py", ModuleNotFoundError),
             ("relative_imports", "my_functions/good_relative_import.py", None),
             ("relative_imports", "bad_relative_import.py", ImportError),
         ],
     )
     def test_validate_folder(self, function_folder, function_path, exception):
-        folder = os.path.join(os.path.dirname(__file__), "function_test_resources", function_folder)
+        folder = os.path.join(os.path.dirname(__file__),
+                              "function_test_resources", function_folder)
         if exception is None:
             validate_function_folder(folder, function_path)
         else:
@@ -418,7 +426,8 @@ class TestFunctionsAPI:
     )
     @pytest.mark.usefixtures("mock_file_create_response")
     def test_zip_and_upload_folder(self, function_folder, function_name, exception, cognite_client):
-        folder = os.path.join(os.path.dirname(__file__), "function_test_resources", function_folder)
+        folder = os.path.join(os.path.dirname(__file__),
+                              "function_test_resources", function_folder)
         cognite_client.functions._zip_and_upload_folder(folder, function_name)
 
     @patch("cognite.client._api.functions.MAX_RETRIES", 1)
@@ -427,39 +436,48 @@ class TestFunctionsAPI:
             cognite_client.functions.create(name="myfunction", file_id=123)
 
     def test_create_with_path(self, mock_functions_create_response, cognite_client):
-        folder = os.path.join(os.path.dirname(__file__), "function_test_resources", "function_code")
-        res = cognite_client.functions.create(name="myfunction", folder=folder, function_path="handler.py")
+        folder = os.path.join(os.path.dirname(__file__),
+                              "function_test_resources", "function_code")
+        res = cognite_client.functions.create(
+            name="myfunction", folder=folder, function_path="handler.py")
 
         assert isinstance(res, Function)
-        assert mock_functions_create_response.calls[3].response.json()["items"][0] == res.dump(camel_case=True)
+        assert mock_functions_create_response.calls[3].response.json()[
+            "items"][0] == res.dump(camel_case=True)
 
     def test_create_with_file_id(self, mock_functions_create_response, cognite_client):
         res = cognite_client.functions.create(name="myfunction", file_id=1234)
 
         assert isinstance(res, Function)
-        assert mock_functions_create_response.calls[1].response.json()["items"][0] == res.dump(camel_case=True)
+        assert mock_functions_create_response.calls[1].response.json()[
+            "items"][0] == res.dump(camel_case=True)
 
     def test_create_with_function_handle(self, mock_functions_create_response, function_handle, cognite_client):
-        res = cognite_client.functions.create(name="myfunction", function_handle=function_handle)
+        res = cognite_client.functions.create(
+            name="myfunction", function_handle=function_handle)
 
         assert isinstance(res, Function)
-        assert mock_functions_create_response.calls[3].response.json()["items"][0] == res.dump(camel_case=True)
+        assert mock_functions_create_response.calls[3].response.json()[
+            "items"][0] == res.dump(camel_case=True)
 
     def test_create_with_function_handle_with_illegal_name_raises(self, function_handle_illegal_name, cognite_client):
         with pytest.raises(TypeError):
-            cognite_client.functions.create(name="myfunction", function_handle=function_handle_illegal_name)
+            cognite_client.functions.create(
+                name="myfunction", function_handle=function_handle_illegal_name)
 
     def test_create_with_function_handle_with_illegal_argument_raises(
         self, function_handle_illegal_argument, cognite_client
     ):
         with pytest.raises(TypeError):
-            cognite_client.functions.create(name="myfunction", function_handle=function_handle_illegal_argument)
+            cognite_client.functions.create(
+                name="myfunction", function_handle=function_handle_illegal_argument)
 
     def test_create_with_handle_function_and_file_id_raises(
         self, mock_functions_create_response, function_handle, cognite_client
     ):
         with pytest.raises(TypeError):
-            cognite_client.functions.create(name="myfunction", function_handle=function_handle, file_id=1234)
+            cognite_client.functions.create(
+                name="myfunction", function_handle=function_handle, file_id=1234)
 
     def test_create_with_path_and_file_id_raises(self, mock_functions_create_response, cognite_client):
         with pytest.raises(TypeError):
@@ -468,29 +486,36 @@ class TestFunctionsAPI:
             )
 
     def test_create_with_cpu_and_memory(self, mock_functions_create_response, cognite_client):
-        res = cognite_client.functions.create(name="myfunction", file_id=1234, cpu=0.2, memory=1)
+        res = cognite_client.functions.create(
+            name="myfunction", file_id=1234, cpu=0.2, memory=1)
 
         assert isinstance(res, Function)
-        assert mock_functions_create_response.calls[1].response.json()["items"][0] == res.dump(camel_case=True)
+        assert mock_functions_create_response.calls[1].response.json()[
+            "items"][0] == res.dump(camel_case=True)
 
     def test_create_with_cpu_not_float_raises(self, mock_functions_create_response, cognite_client):
         with pytest.raises(TypeError):
-            cognite_client.functions.create(name="myfunction", file_id=1234, cpu="0.2")
+            cognite_client.functions.create(
+                name="myfunction", file_id=1234, cpu="0.2")
 
     def test_create_with_memory_not_float_raises(self, mock_functions_create_response, cognite_client):
         with pytest.raises(TypeError):
-            cognite_client.functions.create(name="myfunction", file_id=1234, memory="0.5")
+            cognite_client.functions.create(
+                name="myfunction", file_id=1234, memory="0.5")
 
     def test_delete_single_id(self, mock_functions_delete_response, cognite_client):
         _ = cognite_client.functions.delete(id=1)
-        assert {"items": [{"id": 1}]} == jsgz_load(mock_functions_delete_response.calls[0].request.body)
+        assert {"items": [{"id": 1}]} == jsgz_load(
+            mock_functions_delete_response.calls[0].request.body)
 
     def test_delete_single_external_id(self, mock_functions_delete_response, cognite_client):
         _ = cognite_client.functions.delete(external_id="func1")
-        assert {"items": [{"externalId": "func1"}]} == jsgz_load(mock_functions_delete_response.calls[0].request.body)
+        assert {"items": [{"externalId": "func1"}]} == jsgz_load(
+            mock_functions_delete_response.calls[0].request.body)
 
     def test_delete_multiple_id_and_multiple_external_id(self, mock_functions_delete_response, cognite_client):
-        _ = cognite_client.functions.delete(id=[1, 2, 3], external_id=["func1", "func2"])
+        _ = cognite_client.functions.delete(
+            id=[1, 2, 3], external_id=["func1", "func2"])
         assert {
             "items": [{"id": 1}, {"id": 2}, {"id": 3}, {"externalId": "func1"}, {"externalId": "func2"}]
         } == jsgz_load(mock_functions_delete_response.calls[0].request.body)
@@ -499,7 +524,8 @@ class TestFunctionsAPI:
         res = cognite_client.functions.list()
 
         assert isinstance(res, FunctionList)
-        assert mock_functions_filter_response.calls[0].response.json()["items"] == res.dump(camel_case=True)
+        assert mock_functions_filter_response.calls[0].response.json()[
+            "items"] == res.dump(camel_case=True)
 
     def test_list_with_limits(self, mock_functions_filter_response, cognite_client):
 
@@ -510,12 +536,14 @@ class TestFunctionsAPI:
     def test_retrieve_by_id(self, mock_functions_retrieve_response, cognite_client):
         res = cognite_client.functions.retrieve(id=1)
         assert isinstance(res, Function)
-        assert mock_functions_retrieve_response.calls[0].response.json()["items"][0] == res.dump(camel_case=True)
+        assert mock_functions_retrieve_response.calls[0].response.json()[
+            "items"][0] == res.dump(camel_case=True)
 
     def test_retrieve_by_external_id(self, mock_functions_retrieve_response, cognite_client):
         res = cognite_client.functions.retrieve(external_id="func1")
         assert isinstance(res, Function)
-        assert mock_functions_retrieve_response.calls[0].response.json()["items"][0] == res.dump(camel_case=True)
+        assert mock_functions_retrieve_response.calls[0].response.json()[
+            "items"][0] == res.dump(camel_case=True)
 
     def test_retrieve_by_id_and_external_id_raises(self, cognite_client):
         with pytest.raises(ValueError):
@@ -524,27 +552,34 @@ class TestFunctionsAPI:
     def test_retrieve_multiple_by_ids(self, mock_functions_retrieve_response, cognite_client):
         res = cognite_client.functions.retrieve_multiple(ids=[1])
         assert isinstance(res, FunctionList)
-        assert mock_functions_retrieve_response.calls[0].response.json()["items"] == res.dump(camel_case=True)
+        assert mock_functions_retrieve_response.calls[0].response.json()[
+            "items"] == res.dump(camel_case=True)
 
     def test_retrieve_multiple_by_external_ids(self, mock_functions_retrieve_response, cognite_client):
-        res = cognite_client.functions.retrieve_multiple(external_ids=["func1"])
+        res = cognite_client.functions.retrieve_multiple(
+            external_ids=["func1"])
         assert isinstance(res, FunctionList)
-        assert mock_functions_retrieve_response.calls[0].response.json()["items"] == res.dump(camel_case=True)
+        assert mock_functions_retrieve_response.calls[0].response.json()[
+            "items"] == res.dump(camel_case=True)
 
     def test_retrieve_multiple_by_ids_and_external_ids(self, mock_functions_retrieve_response, cognite_client):
-        res = cognite_client.functions.retrieve_multiple(ids=[1], external_ids=["func1"])
+        res = cognite_client.functions.retrieve_multiple(
+            ids=[1], external_ids=["func1"])
         assert isinstance(res, FunctionList)
-        assert mock_functions_retrieve_response.calls[0].response.json()["items"] == res.dump(camel_case=True)
+        assert mock_functions_retrieve_response.calls[0].response.json()[
+            "items"] == res.dump(camel_case=True)
 
     def test_function_call_from_api_key_flow(self, mock_functions_call_responses, cognite_client_with_api_key):
         res = cognite_client_with_api_key.functions.call(id=FUNCTION_ID)
         assert isinstance(res, FunctionCall)
-        assert mock_functions_call_responses.calls[1].response.json()["items"][0] == res.dump(camel_case=True)
+        assert mock_functions_call_responses.calls[1].response.json(
+        )["items"][0] == res.dump(camel_case=True)
 
     def test_function_call_by_external_id_from_api_key_flow(
         self, mock_functions_call_by_external_id_responses, cognite_client_with_api_key
     ):
-        res = cognite_client_with_api_key.functions.call(external_id=f"func-no-{FUNCTION_ID}")
+        res = cognite_client_with_api_key.functions.call(
+            external_id=f"func-no-{FUNCTION_ID}")
 
         assert isinstance(res, FunctionCall)
         assert mock_functions_call_by_external_id_responses.calls[2].response.json()["items"][0] == res.dump(
@@ -556,47 +591,56 @@ class TestFunctionsAPI:
     ):
         res = cognite_client_with_api_key.functions.call(id=FUNCTION_ID)
         assert isinstance(res, FunctionCall)
-        assert mock_functions_call_failed_response.calls[0].response.json() == res.dump(camel_case=True)
+        assert mock_functions_call_failed_response.calls[0].response.json(
+        ) == res.dump(camel_case=True)
 
     def test_function_call_timeout_from_api_key_flow(
         self, mock_functions_call_timeout_response, cognite_client_with_api_key
     ):
         res = cognite_client_with_api_key.functions.call(id=FUNCTION_ID)
         assert isinstance(res, FunctionCall)
-        assert mock_functions_call_timeout_response.calls[0].response.json() == res.dump(camel_case=True)
+        assert mock_functions_call_timeout_response.calls[0].response.json(
+        ) == res.dump(camel_case=True)
 
     @pytest.mark.usefixtures("mock_sessions_with_client_credentials")
     def test_function_call_from_oidc_client_credentials_flow(
         self, mock_functions_call_responses, cognite_client_with_client_credentials_flow
     ):
-        res = cognite_client_with_client_credentials_flow.functions.call(id=FUNCTION_ID)
+        res = cognite_client_with_client_credentials_flow.functions.call(
+            id=FUNCTION_ID)
 
         assert isinstance(res, FunctionCall)
-        assert mock_functions_call_responses.calls[-1].response.json()["items"][0] == res.dump(camel_case=True)
+        assert mock_functions_call_responses.calls[-1].response.json()[
+            "items"][0] == res.dump(camel_case=True)
 
     @pytest.mark.usefixtures("mock_sessions_with_client_credentials")
     def test_function_call_by_external_id_from_oidc_client_credentials_flow(
         self, mock_functions_call_by_external_id_responses, cognite_client_with_client_credentials_flow
     ):
-        res = cognite_client_with_client_credentials_flow.functions.call(external_id=f"func-no-{FUNCTION_ID}")
+        res = cognite_client_with_client_credentials_flow.functions.call(
+            external_id=f"func-no-{FUNCTION_ID}")
 
         assert isinstance(res, FunctionCall)
-        expected = mock_functions_call_by_external_id_responses.calls[-1].response.json()["items"][0]
+        expected = mock_functions_call_by_external_id_responses.calls[-1].response.json()[
+            "items"][0]
         assert expected == res.dump(camel_case=True)
 
     @pytest.mark.usefixtures("mock_sessions_bad_request_response")
     def test_function_call_with_failing_client_credentials_flow(self, cognite_client_with_client_credentials_flow):
         with pytest.raises(CogniteAPIError) as excinfo:
-            cognite_client_with_client_credentials_flow.functions.call(id=FUNCTION_ID)
+            cognite_client_with_client_credentials_flow.functions.call(
+                id=FUNCTION_ID)
         assert excinfo.value.code == 403
 
     @pytest.mark.usefixtures("mock_sessions_with_client_credentials")
     def test_function_call_timeout_from_oidc_client_credentials_flow(
         self, mock_functions_call_timeout_response, cognite_client_with_client_credentials_flow
     ):
-        res = cognite_client_with_client_credentials_flow.functions.call(id=FUNCTION_ID)
+        res = cognite_client_with_client_credentials_flow.functions.call(
+            id=FUNCTION_ID)
         assert isinstance(res, FunctionCall)
-        assert mock_functions_call_timeout_response.calls[-1].response.json() == res.dump(camel_case=True)
+        assert mock_functions_call_timeout_response.calls[-1].response.json(
+        ) == res.dump(camel_case=True)
 
     @pytest.mark.usefixtures("mock_sessions_with_token_exchange")
     def test_function_call_from_oidc_token_exchange_flow(
@@ -605,13 +649,15 @@ class TestFunctionsAPI:
         res = cognite_client_with_token.functions.call(id=FUNCTION_ID)
 
         assert isinstance(res, FunctionCall)
-        assert mock_functions_call_responses.calls[2].response.json()["items"][0] == res.dump(camel_case=True)
+        assert mock_functions_call_responses.calls[2].response.json(
+        )["items"][0] == res.dump(camel_case=True)
 
     @pytest.mark.usefixtures("mock_sessions_with_token_exchange")
     def test_function_call_by_external_id_from_oidc_token_exchange_flow(
         self, mock_functions_call_by_external_id_responses, cognite_client_with_token
     ):
-        res = cognite_client_with_token.functions.call(external_id=f"func-no-{FUNCTION_ID}")
+        res = cognite_client_with_token.functions.call(
+            external_id=f"func-no-{FUNCTION_ID}")
 
         assert isinstance(res, FunctionCall)
         assert mock_functions_call_by_external_id_responses.calls[3].response.json()["items"][0] == res.dump(
@@ -631,32 +677,38 @@ class TestFunctionsAPI:
     ):
         res = cognite_client_with_token.functions.call(id=FUNCTION_ID)
         assert isinstance(res, FunctionCall)
-        assert mock_functions_call_timeout_response.calls[1].response.json() == res.dump(camel_case=True)
+        assert mock_functions_call_timeout_response.calls[1].response.json(
+        ) == res.dump(camel_case=True)
 
     def test_functions_limits_endpoint(self, mock_functions_limit_response, cognite_client):
         res = cognite_client.functions.limits()
         assert isinstance(res, FunctionsLimits)
-        assert mock_functions_limit_response.calls[0].response.json() == res.dump(camel_case=True)
+        assert mock_functions_limit_response.calls[0].response.json(
+        ) == res.dump(camel_case=True)
 
     def test_functions_status_endpoint(self, mock_functions_status_response, cognite_client):
         res = cognite_client.functions.activate()
         assert isinstance(res, FunctionsStatus)
-        assert mock_functions_status_response.calls[0].response.json() == res.dump(camel_case=True)
+        assert mock_functions_status_response.calls[0].response.json(
+        ) == res.dump(camel_case=True)
 
         res = cognite_client.functions.status()
         assert isinstance(res, FunctionsStatus)
-        assert mock_functions_status_response.calls[1].response.json() == res.dump(camel_case=True)
+        assert mock_functions_status_response.calls[1].response.json(
+        ) == res.dump(camel_case=True)
 
 
 class TestRequirementsParser:
     """Test extraction of requirements.txt from docstring in handle-function"""
 
     def test_validate_requirements(self):
-        parsed = _validate_and_parse_requirements(["asyncio==3.4.3", "numpy==1.23.0", "pandas==1.4.3"])
+        parsed = _validate_and_parse_requirements(
+            ["asyncio==3.4.3", "numpy==1.23.0", "pandas==1.4.3"])
         assert parsed == ["asyncio==3.4.3", "numpy==1.23.0", "pandas==1.4.3"]
 
     def test_validate_requirements_error(self):
-        reqs = [["asyncio=3.4.3"], ["num py==1.23.0"], ["pandas==1.4.3 python_version=='3.8'"]]
+        reqs = [["asyncio=3.4.3"], ["num py==1.23.0"],
+                ["pandas==1.4.3 python_version=='3.8'"]]
         for req in reqs:
             with pytest.raises(Exception):
                 _validate_and_parse_requirements(req)
@@ -704,7 +756,8 @@ class TestRequirementsParser:
         req = "somepackage == 3.8.1"
         file = os.path.join(tmpdir, "requirements.txt")
         with open(file, "w+") as f:
-            f.writelines("\n".join(["# this should not be included", "     " + req]))
+            f.writelines(
+                "\n".join(["# this should not be included", "     " + req]))
         reqs = _extract_requirements_from_file(file_name=file)
         assert type(reqs) == list
         assert len(reqs) == 1
@@ -712,9 +765,11 @@ class TestRequirementsParser:
 
     def test_extract_requirements_from_doc_string(self):
         req_mock = '[requirements]\nSomePackage==3.4.3, >3.4.1; python_version=="3.7"\nSomePackage==21.4.0; python_version=="3.7" and python_full_version<"3.0.0" or python_full_version>="3.5.0" and python_version>="3.7"\nSomePackage==2022.6.15; python_version>="3.8" and python_version<"4"\ncSomePackage==1.15.0; python_version>="3.6"\n[/requirements]\n'
-        doc_string_mock = "this should not be included\n" + req_mock + "neither should this\n"
+        doc_string_mock = "this should not be included\n" + \
+            req_mock + "neither should this\n"
         expected = req_mock.splitlines()[1:-1]
-        assert _extract_requirements_from_doc_string(doc_string_mock) == expected
+        assert _extract_requirements_from_doc_string(
+            doc_string_mock) == expected
 
     def test_extract_requirements_from_doc_string_empty(self):
         doc_string = "[requirements]\n[/requirements]\n"
@@ -736,8 +791,10 @@ def mock_function_calls_retrieve_response(rsps, cognite_client):
 
 @pytest.fixture
 def mock_function_call_response_response(rsps, cognite_client):
-    response_body = {"callId": CALL_ID, "functionId": 1234, "response": {"key": "value"}}
-    url = full_url(cognite_client, f"/functions/{FUNCTION_ID}/calls/{CALL_ID}/response")
+    response_body = {"callId": CALL_ID,
+                     "functionId": 1234, "response": {"key": "value"}}
+    url = full_url(
+        cognite_client, f"/functions/{FUNCTION_ID}/calls/{CALL_ID}/response")
     rsps.assert_all_requests_are_fired = False
     rsps.add(rsps.GET, url, status=200, json=response_body)
 
@@ -752,7 +809,8 @@ def mock_function_call_logs_response(rsps, cognite_client):
             {"timestamp": 1585925310822, "message": "message 2"},
         ]
     }
-    url = full_url(cognite_client, f"/functions/{FUNCTION_ID}/calls/{CALL_ID}/logs")
+    url = full_url(
+        cognite_client, f"/functions/{FUNCTION_ID}/calls/{CALL_ID}/logs")
     rsps.assert_all_requests_are_fired = False
     rsps.add(rsps.GET, url, status=200, json=response_body)
 
@@ -784,7 +842,8 @@ SCHEDULE_WITH_FUNCTION_ID_AND_SESSION = {
 @pytest.fixture
 def mock_filter_function_schedules_response(rsps, cognite_client):
     url = full_url(cognite_client, "/functions/schedules/list")
-    rsps.add(rsps.POST, url, status=200, json={"items": [SCHEDULE_WITH_FUNCTION_EXTERNAL_ID]})
+    rsps.add(rsps.POST, url, status=200, json={
+             "items": [SCHEDULE_WITH_FUNCTION_EXTERNAL_ID]})
 
     yield rsps
 
@@ -793,8 +852,10 @@ def mock_filter_function_schedules_response(rsps, cognite_client):
 def mock_function_schedules_response(rsps, cognite_client):
     url = full_url(cognite_client, "/functions/schedules")
     rsps.assert_all_requests_are_fired = False
-    rsps.add(rsps.GET, url, status=200, json={"items": [SCHEDULE_WITH_FUNCTION_EXTERNAL_ID]})
-    rsps.add(rsps.POST, url, status=200, json={"items": [SCHEDULE_WITH_FUNCTION_EXTERNAL_ID]})
+    rsps.add(rsps.GET, url, status=200, json={
+             "items": [SCHEDULE_WITH_FUNCTION_EXTERNAL_ID]})
+    rsps.add(rsps.POST, url, status=200, json={
+             "items": [SCHEDULE_WITH_FUNCTION_EXTERNAL_ID]})
 
     yield rsps
 
@@ -808,18 +869,21 @@ def mock_function_schedules_response_oidc_client_credentials(rsps, cognite_clien
         session_url,
         status=200,
         json={"items": [{"nonce": "aaabbb"}]},
-        match=[post_body_matcher({"items": [{"clientId": "aabbccdd", "clientSecret": "xxyyzz"}]})],
+        match=[post_body_matcher(
+            {"items": [{"clientId": "aabbccdd", "clientSecret": "xxyyzz"}]})],
     )
 
     url = full_url(cognite_client, "/functions/schedules")
-    rsps.add(rsps.POST, url, status=200, json={"items": [SCHEDULE_WITH_FUNCTION_ID_AND_SESSION]})
+    rsps.add(rsps.POST, url, status=200, json={
+             "items": [SCHEDULE_WITH_FUNCTION_ID_AND_SESSION]})
     yield rsps
 
 
 @pytest.fixture
 def mock_function_schedules_retrieve_response(rsps, cognite_client):
     url = full_url(cognite_client, "/functions/schedules/byids")
-    rsps.add(rsps.POST, url, status=200, json={"items": [SCHEDULE_WITH_FUNCTION_EXTERNAL_ID]})
+    rsps.add(rsps.POST, url, status=200, json={
+             "items": [SCHEDULE_WITH_FUNCTION_EXTERNAL_ID]})
 
     yield rsps
 
@@ -835,8 +899,10 @@ def mock_function_schedules_delete_response(rsps, cognite_client):
 @pytest.fixture
 def mock_schedule_get_data_response(rsps, cognite_client):
     schedule_id = SCHEDULE_WITH_FUNCTION_ID_AND_SESSION["id"]
-    url = full_url(cognite_client, f"/functions/schedules/{schedule_id}/input_data")
-    rsps.add(rsps.GET, url, status=200, json={"id": schedule_id, "data": {"value": 2}})
+    url = full_url(
+        cognite_client, f"/functions/schedules/{schedule_id}/input_data")
+    rsps.add(rsps.GET, url, status=200, json={
+             "id": schedule_id, "data": {"value": 2}})
 
     yield rsps
 
@@ -844,7 +910,8 @@ def mock_schedule_get_data_response(rsps, cognite_client):
 @pytest.fixture
 def mock_schedule_no_data_response(rsps, cognite_client):
     schedule_id = SCHEDULE_WITH_FUNCTION_ID_AND_SESSION["id"]
-    url = full_url(cognite_client, f"/functions/schedules/{schedule_id}/input_data")
+    url = full_url(
+        cognite_client, f"/functions/schedules/{schedule_id}/input_data")
     rsps.add(rsps.GET, url, status=200, json={"id": schedule_id})
 
     yield rsps
@@ -852,15 +919,18 @@ def mock_schedule_no_data_response(rsps, cognite_client):
 
 class TestFunctionSchedulesAPI:
     def test_retrieve_schedules(self, mock_function_schedules_retrieve_response, cognite_client):
-        res = cognite_client.functions.schedules.retrieve(id=SCHEDULE_WITH_FUNCTION_EXTERNAL_ID["id"])
+        res = cognite_client.functions.schedules.retrieve(
+            id=SCHEDULE_WITH_FUNCTION_EXTERNAL_ID["id"])
         assert isinstance(res, FunctionSchedule)
-        expected = mock_function_schedules_retrieve_response.calls[0].response.json()["items"][0]
+        expected = mock_function_schedules_retrieve_response.calls[0].response.json()[
+            "items"][0]
         assert expected == res.dump(camel_case=True)
 
     def test_list_schedules(self, mock_filter_function_schedules_response, cognite_client):
         res = cognite_client.functions.schedules.list()
         assert isinstance(res, FunctionSchedulesList)
-        expected = mock_filter_function_schedules_response.calls[0].response.json()["items"]
+        expected = mock_filter_function_schedules_response.calls[0].response.json()[
+            "items"]
         assert expected == res.dump(camel_case=True)
 
     def test_list_schedules_with_limit(self, mock_filter_function_schedules_response, cognite_client):
@@ -871,8 +941,10 @@ class TestFunctionSchedulesAPI:
 
     def test_list_schedules_with_function_id_and_function_external_id_raises(self, cognite_client):
         with pytest.raises(AssertionError) as excinfo:
-            cognite_client.functions.schedules.list(function_id=123, function_external_id="my-func")
-        assert "Only function_id or function_external_id allowed when listing schedules." in str(excinfo.value)
+            cognite_client.functions.schedules.list(
+                function_id=123, function_external_id="my-func")
+        assert "Only function_id or function_external_id allowed when listing schedules." in str(
+            excinfo.value)
 
     def test_create_schedules_with_function_external_id(self, mock_function_schedules_response, cognite_client):
         res = cognite_client.functions.schedules.create(
@@ -882,8 +954,10 @@ class TestFunctionSchedulesAPI:
             description="Hi",
         )
         assert isinstance(res, FunctionSchedule)
-        assert res._cognite_client is cognite_client  # make sure the created schedule has client ref
-        expected = mock_function_schedules_response.calls[0].response.json()["items"][0]
+        # make sure the created schedule has client ref
+        assert res._cognite_client is cognite_client
+        expected = mock_function_schedules_response.calls[0].response.json()[
+            "items"][0]
         assert expected == res.dump(camel_case=True)
 
     def test_create_schedules_with_function_id_and_client_credentials(
@@ -894,11 +968,13 @@ class TestFunctionSchedulesAPI:
             function_id=123,
             cron_expression="*/5 * * * *",
             description="Hi",
-            client_credentials={"client_id": "aabbccdd", "client_secret": "xxyyzz"},
+            client_credentials={"client_id": "aabbccdd",
+                                "client_secret": "xxyyzz"},
         )
 
         assert isinstance(res, FunctionSchedule)
-        expected = mock_function_schedules_response_oidc_client_credentials.calls[1].response.json()["items"][0]
+        expected = mock_function_schedules_response_oidc_client_credentials.calls[1].response.json()[
+            "items"][0]
         assert expected == res.dump(camel_case=True)
 
     def test_create_schedules_with_function_external_id_and_client_credentials_raises(self, cognite_client):
@@ -908,7 +984,8 @@ class TestFunctionSchedulesAPI:
                 function_external_id="user/hello-cognite/hello-cognite:latest",
                 cron_expression="*/5 * * * *",
                 description="Hi",
-                client_credentials={"client_id": "aabbccdd", "client_secret": "xxyyzz"},
+                client_credentials={
+                    "client_id": "aabbccdd", "client_secret": "xxyyzz"},
             )
 
     def test_create_schedules_with_function_id_and_function_external_id_raises(self, cognite_client):
@@ -919,9 +996,11 @@ class TestFunctionSchedulesAPI:
                 function_external_id="user/hello-cognite/hello-cognite:latest",
                 cron_expression="*/5 * * * *",
                 description="Hi",
-                client_credentials={"client_id": "aabbccdd", "client_secret": "xxyyzz"},
+                client_credentials={
+                    "client_id": "aabbccdd", "client_secret": "xxyyzz"},
             )
-        assert "Exactly one of function_id and function_external_id must be specified" in str(excinfo.value)
+        assert "Exactly one of function_id and function_external_id must be specified" in str(
+            excinfo.value)
 
     def test_create_schedules_with_data(self, mock_function_schedules_response, cognite_client):
         res = cognite_client.functions.schedules.create(
@@ -932,7 +1011,8 @@ class TestFunctionSchedulesAPI:
             data={"value": 2},
         )
         assert isinstance(res, FunctionSchedule)
-        expected = mock_function_schedules_response.calls[0].response.json()["items"][0]
+        expected = mock_function_schedules_response.calls[0].response.json()[
+            "items"][0]
         assert expected == res.dump(camel_case=True)
 
     def test_delete_schedules(self, mock_function_schedules_delete_response, cognite_client):
@@ -940,14 +1020,17 @@ class TestFunctionSchedulesAPI:
         assert res is None
 
     def test_schedule_get_data__function_has_data(self, mock_schedule_get_data_response, cognite_client):
-        res = cognite_client.functions.schedules.get_input_data(id=8012683333564363)
+        res = cognite_client.functions.schedules.get_input_data(
+            id=8012683333564363)
 
         assert isinstance(res, dict)
-        expected = mock_schedule_get_data_response.calls[0].response.json()["data"]
+        expected = mock_schedule_get_data_response.calls[0].response.json()[
+            "data"]
         assert res == expected
 
     def test_schedule_get_data__function_is_missing_data(self, mock_schedule_no_data_response, cognite_client):
-        res = cognite_client.functions.schedules.get_input_data(id=8012683333564363)
+        res = cognite_client.functions.schedules.get_input_data(
+            id=8012683333564363)
         assert res is None
 
 
@@ -961,10 +1044,12 @@ class TestFunctionCallsAPI:
             "start_time": {"min": 1585925306822, "max": 1585925306823},
             "end_time": {"min": 1585925310822, "max": 1585925310823},
         }
-        res = cognite_client.functions.retrieve(id=FUNCTION_ID).list_calls(**filter_kwargs, limit=-1)
+        res = cognite_client.functions.retrieve(
+            id=FUNCTION_ID).list_calls(**filter_kwargs, limit=-1)
 
         assert isinstance(res, FunctionCallList)
-        assert mock_function_calls_filter_response.calls[1].response.json()["items"] == res.dump(camel_case=True)
+        assert mock_function_calls_filter_response.calls[1].response.json()[
+            "items"] == res.dump(camel_case=True)
 
     def test_list_calls_by_function_id(self, mock_function_calls_filter_response, cognite_client):
         filter_kwargs = {
@@ -973,56 +1058,72 @@ class TestFunctionCallsAPI:
             "start_time": {"min": 1585925306822, "max": 1585925306823},
             "end_time": {"min": 1585925310822, "max": 1585925310823},
         }
-        res = cognite_client.functions.calls.list(function_id=FUNCTION_ID, **filter_kwargs, limit=-1)
+        res = cognite_client.functions.calls.list(
+            function_id=FUNCTION_ID, **filter_kwargs, limit=-1)
         assert isinstance(res, FunctionCallList)
-        assert mock_function_calls_filter_response.calls[0].response.json()["items"] == res.dump(camel_case=True)
+        assert mock_function_calls_filter_response.calls[0].response.json()[
+            "items"] == res.dump(camel_case=True)
 
     def test_list_calls_by_function_id_with_limits(
         self, mock_function_calls_filter_response_with_limit, cognite_client
     ):
-        res = cognite_client.functions.calls.list(function_id=FUNCTION_ID, limit=2)
+        res = cognite_client.functions.calls.list(
+            function_id=FUNCTION_ID, limit=2)
         assert isinstance(res, FunctionCallList)
         assert len(res) == 2
 
     @pytest.mark.usefixtures("mock_functions_retrieve_response")
     def test_list_calls_by_function_external_id(self, mock_function_calls_filter_response, cognite_client):
-        res = cognite_client.functions.calls.list(function_external_id=f"func-no-{FUNCTION_ID}")
+        res = cognite_client.functions.calls.list(
+            function_external_id=f"func-no-{FUNCTION_ID}")
         assert isinstance(res, FunctionCallList)
-        assert mock_function_calls_filter_response.calls[1].response.json()["items"] == res.dump(camel_case=True)
+        assert mock_function_calls_filter_response.calls[1].response.json()[
+            "items"] == res.dump(camel_case=True)
 
     def test_list_calls_with_function_id_and_function_external_id_raises(self, cognite_client):
         with pytest.raises(AssertionError) as excinfo:
-            cognite_client.functions.calls.list(function_id=123, function_external_id="my-function")
-        assert "Exactly one of function_id and function_external_id must be specified" in str(excinfo.value)
+            cognite_client.functions.calls.list(
+                function_id=123, function_external_id="my-function")
+        assert "Exactly one of function_id and function_external_id must be specified" in str(
+            excinfo.value)
 
     def test_retrieve_call_by_function_id(self, mock_function_calls_retrieve_response, cognite_client):
-        res = cognite_client.functions.calls.retrieve(call_id=CALL_ID, function_id=FUNCTION_ID)
+        res = cognite_client.functions.calls.retrieve(
+            call_id=CALL_ID, function_id=FUNCTION_ID)
         assert isinstance(res, FunctionCall)
-        assert mock_function_calls_retrieve_response.calls[0].response.json()["items"][0] == res.dump(camel_case=True)
+        assert mock_function_calls_retrieve_response.calls[0].response.json()[
+            "items"][0] == res.dump(camel_case=True)
 
     @pytest.mark.usefixtures("mock_functions_retrieve_response")
     def test_retrieve_call_by_function_external_id(self, mock_function_calls_retrieve_response, cognite_client):
-        res = cognite_client.functions.calls.retrieve(call_id=CALL_ID, function_external_id=f"func-no-{FUNCTION_ID}")
+        res = cognite_client.functions.calls.retrieve(
+            call_id=CALL_ID, function_external_id=f"func-no-{FUNCTION_ID}")
         assert isinstance(res, FunctionCall)
-        assert mock_function_calls_retrieve_response.calls[1].response.json()["items"][0] == res.dump(camel_case=True)
+        assert mock_function_calls_retrieve_response.calls[1].response.json()[
+            "items"][0] == res.dump(camel_case=True)
 
     def test_retrieve_call_with_function_id_and_function_external_id_raises(self, cognite_client):
         with pytest.raises(AssertionError) as excinfo:
             cognite_client.functions.calls.retrieve(
                 call_id=CALL_ID, function_id=FUNCTION_ID, function_external_id=f"func-no-{FUNCTION_ID}"
             )
-        assert "Exactly one of function_id and function_external_id must be specified" in str(excinfo.value)
+        assert "Exactly one of function_id and function_external_id must be specified" in str(
+            excinfo.value)
 
     def test_function_call_logs_by_function_id(self, mock_function_call_logs_response, cognite_client):
-        res = cognite_client.functions.calls.get_logs(call_id=CALL_ID, function_id=FUNCTION_ID)
+        res = cognite_client.functions.calls.get_logs(
+            call_id=CALL_ID, function_id=FUNCTION_ID)
         assert isinstance(res, FunctionCallLog)
-        assert mock_function_call_logs_response.calls[0].response.json()["items"] == res.dump(camel_case=True)
+        assert mock_function_call_logs_response.calls[0].response.json()[
+            "items"] == res.dump(camel_case=True)
 
     @pytest.mark.usefixtures("mock_functions_retrieve_response")
     def test_function_call_logs_by_function_external_id(self, mock_function_call_logs_response, cognite_client):
-        res = cognite_client.functions.calls.get_logs(call_id=CALL_ID, function_external_id=f"func-no-{FUNCTION_ID}")
+        res = cognite_client.functions.calls.get_logs(
+            call_id=CALL_ID, function_external_id=f"func-no-{FUNCTION_ID}")
         assert isinstance(res, FunctionCallLog)
-        assert mock_function_call_logs_response.calls[1].response.json()["items"] == res.dump(camel_case=True)
+        assert mock_function_call_logs_response.calls[1].response.json()[
+            "items"] == res.dump(camel_case=True)
 
     def test_function_call_logs_by_function_id_and_function_external_id_raises(
         self, mock_function_call_logs_response, cognite_client
@@ -1031,14 +1132,17 @@ class TestFunctionCallsAPI:
             cognite_client.functions.calls.get_logs(
                 call_id=CALL_ID, function_id=FUNCTION_ID, function_external_id=f"func-no-{FUNCTION_ID}"
             )
-        assert "Exactly one of function_id and function_external_id must be specified" in str(excinfo.value)
+        assert "Exactly one of function_id and function_external_id must be specified" in str(
+            excinfo.value)
 
     @pytest.mark.usefixtures("mock_function_calls_retrieve_response")
     def test_get_logs_on_retrieved_call_object(self, mock_function_call_logs_response, cognite_client):
-        call = cognite_client.functions.calls.retrieve(call_id=CALL_ID, function_id=FUNCTION_ID)
+        call = cognite_client.functions.calls.retrieve(
+            call_id=CALL_ID, function_id=FUNCTION_ID)
         logs = call.get_logs()
         assert isinstance(logs, FunctionCallLog)
-        assert mock_function_call_logs_response.calls[1].response.json()["items"] == logs.dump(camel_case=True)
+        assert mock_function_call_logs_response.calls[1].response.json()[
+            "items"] == logs.dump(camel_case=True)
 
     @pytest.mark.usefixtures("mock_function_calls_filter_response")
     def test_get_logs_on_listed_call_object(self, mock_function_call_logs_response, cognite_client):
@@ -1046,39 +1150,49 @@ class TestFunctionCallsAPI:
         call = calls[0]
         logs = call.get_logs()
         assert isinstance(logs, FunctionCallLog)
-        assert mock_function_call_logs_response.calls[1].response.json()["items"] == logs.dump(camel_case=True)
+        assert mock_function_call_logs_response.calls[1].response.json()[
+            "items"] == logs.dump(camel_case=True)
 
     @pytest.mark.usefixtures("mock_sessions_with_client_credentials")
     @pytest.mark.usefixtures("mock_functions_call_responses")
     def test_get_logs_on_created_call_object(
         self, mock_function_call_logs_response, cognite_client_with_client_credentials_flow
     ):
-        call = cognite_client_with_client_credentials_flow.functions.call(id=FUNCTION_ID)
+        call = cognite_client_with_client_credentials_flow.functions.call(
+            id=FUNCTION_ID)
         logs = call.get_logs()
         assert isinstance(logs, FunctionCallLog)
-        assert mock_function_call_logs_response.calls[-1].response.json()["items"] == logs.dump(camel_case=True)
+        assert mock_function_call_logs_response.calls[-1].response.json()[
+            "items"] == logs.dump(camel_case=True)
 
     def test_function_call_response_by_function_id(self, mock_function_call_response_response, cognite_client):
-        res = cognite_client.functions.calls.get_response(call_id=CALL_ID, function_id=FUNCTION_ID)
+        res = cognite_client.functions.calls.get_response(
+            call_id=CALL_ID, function_id=FUNCTION_ID)
         assert isinstance(res, dict)
-        assert mock_function_call_response_response.calls[0].response.json()["response"] == res
+        assert mock_function_call_response_response.calls[0].response.json()[
+            "response"] == res
 
     @pytest.mark.usefixtures("mock_functions_retrieve_response")
     def test_function_call_response_by_function_external_id(self, mock_function_call_response_response, cognite_client):
-        res = cognite_client.functions.calls.get_response(call_id=CALL_ID, function_id=FUNCTION_ID)
+        res = cognite_client.functions.calls.get_response(
+            call_id=CALL_ID, function_id=FUNCTION_ID)
         assert isinstance(res, dict)
-        assert mock_function_call_response_response.calls[0].response.json()["response"] == res
+        assert mock_function_call_response_response.calls[0].response.json()[
+            "response"] == res
 
     def test_function_call_response_by_function_id_and_function_external_id_raises(self, cognite_client):
         with pytest.raises(AssertionError) as excinfo:
             cognite_client.functions.calls.get_response(
                 call_id=CALL_ID, function_id=FUNCTION_ID, function_external_id=f"func-no-{FUNCTION_ID}"
             )
-        assert "Exactly one of function_id and function_external_id must be specified" in str(excinfo.value)
+        assert "Exactly one of function_id and function_external_id must be specified" in str(
+            excinfo.value)
 
     @pytest.mark.usefixtures("mock_function_calls_retrieve_response")
     def test_get_response_on_retrieved_call_object(self, mock_function_call_response_response, cognite_client):
-        call = cognite_client.functions.calls.retrieve(call_id=CALL_ID, function_id=FUNCTION_ID)
+        call = cognite_client.functions.calls.retrieve(
+            call_id=CALL_ID, function_id=FUNCTION_ID)
         response = call.get_response()
         assert isinstance(response, dict)
-        assert mock_function_call_response_response.calls[1].response.json()["response"] == response
+        assert mock_function_call_response_response.calls[1].response.json()[
+            "response"] == response


### PR DESCRIPTION
## Description
Please describe the change you have made.

## Checklist:
- [ ] Tests added/updated.
- [ ] Documentation updated. Documentation is generated from docstrings - these must be updated according to your change.
  If a new method has been added it should be referenced in [cognite.rst](https://github.com/cognitedata/cognite-sdk-python/blob/master/docs/source/cognite.rst) in order to generate docs based on its docstring.
- [ ] Changelog updated in [CHANGELOG.md](https://github.com/cognitedata/cognite-sdk-python/blob/master/CHANGELOG.md).
- [ ] Version bumped. If triggering a new release is desired, bump the version number in [_version.py](https://github.com/cognitedata/cognite-sdk-python/blob/master/cognite/client/_version.py) and [pyproject.toml](https://github.com/cognitedata/cognite-sdk-python/blob/master/pyproject.toml) per [semantic versioning](https://semver.org/).
