### PR TITLE
Fix upsert in `AssetsAPI.create_hierarchy`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ Changes are grouped as follows
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
+## [5.10.2] - 12-04-23
+### Fixed
+- Fixed a bug that would cause `AssetsAPI.create_hierarchy` to not respect `upsert=False`.
+
 ## [5.10.1] - 04-04-23
 ### Fixed
 - Add missing field `when` (human readable version of the CRON expression) to `FunctionSchedule` class.

--- a/cognite/client/_api/assets.py
+++ b/cognite/client/_api/assets.py
@@ -903,10 +903,8 @@ class _AssetHierarchyCreator:
                     bad_assets.clear()
                     bad_assets.extend(dupe_assets)
 
-                elif not upsert:
-                    return _TaskResult(successful, failed, unknown)
-
-            if dupe_assets:
+            # If upsert=True, run update on any existing assets:
+            if upsert and dupe_assets:
                 updated = self._update(dupe_assets, upsert_mode)
                 # If update went well: Add to list of successful assets and remove from "bad":
                 if updated is not None:

--- a/cognite/client/_version.py
+++ b/cognite/client/_version.py
@@ -1,4 +1,4 @@
 from __future__ import annotations
 
-__version__ = "5.10.1"
+__version__ = "5.10.2"
 __api_subversion__ = "V20220125"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "cognite-sdk"
 
-version = "5.10.1"
+version = "5.10.2"
 
 description = "Cognite Python SDK"
 readme = "README.md"


### PR DESCRIPTION
## Description
- Fixed a bug that would cause `AssetsAPI.create_hierarchy` to not respect `upsert=False`.

## Checklist:
- [ ] Tests added/updated.
- [ ] Documentation updated. Documentation is generated from docstrings - these must be updated according to your change.
  If a new method has been added it should be referenced in [cognite.rst](https://github.com/cognitedata/cognite-sdk-python/blob/master/docs/source/cognite.rst) in order to generate docs based on its docstring.
- [x] Changelog updated in [CHANGELOG.md](https://github.com/cognitedata/cognite-sdk-python/blob/master/CHANGELOG.md).
- [x] Version bumped. If triggering a new release is desired, bump the version number in [_version.py](https://github.com/cognitedata/cognite-sdk-python/blob/master/cognite/client/_version.py) and [pyproject.toml](https://github.com/cognitedata/cognite-sdk-python/blob/master/pyproject.toml) per [semantic versioning](https://semver.org/).
