### PR TITLE
Fixes the `AttributeError` raised with pandas Timestamp in UTC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,17 +17,19 @@ Changes are grouped as follows
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
-## [6.1.0] - 28-04-25
+## [6.1.1] - 28-04-23
+### Fixed
+- `AttributeError` when passing `pandas.Timestamp`s with different timezones (*of which one was UTC*) to `DatapointsAPI.retrieve_dataframe_in_tz`.
+- A `ValueError` is no longer raised when passing `pandas.Timestamp`s in the same timezone, but with different underlying implementations (e.g. `datetime.timezone.utc` / `pytz.UTC` / `ZoneInfo("UTC")`) to `DatapointsAPI.retrieve_dataframe_in_tz`.
 
+## [6.1.0] - 28-04-23
 ### Added
-- Support for giving `start` and `end` arguments as `pandas.Timestamp` in
-  `DatapointsAPI.retrieve_dataframe_in_tz`.
+- Support for giving `start` and `end` arguments as `pandas.Timestamp` in `DatapointsAPI.retrieve_dataframe_in_tz`.
 
 ### Improved
-
 - Type hints for the `DatapointsAPI` methods.
 
-## [6.0.2] - 27-04-26
+## [6.0.2] - 27-04-23
 ### Fixed
 - Fixed a bug in `DatapointsAPI.retrieve_dataframe_in_tz` that could raise `AmbiguousTimeError` when subdividing the user-specified time range into UTC intervals (with fixed offset).
 

--- a/cognite/client/_version.py
+++ b/cognite/client/_version.py
@@ -1,4 +1,4 @@
 from __future__ import annotations
 
-__version__ = "6.1.0"
+__version__ = "6.1.1"
 __api_subversion__ = "V20220125"

--- a/cognite/client/utils/_time.py
+++ b/cognite/client/utils/_time.py
@@ -6,6 +6,7 @@ import re
 import sys
 import time
 from abc import ABC, abstractmethod
+from contextlib import suppress
 from datetime import datetime, timedelta, timezone
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Union, cast, overload
 
@@ -16,9 +17,9 @@ if TYPE_CHECKING:
     import pandas
 
     if sys.version_info >= (3, 9):
-        from zoneinfo import ZoneInfo
+        from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
     else:
-        from backports.zoneinfo import ZoneInfo
+        from backports.zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 
 UNIT_IN_MS_WITHOUT_WEEK = {"s": 1000, "m": 60000, "h": 3600000, "d": 86400000}
@@ -30,7 +31,7 @@ MIN_TIMESTAMP_MS = -2208988800000  # 1900-01-01 00:00:00.000
 MAX_TIMESTAMP_MS = 4102444799999  # 2099-12-31 23:59:59.999
 
 
-def import_zoneinfo() -> ZoneInfo:
+def import_zoneinfo() -> type[ZoneInfo]:
     try:
         if sys.version_info >= (3, 9):
             from zoneinfo import ZoneInfo
@@ -44,6 +45,14 @@ def import_zoneinfo() -> ZoneInfo:
             "you need to install a backport. This is done automatically for you when installing with the pandas "
             "group: 'cognite-sdk[pandas]', or with poetry: 'poetry install -E pandas'"
         ) from e
+
+
+def _import_zoneinfo_not_found_error() -> type[ZoneInfoNotFoundError]:
+    if sys.version_info >= (3, 9):
+        from zoneinfo import ZoneInfoNotFoundError
+    else:
+        from backports.zoneinfo import ZoneInfoNotFoundError
+    return ZoneInfoNotFoundError
 
 
 def get_utc_zoneinfo() -> ZoneInfo:
@@ -542,23 +551,31 @@ def pandas_date_range_tz(start: datetime, end: datetime, freq: str, inclusive: s
 
 
 def validate_timezone(start: datetime, end: datetime) -> ZoneInfo:
-    ZoneInfo = import_zoneinfo()
-    pd = cast(Any, local_import("pandas"))
-
-    if missing := [name for name, timestamp in zip(("start", "end"), (start, end)) if not timestamp.tzinfo]:
+    if (start_tz := start.tzinfo) is None or (end_tz := end.tzinfo) is None:
+        missing = [name for name, timestamp in zip(("start", "end"), (start, end)) if not timestamp.tzinfo]
         names = " and ".join(missing)
         end_sentence = " do not have timezones." if len(missing) >= 2 else " does not have a timezone."
         raise ValueError(f"All times must be time zone aware, {names}{end_sentence}")
 
-    is_start_valid = isinstance(start, pd.Timestamp) or isinstance(start.tzinfo, ZoneInfo)  # type: ignore [arg-type]
-    is_end_valid = isinstance(end, pd.Timestamp) or isinstance(end.tzinfo, ZoneInfo)  # type: ignore [arg-type]
-    if not is_start_valid or not is_end_valid:
-        raise ValueError("Only pandas.Timestamp or datetime with ZoneInfo implementation of tzinfo are supported.")
+    # There are several ways to pass the same timezone unfortunately (without it being a user error):
+    # Pandas uses 'pytz' under the hood except for UTC, then it uses built-in `datetime.timezone.utc`...
+    # except when given something concrete like pytz.UTC or ZoneInfo(...). Converting to ZoneInfo via
+    # string is safe, all return timezone 'key':
+    ZoneInfo = import_zoneinfo()
+    tz_matches = start_tz is end_tz
+    with suppress(_import_zoneinfo_not_found_error()):
+        tz_matches = ZoneInfo(str(start_tz)) is ZoneInfo(str(end_tz))
+    if not tz_matches:
+        raise ValueError(f"start and end have different timezones, '{start_tz}' and '{end_tz}'.")
 
-    if start.tzinfo is not end.tzinfo:
-        raise ValueError(f"start and end have different timezones, {start.tzinfo.key!r} and {end.tzinfo.key!r}.")  # type: ignore [union-attr]
+    if isinstance(start_tz, ZoneInfo):
+        return start_tz
 
-    return start.tzinfo  # type: ignore [return-value]
+    pd = cast(Any, local_import("pandas"))
+    if isinstance(start, pd.Timestamp):
+        return ZoneInfo(str(start_tz))
+
+    raise ValueError("Only tz-aware pandas.Timestamp and datetime (must be using ZoneInfo) are supported.")
 
 
 def to_pandas_freq(granularity: str, start: datetime) -> str:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "cognite-sdk"
 
-version = "6.1.0"
+version = "6.1.1"
 
 description = "Cognite Python SDK"
 readme = "README.md"

--- a/tests/tests_unit/test_api/test_datapoints.py
+++ b/tests/tests_unit/test_api/test_datapoints.py
@@ -726,28 +726,28 @@ class TestRetrieveDataPointsInTz:
                 {"external_id": "123", "start": datetime(2023, 1, 1), "end": datetime(2023, 1, 2)},
                 None,
                 None,
-                "All times must be time zone aware, start and end do not have timezones.",
+                "All times must be timezone aware, start and end do not have timezones.",
                 id="Naive timezones",
             ),
             pytest.param(
                 {"external_id": "123", "start": datetime(2023, 1, 1), "end": datetime(2023, 1, 2)},
                 "Europe/Oslo",
                 "America/Los_Angeles",
-                "start and end have different timezones, 'Europe/Oslo' and 'America/Los_Angeles'.",
+                "'start' and 'end' represent different timezones: 'Europe/Oslo' and 'America/Los_Angeles'.",
                 id="Mismatch timezone",
             ),
             pytest.param(
                 {"external_id": "123", "start": datetime(2023, 1, 1), "end": datetime(2023, 1, 2)},
                 "Europe/Oslo",
                 None,
-                "All times must be time zone aware, end does not have a timezone.",
+                "All times must be timezone aware, end does not have a timezone.",
                 id="Missing end timezone",
             ),
             pytest.param(
                 {"external_id": "123", "start": datetime(2023, 1, 1), "end": datetime(2023, 1, 2)},
                 None,
                 "America/Los_Angeles",
-                "All times must be time zone aware, start does not have a timezone.",
+                "All times must be timezone aware, start does not have a timezone.",
                 id="Missing start timezone",
             ),
             pytest.param(
@@ -762,7 +762,7 @@ class TestRetrieveDataPointsInTz:
                 "Europe/Oslo",
                 "Europe/Oslo",
                 re.escape("Either input id(s) or external_id(s)"),
-                id="Passed both id or external id",
+                id="Passed both id and external id",
             ),
             pytest.param(
                 {

--- a/tests/tests_unit/test_utils/test_time.py
+++ b/tests/tests_unit/test_utils/test_time.py
@@ -483,25 +483,25 @@ def validate_time_zone_invalid_arguments_data() -> list[ParameterSet]:
         pytest.param(
             datetime(2023, 1, 1, tzinfo=oslo),
             datetime(2023, 1, 10, tzinfo=new_york),
-            "start and end have different timezones, 'Europe/Oslo' and 'America/New_York'.",
+            "'start' and 'end' represent different timezones: 'Europe/Oslo' and 'America/New_York'.",
             id="Different timezones",
         ),
         pytest.param(
             datetime(2023, 1, 1),
             datetime(2023, 1, 10, tzinfo=new_york),
-            "All times must be time zone aware, start does not have a timezone",
+            "All times must be timezone aware, start does not have a timezone",
             id="Missing start timezone",
         ),
         pytest.param(
             datetime(2023, 1, 1),
             datetime(2023, 1, 10),
-            "All times must be time zone aware, start and end do not have timezones",
+            "All times must be timezone aware, start and end do not have timezones",
             id="Missing start and end timezone",
         ),
         pytest.param(
             datetime(2023, 1, 1, tzinfo=oslo),
             datetime(2023, 1, 10),
-            "All times must be time zone aware, end does not have a timezone",
+            "All times must be timezone aware, end does not have a timezone",
             id="Missing end timezone",
         ),
     ]
@@ -512,7 +512,7 @@ def validate_time_zone_valid_arguments_data() -> list[ParameterSet]:
         ZoneInfo = import_zoneinfo()
         import pandas as pd
         import pytz  # hard pandas dependency
-    except CogniteImportError:
+    except (ImportError, CogniteImportError):
         return []
 
     utc = ZoneInfo("UTC")


### PR DESCRIPTION
# Description

## [6.1.1] - 28-04-23
### Fixed
- `AttributeError` when passing `pandas.Timestamp`s with different timezones (*of which one was UTC*) to `DatapointsAPI.retrieve_dataframe_in_tz`.
- A `ValueError` is no longer raised when passing `pandas.Timestamp`s in the same timezone, but with different underlying implementations (e.g. `datetime.timezone.utc` / `pytz.UTC` / `ZoneInfo("UTC")`) to `DatapointsAPI.retrieve_dataframe_in_tz`.

### Internal facing
`def validate_timezone(start: datetime, end: datetime) -> ZoneInfo:`
...was not guaranteed to return `ZoneInfo`, i.e. with `pd.Timestamp` inputs it was either `pytz.timezone(...)` or `datetime.timezone.utc`)


## Checklist:
- [x] Tests added/updated.
- [x] Documentation updated. Documentation is generated from docstrings - these must be updated according to your change.
  If a new method has been added it should be referenced in [cognite.rst](https://github.com/cognitedata/cognite-sdk-python/blob/master/docs/source/cognite.rst) in order to generate docs based on its docstring.
- [x] Changelog updated in [CHANGELOG.md](https://github.com/cognitedata/cognite-sdk-python/blob/master/CHANGELOG.md).
- [x] Version bumped. If triggering a new release is desired, bump the version number in [_version.py](https://github.com/cognitedata/cognite-sdk-python/blob/master/cognite/client/_version.py) and [pyproject.toml](https://github.com/cognitedata/cognite-sdk-python/blob/master/pyproject.toml) per [semantic versioning](https://semver.org/).
