### PR TITLE
source-destination fix to version 6.1.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ Changes are grouped as follows
 
 ## [6.1.5] - 10-05-23
 ### Fixed
-- source and destination project issue fixed. 
+- source and destination project issue fixed. The source and destination project was overrided by the client config project. So, defined project variables seperatly for source and destination. 
 - self.source_nonce = try_get_or_create_nonce(self.source_oidc_credentials, project)
 - self.destination_nonce = try_get_or_create_nonce(self.destination_oidc_credentials, project)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ Changes are grouped as follows
 ## [6.1.5] - 10-05-23
 ### Fixed
 - source and destination project issue fixed. 
+- self.source_nonce = try_get_or_create_nonce(self.source_oidc_credentials, project)
+- self.destination_nonce = try_get_or_create_nonce(self.destination_oidc_credentials, project)
 
 ## [6.1.4] - 08-05-23
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,9 +19,7 @@ Changes are grouped as follows
 
 ## [6.1.5] - 10-05-23
 ### Fixed
-- When create a transformation with different source and destination project, the system has been overriden the source and destination project with the client config project. Therefore, the user was not able to read from the required source project and write to required destination prject. 
-- Form this version release, now source and destination project is taken from the user defined source and destination project value. 
-
+- When creating a transformation with a different source- and destination CDF project, the project setting is no longer overridden by the setting in the `CogniteClient` configuration allowing the user to read from the specified source project and write to the specified and potentially different destination project. 
 
 ## [6.1.4] - 08-05-23
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ Changes are grouped as follows
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
+## [6.1.5] - 10-05-23
+### Fixed
+- source and destination project issue fixed. 
+
 ## [6.1.4] - 08-05-23
 ### Fixed
 - Pickling a `CogniteClient` instance with certain `CredentialProvider`s no longer causes a `TypeError: cannot pickle ...` to be raised.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,9 +19,9 @@ Changes are grouped as follows
 
 ## [6.1.5] - 10-05-23
 ### Fixed
-- source and destination project issue fixed. The source and destination project was overrided by the client config project. So, defined project variables seperatly for source and destination. 
-- self.source_nonce = try_get_or_create_nonce(self.source_oidc_credentials, project)
-- self.destination_nonce = try_get_or_create_nonce(self.destination_oidc_credentials, project)
+- When create a transformation with different source and destination project, the system has been overriden the source and destination project with the client config project. Therefore, the user was not able to read from the required source project and write to required destination prject. 
+- Form this version release, now source and destination project is taken from the user defined source and destination project value. 
+
 
 ## [6.1.4] - 08-05-23
 ### Fixed

--- a/cognite/client/_version.py
+++ b/cognite/client/_version.py
@@ -1,4 +1,4 @@
 from __future__ import annotations
 
-__version__ = "6.1.4"
+__version__ = "6.1.5"
 __api_subversion__ = "V20220125"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "cognite-sdk"
 
-version = "6.1.4"
+version = "6.1.5"
 
 description = "Cognite Python SDK"
 readme = "README.md"


### PR DESCRIPTION
## Description
Version 6.1.5 release with source-destination fixed. 

## Checklist:
- [ ] Changelog updated in [CHANGELOG.md](https://github.com/cognitedata/cognite-sdk-python/blob/master/CHANGELOG.md).
- [ ] Version bumped.updated the version number in [_version.py](https://github.com/cognitedata/cognite-sdk-python/blob/master/cognite/client/_version.py) and [pyproject.toml](https://github.com/cognitedata/cognite-sdk-python/blob/master/pyproject.toml) per [semantic versioning](https://semver.org/).
