### PR TITLE
tests: fix comparison of spaces

### DIFF
--- a/tests/tests_integration/test_api/test_spaces.py
+++ b/tests/tests_integration/test_api/test_spaces.py
@@ -15,8 +15,13 @@ def cdf_spaces(cognite_client):
 
 def _dump(list_: SpaceList | Space) -> list[dict]:
     if isinstance(list_, Space):
-        return [list_.dump()]
-    return sorted((s.dump() for s in list_), key=lambda s: s["space"])
+        output = [list_.dump()]
+    else:
+        output = sorted((s.dump() for s in list_), key=lambda s: s["space"])
+    for entry in output:
+        if "last_updated_time" in entry:
+            entry["last_updated_time"] = None
+    return output
 
 
 class TestSpacesAPI:


### PR DESCRIPTION
## Description
The comparison of listet spaces in the master branch test is failing. This fixes the comparison. 

## Checklist:
- [x] Tests added/updated.
- [ ] Documentation updated. Documentation is generated from docstrings - these must be updated according to your change.
  If a new method has been added it should be referenced in [cognite.rst](https://github.com/cognitedata/cognite-sdk-python/blob/master/docs/source/cognite.rst) in order to generate docs based on its docstring.
- [ ] Changelog updated in [CHANGELOG.md](https://github.com/cognitedata/cognite-sdk-python/blob/master/CHANGELOG.md).
- [ ] Version bumped. If triggering a new release is desired, bump the version number in [_version.py](https://github.com/cognitedata/cognite-sdk-python/blob/master/cognite/client/_version.py) and [pyproject.toml](https://github.com/cognitedata/cognite-sdk-python/blob/master/pyproject.toml) per [semantic versioning](https://semver.org/).
