### PR TITLE
Fix ExtractionPipelineRun:dump method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,10 +17,16 @@ Changes are grouped as follows
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
+## [6.1.8] - 12-05-23
+### Fixed
+- ExtractionPipelinesRun:dump method will not throw an error when camel_case=True anymore
+
 ## [6.1.7] - 11-05-23
+### Removed
 - Removed DMS v2 destination in transformations
 
 ## [6.1.6] - 11-05-23
+### Fixed
 - `FunctionsAPI.create` now work in Wasm-like Python runtimes such as `pyodide`.
 
 ## [6.1.5] - 10-05-23

--- a/cognite/client/_api/extractionpipelines.py
+++ b/cognite/client/_api/extractionpipelines.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Dict, Optional, Sequence, Union, overload
+from typing import TYPE_CHECKING, Any, Dict, Literal, Optional, Sequence, Union, overload
 
 from cognite.client import utils
 from cognite.client._api_client import APIClient
@@ -264,21 +264,21 @@ class ExtractionPipelineRunsAPI(APIClient):
                 message=StringFilter(substring=message_substring),
                 created_time=created_time,
             ).dump(camel_case=True)
-            return self._list(
-                list_cls=ExtractionPipelineRunList,
-                resource_cls=ExtractionPipelineRun,
-                method="POST",
-                limit=limit,
-                filter=filter,
-            )
+            method: Literal["POST", "GET"] = "POST"
+        else:
+            filter = {"externalId": external_id}
+            method = "GET"
 
-        return self._list(
+        res = self._list(
             list_cls=ExtractionPipelineRunList,
             resource_cls=ExtractionPipelineRun,
-            method="GET",
+            method=method,
             limit=limit,
-            filter={"externalId": external_id},
+            filter=filter,
         )
+        for run in res:
+            run.extpipe_external_id = external_id
+        return res
 
     @overload
     def create(self, run: ExtractionPipelineRun) -> ExtractionPipelineRun:

--- a/cognite/client/_version.py
+++ b/cognite/client/_version.py
@@ -1,4 +1,4 @@
 from __future__ import annotations
 
-__version__ = "6.1.7"
+__version__ = "6.1.8"
 __api_subversion__ = "V20220125"

--- a/cognite/client/data_classes/extractionpipelines.py
+++ b/cognite/client/data_classes/extractionpipelines.py
@@ -242,9 +242,9 @@ class ExtractionPipelineRun(CogniteResource):
         #   - Problem: This dump method might be surprising to the user - if used (its public)...
         # ...and 2 was chosen:
         if camel_case:
-            dct["externalId"] = dct.pop("extpipeExternalId")
+            dct["externalId"] = dct.pop("extpipeExternalId", None)
         else:
-            dct["external_id"] = dct.pop("extpipe_external_id")
+            dct["external_id"] = dct.pop("extpipe_external_id", None)
         return dct
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "cognite-sdk"
 
-version = "6.1.7"
+version = "6.1.8"
 
 description = "Cognite Python SDK"
 readme = "README.md"

--- a/tests/tests_integration/test_api/test_extraction_pipelines.py
+++ b/tests/tests_integration/test_api/test_extraction_pipelines.py
@@ -1,5 +1,6 @@
 import pytest
 
+from cognite.client import CogniteClient
 from cognite.client.data_classes import ExtractionPipeline, ExtractionPipelineRun, ExtractionPipelineUpdate
 from cognite.client.data_classes.extractionpipelines import ExtractionPipelineContact
 from cognite.client.exceptions import CogniteNotFoundError
@@ -100,3 +101,18 @@ class TestExtractionPipelinesAPI:
         assert extpipe.last_failure != 0
         assert extpipe.last_success != 0
         assert extpipe.last_seen != 0
+
+    def test_list_extraction_pipeline_runs(
+        self, cognite_client: CogniteClient, new_extpipe: ExtractionPipeline
+    ) -> None:
+        cognite_client.extraction_pipelines.runs.create(
+            ExtractionPipelineRun(extpipe_external_id=new_extpipe.external_id, status="seen")
+        )
+        res = cognite_client.extraction_pipelines.runs.list(new_extpipe.external_id)
+        for run in res:
+            assert run.extpipe_external_id == new_extpipe.external_id
+
+        # Make sure we can dump it without errors
+        dumped = res.dump()
+        for run in dumped:
+            assert run["external_id"] == new_extpipe.external_id


### PR DESCRIPTION
- Fix ExtractionPiplineRun:dump
- Bump version and changelog

## Description
Please describe the change you have made.

## Checklist:
- [ ] Tests added/updated.
- [ ] Documentation updated. Documentation is generated from docstrings - these must be updated according to your change.
  If a new method has been added it should be referenced in [cognite.rst](https://github.com/cognitedata/cognite-sdk-python/blob/master/docs/source/cognite.rst) in order to generate docs based on its docstring.
- [ ] Changelog updated in [CHANGELOG.md](https://github.com/cognitedata/cognite-sdk-python/blob/master/CHANGELOG.md).
- [ ] Version bumped. If triggering a new release is desired, bump the version number in [_version.py](https://github.com/cognitedata/cognite-sdk-python/blob/master/cognite/client/_version.py) and [pyproject.toml](https://github.com/cognitedata/cognite-sdk-python/blob/master/pyproject.toml) per [semantic versioning](https://semver.org/).
