### PR TITLE
Set license for poetry build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,11 @@ Changes are grouped as follows
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
+## [6.1.3] - 08-05-23
+### Fixed
+- Set the license of the package in poetry build.
+
+
 ## [6.1.2] - 04-05-23
 ### Improved
 - The SDK has received several minor bugfixes to be more user-friendly on Windows.

--- a/cognite/client/_version.py
+++ b/cognite/client/_version.py
@@ -1,4 +1,4 @@
 from __future__ import annotations
 
-__version__ = "6.1.2"
+__version__ = "6.1.3"
 __api_subversion__ = "V20220125"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,7 @@ description = "Cognite Python SDK"
 readme = "README.md"
 documentation = "https://cognite-sdk-python.readthedocs-hosted.com"
 authors = ["Erlend Vollset <erlend.vollset@cognite.com>"]
+license = "Apache-2.0"
 
 packages = [{ include="cognite", from="." }]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "cognite-sdk"
 
-version = "6.1.2"
+version = "6.1.3"
 
 description = "Cognite Python SDK"
 readme = "README.md"

--- a/tests/tests_integration/test_api/test_geospatial.py
+++ b/tests/tests_integration/test_api/test_geospatial.py
@@ -706,8 +706,8 @@ class TestGeospatialAPI:
         assert res.skew_x == 0.0
         assert res.skew_y == 0.0
         assert res.srid == 3857
-        assert res.upper_left_x == -0.5891363261459447
-        assert res.upper_left_y == -0.31623471547260973
+        assert abs(res.upper_left_x - -0.5891363261459447) < 1e-6
+        assert abs(res.upper_left_y - -0.31623471547260973) < 1e-6
 
     def test_delete_raster(self, cognite_client, test_feature_type, test_feature_with_raster):
         res = cognite_client.geospatial.delete_raster(


### PR DESCRIPTION
## Description
Gives poetry the meta data such that license appear on pypi.org
![image](https://user-images.githubusercontent.com/60234212/236813354-30264a43-3d3a-4bcc-abef-3883bce5844b.png)

## Checklist:
- [ ] Tests added/updated.
- [ ] Documentation updated. Documentation is generated from docstrings - these must be updated according to your change.
  If a new method has been added it should be referenced in [cognite.rst](https://github.com/cognitedata/cognite-sdk-python/blob/master/docs/source/cognite.rst) in order to generate docs based on its docstring.
- [x] Changelog updated in [CHANGELOG.md](https://github.com/cognitedata/cognite-sdk-python/blob/master/CHANGELOG.md).
- [x] Version bumped. If triggering a new release is desired, bump the version number in [_version.py](https://github.com/cognitedata/cognite-sdk-python/blob/master/cognite/client/_version.py) and [pyproject.toml](https://github.com/cognitedata/cognite-sdk-python/blob/master/pyproject.toml) per [semantic versioning](https://semver.org/).
