### PR TITLE
Transformation create with sourceOidcCredentials , destinationOidcCredentials project error fixed

### DIFF
--- a/cognite/client/_api/transformations/__init__.py
+++ b/cognite/client/_api/transformations/__init__.py
@@ -68,17 +68,22 @@ class TransformationsAPI(APIClient):
                 >>>      Transformation(
                 >>>      name="transformation3",
                 >>>      view = ViewInfo(space="TypeSpace", external_id="TypeExtId", version="version"),
-                >>>      destination=TransformationDestination.instance_nodes(view, "InstanceSpace")
+                >>>      destination=TransformationDestination.nodes(view, "InstanceSpace")
                 >>>      ),
                 >>>      Transformation(
                 >>>      name="transformation4",
                 >>>      view = ViewInfo(space="TypeSpace", external_id="TypeExtId", version="version"),
-                >>>      destination=TransformationDestination.instance_edges(view, "InstanceSpace")
+                >>>      destination=TransformationDestination.nodes("InstanceSpace")
                 >>>      ),
                 >>>      Transformation(
                 >>>      name="transformation5",
+                >>>      view = ViewInfo(space="TypeSpace", external_id="TypeExtId", version="version"),
+                >>>      destination=TransformationDestination.edges(view, "InstanceSpace")
+                >>>      ),
+                >>>      Transformation(
+                >>>      name="transformation6",
                 >>>      edge_type = EdgeType(space="TypeSpace", external_id="TypeExtId"),
-                >>>      destination=TransformationDestination.instance_edges(edge_type,"InstanceSpace")
+                >>>      destination=TransformationDestination.edges(edge_type,"InstanceSpace")
                 >>>      ),
                 >>> ]
                 >>> res = c.transformations.create(transformations)

--- a/cognite/client/_api/transformations/__init__.py
+++ b/cognite/client/_api/transformations/__init__.py
@@ -11,6 +11,8 @@ from cognite.client.data_classes import Transformation, TransformationJob, Trans
 from cognite.client.data_classes.shared import TimestampRange
 from cognite.client.data_classes.transformations import (
     NonceCredentials,
+    SourceNonceCredentials,
+    DestinationNonceCredentials,
     TagsFilter,
     TransformationFilter,
     TransformationPreviewResult,
@@ -89,7 +91,7 @@ class TransformationsAPI(APIClient):
 
         """
         if isinstance(transformation, Sequence):
-            sessions: Dict[str, NonceCredentials] = {}
+            sessions: Dict[str, Union[NonceCredentials, SourceNonceCredentials, DestinationNonceCredentials]] = {}
             transformation = [t.copy() for t in transformation]
             for t in transformation:
                 t._cognite_client = self._cognite_client
@@ -298,7 +300,7 @@ class TransformationsAPI(APIClient):
 
         if isinstance(item, Sequence):
             item = list(item).copy()
-            sessions: Dict[str, NonceCredentials] = {}
+            sessions: Dict[str,  Union[NonceCredentials, SourceNonceCredentials, DestinationNonceCredentials]] = {}
             for (i, t) in enumerate(item):
                 if isinstance(t, Transformation):
                     t = t.copy()

--- a/cognite/client/_api/transformations/__init__.py
+++ b/cognite/client/_api/transformations/__init__.py
@@ -72,7 +72,6 @@ class TransformationsAPI(APIClient):
                 >>>      ),
                 >>>      Transformation(
                 >>>      name="transformation4",
-                >>>      view = ViewInfo(space="TypeSpace", external_id="TypeExtId", version="version"),
                 >>>      destination=TransformationDestination.nodes("InstanceSpace")
                 >>>      ),
                 >>>      Transformation(

--- a/cognite/client/_api/transformations/schema.py
+++ b/cognite/client/_api/transformations/schema.py
@@ -41,7 +41,7 @@ class TransformationSchemaAPI(APIClient):
         filter = destination.dump(True)
         filter.pop("type")
 
-        if isinstance(destination, DataModelInstances):
+        if isinstance(destination, DataModel):
             filter["externalId"] = filter.pop("modelExternalId")
             filter.pop("instanceSpaceExternalId")
         if conflict_mode:

--- a/cognite/client/_api/transformations/schema.py
+++ b/cognite/client/_api/transformations/schema.py
@@ -9,7 +9,7 @@ from cognite.client.data_classes import (
     TransformationSchemaColumn,
     TransformationSchemaColumnList,
 )
-from cognite.client.data_classes.transformations.common import DataModelInstances
+from cognite.client.data_classes.transformations.common import DataModel
 
 
 class TransformationSchemaAPI(APIClient):

--- a/cognite/client/data_classes/__init__.py
+++ b/cognite/client/data_classes/__init__.py
@@ -114,6 +114,8 @@ from cognite.client.data_classes.time_series import (
 )
 from cognite.client.data_classes.transformations import (
     OidcCredentials,
+    SourceOidcCredentials,
+    DestinationOidcCredentials,
     RawTable,
     Transformation,
     TransformationBlockedInfo,

--- a/cognite/client/data_classes/transformations/__init__.py
+++ b/cognite/client/data_classes/transformations/__init__.py
@@ -18,7 +18,11 @@ from cognite.client.data_classes.shared import TimestampRange
 from cognite.client.data_classes.transformations.common import (
     DataModel,
     NonceCredentials,
+    SourceNonceCredentials,
+    DestinationNonceCredentials,
     OidcCredentials,
+    SourceOidcCredentials,
+    DestinationOidcCredentials,
     RawTable,
     SequenceRows,
     TransformationBlockedInfo,
@@ -68,6 +72,73 @@ class SessionDetails:
             return convert_all_keys_to_camel_case(ret)
         return ret
 
+class SessionSourceDetails:
+    """Details of a session which provid.
+
+    Args:
+        session_id (int): CDF session ID
+        client_id (str): Idp client ID
+        project_name (str): CDF project name
+    """
+
+    def __init__(
+        self,
+        session_id: int = None,
+        client_id: str = None,
+        project_name: str = None,
+    ):
+        self.session_id = session_id
+        self.client_id = client_id
+        self.project_name = project_name
+
+    def dump(self, camel_case: bool = False) -> Dict[str, Any]:
+        """Dump the instance into a json serializable Python data type.
+
+        Args:
+            camel_case (bool): Use camelCase for attribute names. Defaults to False.
+
+        Returns:
+            Dict[str, Any]: A dictionary representation of the instance.
+        """
+        ret = vars(self)
+
+        if camel_case:
+            return convert_all_keys_to_camel_case(ret)
+        return ret
+
+class SessionDestinationDetails:
+    """Details of a session which provid.
+
+    Args:
+        session_id (int): CDF session ID
+        client_id (str): Idp client ID
+        project_name (str): CDF project name
+    """
+
+    def __init__(
+        self,
+        session_id: int = None,
+        client_id: str = None,
+        project_name: str = None,
+    ):
+        self.session_id = session_id
+        self.client_id = client_id
+        self.project_name = project_name
+
+    def dump(self, camel_case: bool = False) -> Dict[str, Any]:
+        """Dump the instance into a json serializable Python data type.
+
+        Args:
+            camel_case (bool): Use camelCase for attribute names. Defaults to False.
+
+        Returns:
+            Dict[str, Any]: A dictionary representation of the instance.
+        """
+        ret = vars(self)
+
+        if camel_case:
+            return convert_all_keys_to_camel_case(ret)
+        return ret
 
 class Transformation(CogniteResource):
     """The transformations resource allows transforming data in CDF.
@@ -83,8 +154,8 @@ class Transformation(CogniteResource):
         ignore_null_fields (bool): Indicates how null values are handled on updates: ignore or set null.
         source_api_key (str): Configures the transformation to authenticate with the given api key on the source.
         destination_api_key (str): Configures the transformation to authenticate with the given api key on the destination.
-        source_oidc_credentials (Optional[OidcCredentials]): Configures the transformation to authenticate with the given oidc credentials key on the destination.
-        destination_oidc_credentials (Optional[OidcCredentials]): Configures the transformation to authenticate with the given oidc credentials on the destination.
+        source_oidc_credentials (Optional[SourceOidcCredentials]): Configures the transformation to authenticate with the given oidc credentials key on the destination.
+        destination_oidc_credentials (Optional[DestinationOidcCredentials]): Configures the transformation to authenticate with the given oidc credentials on the destination.
         created_time (int): The number of milliseconds since 00:00:00 Thursday, 1 January 1970, Coordinated Universal Time (UTC), minus leap seconds.
         last_updated_time (int): The number of milliseconds since 00:00:00 Thursday, 1 January 1970, Coordinated Universal Time (UTC), minus leap seconds.
         owner (str): Owner of the transformation: requester's identity.
@@ -98,10 +169,10 @@ class Transformation(CogniteResource):
         blocked (TransformationBlockedInfo): Provides reason and time if the transformation is blocked.
         schedule (TransformationSchedule): Details for the schedule if the transformation is scheduled.
         cognite_client (CogniteClient): The client to associate with this object.
-        source_nonce (NonceCredentials): Single use credentials to bind to a CDF session for reading.
-        destination_nonce (NonceCredentials): Single use credentials to bind to a CDF session for writing.
-        source_session (SessionDetails): Details for the session used to read from the source project.
-        destination_session (SessionDetails): Details for the session used to write to the destination project.
+        source_nonce (SourceNonceCredentials): Single use credentials to bind to a CDF session for reading.
+        destination_nonce (DestinationNonceCredentials): Single use credentials to bind to a CDF session for writing.
+        source_session (SessionSourceDetails): Details for the session used to read from the source project.
+        destination_session (SessionDestinationDetails): Details for the session used to write to the destination project.
     """
 
     def __init__(
@@ -116,8 +187,8 @@ class Transformation(CogniteResource):
         ignore_null_fields: bool = False,
         source_api_key: str = None,
         destination_api_key: str = None,
-        source_oidc_credentials: Optional[OidcCredentials] = None,
-        destination_oidc_credentials: Optional[OidcCredentials] = None,
+        source_oidc_credentials: Optional[SourceOidcCredentials] = None,
+        destination_oidc_credentials: Optional[DestinationOidcCredentials] = None,
         created_time: Optional[int] = None,
         last_updated_time: Optional[int] = None,
         owner: str = None,
@@ -132,10 +203,10 @@ class Transformation(CogniteResource):
         schedule: TransformationSchedule = None,
         data_set_id: int = None,
         cognite_client: CogniteClient = None,
-        source_nonce: Optional[NonceCredentials] = None,
-        destination_nonce: Optional[NonceCredentials] = None,
-        source_session: Optional[SessionDetails] = None,
-        destination_session: Optional[SessionDetails] = None,
+        source_nonce: Optional[SourceNonceCredentials] = None,
+        destination_nonce: Optional[DestinationNonceCredentials] = None,
+        source_session: Optional[SessionSourceDetails] = None,
+        destination_session: Optional[SessionDestinationDetails] = None,
         tags: Optional[List[str]] = None,
     ):
         self.id = id
@@ -207,7 +278,7 @@ class Transformation(CogniteResource):
             self.tags,
         )
 
-    def _process_credentials(self, sessions_cache: Dict[str, NonceCredentials] = None, keep_none: bool = False) -> None:
+    def _process_credentials(self, sessions_cache: Dict[str, Union[NonceCredentials, SourceNonceCredentials, DestinationNonceCredentials]] = None, keep_none: bool = False) -> None:
         if sessions_cache is None:
             sessions_cache = {}
 
@@ -238,14 +309,68 @@ class Transformation(CogniteResource):
                     ret = None
             return ret
 
-        if self.source_api_key is None and self.source_nonce is None:
-            self.source_nonce = try_get_or_create_nonce(self.source_oidc_credentials)
-            if self.source_nonce:
+        def try_get_or_create_source_nonce(source_oidc_credentials: Optional[SourceOidcCredentials]) -> Optional[SourceNonceCredentials]:
+            if keep_none and source_oidc_credentials is None:
+                return None
+
+            # MyPy requires this to make sure it's not changed to None after inner declaration
+            assert sessions_cache is not None
+
+            key = (
+                f"{source_oidc_credentials.client_id}:{hash(source_oidc_credentials.client_secret)}"
+                if source_oidc_credentials
+                else "DEFAULT"
+            )
+
+            ret = sessions_cache.get(key)
+            if not ret:
+                if source_oidc_credentials and source_oidc_credentials.client_id and source_oidc_credentials.client_secret:
+                    credentials = ClientCredentials(source_oidc_credentials.client_id, source_oidc_credentials.client_secret)
+                else:
+                    credentials = None
+                try:
+                    session = self._cognite_client.iam.sessions.create(credentials)
+                    ret = SourceNonceCredentials(session.id, session.nonce, self.source_oidc_credentials.cdf_project_name)
+                    sessions_cache[key] = ret
+                except Exception:
+                    ret = None
+            return ret
+
+        def try_get_or_create_destination_nonce(destination_oidc_credentials: Optional[DestinationOidcCredentials]) -> Optional[DestinationNonceCredentials]:
+            if keep_none and destination_oidc_credentials is None:
+                return None
+
+            # MyPy requires this to make sure it's not changed to None after inner declaration
+            assert sessions_cache is not None
+
+            key = (
+                f"{destination_oidc_credentials.client_id}:{hash(destination_oidc_credentials.client_secret)}"
+                if destination_oidc_credentials
+                else "DEFAULT"
+            )
+
+            ret = sessions_cache.get(key)
+            if not ret:
+                if destination_oidc_credentials and destination_oidc_credentials.client_id and destination_oidc_credentials.client_secret:
+                    credentials = ClientCredentials(destination_oidc_credentials.client_id, destination_oidc_credentials.client_secret)
+                else:
+                    credentials = None
+                try:
+                    session = self._cognite_client.iam.sessions.create(credentials)
+                    ret = DestinationNonceCredentials(session.id, session.nonce, self.destination_oidc_credentials.cdf_project_name)
+                    sessions_cache[key] = ret
+                except Exception:
+                    ret = None
+            return ret
+
+        if self.source_nonce:
+            self.source_nonce = try_get_or_create_source_nonce(self.source_oidc_credentials)
+            if self.source_nonce is None:
                 self.source_oidc_credentials = None
 
-        if self.destination_api_key is None and self.destination_nonce is None:
-            self.destination_nonce = try_get_or_create_nonce(self.destination_oidc_credentials)
-            if self.destination_nonce:
+        if  self.destination_nonce:
+            self.destination_nonce = try_get_or_create_destination_nonce(self.destination_oidc_credentials)
+            if self.destination_nonce is None:
                 self.destination_oidc_credentials = None
 
     def run(self, wait: bool = True, timeout: Optional[float] = None) -> TransformationJob:
@@ -288,11 +413,11 @@ class Transformation(CogniteResource):
 
         if isinstance(instance.source_session, dict):
             snake_dict = convert_all_keys_to_snake_case(instance.source_session)
-            instance.source_session = SessionDetails(**snake_dict)
+            instance.source_session = SessionSourceDetails(**snake_dict)
 
         if isinstance(instance.destination_session, dict):
             snake_dict = convert_all_keys_to_snake_case(instance.destination_session)
-            instance.destination_session = SessionDetails(**snake_dict)
+            instance.destination_session = SessionDestinationDetails(**snake_dict)
         return instance
 
     def dump(self, camel_case: bool = False) -> Dict[str, Any]:
@@ -310,7 +435,7 @@ class Transformation(CogniteResource):
         for name, prop in ret.items():
             if isinstance(
                 prop,
-                (OidcCredentials, NonceCredentials, TransformationDestination, SessionDetails, TransformationSchedule),
+                (OidcCredentials, SourceOidcCredentials, DestinationOidcCredentials,  NonceCredentials, SourceNonceCredentials, DestinationNonceCredentials, TransformationDestination, SessionDetails, SessionSourceDetails, SessionDestinationDetails, TransformationSchedule),
             ):
                 ret[name] = prop.dump(camel_case=camel_case)
         return ret
@@ -406,7 +531,7 @@ class TransformationUpdate(CogniteUpdate):
 
         for update in obj.get("update", {}).values():
             item = update.get("set")
-            if isinstance(item, (TransformationDestination, OidcCredentials, NonceCredentials)):
+            if isinstance(item, (TransformationDestination, OidcCredentials, SourceOidcCredentials, DestinationOidcCredentials, SourceNonceCredentials, DestinationNonceCredentials)):
                 update["set"] = item.dump(camel_case=camel_case)
         return obj
 

--- a/cognite/client/data_classes/transformations/__init__.py
+++ b/cognite/client/data_classes/transformations/__init__.py
@@ -16,7 +16,7 @@ from cognite.client.data_classes._base import (
 from cognite.client.data_classes.iam import ClientCredentials
 from cognite.client.data_classes.shared import TimestampRange
 from cognite.client.data_classes.transformations.common import (
-    DataModelInstances,
+    DataModel,
     NonceCredentials,
     OidcCredentials,
     RawTable,

--- a/cognite/client/data_classes/transformations/common.py
+++ b/cognite/client/data_classes/transformations/common.py
@@ -115,7 +115,7 @@ class TransformationDestination:
     @staticmethod
     def data_model_instances(
         model_external_id: str = "", space_external_id: str = "", instance_space_external_id: str = ""
-    ) -> DataModelInstances:
+    ) -> DataModel:
         """
         Args:
             model_external_id (str): external_id of the flexible data model.
@@ -124,14 +124,14 @@ class TransformationDestination:
         Returns:
             TransformationDestination pointing to the target flexible data model.
         """
-        return DataModelInstances(
+        return DataModel(
             model_external_id=model_external_id,
             space_external_id=space_external_id,
             instance_space_external_id=instance_space_external_id,
         )
 
     @staticmethod
-    def nodes(view: Optional[ViewInfo] = None, instance_space: Optional[str] = None) -> InstanceNodes:
+    def nodes(view: Optional[ViewInfo] = None, instance_space: Optional[str] = None) -> Nodes:
         """
         Args:
             view (ViewInfo): information of the view.
@@ -139,14 +139,14 @@ class TransformationDestination:
         Returns:
             InstanceNodes: pointing to the target flexible data model.
         """
-        return InstanceNodes(view=view, instance_space=instance_space)
+        return Nodes(view=view, instance_space=instance_space)
 
     @staticmethod
     def edges(
         view: Optional[ViewInfo] = None,
         instance_space: Optional[str] = None,
         edge_type: Optional[EdgeType] = None,
-    ) -> InstanceEdges:
+    ) -> Edges:
         """
         Args:
             view (ViewInfo): information of the view.
@@ -155,12 +155,12 @@ class TransformationDestination:
         Returns:
             InstanceEdges: pointing to the target flexible data model.
         """
-        return InstanceEdges(view=view, instance_space=instance_space, edge_type=edge_type)
+        return Edges(view=view, instance_space=instance_space, edge_type=edge_type)
 
     @staticmethod
     def instances(
         data_model: Optional[DataModelInfo] = None, instance_space: Optional[str] = None
-    ) -> InstanceDataModel:
+    ) -> Instances:
         """
         Args:
             dataModel (DataModelInfo): information of the Data Model.
@@ -168,7 +168,7 @@ class TransformationDestination:
         Returns:
             InstanceDataModel: pointing to the target centric data model.
         """
-        return InstanceDataModel(data_model=data_model, instance_space=instance_space)
+        return Instances(data_model=data_model, instance_space=instance_space)
 
 
 class RawTable(TransformationDestination):
@@ -190,7 +190,7 @@ class SequenceRows(TransformationDestination):
         return hash((self.type, self.external_id))
 
 
-class DataModelInstances(TransformationDestination):
+class DataModel(TransformationDestination):
     def __init__(
         self, model_external_id: str = None, space_external_id: str = None, instance_space_external_id: str = None
     ):
@@ -267,7 +267,7 @@ class DataModelInfo:
         return basic_obj_dump(self, camel_case)
 
 
-class InstanceNodes(TransformationDestination):
+class Nodes(TransformationDestination):
     def __init__(
         self,
         view: Optional[ViewInfo] = None,
@@ -290,7 +290,7 @@ class InstanceNodes(TransformationDestination):
         return inst
 
 
-class InstanceEdges(TransformationDestination):
+class Edges(TransformationDestination):
     def __init__(
         self,
         view: Optional[ViewInfo] = None,
@@ -317,7 +317,7 @@ class InstanceEdges(TransformationDestination):
         return inst
 
 
-class InstanceDataModel(TransformationDestination):
+class Instances(TransformationDestination):
     def __init__(
         self,
         data_model: Optional[DataModelInfo] = None,
@@ -410,10 +410,10 @@ def _load_destination_dct(
     dct: Dict[str, Any]
 ) -> Union[
     RawTable,
-    DataModelInstances,
-    InstanceNodes,
-    InstanceEdges,
-    InstanceDataModel,
+    DataModel,
+    Nodes,
+    Edges,
+    Instances,
     SequenceRows,
     TransformationDestination,
 ]:
@@ -422,16 +422,16 @@ def _load_destination_dct(
     destination_type = snake_dict.pop("type")
     simple = {
         "raw": RawTable,
-        "data_model_instances": DataModelInstances,
+        "data_model_instances": DataModel,
         "sequence_rows": SequenceRows,
     }
     if destination_type in simple:
         return simple[destination_type](**snake_dict)
 
-    nested: Dict[str, Union[type[InstanceNodes], type[InstanceEdges], type[InstanceDataModel]]] = {
-        "nodes": InstanceNodes,
-        "edges": InstanceEdges,
-        "instances": InstanceDataModel,
+    nested: Dict[str, Union[type[Nodes], type[Edges], type[Instances]]] = {
+        "nodes": Nodes,
+        "edges": Edges,
+        "instances": Instances,
     }
     if destination_type in nested:
         return nested[destination_type]._load(snake_dict)

--- a/cognite/client/data_classes/transformations/common.py
+++ b/cognite/client/data_classes/transformations/common.py
@@ -367,6 +367,63 @@ class OidcCredentials:
         """
         return basic_obj_dump(self, camel_case)
 
+class SourceOidcCredentials:
+    def __init__(
+        self,
+        client_id: str = None,
+        client_secret: str = None,
+        scopes: str = None,
+        token_uri: str = None,
+        audience: str = None,
+        cdf_project_name: str = None,
+    ):
+
+        self.client_id = client_id
+        self.client_secret = client_secret
+        self.scopes = scopes
+        self.token_uri = token_uri
+        self.audience = audience
+        self.cdf_project_name = cdf_project_name
+
+    def dump(self, camel_case: bool = False) -> Dict[str, Any]:
+        """Dump the instance into a json serializable Python data type.
+
+        Args:
+            camel_case (bool): Use camelCase for attribute names. Defaults to False.
+
+        Returns:
+            Dict[str, Any]: A dictionary representation of the instance.
+        """
+        return basic_obj_dump(self, camel_case)
+
+class DestinationOidcCredentials:
+    def __init__(
+        self,
+        client_id: str = None,
+        client_secret: str = None,
+        scopes: str = None,
+        token_uri: str = None,
+        audience: str = None,
+        cdf_project_name: str = None,
+    ):
+
+        self.client_id = client_id
+        self.client_secret = client_secret
+        self.scopes = scopes
+        self.token_uri = token_uri
+        self.audience = audience
+        self.cdf_project_name = cdf_project_name
+
+    def dump(self, camel_case: bool = False) -> Dict[str, Any]:
+        """Dump the instance into a json serializable Python data type.
+
+        Args:
+            camel_case (bool): Use camelCase for attribute names. Defaults to False.
+
+        Returns:
+            Dict[str, Any]: A dictionary representation of the instance.
+        """
+        return basic_obj_dump(self, camel_case)
 
 class NonceCredentials:
     def __init__(
@@ -390,6 +447,49 @@ class NonceCredentials:
         """
         return basic_obj_dump(self, camel_case)
 
+class SourceNonceCredentials:
+    def __init__(
+        self,
+        session_id: int,
+        nonce: str,
+        cdf_project_name: str,
+    ):
+        self.session_id = session_id
+        self.nonce = nonce
+        self.cdf_project_name = cdf_project_name
+
+    def dump(self, camel_case: bool = False) -> Dict[str, Any]:
+        """Dump the instance into a json serializable Python data type.
+
+        Args:
+            camel_case (bool): Use camelCase for attribute names. Defaults to False.
+
+        Returns:
+            Dict[str, Any]: A dictionary representation of the instance.
+        """
+        return basic_obj_dump(self, camel_case)
+
+class DestinationNonceCredentials:
+    def __init__(
+        self,
+        session_id: int,
+        nonce: str,
+        cdf_project_name: str,
+    ):
+        self.session_id = session_id
+        self.nonce = nonce
+        self.cdf_project_name = cdf_project_name
+
+    def dump(self, camel_case: bool = False) -> Dict[str, Any]:
+        """Dump the instance into a json serializable Python data type.
+
+        Args:
+            camel_case (bool): Use camelCase for attribute names. Defaults to False.
+
+        Returns:
+            Dict[str, Any]: A dictionary representation of the instance.
+        """
+        return basic_obj_dump(self, camel_case)
 
 class TransformationBlockedInfo:
     """Information about the reason why and when a transformation is blocked.

--- a/cognite/client/data_classes/transformations/common.py
+++ b/cognite/client/data_classes/transformations/common.py
@@ -116,9 +116,7 @@ class TransformationDestination:
     def data_model_instances(
         model_external_id: str = "", space_external_id: str = "", instance_space_external_id: str = ""
     ) -> DataModelInstances:
-        """To be used when the transformation is meant to produce data model instances.
-            Flexible Data Models resource type is on `beta` version currently.
-
+        """
         Args:
             model_external_id (str): external_id of the flexible data model.
             space_external_id (str): space external_id of the flexible data model.
@@ -133,10 +131,8 @@ class TransformationDestination:
         )
 
     @staticmethod
-    def instance_nodes(view: Optional[ViewInfo] = None, instance_space: Optional[str] = None) -> InstanceNodes:
-        """To be used when the transformation is meant to produce node's instances.
-            Flexible Data Models resource type is on `beta` version currently.
-
+    def nodes(view: Optional[ViewInfo] = None, instance_space: Optional[str] = None) -> InstanceNodes:
+        """
         Args:
             view (ViewInfo): information of the view.
             instance_space (str): space id of the instance.
@@ -146,14 +142,12 @@ class TransformationDestination:
         return InstanceNodes(view=view, instance_space=instance_space)
 
     @staticmethod
-    def instance_edges(
+    def edges(
         view: Optional[ViewInfo] = None,
         instance_space: Optional[str] = None,
         edge_type: Optional[EdgeType] = None,
     ) -> InstanceEdges:
-        """To be used when the transformation is meant to produce edge's instances.
-            Flexible Data Models resource type is on `beta` version currently.
-
+        """
         Args:
             view (ViewInfo): information of the view.
             instance_space (str): space id of the instance.
@@ -164,12 +158,10 @@ class TransformationDestination:
         return InstanceEdges(view=view, instance_space=instance_space, edge_type=edge_type)
 
     @staticmethod
-    def instance_data_model(
+    def instances(
         data_model: Optional[DataModelInfo] = None, instance_space: Optional[str] = None
     ) -> InstanceDataModel:
-        """To be used when the transformation is meant to produce dataModel's instances.
-            Flexible Data Models resource type is on `beta` version currently.
-
+        """
         Args:
             dataModel (DataModelInfo): information of the Data Model.
             instance_space (str): space id of the instance.

--- a/cognite/client/data_classes/transformations/common.py
+++ b/cognite/client/data_classes/transformations/common.py
@@ -137,7 +137,7 @@ class TransformationDestination:
             view (ViewInfo): information of the view.
             instance_space (str): space id of the instance.
         Returns:
-            InstanceNodes: pointing to the target flexible data model.
+            Nodes: pointing to the target flexible data model.
         """
         return Nodes(view=view, instance_space=instance_space)
 
@@ -153,20 +153,18 @@ class TransformationDestination:
             instance_space (str): space id of the instance.
             edge_type (EdgeType): information about the type of the edge
         Returns:
-            InstanceEdges: pointing to the target flexible data model.
+            Edges: pointing to the target flexible data model.
         """
         return Edges(view=view, instance_space=instance_space, edge_type=edge_type)
 
     @staticmethod
-    def instances(
-        data_model: Optional[DataModelInfo] = None, instance_space: Optional[str] = None
-    ) -> Instances:
+    def instances(data_model: Optional[DataModelInfo] = None, instance_space: Optional[str] = None) -> Instances:
         """
         Args:
             dataModel (DataModelInfo): information of the Data Model.
             instance_space (str): space id of the instance.
         Returns:
-            InstanceDataModel: pointing to the target centric data model.
+            Instances: pointing to the target centric data model.
         """
         return Instances(data_model=data_model, instance_space=instance_space)
 
@@ -283,7 +281,7 @@ class Nodes(TransformationDestination):
         self.instance_space = instance_space
 
     @classmethod
-    def _load(cls, resource: Dict[str, Any]) -> InstanceNodes:
+    def _load(cls, resource: Dict[str, Any]) -> Nodes:
         inst = cls(**resource)
         if isinstance(inst.view, dict):
             inst.view = ViewInfo(**convert_all_keys_to_snake_case(inst.view))
@@ -308,7 +306,7 @@ class Edges(TransformationDestination):
         self.edge_type = edge_type
 
     @classmethod
-    def _load(cls, resource: Dict[str, Any]) -> InstanceEdges:
+    def _load(cls, resource: Dict[str, Any]) -> Edges:
         inst = cls(**resource)
         if isinstance(inst.view, dict):
             inst.view = ViewInfo(**convert_all_keys_to_snake_case(inst.view))
@@ -333,7 +331,7 @@ class Instances(TransformationDestination):
         self.instance_space = instance_space
 
     @classmethod
-    def _load(cls, resource: Dict[str, Any]) -> InstanceDataModel:
+    def _load(cls, resource: Dict[str, Any]) -> Instances:
         inst = cls(**resource)
         if isinstance(inst.data_model, dict):
             inst.data_model = DataModelInfo(**convert_all_keys_to_snake_case(inst.data_model))
@@ -408,15 +406,7 @@ class TransformationBlockedInfo:
 
 def _load_destination_dct(
     dct: Dict[str, Any]
-) -> Union[
-    RawTable,
-    DataModel,
-    Nodes,
-    Edges,
-    Instances,
-    SequenceRows,
-    TransformationDestination,
-]:
+) -> Union[RawTable, DataModel, Nodes, Edges, Instances, SequenceRows, TransformationDestination,]:
     """Helper function to load destination from dictionary"""
     snake_dict = convert_all_keys_to_snake_case(dct)
     destination_type = snake_dict.pop("type")

--- a/cognite/client/data_classes/transformations/common.py
+++ b/cognite/client/data_classes/transformations/common.py
@@ -32,9 +32,6 @@ class TransformationDestination:
                 ret[k] = ret[k].dump(camel_case=camel_case)
         return ret
 
-
-
-
     @staticmethod
     def assets() -> TransformationDestination:
         """To be used when the transformation is meant to produce assets."""
@@ -167,7 +164,9 @@ class TransformationDestination:
         return InstanceEdges(view=view, instance_space=instance_space, edge_type=edge_type)
 
     @staticmethod
-    def instance_data_model(data_model: Optional[DataModelInfo] = None, instance_space: Optional[str] = None) -> InstanceDataModel:
+    def instance_data_model(
+        data_model: Optional[DataModelInfo] = None, instance_space: Optional[str] = None
+    ) -> InstanceDataModel:
         """To be used when the transformation is meant to produce dataModel's instances.
             Flexible Data Models resource type is on `beta` version currently.
 
@@ -178,6 +177,7 @@ class TransformationDestination:
             InstanceDataModel: pointing to the target centric data model.
         """
         return InstanceDataModel(data_model=data_model, instance_space=instance_space)
+
 
 class RawTable(TransformationDestination):
     def __init__(self, database: str = None, table: str = None):
@@ -240,8 +240,16 @@ class EdgeType:
     def dump(self, camel_case: bool = False) -> Dict[str, Any]:
         return basic_obj_dump(self, camel_case)
 
+
 class DataModelInfo:
-    def __init__(self, space: str, external_id: str, version: str, destination_type: str, destination_relationship_from_type: Optional[str] = None):
+    def __init__(
+        self,
+        space: str,
+        external_id: str,
+        version: str,
+        destination_type: str,
+        destination_relationship_from_type: Optional[str] = None,
+    ):
 
         self.space = space
         self.external_id = external_id
@@ -251,13 +259,21 @@ class DataModelInfo:
 
     def __hash__(self) -> int:
         if self.destination_relationship_from_type is not None:
-            return hash((self.space, self.external_id, self.version, self.destination_type,
-                         self.destination_relationship_from_type))
+            return hash(
+                (
+                    self.space,
+                    self.external_id,
+                    self.version,
+                    self.destination_type,
+                    self.destination_relationship_from_type,
+                )
+            )
         else:
             return hash((self.space, self.external_id, self.version, self.destination_type))
 
     def dump(self, camel_case: bool = False) -> Dict[str, Any]:
         return basic_obj_dump(self, camel_case)
+
 
 class InstanceNodes(TransformationDestination):
     def __init__(
@@ -307,6 +323,7 @@ class InstanceEdges(TransformationDestination):
         if isinstance(inst.edge_type, dict):
             inst.edge_type = EdgeType(**convert_all_keys_to_snake_case(inst.edge_type))
         return inst
+
 
 class InstanceDataModel(TransformationDestination):
     def __init__(
@@ -399,7 +416,15 @@ class TransformationBlockedInfo:
 
 def _load_destination_dct(
     dct: Dict[str, Any]
-) -> Union[RawTable, DataModelInstances, InstanceNodes, InstanceEdges, InstanceDataModel, SequenceRows, TransformationDestination]:
+) -> Union[
+    RawTable,
+    DataModelInstances,
+    InstanceNodes,
+    InstanceEdges,
+    InstanceDataModel,
+    SequenceRows,
+    TransformationDestination,
+]:
     """Helper function to load destination from dictionary"""
     snake_dict = convert_all_keys_to_snake_case(dct)
     destination_type = snake_dict.pop("type")

--- a/cognite/client/data_classes/transformations/common.py
+++ b/cognite/client/data_classes/transformations/common.py
@@ -255,8 +255,7 @@ class DataModelInfo:
                          self.destination_relationship_from_type))
         else:
             return hash((self.space, self.external_id, self.version, self.destination_type))
-    def __hash__(self) -> int:
-        return hash((self.space, self.external_id, self.version, self.destination_type))
+
     def dump(self, camel_case: bool = False) -> Dict[str, Any]:
         return basic_obj_dump(self, camel_case)
 

--- a/tests/tests_integration/test_api/test_transformations/test_transformations.py
+++ b/tests/tests_integration/test_api/test_transformations/test_transformations.py
@@ -13,15 +13,15 @@ from cognite.client.data_classes import (
 )
 from cognite.client.data_classes.transformations import ContainsAny
 from cognite.client.data_classes.transformations.common import (
+    DataModelInfo,
     EdgeType,
+    InstanceDataModel,
     InstanceEdges,
     InstanceNodes,
-    InstanceDataModel,
     NonceCredentials,
     OidcCredentials,
     SequenceRows,
     ViewInfo,
-    DataModelInfo,
 )
 from cognite.client.utils._text import random_string
 
@@ -236,7 +236,7 @@ class TestTransformationsAPI:
                 external_id="author_book",
                 version="v2",
                 destination_type="AuthorBook_relation",
-                destination_relationship_from_type =  None
+                destination_relationship_from_type=None,
             ),
             instance_space="test-instanceSpace",
         )
@@ -255,7 +255,6 @@ class TestTransformationsAPI:
         assert ts.destination.data_model.external_id == "author_book"
         assert ts.destination.data_model.version == "v2"
         assert ts.destination.data_model.destination_type == "AuthorBook_relation"
-
         assert ts.destination.instance_space == "test-instanceSpace"
 
         cognite_client.transformations.delete(id=ts.id)
@@ -454,7 +453,8 @@ class TestTransformationsAPI:
         )
         partial_update = TransformationUpdate(id=new_transformation.id).destination.set(
             TransformationDestination.instance_data_model(
-                DataModelInfo("authorBook", "author_book", "v2", "AuthorBook_relation", "author_book"), "test-instanceSpace"
+                DataModelInfo("authorBook", "author_book", "v2", "AuthorBook_relation", "author_book"),
+                "test-instanceSpace",
             )
         )
         updated_transformation = cognite_client.transformations.update(new_transformation)
@@ -465,6 +465,7 @@ class TestTransformationsAPI:
         assert partial_updated.destination == TransformationDestination.instance_data_model(
             DataModelInfo("authorBook", "author_book", "v2", "AuthorBook_relation", "author_book"), "test-instanceSpace"
         )
+
     def test_update_sequence_rows_update(self, cognite_client, new_transformation):
         new_transformation.destination = SequenceRows("myTest")
         updated_transformation = cognite_client.transformations.update(new_transformation)

--- a/tests/tests_integration/test_api/test_transformations/test_transformations.py
+++ b/tests/tests_integration/test_api/test_transformations/test_transformations.py
@@ -413,9 +413,7 @@ class TestTransformationsAPI:
             ViewInfo("myViewExternalId", "myViewVersion", "test-space"), "test-space"
         )
         partial_update = TransformationUpdate(id=new_transformation.id).destination.set(
-            TransformationDestination.nodes(
-                ViewInfo("myViewExternalId", "myViewVersion2", "test-space"), "test-space"
-            )
+            TransformationDestination.nodes(ViewInfo("myViewExternalId", "myViewVersion2", "test-space"), "test-space")
         )
         updated_transformation = cognite_client.transformations.update(new_transformation)
         assert updated_transformation.destination == TransformationDestination.nodes(

--- a/tests/tests_integration/test_api/test_transformations/test_transformations.py
+++ b/tests/tests_integration/test_api/test_transformations/test_transformations.py
@@ -144,7 +144,7 @@ class TestTransformationsAPI:
 
     def test_create_instance_nodes_transformation(self, cognite_client):
         prefix = random_string(6, string.ascii_letters)
-        instance_nodes = TransformationDestination.instance_nodes(
+        nodes = TransformationDestination.nodes(
             view=ViewInfo(
                 space="test-space", external_id="testInstanceViewExternalId", version="testInstanceViewVersion"
             ),
@@ -153,7 +153,7 @@ class TestTransformationsAPI:
         transform = Transformation(
             name="any",
             external_id=f"{prefix}-transformation",
-            destination=instance_nodes,
+            destination=nodes,
         )
         ts = cognite_client.transformations.create(transform)
         assert isinstance(ts.destination, InstanceNodes)
@@ -170,7 +170,7 @@ class TestTransformationsAPI:
 
     def test_create_instance_edges_view_transformation(self, cognite_client):
         prefix = random_string(6, string.ascii_letters)
-        instance_edges = TransformationDestination.instance_edges(
+        edges = TransformationDestination.edges(
             view=ViewInfo(
                 external_id="view-testInstanceViewExternalId",
                 version="view-testInstanceViewVersion",
@@ -183,7 +183,7 @@ class TestTransformationsAPI:
         transform = Transformation(
             name="any",
             external_id=f"{prefix}-transformation",
-            destination=instance_edges,
+            destination=edges,
         )
         ts = cognite_client.transformations.create(transform)
         assert ts.destination.type == "edges"
@@ -201,7 +201,7 @@ class TestTransformationsAPI:
 
     def test_create_instance_edges_type_transformation(self, cognite_client):
         prefix = random_string(6, string.ascii_letters)
-        instance_edges = TransformationDestination.instance_edges(
+        edges = TransformationDestination.edges(
             view=None,
             instance_space="test-instance-space",
             edge_type=EdgeType(
@@ -213,7 +213,7 @@ class TestTransformationsAPI:
         transform = Transformation(
             name="any",
             external_id=f"{prefix}-transformation",
-            destination=instance_edges,
+            destination=edges,
         )
         ts = cognite_client.transformations.create(transform)
         assert ts.destination.type == "edges"
@@ -230,7 +230,7 @@ class TestTransformationsAPI:
 
     def test_create_instance_data_model_transformation(self, cognite_client):
         prefix = random_string(6, string.ascii_letters)
-        instance_data_model = TransformationDestination.instance_data_model(
+        instances = TransformationDestination.instances(
             data_model=DataModelInfo(
                 space="authorBook",
                 external_id="author_book",
@@ -244,7 +244,7 @@ class TestTransformationsAPI:
             name="any",
             external_id=f"{prefix}-transformation",
             query="SELECT * FROM my_source_table",
-            destination=instance_data_model,
+            destination=instances,
         )
         ts = cognite_client.transformations.create(transform)
         assert isinstance(ts.destination, InstanceDataModel)
@@ -409,60 +409,60 @@ class TestTransformationsAPI:
         )
 
     def test_update_instance_nodes(self, cognite_client, new_transformation):
-        new_transformation.destination = TransformationDestination.instance_nodes(
+        new_transformation.destination = TransformationDestination.nodes(
             ViewInfo("myViewExternalId", "myViewVersion", "test-space"), "test-space"
         )
         partial_update = TransformationUpdate(id=new_transformation.id).destination.set(
-            TransformationDestination.instance_nodes(
+            TransformationDestination.nodes(
                 ViewInfo("myViewExternalId", "myViewVersion2", "test-space"), "test-space"
             )
         )
         updated_transformation = cognite_client.transformations.update(new_transformation)
-        assert updated_transformation.destination == TransformationDestination.instance_nodes(
+        assert updated_transformation.destination == TransformationDestination.nodes(
             ViewInfo("myViewExternalId", "myViewVersion", "test-space"), "test-space"
         )
         partial_updated = cognite_client.transformations.update(partial_update)
-        assert partial_updated.destination == TransformationDestination.instance_nodes(
+        assert partial_updated.destination == TransformationDestination.nodes(
             ViewInfo("myViewExternalId", "myViewVersion2", "test-space"), "test-space"
         )
 
     def test_update_instance_edges(self, cognite_client, new_transformation):
-        new_transformation.destination = TransformationDestination.instance_edges(
+        new_transformation.destination = TransformationDestination.edges(
             instance_space="test-space", edge_type=EdgeType("edge-space", "myEdge")
         )
         partial_update = TransformationUpdate(id=new_transformation.id).destination.set(
-            TransformationDestination.instance_edges(
+            TransformationDestination.edges(
                 instance_space="test-space",
                 edge_type=EdgeType("edge-space2", "myEdge2"),
             )
         )
         updated_transformation = cognite_client.transformations.update(new_transformation)
-        assert updated_transformation.destination == TransformationDestination.instance_edges(
+        assert updated_transformation.destination == TransformationDestination.edges(
             None, "test-space", EdgeType("edge-space", "myEdge")
         )
         partial_updated = cognite_client.transformations.update(partial_update)
-        assert partial_updated.destination == TransformationDestination.instance_edges(
+        assert partial_updated.destination == TransformationDestination.edges(
             None,
             "test-space",
             EdgeType("edge-space2", "myEdge2"),
         )
 
     def test_update_instance_data_model(self, cognite_client, new_transformation):
-        new_transformation.destination = TransformationDestination.instance_data_model(
+        new_transformation.destination = TransformationDestination.instances(
             DataModelInfo("authorBook", "author_book", "v2", "AuthorBook_relation", None), "test-instanceSpace"
         )
         partial_update = TransformationUpdate(id=new_transformation.id).destination.set(
-            TransformationDestination.instance_data_model(
+            TransformationDestination.instances(
                 DataModelInfo("authorBook", "author_book", "v2", "AuthorBook_relation", "author_book"),
                 "test-instanceSpace",
             )
         )
         updated_transformation = cognite_client.transformations.update(new_transformation)
-        assert updated_transformation.destination == TransformationDestination.instance_data_model(
+        assert updated_transformation.destination == TransformationDestination.instances(
             DataModelInfo("authorBook", "author_book", "v2", "AuthorBook_relation", None), "test-instanceSpace"
         )
         partial_updated = cognite_client.transformations.update(partial_update)
-        assert partial_updated.destination == TransformationDestination.instance_data_model(
+        assert partial_updated.destination == TransformationDestination.instances(
             DataModelInfo("authorBook", "author_book", "v2", "AuthorBook_relation", "author_book"), "test-instanceSpace"
         )
 

--- a/tests/tests_integration/test_api/test_transformations/test_transformations.py
+++ b/tests/tests_integration/test_api/test_transformations/test_transformations.py
@@ -255,6 +255,7 @@ class TestTransformationsAPI:
         assert ts.destination.data_model.external_id == "author_book"
         assert ts.destination.data_model.version == "v2"
         assert ts.destination.data_model.destination_type == "AuthorBook_relation"
+
         assert ts.destination.instance_space == "test-instanceSpace"
 
         cognite_client.transformations.delete(id=ts.id)

--- a/tests/tests_integration/test_api/test_transformations/test_transformations.py
+++ b/tests/tests_integration/test_api/test_transformations/test_transformations.py
@@ -14,9 +14,9 @@ from cognite.client.data_classes import (
 from cognite.client.data_classes.transformations import ContainsAny
 from cognite.client.data_classes.transformations.common import (
     DataModelInfo,
+    Edges,
     EdgeType,
     Instances,
-    Edges,
     Nodes,
     NonceCredentials,
     OidcCredentials,

--- a/tests/tests_integration/test_api/test_transformations/test_transformations.py
+++ b/tests/tests_integration/test_api/test_transformations/test_transformations.py
@@ -16,10 +16,12 @@ from cognite.client.data_classes.transformations.common import (
     EdgeType,
     InstanceEdges,
     InstanceNodes,
+    InstanceDataModel,
     NonceCredentials,
     OidcCredentials,
     SequenceRows,
     ViewInfo,
+    DataModelInfo,
 )
 from cognite.client.utils._text import random_string
 
@@ -226,6 +228,38 @@ class TestTransformationsAPI:
 
         cognite_client.transformations.delete(id=ts.id)
 
+    def test_create_instance_data_model_transformation(self, cognite_client):
+        prefix = random_string(6, string.ascii_letters)
+        instance_data_model = TransformationDestination.instance_data_model(
+            data_model=DataModelInfo(
+                space="authorBook",
+                external_id="author_book",
+                version="v2",
+                destination_type="AuthorBook_relation",
+                destination_relationship_from_type =  None
+            ),
+            instance_space="test-instanceSpace",
+        )
+        transform = Transformation(
+            name="any",
+            external_id=f"{prefix}-transformation",
+            query="SELECT * FROM my_source_table",
+            destination=instance_data_model,
+        )
+        ts = cognite_client.transformations.create(transform)
+        assert isinstance(ts.destination, InstanceDataModel)
+        assert ts.destination.type == "instances"
+
+        assert isinstance(ts.destination.data_model, DataModelInfo)
+        assert ts.destination.data_model.space == "authorBook"
+        assert ts.destination.data_model.external_id == "author_book"
+        assert ts.destination.data_model.version == "v2"
+        assert ts.destination.data_model.destination_type == "AuthorBook_relation"
+        assert ts.destination.data_model.destination_relationship_from_type == None
+        assert ts.destination.instance_space == "test-instanceSpace"
+
+        cognite_client.transformations.delete(id=ts.id)
+
     def test_create_sequence_rows_transformation(self, cognite_client):
         prefix = random_string(6, string.ascii_letters)
         transform = Transformation(
@@ -414,6 +448,23 @@ class TestTransformationsAPI:
             EdgeType("edge-space2", "myEdge2"),
         )
 
+    def test_update_instance_data_model(self, cognite_client, new_transformation):
+        new_transformation.destination = TransformationDestination.instance_data_model(
+            DataModelInfo("authorBook", "author_book", "v2", "AuthorBook_relation", None), "test-instanceSpace"
+        )
+        partial_update = TransformationUpdate(id=new_transformation.id).destination.set(
+            TransformationDestination.instance_data_model(
+                DataModelInfo("authorBook", "author_book", "v2", "AuthorBook_relation", "author_book"), "test-instanceSpace"
+            )
+        )
+        updated_transformation = cognite_client.transformations.update(new_transformation)
+        assert updated_transformation.destination == TransformationDestination.instance_data_model(
+            DataModelInfo("authorBook", "author_book", "v2", "AuthorBook_relation", None), "test-instanceSpace"
+        )
+        partial_updated = cognite_client.transformations.update(partial_update)
+        assert partial_updated.destination == TransformationDestination.instance_data_model(
+            DataModelInfo("authorBook", "author_book", "v2", "AuthorBook_relation", "author_book"), "test-instanceSpace"
+        )
     def test_update_sequence_rows_update(self, cognite_client, new_transformation):
         new_transformation.destination = SequenceRows("myTest")
         updated_transformation = cognite_client.transformations.update(new_transformation)

--- a/tests/tests_integration/test_api/test_transformations/test_transformations.py
+++ b/tests/tests_integration/test_api/test_transformations/test_transformations.py
@@ -255,7 +255,6 @@ class TestTransformationsAPI:
         assert ts.destination.data_model.external_id == "author_book"
         assert ts.destination.data_model.version == "v2"
         assert ts.destination.data_model.destination_type == "AuthorBook_relation"
-        assert ts.destination.data_model.destination_relationship_from_type == None
         assert ts.destination.instance_space == "test-instanceSpace"
 
         cognite_client.transformations.delete(id=ts.id)

--- a/tests/tests_integration/test_api/test_transformations/test_transformations.py
+++ b/tests/tests_integration/test_api/test_transformations/test_transformations.py
@@ -15,9 +15,9 @@ from cognite.client.data_classes.transformations import ContainsAny
 from cognite.client.data_classes.transformations.common import (
     DataModelInfo,
     EdgeType,
-    InstanceDataModel,
-    InstanceEdges,
-    InstanceNodes,
+    Instances,
+    Edges,
+    Nodes,
     NonceCredentials,
     OidcCredentials,
     SequenceRows,
@@ -156,7 +156,7 @@ class TestTransformationsAPI:
             destination=nodes,
         )
         ts = cognite_client.transformations.create(transform)
-        assert isinstance(ts.destination, InstanceNodes)
+        assert isinstance(ts.destination, Nodes)
         assert ts.destination.type == "nodes"
 
         assert isinstance(ts.destination.view, ViewInfo)
@@ -187,7 +187,7 @@ class TestTransformationsAPI:
         )
         ts = cognite_client.transformations.create(transform)
         assert ts.destination.type == "edges"
-        assert isinstance(ts.destination, InstanceEdges)
+        assert isinstance(ts.destination, Edges)
         assert isinstance(ts.destination.view, ViewInfo)
 
         assert ts.destination.view.external_id == "view-testInstanceViewExternalId"
@@ -217,7 +217,7 @@ class TestTransformationsAPI:
         )
         ts = cognite_client.transformations.create(transform)
         assert ts.destination.type == "edges"
-        assert isinstance(ts.destination, InstanceEdges)
+        assert isinstance(ts.destination, Edges)
 
         assert ts.destination.view is None
 
@@ -247,7 +247,7 @@ class TestTransformationsAPI:
             destination=instances,
         )
         ts = cognite_client.transformations.create(transform)
-        assert isinstance(ts.destination, InstanceDataModel)
+        assert isinstance(ts.destination, Instances)
         assert ts.destination.type == "instances"
 
         assert isinstance(ts.destination.data_model, DataModelInfo)


### PR DESCRIPTION
- tests/tests_integration/test_api/test_transformations/test_transformations.py
test_create_asset_with_source_destination_oidc_transformation -> created,  test_update_nonce, test_update_non
ce_full -> updated

- cognite/client/data_classes/transformations/common.py

SourceOidcCredentials, DestinationOidcCredentials, SourceNonceCredentials, DestinationNonceCredentials, Sessi
onSourceDetails, SessionDestinationDetails classes defined

- cognite/client/data_classes/transformations/__init__.py

        if self.source_nonce:
            self.source_nonce = try_get_or_create_source_nonce(self.source_oidc_credentials)
            if self.source_nonce is None:
                self.source_oidc_credentials = None

        if  self.destination_nonce:
            self.destination_nonce = try_get_or_create_destination_nonce(self.destination_oidc_credentials)
            if self.destination_nonce is None:
                self.destination_oidc_credentials = None

- cognite/client/data_classes/__init__.py

    SourceOidcCredentials, DestinationOidcCredentials, imported to from cognite.client.data_classes.transformations

- cognite/client/_api/transformations/__init__.py

sessions: Dict[str, Union[NonceCredentials, SourceNonceCredentials, DestinationNonceCredentials]] 
