### PR TITLE
Make `CogniteClient` picklable again

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ Changes are grouped as follows
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
+## [6.2.0] - 05-05-23
+### Fixed
+- Pickling a `CogniteClient` instance with certain `CredentialProvider`s no longer causes a `TypeError: cannot pickle ...` to be raised.
+
 ## [6.1.2] - 04-05-23
 ### Improved
 - The SDK has received several minor bugfixes to be more user-friendly on Windows.

--- a/cognite/client/_version.py
+++ b/cognite/client/_version.py
@@ -1,4 +1,4 @@
 from __future__ import annotations
 
-__version__ = "6.1.2"
+__version__ = "6.2.0"
 __api_subversion__ = "V20220125"

--- a/cognite/client/credentials.py
+++ b/cognite/client/credentials.py
@@ -68,6 +68,17 @@ class _OAuthCredentialProviderWithTokenRefresh(CredentialProvider):
         self.__access_token: Optional[str] = None
         self.__access_token_expires_at: Optional[float] = None
 
+    def __getstate__(self) -> dict[str, Any]:
+        # threading.Lock is not picklable, temporarily remove:
+        lock_tmp, self.__token_refresh_lock = self.__token_refresh_lock, None  # type: ignore [assignment]
+        state = self.__dict__.copy()
+        self.__token_refresh_lock = lock_tmp
+        return state
+
+    def __setstate__(self, state: dict[str, Any]) -> None:
+        self.__dict__ = state
+        self.__token_refresh_lock = threading.Lock()
+
     @abstractmethod
     def _refresh_access_token(self) -> Tuple[str, float]:
         """This method should return the access_token and expiry time"""
@@ -303,8 +314,11 @@ class OAuthClientCredentials(_OAuthCredentialProviderWithTokenRefresh):
         self.__client_secret = client_secret
         self.__scopes = scopes
         self.__token_custom_args: Dict[str, Any] = token_custom_args
-        self.__oauth = OAuth2Session(client=BackendApplicationClient(client_id=self.__client_id, scope=self.__scopes))
+        self.__oauth = self._create_oauth_session()
         self._validate_token_custom_args()
+
+    def _create_oauth_session(self) -> OAuth2Session:
+        return OAuth2Session(client=BackendApplicationClient(client_id=self.__client_id, scope=self.__scopes))
 
     def _validate_token_custom_args(self) -> None:
         # We make sure that whatever is passed as part of 'token_custom_args' can't set or override any of the
@@ -315,6 +329,17 @@ class OAuthClientCredentials(_OAuthCredentialProviderWithTokenRefresh):
                 f"The following reserved token custom arg(s) were passed: {sorted(bad_args)}. The full list of "
                 f"reserved custom args is: {sorted(reserved)}."
             )
+
+    def __getstate__(self) -> dict[str, Any]:
+        # OAuth2Session is not picklable, temporarily remove:
+        oauth_session_tmp, self.__oauth = self.__oauth, None
+        state = super().__getstate__()
+        self.__oauth = oauth_session_tmp
+        return state
+
+    def __setstate__(self, state: dict[str, Any]) -> None:
+        super().__setstate__(state)
+        self.__oauth = self._create_oauth_session()
 
     @property
     def token_url(self) -> str:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "cognite-sdk"
 
-version = "6.1.2"
+version = "6.2.0"
 
 description = "Cognite Python SDK"
 readme = "README.md"

--- a/tests/tests_integration/test_api/test_geospatial.py
+++ b/tests/tests_integration/test_api/test_geospatial.py
@@ -1,3 +1,4 @@
+import math
 import random
 import re
 import time
@@ -706,8 +707,8 @@ class TestGeospatialAPI:
         assert res.skew_x == 0.0
         assert res.skew_y == 0.0
         assert res.srid == 3857
-        assert res.upper_left_x == -0.5891363261459447
-        assert res.upper_left_y == -0.31623471547260973
+        assert math.isclose(res.upper_left_x, -0.5891363261459447)
+        assert math.isclose(res.upper_left_y, -0.31623471547260973)
 
     def test_delete_raster(self, cognite_client, test_feature_type, test_feature_with_raster):
         res = cognite_client.geospatial.delete_raster(

--- a/tests/tests_integration/test_api/test_geospatial.py
+++ b/tests/tests_integration/test_api/test_geospatial.py
@@ -708,7 +708,7 @@ class TestGeospatialAPI:
         assert res.skew_y == 0.0
         assert res.srid == 3857
         assert math.isclose(res.upper_left_x, -0.5891363261459447)
-        assert math.isclose(res.upper_left_y, -0.31623471547260973)
+        assert math.isclose(res.upper_left_y, -0.31623471547260973, rel_tol=5e-7)
 
     def test_delete_raster(self, cognite_client, test_feature_type, test_feature_with_raster):
         res = cognite_client.geospatial.delete_raster(

--- a/tests/tests_integration/test_cognite_client.py
+++ b/tests/tests_integration/test_cognite_client.py
@@ -1,5 +1,8 @@
+import pickle
+
 import pytest
 
+from cognite.client.credentials import OAuthClientCertificate
 from cognite.client.exceptions import CogniteAPIError
 
 
@@ -28,3 +31,11 @@ class TestCogniteClient:
         with pytest.raises(CogniteAPIError) as e:
             cognite_client.delete("/login")
         assert e.value.code == 404
+
+
+def test_cognite_client_is_picklable(cognite_client):
+    if isinstance(cognite_client.config.credentials, OAuthClientCertificate):
+        pytest.skip("Not yet implemented")
+
+    roundtrip_client = pickle.loads(pickle.dumps(cognite_client))
+    assert roundtrip_client.iam.token.inspect().projects

--- a/tests/tests_integration/test_cognite_client.py
+++ b/tests/tests_integration/test_cognite_client.py
@@ -2,7 +2,7 @@ import pickle
 
 import pytest
 
-from cognite.client.credentials import OAuthClientCertificate
+from cognite.client.credentials import OAuthClientCertificate, Token
 from cognite.client.exceptions import CogniteAPIError
 
 
@@ -34,8 +34,7 @@ class TestCogniteClient:
 
 
 def test_cognite_client_is_picklable(cognite_client):
-    if isinstance(cognite_client.config.credentials, OAuthClientCertificate):
-        pytest.skip("Not yet implemented")
-
+    if isinstance(cognite_client.config.credentials, (Token, OAuthClientCertificate)):
+        pytest.skip()
     roundtrip_client = pickle.loads(pickle.dumps(cognite_client))
     assert roundtrip_client.iam.token.inspect().projects

--- a/tests/tests_integration/test_credential_providers.py
+++ b/tests/tests_integration/test_credential_providers.py
@@ -1,0 +1,29 @@
+import pickle
+
+import pytest
+
+from cognite.client.credentials import (
+    OAuthClientCredentials,
+    OAuthDeviceCode,
+    OAuthInteractive,
+)
+
+# These tests need to be part of the integration tests as 'msal' sends an HTTP request to verify
+# the authority URI; and will -raise- if not given a valid one:
+AUTHORITY_URL = "https://login.microsoftonline.com/dff7763f-e2f5-4ffd-9b8a-4ba4bafba5ea"
+
+
+class TestCredentialProvidersArePicklable:
+    @pytest.mark.parametrize(
+        "auth_cls, args",
+        (
+            # client_id is used to pick a cache location, so we vary it:
+            (OAuthClientCredentials, ["token_url", "client_id0", "client_secret", "scopes"]),
+            (OAuthDeviceCode, [AUTHORITY_URL, "client_id1", "scopes"]),
+            (OAuthInteractive, [AUTHORITY_URL, "client_id2", "scopes"]),
+        ),
+    )
+    def test_serialize_and_deserialize(self, auth_cls, args, cognite_client):
+        cred_prov = auth_cls(*args)
+        roundtrip_cred_prov = pickle.loads(pickle.dumps(cred_prov))
+        assert type(roundtrip_cred_prov) is auth_cls

--- a/tests/tests_unit/test_credential_providers.py
+++ b/tests/tests_unit/test_credential_providers.py
@@ -4,7 +4,11 @@ from unittest.mock import Mock, patch
 import pytest
 from oauthlib.oauth2 import InvalidClientIdError
 
-from cognite.client.credentials import OAuthClientCertificate, OAuthClientCredentials, Token
+from cognite.client.credentials import (
+    OAuthClientCertificate,
+    OAuthClientCredentials,
+    Token,
+)
 from cognite.client.exceptions import CogniteAuthError
 
 


### PR DESCRIPTION
## Description
The various `CredentialProvider`s have e.g. thread locks and `OAuth2Session` which hinders pickling/unpickling. This PR fixes this.

### Rationale
In the virtual flow meter service, we use `kedro`, and we need the client to be serializable to be passed between computation nodes.

## ~~TODO~~
- Add a test that does `pickle.loads(pickle.dumps(client))` then makes an API call.

## Checklist:
- [ ] Tests added/updated.
- [ ] Documentation updated. Documentation is generated from docstrings - these must be updated according to your change.
  If a new method has been added it should be referenced in [cognite.rst](https://github.com/cognitedata/cognite-sdk-python/blob/master/docs/source/cognite.rst) in order to generate docs based on its docstring.
- [x] Changelog updated in [CHANGELOG.md](https://github.com/cognitedata/cognite-sdk-python/blob/master/CHANGELOG.md).
- [x] Version bumped. If triggering a new release is desired, bump the version number in [_version.py](https://github.com/cognitedata/cognite-sdk-python/blob/master/cognite/client/_version.py) and [pyproject.toml](https://github.com/cognitedata/cognite-sdk-python/blob/master/pyproject.toml) per [semantic versioning](https://semver.org/).
