### PR TITLE
Refactor function schedule create after API-key deprecation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ Changes are grouped as follows
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
-## [6.2.2] - 2023-06-01
+## [6.2.2] - 2023-06-05
 ### Fixed
 - Creating function schedules with current user credentials now works (used to fail at runtime with "Could not fetch a valid token (...)" because a session was never created.)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ Changes are grouped as follows
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
+## [6.2.2] - 2023-06-01
+### Fixed
+- Creating function schedules with current user credentials now works (used to fail at runtime with "Could not fetch a valid token (...)" because a session was never created.)
+
 ## [6.2.1] - 2023-05-26
 ### Added
 - Data model centric support in transformation

--- a/cognite/client/_api/functions.py
+++ b/cognite/client/_api/functions.py
@@ -916,6 +916,7 @@ class FunctionSchedulesAPI(APIClient):
 
         return FunctionSchedulesList._load(res.json()["items"], cognite_client=self._cognite_client)
 
+    # TODO: Major version 7, remove 'function_external_id' which only worked when using API-keys.
     def create(
         self,
         name: str,
@@ -931,41 +932,53 @@ class FunctionSchedulesAPI(APIClient):
         Args:
             name (str): Name of the schedule.
             function_id (optional, int): Id of the function. This is required if the schedule is created with client_credentials.
-            function_external_id (optional, str): External id of the function. This is deprecated and cannot be used together with client_credentials.
+            function_external_id (optional, str): External id of the function. **NOTE**: This is deprecated and will be removed in a future major version.
             description (str): Description of the schedule.
             cron_expression (str): Cron expression.
             client_credentials: (optional, ClientCredentials, Dict): Instance of ClientCredentials or a dictionary containing client credentials:
                 client_id
                 client_secret
-            data (optional, Dict): Data to be passed to the scheduled run. **WARNING:** Secrets or other confidential information should not be passed via this argument. There is a dedicated `secrets` argument in FunctionsAPI.create() for this purpose.
+            data (optional, Dict): Data to be passed to the scheduled run.
 
         Returns:
             FunctionSchedule: Created function schedule.
 
+        Warning:
+            Do not pass secrets or other confidential information via the ``data`` argument. There is a dedicated
+            ``secrets`` argument in FunctionsAPI.create() for this purpose.
+
         Examples:
 
-            Create function schedule::
+            Create a function schedule that runs using specified client credentials (**recommended**)::
 
+                >>> import os
                 >>> from cognite.client import CogniteClient
                 >>> from cognite.client.data_classes import ClientCredentials
                 >>> c = CogniteClient()
                 >>> schedule = c.functions.schedules.create(
-                ...     name= "My schedule",
+                ...     name="My schedule",
                 ...     function_id=123,
                 ...     cron_expression="*/5 * * * *",
-                ...     client_credentials=ClientCredentials("my-client-id", "my-client-secret"),
-                ...     description="This schedule does magic stuff."
+                ...     client_credentials=ClientCredentials("my-client-id", os.environ["MY_CLIENT_SECRET"]),
+                ...     description="This schedule does magic stuff.",
+                ...     data={"magic": "stuff"},
+                ... )
+
+            You may also create a schedule that runs with your -current- credentials, i.e. the same credentials you used
+            to instantiate the ``CogniteClient`` (that you're using right now). **Note**: Unless you happen to already use
+            client credentials, *this is not a recommended way to create schedules*, as it will create an explicit dependency
+            on your user account, which it will run the function "on behalf of" (until the schedule is eventually removed)::
+
+                >>> schedule = c.functions.schedules.create(
+                ...     name="My schedule",
+                ...     function_id=456,
+                ...     cron_expression="*/5 * * * *",
+                ...     description="A schedule just used for some temporary testing.",
                 ... )
 
         """
         _get_function_identifier(function_id, function_external_id)
-
-        nonce = None
-        if client_credentials is not None:
-            if function_id is None:
-                raise ValueError("When passing 'client_credentials', 'function_id' must be set")
-            nonce = _create_session_and_return_nonce(self._cognite_client, client_credentials)
-
+        nonce = _create_session_and_return_nonce(self._cognite_client, client_credentials)
         body: Dict[str, List[Dict[str, Union[str, int, None, Dict]]]] = {
             "items": [
                 {

--- a/cognite/client/_version.py
+++ b/cognite/client/_version.py
@@ -1,4 +1,4 @@
 from __future__ import annotations
 
-__version__ = "6.2.1"
+__version__ = "6.2.2"
 __api_subversion__ = "V20220125"

--- a/poetry.lock
+++ b/poetry.lock
@@ -1246,18 +1246,6 @@ dev = ["pre-commit", "tox"]
 testing = ["pytest", "pytest-benchmark"]
 
 [[package]]
-name = "pprintpp"
-version = "0.4.0"
-description = "A drop-in replacement for pprint that's actually pretty"
-category = "dev"
-optional = false
-python-versions = "*"
-files = [
-    {file = "pprintpp-0.4.0-py2.py3-none-any.whl", hash = "sha256:b6b4dcdd0c0c0d75e4d7b2f21a9e933e5b2ce62b26e1a54537f9651ae5a5c01d"},
-    {file = "pprintpp-0.4.0.tar.gz", hash = "sha256:ea826108e2c7f49dc6d66c752973c3fc9749142a798d6b254e1e301cfdbc6403"},
-]
-
-[[package]]
 name = "pre-commit"
 version = "2.21.0"
 description = "A framework for managing and maintaining multi-language pre-commit hooks."
@@ -1472,22 +1460,6 @@ pytest = ">=7.0.0"
 [package.extras]
 docs = ["sphinx (>=5.3)", "sphinx-rtd-theme (>=1.0)"]
 testing = ["coverage (>=6.2)", "flaky (>=3.5.0)", "hypothesis (>=5.7.1)", "mypy (>=0.931)", "pytest-trio (>=0.7.0)"]
-
-[[package]]
-name = "pytest-clarity"
-version = "1.0.1"
-description = "A plugin providing an alternative, colourful diff output for failing assertions."
-category = "dev"
-optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
-files = [
-    {file = "pytest-clarity-1.0.1.tar.gz", hash = "sha256:505fe345fad4fe11c6a4187fe683f2c7c52c077caa1e135f3e483fe112db7772"},
-]
-
-[package.dependencies]
-pprintpp = ">=0.4.0"
-pytest = ">=3.5.0"
-rich = ">=8.0.0"
 
 [[package]]
 name = "pytest-cov"
@@ -2284,4 +2256,4 @@ sympy = ["sympy"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8"
-content-hash = "26fe97dca25dbe6bd7b1938190416212126557d307dd9580c904d2301c0ab0fb"
+content-hash = "6e9e3f755b9ced3676f3e409c706c35f3b2025823088779f07b2138c60989279"

--- a/poetry.lock
+++ b/poetry.lock
@@ -2284,4 +2284,4 @@ sympy = ["sympy"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8"
-content-hash = "88e0aec7a48a37001983084f6d991314d1498a29995c1cbef8612ec7524c34a3"
+content-hash = "26fe97dca25dbe6bd7b1938190416212126557d307dd9580c904d2301c0ab0fb"

--- a/poetry.lock
+++ b/poetry.lock
@@ -1246,6 +1246,18 @@ dev = ["pre-commit", "tox"]
 testing = ["pytest", "pytest-benchmark"]
 
 [[package]]
+name = "pprintpp"
+version = "0.4.0"
+description = "A drop-in replacement for pprint that's actually pretty"
+category = "dev"
+optional = false
+python-versions = "*"
+files = [
+    {file = "pprintpp-0.4.0-py2.py3-none-any.whl", hash = "sha256:b6b4dcdd0c0c0d75e4d7b2f21a9e933e5b2ce62b26e1a54537f9651ae5a5c01d"},
+    {file = "pprintpp-0.4.0.tar.gz", hash = "sha256:ea826108e2c7f49dc6d66c752973c3fc9749142a798d6b254e1e301cfdbc6403"},
+]
+
+[[package]]
 name = "pre-commit"
 version = "2.21.0"
 description = "A framework for managing and maintaining multi-language pre-commit hooks."
@@ -1460,6 +1472,22 @@ pytest = ">=7.0.0"
 [package.extras]
 docs = ["sphinx (>=5.3)", "sphinx-rtd-theme (>=1.0)"]
 testing = ["coverage (>=6.2)", "flaky (>=3.5.0)", "hypothesis (>=5.7.1)", "mypy (>=0.931)", "pytest-trio (>=0.7.0)"]
+
+[[package]]
+name = "pytest-clarity"
+version = "1.0.1"
+description = "A plugin providing an alternative, colourful diff output for failing assertions."
+category = "dev"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+files = [
+    {file = "pytest-clarity-1.0.1.tar.gz", hash = "sha256:505fe345fad4fe11c6a4187fe683f2c7c52c077caa1e135f3e483fe112db7772"},
+]
+
+[package.dependencies]
+pprintpp = ">=0.4.0"
+pytest = ">=3.5.0"
+rich = ">=8.0.0"
 
 [[package]]
 name = "pytest-cov"
@@ -2256,4 +2284,4 @@ sympy = ["sympy"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8"
-content-hash = "6e9e3f755b9ced3676f3e409c706c35f3b2025823088779f07b2138c60989279"
+content-hash = "88e0aec7a48a37001983084f6d991314d1498a29995c1cbef8612ec7524c34a3"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,7 +68,6 @@ types-requests = "^2.28.1"
 pep8-naming = "^0"
 types-backports = "^0.1.3"
 types-protobuf = "^4.22.0.2"
-pytest-clarity = ">=1"
 
 [build-system]
 requires = ["poetry>=1.0"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,6 +68,7 @@ types-requests = "^2.28.1"
 pep8-naming = "^0"
 types-backports = "^0.1.3"
 types-protobuf = "^4.22.0.2"
+pytest-clarity = ">=1"
 
 [build-system]
 requires = ["poetry>=1.0"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "cognite-sdk"
 
-version = "6.2.1"
+version = "6.2.2"
 
 
 description = "Cognite Python SDK"


### PR DESCRIPTION
## Description
After API keys were phased out in major version 6, `FunctionSchedulesAPI.create` should also have been updated, but that's too late now (and will have to wait for v7). Either way, this PR does a few things:

1. Makes it so that schedules can be created as specified by the official documentation:

> Nonce retrieved from sessions API when creating a session. This will be used to bind the session before executing the function. The corresponding access token will be passed to the function and used to instantiate the client of the handle() function. You can create a session via the Sessions API. **_When using the Python SDK, the session will be created behind the scenes when creating the schedule_**.

This used to only happen when passing explicit client credentials. It now also works for current user credentials which used to fail at runtime with "Could not fetch a valid token (...)" because a session was never created for the user it was just assumed that an API key was used to create the function.
 
2. Remove the `ValueError` as this is already enforced directly by the API:
`CogniteAPIError: When creating a schedule with OIDC-tokens, you must use 'function_id' and not 'function_external_id'  | code: 400 | X-Request-ID: 57f30ed5-eb68-955d-90c3-1fd0e0d73b97`

3. Improve documentation with an extra example that uses current user credentials. Also moves the warning on the `data` argument to a separate box to make it more clear:

<img width="741" alt="Screenshot 2023-05-31 at 21 46 54" src="https://github.com/cognitedata/cognite-sdk-python/assets/8521241/21f9486c-fd3e-4c88-805a-09928f65ff92">

## Checklist:
- [x] Tests added/updated.
- [x] Documentation updated. Documentation is generated from docstrings - these must be updated according to your change.
  If a new method has been added it should be referenced in [cognite.rst](https://github.com/cognitedata/cognite-sdk-python/blob/master/docs/source/cognite.rst) in order to generate docs based on its docstring.
- [x] Changelog updated in [CHANGELOG.md](https://github.com/cognitedata/cognite-sdk-python/blob/master/CHANGELOG.md).
- [x] Version bumped. If triggering a new release is desired, bump the version number in [_version.py](https://github.com/cognitedata/cognite-sdk-python/blob/master/cognite/client/_version.py) and [pyproject.toml](https://github.com/cognitedata/cognite-sdk-python/blob/master/pyproject.toml) per [semantic versioning](https://semver.org/).
