### PR TITLE
Remove dms v2 destination in transformations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ Changes are grouped as follows
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
+## [6.1.7] - 11-05-23
+- Removed DMS v2 destination in transformations
+
 ## [6.1.6] - 11-05-23
 - `FunctionsAPI.create` now work in Wasm-like Python runtimes such as `pyodide`.
 

--- a/cognite/client/_api/transformations/schema.py
+++ b/cognite/client/_api/transformations/schema.py
@@ -37,10 +37,14 @@ class TransformationSchemaAPI(APIClient):
         """
 
         url_path = utils._auxiliary.interpolate_and_url_encode(self._RESOURCE_PATH + "/{}", str(destination.type))
+        filter = destination.dump(True)
+        filter.pop("type")
         other_params = {"conflictMode": conflict_mode} if conflict_mode else None
+
         return self._list(
             list_cls=TransformationSchemaColumnList,
             resource_cls=TransformationSchemaColumn,
             method="GET",
             resource_path=url_path,
+            filter=other_params,
         )

--- a/cognite/client/_api/transformations/schema.py
+++ b/cognite/client/_api/transformations/schema.py
@@ -9,7 +9,6 @@ from cognite.client.data_classes import (
     TransformationSchemaColumn,
     TransformationSchemaColumnList,
 )
-from cognite.client.data_classes.transformations.common import DataModelInstances
 
 
 class TransformationSchemaAPI(APIClient):
@@ -38,18 +37,3 @@ class TransformationSchemaAPI(APIClient):
         """
 
         url_path = utils._auxiliary.interpolate_and_url_encode(self._RESOURCE_PATH + "/{}", str(destination.type))
-        filter = destination.dump(True)
-        filter.pop("type")
-
-        if isinstance(destination, DataModelInstances):
-            filter["externalId"] = filter.pop("modelExternalId")
-            filter.pop("instanceSpaceExternalId")
-        if conflict_mode:
-            filter["conflictMode"] = conflict_mode
-        return self._list(
-            list_cls=TransformationSchemaColumnList,
-            resource_cls=TransformationSchemaColumn,
-            method="GET",
-            resource_path=url_path,
-            filter=filter,
-        )

--- a/cognite/client/_api/transformations/schema.py
+++ b/cognite/client/_api/transformations/schema.py
@@ -37,3 +37,10 @@ class TransformationSchemaAPI(APIClient):
         """
 
         url_path = utils._auxiliary.interpolate_and_url_encode(self._RESOURCE_PATH + "/{}", str(destination.type))
+        other_params = {"conflictMode": conflict_mode} if conflict_mode else None
+        return self._list(
+            list_cls=TransformationSchemaColumnList,
+            resource_cls=TransformationSchemaColumn,
+            method="GET",
+            resource_path=url_path,
+        )

--- a/cognite/client/_version.py
+++ b/cognite/client/_version.py
@@ -1,4 +1,4 @@
 from __future__ import annotations
 
-__version__ = "6.1.6"
+__version__ = "6.1.7"
 __api_subversion__ = "V20220125"

--- a/cognite/client/data_classes/transformations/common.py
+++ b/cognite/client/data_classes/transformations/common.py
@@ -163,8 +163,6 @@ class SequenceRows(TransformationDestination):
     def __hash__(self) -> int:
         return hash((self.type, self.external_id))
 
-    def __hash__(self) -> int:
-        return hash((self.type, self.model_external_id, self.space_external_id, self.instance_space_external_id))
 
 
 class ViewInfo:

--- a/cognite/client/data_classes/transformations/common.py
+++ b/cognite/client/data_classes/transformations/common.py
@@ -112,7 +112,6 @@ class TransformationDestination:
         """
         return SequenceRows(external_id=external_id)
 
-
     @staticmethod
     def instance_nodes(view: Optional[ViewInfo] = None, instance_space: Optional[str] = None) -> InstanceNodes:
         """To be used when the transformation is meant to produce node's instances.
@@ -162,7 +161,6 @@ class SequenceRows(TransformationDestination):
 
     def __hash__(self) -> int:
         return hash((self.type, self.external_id))
-
 
 
 class ViewInfo:

--- a/cognite/client/data_classes/transformations/common.py
+++ b/cognite/client/data_classes/transformations/common.py
@@ -112,25 +112,6 @@ class TransformationDestination:
         """
         return SequenceRows(external_id=external_id)
 
-    @staticmethod
-    def data_model_instances(
-        model_external_id: str = "", space_external_id: str = "", instance_space_external_id: str = ""
-    ) -> DataModelInstances:
-        """To be used when the transformation is meant to produce data model instances.
-            Flexible Data Models resource type is on `beta` version currently.
-
-        Args:
-            model_external_id (str): external_id of the flexible data model.
-            space_external_id (str): space external_id of the flexible data model.
-            instance_space_external_id (str): space external_id of the flexible data model instance.
-        Returns:
-            TransformationDestination pointing to the target flexible data model.
-        """
-        return DataModelInstances(
-            model_external_id=model_external_id,
-            space_external_id=space_external_id,
-            instance_space_external_id=instance_space_external_id,
-        )
 
     @staticmethod
     def instance_nodes(view: Optional[ViewInfo] = None, instance_space: Optional[str] = None) -> InstanceNodes:
@@ -181,21 +162,6 @@ class SequenceRows(TransformationDestination):
 
     def __hash__(self) -> int:
         return hash((self.type, self.external_id))
-
-
-class DataModelInstances(TransformationDestination):
-    def __init__(
-        self, model_external_id: str = None, space_external_id: str = None, instance_space_external_id: str = None
-    ):
-        warnings.warn(
-            "Feature DataModelStorage is in beta and still in development. "
-            "Breaking changes can happen in between patch versions.",
-            stacklevel=2,
-        )
-        super().__init__(type="data_model_instances")
-        self.model_external_id = model_external_id
-        self.space_external_id = space_external_id
-        self.instance_space_external_id = instance_space_external_id
 
     def __hash__(self) -> int:
         return hash((self.type, self.model_external_id, self.space_external_id, self.instance_space_external_id))
@@ -344,13 +310,12 @@ class TransformationBlockedInfo:
 
 def _load_destination_dct(
     dct: Dict[str, Any]
-) -> Union[RawTable, DataModelInstances, InstanceNodes, InstanceEdges, SequenceRows, TransformationDestination]:
+) -> Union[RawTable, InstanceNodes, InstanceEdges, SequenceRows, TransformationDestination]:
     """Helper function to load destination from dictionary"""
     snake_dict = convert_all_keys_to_snake_case(dct)
     destination_type = snake_dict.pop("type")
     simple = {
         "raw": RawTable,
-        "data_model_instances": DataModelInstances,
         "sequence_rows": SequenceRows,
     }
     if destination_type in simple:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "cognite-sdk"
 
-version = "6.1.6"
+version = "6.1.7"
 
 description = "Cognite Python SDK"
 readme = "README.md"

--- a/tests/tests_integration/test_api/test_transformations/test_schema.py
+++ b/tests/tests_integration/test_api/test_transformations/test_schema.py
@@ -34,47 +34,4 @@ class TestTransformationSchemaAPI:
         assert len(asset_columns) > 0
         assert len([col for col in asset_columns if col.name == "externalId"]) > 0
 
-    def test_data_model_schema(self, cognite_client):
-        project_name = os.environ["COGNITE_PROJECT"]
-        dm_name = "python-sdk-test-dm"
-        space_name = "test-space"
-        cognite_client.post(
-            f"/api/v1/projects/{project_name}/datamodelstorage/spaces",
-            json={"items": [{"externalId": space_name}]},
-            params={},
-            headers={"cdf-version": "alpha"},
-        )
 
-        cognite_client.post(
-            f"/api/v1/projects/{project_name}/datamodelstorage/models",
-            json={
-                "spaceExternalId": space_name,
-                "items": [
-                    {
-                        "externalId": dm_name,
-                        "allowNode": True,
-                        "allowEdge": False,
-                        "properties": {
-                            "test": {"type": "text", "nullable": True},
-                            "test2": {"type": "int64", "nullable": True},
-                        },
-                    }
-                ],
-            },
-            params={},
-            headers={"cdf-version": "alpha"},
-        )
-        model_cols = cognite_client.transformations.schema.retrieve(
-            TransformationDestination.data_model_instances(dm_name, space_name, space_name)
-        )
-        assert len(model_cols) == 3
-        assert [col for col in model_cols if col.name == "externalId"][0].type.type == "string"
-        assert [col for col in model_cols if col.name == "test"][0].type.type == "string"
-        assert [col for col in model_cols if col.name == "test2"][0].type.type == "long"
-
-        # cognite_client.post(
-        #     f"/api/v1/projects/{project_name}/datamodelstorage/models/delete",
-        #     json={"spaceExternalId": space_name, "items": [{"externalId": dm_name}]},
-        #     params={},
-        #     headers={"cdf-version": "alpha"},
-        # )

--- a/tests/tests_integration/test_api/test_transformations/test_schema.py
+++ b/tests/tests_integration/test_api/test_transformations/test_schema.py
@@ -1,5 +1,3 @@
-import os
-
 from cognite.client.data_classes import TransformationDestination
 
 
@@ -33,5 +31,3 @@ class TestTransformationSchemaAPI:
         )
         assert len(asset_columns) > 0
         assert len([col for col in asset_columns if col.name == "externalId"]) > 0
-
-

--- a/tests/tests_integration/test_api/test_transformations/test_transformations.py
+++ b/tests/tests_integration/test_api/test_transformations/test_transformations.py
@@ -385,21 +385,6 @@ class TestTransformationsAPI:
         # just make sure it doesnt raise exceptions
         str(query_result)
 
-    def test_update_dmi(self, cognite_client, new_transformation):
-        new_transformation.destination = TransformationDestination.data_model_instances(
-            "myTest", "test-space", "test-space"
-        )
-        partial_update = TransformationUpdate(id=new_transformation.id).destination.set(
-            TransformationDestination.data_model_instances("myTest2", "test-space", "test-space")
-        )
-        updated_transformation = cognite_client.transformations.update(new_transformation)
-        assert updated_transformation.destination == TransformationDestination.data_model_instances(
-            "myTest", "test-space", "test-space"
-        )
-        partial_updated = cognite_client.transformations.update(partial_update)
-        assert partial_updated.destination == TransformationDestination.data_model_instances(
-            "myTest2", "test-space", "test-space"
-        )
 
     def test_update_instance_nodes(self, cognite_client, new_transformation):
         new_transformation.destination = TransformationDestination.instance_nodes(

--- a/tests/tests_integration/test_api/test_transformations/test_transformations.py
+++ b/tests/tests_integration/test_api/test_transformations/test_transformations.py
@@ -385,7 +385,6 @@ class TestTransformationsAPI:
         # just make sure it doesnt raise exceptions
         str(query_result)
 
-
     def test_update_instance_nodes(self, cognite_client, new_transformation):
         new_transformation.destination = TransformationDestination.instance_nodes(
             ViewInfo("myViewExternalId", "myViewVersion", "test-space"), "test-space"


### PR DESCRIPTION
## Description
Remove dms v2 destination in transformations

## Checklist:
- [x] Removed "DataModelInstances" class 
- [x] Updated in [CHANGELOG.md](https://github.com/cognitedata/cognite-sdk-python/blob/master/CHANGELOG.md).
- [x] Updated version 6.1.7 in [_version.py](https://github.com/cognitedata/cognite-sdk-python/blob/master/cognite/client/_version.py) and [pyproject.toml](https://github.com/cognitedata/cognite-sdk-python/blob/master/pyproject.toml) per [semantic versioning](https://semver.org/).
