### PR TITLE
Bug DatapointsAPI.retrieve_dataframe_in_tz all empty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ Changes are grouped as follows
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
+## [6.0.1] - 20-04-23
+### Fixed
+- Fixed a bug that would cause `DatapointsAPI.retrieve_dataframe_in_tz` to raise an `IndexError` if there are empty time series in the response.
+
 ## [6.0.0] - 19-04-23
 ### Removed
 - Removed support for legacy auth (apikeys, serviceaccounts, login.status)

--- a/cognite/client/_version.py
+++ b/cognite/client/_version.py
@@ -1,4 +1,4 @@
 from __future__ import annotations
 
-__version__ = "6.0.0"
+__version__ = "6.0.1"
 __api_subversion__ = "V20220125"

--- a/cognite/client/data_classes/datapoints.py
+++ b/cognite/client/data_classes/datapoints.py
@@ -228,9 +228,12 @@ class DatapointsArray(CogniteResource):
     @classmethod
     def create_from_arrays(cls, *arrays: DatapointsArray) -> DatapointsArray:
         sort_by_time = sorted((a for a in arrays if len(a.timestamp) > 0), key=lambda a: a.timestamp[0])
+        if len(sort_by_time) == 0:
+            return arrays[0]
+        elif len(sort_by_time) == 1:
+            return sort_by_time[0]
+
         first = sort_by_time[0]
-        if len(sort_by_time) == 1:
-            return first
 
         arrays_by_attribute = defaultdict(list)
         for array in sort_by_time:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "cognite-sdk"
 
-version = "6.0.0"
+version = "6.0.1"
 
 description = "Cognite Python SDK"
 readme = "README.md"

--- a/tests/tests_integration/test_api/test_datapoints.py
+++ b/tests/tests_integration/test_api/test_datapoints.py
@@ -1377,6 +1377,29 @@ class TestRetrieveTimezoneDatapointsAPI:
 
         pd.testing.assert_frame_equal(actual_df[sorted(actual_df)], expected_df[sorted(expected_df)])
 
+    @staticmethod
+    def test_retrieve_dataframe_in_tz_empty_timeseries(cognite_client, hourly_normal_dist, minutely_normal_dist):
+        oslo = ZoneInfo("Europe/Oslo")
+        start, end = datetime(2010, 1, 1, tzinfo=oslo), datetime(2022, 1, 1, tzinfo=oslo)
+        index = pd.date_range("2020-01-01", "2021-12-31", tz="Europe/Oslo", freq="AS")
+        expected_df = pd.DataFrame(
+            [[366 * 24 - 1, pd.NA], [365 * 24, pd.NA]],
+            index=index,
+            columns=[hourly_normal_dist.external_id, minutely_normal_dist.external_id],
+            dtype="Int64",
+        )
+
+        actual_df = cognite_client.time_series.data.retrieve_dataframe_in_tz(
+            external_id=[hourly_normal_dist.external_id, minutely_normal_dist.external_id],
+            start=start,
+            end=end,
+            aggregates="count",
+            granularity="1year",
+            include_aggregate_name=False,
+        )
+
+        pd.testing.assert_frame_equal(actual_df[sorted(actual_df)], expected_df[sorted(expected_df)], check_freq=False)
+
 
 class TestRetrieveMixedRawAndAgg:
     def test_multiple_settings_for_ignore_unknown_ids(


### PR DESCRIPTION
## Description

There is a bug in the `DatapointsArray.create_from_arrays` if all arrays have no datapoints:

```bash
IndexError                                Traceback (most recent call last)
Cell In[71], line 3
      1 from datetime import datetime
      2 from cognite.client.utils import ZoneInfo
----> 3 dps = client.time_series.data.retrieve_dataframe_in_tz(
      4         external_id=xid,
      5         start=datetime(1901, 1, 1, tzinfo=ZoneInfo("Europe/Oslo")),
      6         end=datetime(2023, 1, 1, tzinfo=ZoneInfo("Europe/Oslo")),    
      7         aggregates=["average"],
      8         granularity="1y")

File /opt/homebrew/lib/python3.11/site-packages/cognite/client/_api/datapoints.py:1148, in DatapointsAPI.retrieve_dataframe_in_tz(self, id, external_id, start, end, aggregates, granularity, ignore_unknown_ids, uniform_index, include_aggregate_name, include_granularity_name, column_names)
   1142 arrays = self.retrieve_arrays(
   1143     limit=None,
   1144     ignore_unknown_ids=ignore_unknown_ids,
   1145     **{identifiers[0].name(): queries},  # type: ignore [arg-type]
   1146 )
   1147 assert isinstance(arrays, DatapointsArrayList)  # mypy
-> 1148 arrays.concat_duplicate_ids()
   1149 df = (
   1150     arrays.to_pandas(column_names, include_aggregate_name, include_granularity_name)
   1151     .tz_localize("utc")
   1152     .tz_convert(tz.key)
   1153 )
   1155 if uniform_index:

File /opt/homebrew/lib/python3.11/site-packages/cognite/client/data_classes/datapoints.py:681, in DatapointsArrayList.concat_duplicate_ids(self)
    679         has_external_ids.add(items.id)
    680     continue
--> 681 concatenated = DatapointsArray.create_from_arrays(*items)
    682 self._external_id_to_item[ext_id] = concatenated
    683 if concatenated.id is not None:

File /opt/homebrew/lib/python3.11/site-packages/cognite/client/data_classes/datapoints.py:231, in DatapointsArray.create_from_arrays(cls, *arrays)
    228 @classmethod
    229 def create_from_arrays(cls, *arrays: DatapointsArray) -> DatapointsArray:
    230     sort_by_time = sorted((a for a in arrays if len(a.timestamp) > 0), key=lambda a: a.timestamp[0])
--> 231     first = sort_by_time[0]
    232     if len(sort_by_time) == 1:
    233         return first

IndexError: list index out of range
```

## Checklist:
- [x] Tests added/updated.
- [ ] Documentation updated. Documentation is generated from docstrings - these must be updated according to your change.
  If a new method has been added it should be referenced in [cognite.rst](https://github.com/cognitedata/cognite-sdk-python/blob/master/docs/source/cognite.rst) in order to generate docs based on its docstring.
- [x] Changelog updated in [CHANGELOG.md](https://github.com/cognitedata/cognite-sdk-python/blob/master/CHANGELOG.md).
- [x] Version bumped. If triggering a new release is desired, bump the version number in [_version.py](https://github.com/cognitedata/cognite-sdk-python/blob/master/cognite/client/_version.py) and [pyproject.toml](https://github.com/cognitedata/cognite-sdk-python/blob/master/pyproject.toml) per [semantic versioning](https://semver.org/).
