### PR TITLE
Fix `AttributeError` on `MainThreadExecutor` for `_work_queue`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ Changes are grouped as follows
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
+## [6.1.9] - 16-05-23
+### Fixed
+- Fixed a rare issue with datapoints fetching that could raise `AttributeError` when running with `pyodide`.
+
 ## [6.1.8] - 12-05-23
 ### Fixed
 - ExtractionPipelinesRun:dump method will not throw an error when camel_case=True anymore

--- a/cognite/client/_api/datapoints.py
+++ b/cognite/client/_api/datapoints.py
@@ -451,7 +451,7 @@ class ChunkingDpsFetcher(DpsFetchStrategy):
     def _queue_new_subtasks(
         self, pool: PriorityThreadPoolExecutor, futures_dct: Dict[Future, List[BaseDpsFetchSubtask]]
     ) -> None:
-        while pool._work_queue.qsize() == 0 and any(self.subtask_pools):
+        while pool._work_queue.empty() and any(self.subtask_pools):
             # While the number of unstarted tasks is 0 and we have unqueued subtasks in one of the pools,
             # we keep combining subtasks into "chunked dps requests" to feed to the thread pool
             if (new_request := self._combine_subtasks_into_new_request()) is None:

--- a/cognite/client/_version.py
+++ b/cognite/client/_version.py
@@ -1,4 +1,4 @@
 from __future__ import annotations
 
-__version__ = "6.1.8"
+__version__ = "6.1.9"
 __api_subversion__ = "V20220125"

--- a/cognite/client/utils/_concurrency.py
+++ b/cognite/client/utils/_concurrency.py
@@ -168,6 +168,15 @@ class MainThreadExecutor(TaskExecutor):
     protocol but just executes everything serially in the main thread.
     """
 
+    def __init__(self) -> None:
+        # This "queue" is not used, but currently needed because of the datapoints logic that
+        # decides when to add new tasks to the task executor task pool.
+        class AlwaysEmpty:
+            def empty(self) -> Literal[True]:
+                return True
+
+        self._work_queue = AlwaysEmpty()
+
     def submit(self, fn: Callable[..., T_Result], *args: Any, **kwargs: Any) -> SyncFuture:
         if "priority" in inspect.signature(fn).parameters:
             raise TypeError(f"Given function {fn} cannot accept reserved parameter name `priority`")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "cognite-sdk"
 
-version = "6.1.8"
+version = "6.1.9"
 
 description = "Cognite Python SDK"
 readme = "README.md"


### PR DESCRIPTION
## Description
When fetching multiple time series in `JupyterLite` (`pyodide` runtime), we use the fake thread pool executor. Turns out I forgot to give it a bogus `_work_queue` (which is where unstarted work usually gets stuffed before a thread picks up a task).

```py
File /lib/python3.11/site-packages/cognite/client/_api/datapoints.py:454, in ChunkingDpsFetcher._queue_new_subtasks(self, pool, futures_dct)
    451 def _queue_new_subtasks(
    452     self, pool: PriorityThreadPoolExecutor, futures_dct: Dict[Future, List[BaseDpsFetchSubtask]]
    453 ) -> None:
--> 454     while pool._work_queue.qsize() == 0 and any(self.subtask_pools):
    455         # While the number of unstarted tasks is 0 and we have unqueued subtasks in one of the pools,
    456         # we keep combining subtasks into "chunked dps requests" to feed to the thread pool
    457         if (new_request := self._combine_subtasks_into_new_request()) is None:
    458             return

AttributeError: 'MainThreadExecutor' object has no attribute '_work_queue'
```

I have tested this out... by... monkey-patching the SDK in `JupyterLite`. Really got to find a better way to test... 

## Checklist:
- [ ] Tests added/updated.
- [ ] Documentation updated. Documentation is generated from docstrings - these must be updated according to your change.
  If a new method has been added it should be referenced in [cognite.rst](https://github.com/cognitedata/cognite-sdk-python/blob/master/docs/source/cognite.rst) in order to generate docs based on its docstring.
- [x] Changelog updated in [CHANGELOG.md](https://github.com/cognitedata/cognite-sdk-python/blob/master/CHANGELOG.md).
- [x] Version bumped. If triggering a new release is desired, bump the version number in [_version.py](https://github.com/cognitedata/cognite-sdk-python/blob/master/cognite/client/_version.py) and [pyproject.toml](https://github.com/cognitedata/cognite-sdk-python/blob/master/pyproject.toml) per [semantic versioning](https://semver.org/).
