### PR TITLE
Mocked APIs that change attribute path will now fail in tests

### DIFF
--- a/tests/utils.py
+++ b/tests/utils.py
@@ -32,11 +32,11 @@ def all_subclasses(base: type) -> list[type]:
     )
 
 
-def all_mock_children(mock, parent_names=()):
+def all_mock_children(mock, parent_name=()):
     """Returns a dictionary with correct dotted names mapping to mocked classes."""
-    dct = {".".join((*parent_names, k)): v for k, v in mock._mock_children.items()}
+    dct = {".".join((*parent_name, k)): v for k, v in mock._mock_children.items()}
     for name, child in dct.copy().items():
-        dct.update(all_mock_children(child, parent_names=(*parent_names, name)))
+        dct.update(all_mock_children(child, parent_name=(name,)))
     return dct
 
 


### PR DESCRIPTION
## Description
Mocked APIs that change attribute path will now fail in tests.

Discovered here: https://github.com/cognitedata/cognite-sdk-python/pull/1231#discussion_r1204758219 

This will now fail in tests:
`Failed: Attribute 'models' for API (or sub-API): <class 'cognite.client._api.data_modeling.DataModelingAPI'> available on 'CogniteClientMock', was not found on the 'CogniteClient' object, has it been misspelled?`

## Checklist:
- [x] Tests added/updated.