### PR TITLE
Change in documentation regarding list raw rows.

### DIFF
--- a/cognite/client/_api/raw.py
+++ b/cognite/client/_api/raw.py
@@ -321,8 +321,8 @@ class RawRowsAPI(APIClient):
             table_name (str): Name of the table to iterate over rows for
             chunk_size (int, optional): Number of rows to return in each chunk. Defaults to yielding one row a time.
             limit (int, optional): Maximum number of rows to return. Defaults to return all items.
-            min_last_updated_time (int): Rows must have been last updated after this time. ms since epoch.
-            max_last_updated_time (int): Rows must have been last updated before this time. ms since epoch.
+            min_last_updated_time (int): Rows must have been last updated after this time (exclusive). ms since epoch.
+            max_last_updated_time (int): Rows must have been last updated before this time (inclusive). ms since epoch.
             columns (List[str]): List of column keys. Set to `None` for retrieving all, use [] to retrieve only row keys.
         """
         return self._list_generator(
@@ -501,8 +501,8 @@ class RawRowsAPI(APIClient):
         Args:
             db_name (str): Name of the database.
             table_name (str): Name of the table.
-            min_last_updated_time (int): Rows must have been last updated after this time. ms since epoch.
-            max_last_updated_time (int): Rows must have been last updated before this time. ms since epoch.
+            min_last_updated_time (int): Rows must have been last updated after this time (exclusive). ms since epoch.
+            max_last_updated_time (int): Rows must have been last updated before this time (inclusive). ms since epoch.
             columns (List[str]): List of column keys. Set to `None` for retrieving all, use [] to retrieve only row keys.
             limit (int): The number of rows to retrieve. Defaults to 25. Set to -1, float("inf") or None to return all items.
 


### PR DESCRIPTION
## Description
Made a correction in documentation in RawRowsApi.list.
Presently, documentation is stating that max_last_updated_time (int) – Rows must have been last updated before this time.
This is not correct. This parameter is inclusive, contrary to min_last_updated_time.
RawRowsApi.list returns a list of rows updated between min_last_updated_time (exclusive) and max_last_updated_time (inclusive).

## Checklist:
- [ ] Tests added/updated.
- [x] Documentation updated. Documentation is generated from docstrings - these must be updated according to your change.
  If a new method has been added it should be referenced in [cognite.rst](https://github.com/cognitedata/cognite-sdk-python/blob/master/docs/source/cognite.rst) in order to generate docs based on its docstring.
- [ ] Changelog updated in [CHANGELOG.md](https://github.com/cognitedata/cognite-sdk-python/blob/master/CHANGELOG.md).
- [ ] Version bumped. If triggering a new release is desired, bump the version number in [_version.py](https://github.com/cognitedata/cognite-sdk-python/blob/master/cognite/client/_version.py) and [pyproject.toml](https://github.com/cognitedata/cognite-sdk-python/blob/master/pyproject.toml) per [semantic versioning](https://semver.org/).
