### PR TITLE
Test Suite on Windows Image

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,6 +27,18 @@ jobs:
         run: |
           pre-commit run --all-files
 
+      - name: Verify proto files
+        env:
+          TMPDIR: latest_proto
+          PROTO_URL: https://raw.githubusercontent.com/cognitedata/protobuf-files/master/v1/timeseries
+        run: |
+          mkdir $TMPDIR
+          curl --silent $PROTO_URL/data_points.proto --output $TMPDIR/data_points.proto
+          curl --silent $PROTO_URL/data_point_list_response.proto --output $TMPDIR/data_point_list_response.proto
+          diff $TMPDIR/data_points.proto cognite/client/_proto/data_points.proto
+          diff $TMPDIR/data_point_list_response.proto cognite/client/_proto/data_point_list_response.proto
+
+
   build_docs:
     runs-on: ubuntu-latest
     steps:
@@ -101,9 +113,6 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           file: ./coverage.xml
 
-      - name: Build package
-        run: poetry build
-
   build:
     runs-on: ubuntu-latest
     steps:
@@ -115,24 +124,6 @@ jobs:
       - name: Install full dependencies
         run: |
           python3 -m pip install --upgrade pip poetry
-          poetry config virtualenvs.create false
-          poetry install -E all
-
-      - name: Verify proto files
-        env:
-          TMPDIR: latest_proto
-          PROTO_URL: https://raw.githubusercontent.com/cognitedata/protobuf-files/master/v1/timeseries
-        run: |
-          mkdir $TMPDIR
-          curl --silent $PROTO_URL/data_points.proto --output $TMPDIR/data_points.proto
-          curl --silent $PROTO_URL/data_point_list_response.proto --output $TMPDIR/data_point_list_response.proto
-          diff $TMPDIR/data_points.proto cognite/client/_proto/data_points.proto
-          diff $TMPDIR/data_point_list_response.proto cognite/client/_proto/data_point_list_response.proto
-
-      - uses: codecov/codecov-action@v3
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          file: ./coverage.xml
 
       - name: Build package
         run: poetry build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,6 +5,9 @@ on:
   pull_request:
     branches: [master]
 
+env:
+  PYTHON_VERSION: '3.8'
+
 jobs:
   lint:
     runs-on: ubuntu-latest
@@ -12,7 +15,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
-          python-version: 3.8
+          python-version: ${{ env.PYTHON_VERSION }}
 
       - name: Install required dependencies
         run: |
@@ -30,7 +33,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
-          python-version: 3.8
+          python-version: ${{ env.PYTHON_VERSION }}
 
       - name: Install core dependencies
         run: |
@@ -47,7 +50,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
-          python-version: 3.8
+          python-version: ${{ env.PYTHON_VERSION }}
 
       - name: Install core dependencies
         run: |
@@ -61,13 +64,53 @@ jobs:
         run: pytest tests/tests_unit -n8 --dist loadscope --maxfail 10 -m 'not dsl'
           --test-deps-only-core
 
-  test_full_and_build:
+  test_full:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      - name: Install full dependencies
+        run: |
+          python3 -m pip install --upgrade pip poetry
+          poetry config virtualenvs.create false
+          poetry install -E all
+
+      - name: Test full
+        env:
+          LOGIN_FLOW: client_credentials
+          COGNITE_CLIENT_SECRET: ${{ secrets.COGNITE_CLIENT_SECRET }}
+          COGNITE_TOKEN_URL: https://login.microsoftonline.com/dff7763f-e2f5-4ffd-9b8a-4ba4bafba5ea/oauth2/v2.0/token
+          COGNITE_TOKEN_SCOPES: https://greenfield.cognitedata.com/.default
+          COGNITE_CLIENT_ID: 14fd282e-f77a-457d-add5-928ec2bcbf04
+          COGNITE_PROJECT: python-sdk-test
+          COGNITE_BASE_URL: https://greenfield.cognitedata.com
+          COGNITE_CLIENT_NAME: python-sdk-integration-tests
+          CI: 1
+        run: |
+          pytest tests --durations=10 --cov --cov-report xml:coverage.xml -n8 --dist loadscope --reruns 2
+
+      - uses: codecov/codecov-action@v3
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          file: ./coverage.xml
+
+      - name: Build package
+        run: poetry build
+
+  build:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
-          python-version: 3.8
+          python-version: ${{ env.PYTHON_VERSION }}
 
       - name: Install full dependencies
         run: |
@@ -85,20 +128,6 @@ jobs:
           curl --silent $PROTO_URL/data_point_list_response.proto --output $TMPDIR/data_point_list_response.proto
           diff $TMPDIR/data_points.proto cognite/client/_proto/data_points.proto
           diff $TMPDIR/data_point_list_response.proto cognite/client/_proto/data_point_list_response.proto
-
-      - name: Test full
-        env:
-          LOGIN_FLOW: client_credentials
-          COGNITE_CLIENT_SECRET: ${{ secrets.COGNITE_CLIENT_SECRET }}
-          COGNITE_TOKEN_URL: https://login.microsoftonline.com/dff7763f-e2f5-4ffd-9b8a-4ba4bafba5ea/oauth2/v2.0/token
-          COGNITE_TOKEN_SCOPES: https://greenfield.cognitedata.com/.default
-          COGNITE_CLIENT_ID: 14fd282e-f77a-457d-add5-928ec2bcbf04
-          COGNITE_PROJECT: python-sdk-test
-          COGNITE_BASE_URL: https://greenfield.cognitedata.com
-          COGNITE_CLIENT_NAME: python-sdk-integration-tests
-          CI: 1
-        run: |
-          pytest tests --durations=10 --cov --cov-report xml:coverage.xml -n8 --dist loadscope --reruns 2
 
       - uses: codecov/codecov-action@v3
         with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -5,6 +5,9 @@ on:
   push:
     branches: [master]
 
+env:
+  PYTHON_VERSION: '3.8'
+
 jobs:
   lint:
     runs-on: ubuntu-latest
@@ -12,7 +15,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
-          python-version: 3.8
+          python-version: ${{ env.PYTHON_VERSION }}
 
       - name: Install required dependencies
         run: |
@@ -24,13 +27,24 @@ jobs:
         run: |
           pre-commit run --all-files
 
+      - name: Verify proto files
+        env:
+          TMPDIR: latest_proto
+          PROTO_URL: https://raw.githubusercontent.com/cognitedata/protobuf-files/master/v1/timeseries
+        run: |
+          mkdir $TMPDIR
+          curl --silent $PROTO_URL/data_points.proto --output $TMPDIR/data_points.proto
+          curl --silent $PROTO_URL/data_point_list_response.proto --output $TMPDIR/data_point_list_response.proto
+          diff $TMPDIR/data_points.proto cognite/client/_proto/data_points.proto
+          diff $TMPDIR/data_point_list_response.proto cognite/client/_proto/data_point_list_response.proto
+
   test_core:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
-          python-version: 3.8
+          python-version: ${{ env.PYTHON_VERSION }}
 
       - name: Install required dependencies
         run: |
@@ -44,30 +58,23 @@ jobs:
         run: pytest tests/tests_unit -n8 --dist loadscope --maxfail 10 -m 'not dsl'
           --test-deps-only-core
 
-  test_full_and_build_and_release:
-    runs-on: ubuntu-latest
+  test_full:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest]
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
-          python-version: 3.8
+          python-version: ${{ env.PYTHON_VERSION }}
 
       - name: Install full dependencies
         run: |
           python3 -m pip install --upgrade pip poetry
           poetry config virtualenvs.create false
           poetry install -E all
-
-      - name: Verify proto files
-        env:
-          TMPDIR: latest_proto
-          PROTO_URL: https://raw.githubusercontent.com/cognitedata/protobuf-files/master/v1/timeseries
-        run: |
-          mkdir $TMPDIR
-          curl --silent $PROTO_URL/data_points.proto --output $TMPDIR/data_points.proto
-          curl --silent $PROTO_URL/data_point_list_response.proto --output $TMPDIR/data_point_list_response.proto
-          diff $TMPDIR/data_points.proto cognite/client/_proto/data_points.proto
-          diff $TMPDIR/data_point_list_response.proto cognite/client/_proto/data_point_list_response.proto
 
       - name: Test full
         env:
@@ -81,12 +88,26 @@ jobs:
           COGNITE_CLIENT_NAME: python-sdk-integration-tests
           CI: 1
         run: |
-          pytest tests --cov --cov-report xml:coverage.xml -n8 --dist loadscope --reruns 2
+          pytest tests --durations=10 --cov --cov-report xml:coverage.xml -n8 --dist loadscope --reruns 2
 
       - uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           file: ./coverage.xml
+
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      - name: Install full dependencies
+        run: |
+          python3 -m pip install --upgrade pip poetry
+          poetry config virtualenvs.create false
+          poetry install -E all
 
       - name: Build package
         run: poetry build

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -88,7 +88,7 @@ jobs:
           COGNITE_CLIENT_NAME: python-sdk-integration-tests
           CI: 1
         run: |
-          pytest tests --durations=10 --cov --cov-report xml:coverage.xml -n8 --dist loadscope --reruns 2
+          pytest tests --cov --cov-report xml:coverage.xml -n8 --dist loadscope --reruns 2
 
       - uses: codecov/codecov-action@v3
         with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -97,6 +97,7 @@ jobs:
 
   build:
     runs-on: ubuntu-latest
+    needs: [lint, test_full]
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,14 +34,14 @@ repos:
       - id: debug-statements
       - id: check-docstring-first
 
-  - hooks:
-    - id: mypy
-      name: mypy
-      entry: mypy run -- cognite
-      files: ^.*.(py|pyi)$
-      language: system
-      pass_filenames: false
-    repo: local
+#  - hooks:
+#    - id: mypy
+#      name: mypy
+#      entry: dmypy run -- cognite
+#      files: ^.*.(py|pyi)$
+#      language: system
+#      pass_filenames: false
+#    repo: local
 
   - hooks:
       - id: version-match-check

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,7 +37,7 @@ repos:
   - hooks:
     - id: mypy
       name: mypy
-      entry: dmypy run -- cognite
+      entry: mypy run -- cognite
       files: ^.*.(py|pyi)$
       language: system
       pass_filenames: false

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,14 +34,14 @@ repos:
       - id: debug-statements
       - id: check-docstring-first
 
-#  - hooks:
-#    - id: mypy
-#      name: mypy
-#      entry: dmypy run -- cognite
-#      files: ^.*.(py|pyi)$
-#      language: system
-#      pass_filenames: false
-#    repo: local
+  - hooks:
+    - id: mypy
+      name: mypy
+      entry: dmypy run -- cognite
+      files: ^.*.(py|pyi)$
+      language: system
+      pass_filenames: false
+    repo: local
 
   - hooks:
       - id: version-match-check

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,9 +17,9 @@ Changes are grouped as follows
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
-## [6.1.2] - 02-05-23
+## [6.1.2] - 03-05-23
 ### Fixed
-- Handling negative epochs in the `DatapointsAPI` on Windows.
+- Handling `datetime`s in local time (naive) before epoch no longer raises on Windows (utility function `cognite.client.utils.datetime_to_ms`).
 
 ## [6.1.1] - 28-04-23
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,11 @@ Changes are grouped as follows
 
 ## [6.1.2] - 04-05-23
 ### Improved
-- Error message when failing to convert naive `datetime`s in the utility function `cognite.client.utils.datetime_to_ms`.
+- The SDK has received several minor bugfixes to be more user-friendly on Windows.
+
+### Fixed
+- The utility function `cognite.client.utils.datetime_to_ms` now raises an understandable `ValueError` when unable to convert pre-epoch datetimes.
+- Several functions reading and writing to disk now explicitly use UTF-8 encoding
 
 ## [6.1.1] - 28-04-23
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ Changes are grouped as follows
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
+## [6.1.2] - 02-05-23
+### Fixed
+- Handling negative epochs in the `DatapointsAPI` on Windows.
+
 ## [6.1.1] - 28-04-23
 ### Fixed
 - `AttributeError` when passing `pandas.Timestamp`s with different timezones (*of which one was UTC*) to `DatapointsAPI.retrieve_dataframe_in_tz`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,9 +17,9 @@ Changes are grouped as follows
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
-## [6.1.2] - 03-05-23
-### Fixed
-- Handling `datetime`s in local time (naive) before epoch no longer raises on Windows (utility function `cognite.client.utils.datetime_to_ms`).
+## [6.1.2] - 04-05-23
+### Improved
+- Error message when failing to convert naive `datetime`s in the utility function `cognite.client.utils.datetime_to_ms`.
 
 ## [6.1.1] - 28-04-23
 ### Fixed

--- a/cognite/client/_api/geospatial.py
+++ b/cognite/client/_api/geospatial.py
@@ -1107,7 +1107,7 @@ class GeospatialAPI(APIClient):
         <https://docs.cognite.com/api/v1/#tag/Geospatial/operation/getRaster>
 
         Args:
-            feature_type_external_id : Feature type definition for the features to create.
+            feature_type_external_id: Feature type definition for the features to create.
             feature_external_id: one feature or a list of features to create
             raster_property_name: the raster property name
             raster_format: the raster output format

--- a/cognite/client/_version.py
+++ b/cognite/client/_version.py
@@ -1,4 +1,4 @@
 from __future__ import annotations
 
-__version__ = "6.1.1"
+__version__ = "6.1.2"
 __api_subversion__ = "V20220125"

--- a/cognite/client/data_classes/assets.py
+++ b/cognite/client/data_classes/assets.py
@@ -750,7 +750,7 @@ class AssetHierarchy:
         if output_file is None:
             print(out)  # noqa: T201
         elif isinstance(output_file, Path):
-            with output_file.open("a") as file:
+            with output_file.open("a", encoding="utf-8") as file:
                 print(out, file=file)
         else:
             try:

--- a/cognite/client/utils/_time.py
+++ b/cognite/client/utils/_time.py
@@ -73,8 +73,8 @@ def datetime_to_ms(dt: datetime) -> int:
     try:
         return int(1000 * dt.timestamp())
     except OSError:
-        # OSError is raised if dt.timestamp() is called before 1970-01-01 on Windows
-        return int(1000 * (dt - datetime(1970, 1, 1, tzinfo=dt.tzinfo)).total_seconds())
+        # OSError is raised if dt.timestamp() is called before 1970-01-01 on Windows for naive datetime.
+        return int(1000 * (dt - datetime(1970, 1, 1)).total_seconds())
 
 
 def ms_to_datetime(ms: Union[int, float]) -> datetime:

--- a/cognite/client/utils/_time.py
+++ b/cognite/client/utils/_time.py
@@ -79,6 +79,7 @@ def datetime_to_ms(dt: datetime) -> int:
         except TypeError:
             return int(1000 * (dt - datetime(1970, 1, 1, tzinfo=timezone.utc)).total_seconds())
 
+
 def ms_to_datetime(ms: Union[int, float]) -> datetime:
     """Converts valid Cognite timestamps, i.e. milliseconds since epoch, to datetime object.
 

--- a/cognite/client/utils/_time.py
+++ b/cognite/client/utils/_time.py
@@ -72,12 +72,11 @@ def datetime_to_ms(dt: datetime) -> int:
     """
     try:
         return int(1000 * dt.timestamp())
-    except OSError:
+    except OSError as e:
         # OSError is raised if dt.timestamp() is called before 1970-01-01 on Windows for naive datetime.
-        try:
-            return int(1000 * (dt - datetime(1970, 1, 1)).total_seconds())
-        except TypeError:
-            return int(1000 * (dt - datetime(1970, 1, 1, tzinfo=timezone.utc)).total_seconds())
+        raise ValueError("Failed to convert datetime to epoch. "
+                         "This likely because you are using a naive datetime."
+                         " Try using a timezone aware datetime instead.") from e
 
 
 def ms_to_datetime(ms: Union[int, float]) -> datetime:

--- a/cognite/client/utils/_time.py
+++ b/cognite/client/utils/_time.py
@@ -62,7 +62,7 @@ def get_utc_zoneinfo() -> ZoneInfo:
 
 
 def datetime_to_ms(dt: datetime) -> int:
-    """Converts datetime object to milliseconds since epoch.
+    """Converts a datetime object to milliseconds since epoch.
 
     Args:
         dt (datetime): Naive or aware datetime object. Naive datetimes are interpreted as local time.
@@ -70,7 +70,11 @@ def datetime_to_ms(dt: datetime) -> int:
     Returns:
         ms: Milliseconds since epoch (negative for time prior to 1970-01-01)
     """
-    return int(1000 * dt.timestamp())
+    try:
+        return int(1000 * dt.timestamp())
+    except OSError:
+        # OSError is raised if dt.timestamp() is called before 1970-01-01 on Windows
+        return int(1000 * (dt - datetime(1970, 1, 1, tzinfo=dt.tzinfo)).total_seconds())
 
 
 def ms_to_datetime(ms: Union[int, float]) -> datetime:

--- a/cognite/client/utils/_time.py
+++ b/cognite/client/utils/_time.py
@@ -74,8 +74,10 @@ def datetime_to_ms(dt: datetime) -> int:
         return int(1000 * dt.timestamp())
     except OSError:
         # OSError is raised if dt.timestamp() is called before 1970-01-01 on Windows for naive datetime.
-        return int(1000 * (dt - datetime(1970, 1, 1)).total_seconds())
-
+        try:
+            return int(1000 * (dt - datetime(1970, 1, 1)).total_seconds())
+        except TypeError:
+            return int(1000 * (dt - datetime(1970, 1, 1, tzinfo=timezone.utc)).total_seconds())
 
 def ms_to_datetime(ms: Union[int, float]) -> datetime:
     """Converts valid Cognite timestamps, i.e. milliseconds since epoch, to datetime object.

--- a/cognite/client/utils/_time.py
+++ b/cognite/client/utils/_time.py
@@ -74,9 +74,11 @@ def datetime_to_ms(dt: datetime) -> int:
         return int(1000 * dt.timestamp())
     except OSError as e:
         # OSError is raised if dt.timestamp() is called before 1970-01-01 on Windows for naive datetime.
-        raise ValueError("Failed to convert datetime to epoch. "
-                         "This likely because you are using a naive datetime."
-                         " Try using a timezone aware datetime instead.") from e
+        raise ValueError(
+            "Failed to convert datetime to epoch. "
+            "This likely because you are using a naive datetime."
+            " Try using a timezone aware datetime instead."
+        ) from e
 
 
 def ms_to_datetime(ms: Union[int, float]) -> datetime:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "cognite-sdk"
 
-version = "6.1.1"
+version = "6.1.2"
 
 description = "Cognite Python SDK"
 readme = "README.md"

--- a/tests/tests_integration/test_api/test_datapoints.py
+++ b/tests/tests_integration/test_api/test_datapoints.py
@@ -11,7 +11,7 @@ import random
 import re
 import time
 from contextlib import nullcontext as does_not_raise
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Literal
 from unittest.mock import patch
 
@@ -1703,7 +1703,9 @@ class TestInsertDatapointsAPI:
 
     @pytest.mark.usefixtures("post_spy")
     def test_insert_before_epoch(self, cognite_client, new_ts, monkeypatch):
-        datapoints = [(datetime(year=1950, month=1, day=1, hour=1, minute=i), i) for i in range(60)]
+        datapoints = [
+            (datetime(year=1950, month=1, day=1, hour=1, minute=i, tzinfo=timezone.utc), i) for i in range(60)
+        ]
         monkeypatch.setattr(cognite_client.time_series.data, "_DPS_INSERT_LIMIT", 30)
         monkeypatch.setattr(cognite_client.time_series.data, "_POST_DPS_OBJECTS_LIMIT", 30)
         cognite_client.time_series.data.insert(datapoints, id=new_ts.id)

--- a/tests/tests_integration/test_api/test_files.py
+++ b/tests/tests_integration/test_api/test_files.py
@@ -1,6 +1,5 @@
 import time
 import uuid
-from tempfile import NamedTemporaryFile, TemporaryDirectory
 
 import pytest
 
@@ -166,15 +165,14 @@ class TestFilesAPI:
     def test_download_new_file(self, cognite_client, new_file):
         assert b"blabla" == cognite_client.files.download_bytes(id=new_file.id)
 
-    def test_download_empty_file(self, cognite_client, empty_file):
+    def test_download_empty_file(self, cognite_client, empty_file, tmp_path):
         content = cognite_client.files.download_bytes(external_id=empty_file.external_id)
         assert content == b""
 
-        with TemporaryDirectory() as tmpdir:
-            cognite_client.files.download(directory=tmpdir, external_id=empty_file.external_id)
+        cognite_client.files.download(directory=tmp_path, external_id=empty_file.external_id)
 
-        with NamedTemporaryFile() as tmpfile:
-            cognite_client.files.download_to_path(path=tmpfile.name, external_id=empty_file.external_id)
+        tmp_file = tmp_path / empty_file.name
+        cognite_client.files.download_to_path(path=tmp_file, external_id=empty_file.external_id)
 
     def test_retrieve_file_with_labels(self, cognite_client, new_file_with_label):
         file, label_external_id = new_file_with_label

--- a/tests/tests_integration/test_api/test_geospatial.py
+++ b/tests/tests_integration/test_api/test_geospatial.py
@@ -2,6 +2,7 @@ import random
 import re
 import time
 import uuid
+from pathlib import Path
 
 import pytest
 
@@ -24,6 +25,8 @@ from cognite.client.exceptions import CogniteAPIError
 from tests.utils import set_request_limit
 
 FIXED_SRID = 121111 + random.randint(0, 1_000)
+
+GEOSPATIAL_TEST_RESOURCES = Path(__file__).parent / "geospatial_test_resources"
 
 
 @pytest.fixture()
@@ -640,10 +643,8 @@ class TestGeospatialAPI:
             raster_property_name="raster",
             raster_format="XYZ",
         )
-        raster_content = open(
-            "tests/tests_integration/test_api/geospatial_test_resources/raster-grid-example.xyz", "rb"
-        ).read()
-        assert res == raster_content
+        raster_content = (GEOSPATIAL_TEST_RESOURCES / "raster-grid-example.xyz").read_text()
+        assert res.decode(encoding="utf-8") == raster_content
 
         res = cognite_client.geospatial.get_raster(
             feature_type_external_id=test_feature_type.external_id,
@@ -652,10 +653,8 @@ class TestGeospatialAPI:
             raster_format="XYZ",
             raster_options={"DECIMAL_PRECISION": 5},
         )
-        raster_content = open(
-            "tests/tests_integration/test_api/geospatial_test_resources/raster-grid-5-decimal.xyz", "rb"
-        ).read()
-        assert res == raster_content
+        raster_content = (GEOSPATIAL_TEST_RESOURCES / "raster-grid-5-decimal.xyz").read_text()
+        assert res.decode(encoding="utf-8") == raster_content
 
     def test_get_raster_with_transformation(self, cognite_client, test_feature_type, test_feature_with_raster):
         res = cognite_client.geospatial.get_raster(
@@ -666,10 +665,8 @@ class TestGeospatialAPI:
             raster_srid=54030,
             allow_crs_transformation=True,
         )
-        raster_content = open(
-            "tests/tests_integration/test_api/geospatial_test_resources/raster-grid-54030-example.xyz", "rb"
-        ).read()
-        assert res == raster_content
+        raster_content = (GEOSPATIAL_TEST_RESOURCES / "raster-grid-54030-example.xyz").read_text()
+        assert res.decode(encoding="utf-8") == raster_content
 
     def test_retrieve_features_with_raster_property(self, cognite_client, test_feature_type, test_feature_with_raster):
         res = cognite_client.geospatial.retrieve_features(

--- a/tests/tests_integration/test_api/test_synthetic_time_series.py
+++ b/tests/tests_integration/test_api/test_synthetic_time_series.py
@@ -1,5 +1,5 @@
 import re
-from datetime import datetime
+from datetime import datetime, timezone
 from unittest import mock
 
 import pytest
@@ -37,7 +37,7 @@ class TestSyntheticDatapointsAPI:
     def test_query_with_start_before_epoch(self, cognite_client, test_time_series, post_spy):
         query = f"ts{{id:{test_time_series[0].id}}} + ts{{id:{test_time_series[1].id}}}"
         dps = cognite_client.time_series.data.synthetic.query(
-            expressions=query, start=datetime(1920, 1, 1), end="now", limit=23456
+            expressions=query, start=datetime(1920, 1, 1, tzinfo=timezone.utc), end="now", limit=23456
         )
         assert 23456 == len(dps)
         assert 3 == cognite_client.time_series.data.synthetic._post.call_count

--- a/tests/tests_integration/test_api/test_transformations/test_transformations.py
+++ b/tests/tests_integration/test_api/test_transformations/test_transformations.py
@@ -43,7 +43,8 @@ def new_datasets(cognite_client):
 def new_transformation(cognite_client, new_datasets):
     prefix = random_string(6, string.ascii_letters)
     creds = cognite_client.config.credentials
-    assert isinstance(creds, OAuthClientCredentials) or isinstance(creds, OAuthClientCertificate)
+    if not isinstance(creds, (OAuthClientCredentials, OAuthClientCertificate)):
+        pytest.skip("Only run in CI environment")
     transform = Transformation(
         name="any",
         query="select 1",

--- a/tests/tests_unit/test_data_classes/test_assets.py
+++ b/tests/tests_unit/test_data_classes/test_assets.py
@@ -352,7 +352,7 @@ class TestAssetHierarchy:
 
         # Try again with Path instead of str:
         AssetHierarchy(assets).validate_and_report(output_file=tmp_path)
-        assert exp_output == (output := tmp_path.read_text()) or output.startswith(exp_output)
+        assert exp_output == (output := tmp_path.read_text(encoding="utf-8")) or output.startswith(exp_output)
 
     @pytest.mark.parametrize(
         "assets, exp_output",
@@ -363,9 +363,9 @@ class TestAssetHierarchy:
     )
     def test_validate_asset_hierarchy__arbitrart_file_obj(self, tmp_path, assets, exp_output):
         outfile = Path(tmp_path) / "report.txt"
-        with outfile.open("w") as file:
+        with outfile.open("w", encoding="utf-8") as file:
             AssetHierarchy(assets).validate_and_report(output_file=file)
-        assert exp_output == (output := outfile.read_text()) or output.startswith(exp_output)
+        assert exp_output == (output := outfile.read_text(encoding="utf-8")) or output.startswith(exp_output)
 
         with io.StringIO() as file_like:
             AssetHierarchy(assets).validate_and_report(output_file=file_like)

--- a/tests/tests_unit/test_utils/test_time.py
+++ b/tests/tests_unit/test_utils/test_time.py
@@ -51,12 +51,15 @@ class TestDatetimeToMs:
             assert datetime_to_ms(datetime(2018, 1, 31, tzinfo=None)) == expected_ms
             assert timestamp_to_ms(datetime(2018, 1, 31, tzinfo=None)) == expected_ms
 
-    @pytest.mark.skipif(
-        platform.system() != "Windows", reason="Windows assume naive dateimes are UTC, Unix assumes they are local"
-    )
+    @pytest.mark.skipif(platform.system() != "Windows", reason="Windows is typically unable to handle negative epochs.")
     def test_naive_datetime_to_ms_windows(self):
-        assert datetime_to_ms(datetime(1900, 1, 1)) == -2208988800000
-        assert datetime_to_ms(datetime(1925, 8, 3)) == -1401580800000
+        with pytest.raises(
+            ValueError,
+            match="Failed to convert datetime to epoch. "
+            "This likely because you are using a naive datetime. "
+            "Try using a timezone aware datetime instead.",
+        ):
+            datetime_to_ms(datetime(1925, 8, 3))
 
     def test_aware_datetime_to_ms(self):
         # TODO: Starting from PY39 we should also add tests using:

--- a/tests/tests_unit/test_utils/test_time.py
+++ b/tests/tests_unit/test_utils/test_time.py
@@ -51,6 +51,10 @@ class TestDatetimeToMs:
             assert datetime_to_ms(datetime(2018, 1, 31, tzinfo=None)) == expected_ms
             assert timestamp_to_ms(datetime(2018, 1, 31, tzinfo=None)) == expected_ms
 
+    def test_naive_datetime_to_ms_including_windows(self):
+        assert datetime_to_ms(datetime(1900, 1, 1)) == -2208988800000
+        assert datetime_to_ms(datetime(1925, 8, 3)) == -1401580800000
+
     def test_aware_datetime_to_ms(self):
         # TODO: Starting from PY39 we should also add tests using:
         # from zoneinfo import ZoneInfo
@@ -59,7 +63,14 @@ class TestDatetimeToMs:
         assert datetime_to_ms(datetime(2018, 1, 31, tzinfo=utc)) == 1517356800000
         assert datetime_to_ms(datetime(2018, 1, 31, 11, 11, 11, tzinfo=utc)) == 1517397071000
         assert datetime_to_ms(datetime(100, 1, 31, tzinfo=utc)) == -59008867200000
-        assert datetime_to_ms(datetime(1900, 1, 1, tzinfo=utc)) == -2208988800000
+
+    @pytest.mark.dsl
+    def test_aware_datetime_to_ms_zoneinfo(self):
+        ZoneInfo = import_zoneinfo()
+        # The correct answer was obtained using: https://dencode.com/en/date/unix-time
+        assert datetime_to_ms(datetime(2018, 1, 31, tzinfo=ZoneInfo("Europe/Oslo"))) == 1517353200000
+        assert datetime_to_ms(datetime(1900, 1, 1, tzinfo=ZoneInfo("Europe/Oslo"))) == -2208992400000
+        assert datetime_to_ms(datetime(1900, 1, 1, tzinfo=ZoneInfo("America/New_York"))) == -2208970800000
 
     def test_ms_to_datetime__valid_input(self):  # TODO: Many tests here could benefit from parametrize
         utc = timezone.utc

--- a/tests/tests_unit/test_utils/test_time.py
+++ b/tests/tests_unit/test_utils/test_time.py
@@ -45,13 +45,16 @@ class TestDatetimeToMs:
             ("America/Los_Angeles", 1517385600000),
         ],
     )
-    def test_naive_datetime_to_ms(self, local_tz, expected_ms):
+    def test_naive_datetime_to_ms_unix(self, local_tz, expected_ms):
         with tmp_set_envvar("TZ", local_tz):
             time.tzset()
             assert datetime_to_ms(datetime(2018, 1, 31, tzinfo=None)) == expected_ms
             assert timestamp_to_ms(datetime(2018, 1, 31, tzinfo=None)) == expected_ms
 
-    def test_naive_datetime_to_ms_including_windows(self):
+    @pytest.mark.skipif(
+        platform.system() != "Windows", reason="Windows assume naive dateimes are UTC, Unix assumes they are local"
+    )
+    def test_naive_datetime_to_ms_windows(self):
         assert datetime_to_ms(datetime(1900, 1, 1)) == -2208988800000
         assert datetime_to_ms(datetime(1925, 8, 3)) == -1401580800000
 

--- a/tests/tests_unit/test_utils/test_time.py
+++ b/tests/tests_unit/test_utils/test_time.py
@@ -159,7 +159,7 @@ class TestTimestampToMs:
         time_now = timestamp_to_ms("now")
         assert abs(expected_time_now - time_now) > 190
 
-    @pytest.mark.parametrize("t", [MIN_TIMESTAMP_MS - 1, datetime(1899, 12, 31), "100000000w-ago"])
+    @pytest.mark.parametrize("t", [MIN_TIMESTAMP_MS - 1, datetime(1899, 12, 31, tzinfo=timezone.utc), "100000000w-ago"])
     def test_negative(self, t):
         with pytest.raises(ValueError, match="must represent a time after 1.1.1900"):
             timestamp_to_ms(t)

--- a/tests/tests_unit/test_utils/test_time.py
+++ b/tests/tests_unit/test_utils/test_time.py
@@ -59,6 +59,7 @@ class TestDatetimeToMs:
         assert datetime_to_ms(datetime(2018, 1, 31, tzinfo=utc)) == 1517356800000
         assert datetime_to_ms(datetime(2018, 1, 31, 11, 11, 11, tzinfo=utc)) == 1517397071000
         assert datetime_to_ms(datetime(100, 1, 31, tzinfo=utc)) == -59008867200000
+        assert datetime_to_ms(datetime(1900, 1, 1, tzinfo=utc)) == -2208988800000
 
     def test_ms_to_datetime__valid_input(self):  # TODO: Many tests here could benefit from parametrize
         utc = timezone.utc


### PR DESCRIPTION
## Description

Restarting the effort from https://github.com/cognitedata/cognite-sdk-python/pull/1035. Starting from scratch rather than continue on that one for two reasons:
1. No need to merge in all changes.
2. Fiona, as of [1.9a3 (2022-10-17)](https://github.com/Toblerity/Fiona/blob/master/CHANGES.txt#L93) includes GDAL in its wheel. This means that there is no need to download wheels manually for GDAL. 

**Note** I ended up splitting the `full_test_and_build` into `full_test` and `build`, so branch protection rules needs to be updated. 


## [6.1.2] - 04-05-23
### Improved
- The SDK has received several minor bugfixes to be more user-friendly on Windows.

### Fixed
- The utility function `cognite.client.utils.datetime_to_ms` now raises an understandable `ValueError` when unable to convert pre-epoch datetimes.
- Several functions reading and writing to disk now explicitly use UTF-8 encoding



## Progress
There are initially 10 tests failing on Windows:

- [x] `TestInsertDatapointsAPI.test_insert_before_epoch`
- [x] `TestFilesAPI.test_download_empty_file`
- [x] `TestGeospatialAPI.test_get_raster`
- [x] `TestGeospatialAPI.test_get_raster_with_transformation`
- [x] `TestSyntheticDatapointsAPI.test_query_with_start_before_epoch`
- [x] `TestAssetHierarchy.test_validate_asset_hierarchy_report_to_file` x 2
- [x] `TestAssetHierarchy.test_validate_asset_hierarchy_arbitrat_file_obj` x 2
- [x] `TestTimestampToMs.test_negative.t1`

## Checklist:
- [x] Tests added/updated.
- [ ] Documentation updated. Documentation is generated from docstrings - these must be updated according to your change.
  If a new method has been added it should be referenced in [cognite.rst](https://github.com/cognitedata/cognite-sdk-python/blob/master/docs/source/cognite.rst) in order to generate docs based on its docstring.
- [x] Changelog updated in [CHANGELOG.md](https://github.com/cognitedata/cognite-sdk-python/blob/master/CHANGELOG.md).
- [x] Version bumped. If triggering a new release is desired, bump the version number in [_version.py](https://github.com/cognitedata/cognite-sdk-python/blob/master/cognite/client/_version.py) and [pyproject.toml](https://github.com/cognitedata/cognite-sdk-python/blob/master/pyproject.toml) per [semantic versioning](https://semver.org/).
