### PR TITLE
Remove class variables `_LIST_CLASS`

### DIFF
--- a/cognite/client/_api/extractionpipelines.py
+++ b/cognite/client/_api/extractionpipelines.py
@@ -219,7 +219,6 @@ class ExtractionPipelinesAPI(APIClient):
 
 class ExtractionPipelineRunsAPI(APIClient):
     _RESOURCE_PATH = "/extpipes/runs"
-    _LIST_CLASS = ExtractionPipelineRunList
 
     def list(
         self,
@@ -317,7 +316,6 @@ class ExtractionPipelineRunsAPI(APIClient):
 
 class ExtractionPipelineConfigsAPI(APIClient):
     _RESOURCE_PATH = "/extpipes/config"
-    _LIST_CLASS = ExtractionPipelineConfigRevisionList
 
     def retrieve(
         self, external_id: str, revision: Optional[int] = None, active_at_time: Optional[int] = None

--- a/cognite/client/_api/iam.py
+++ b/cognite/client/_api/iam.py
@@ -185,7 +185,6 @@ class TokenAPI(APIClient):
 
 
 class SessionsAPI(APIClient):
-    _LIST_CLASS = SessionList
     _RESOURCE_PATH = "/sessions"
 
     def __init__(self, config: ClientConfig, api_version: Optional[str], cognite_client: CogniteClient) -> None:
@@ -223,7 +222,7 @@ class SessionsAPI(APIClient):
         identifiers = IdentifierSequence.load(ids=id, external_ids=None)
         items = {"items": identifiers.as_dicts()}
 
-        return self._LIST_CLASS._load(self._post(self._RESOURCE_PATH + "/revoke", items).json()["items"])
+        return SessionList._load(self._post(self._RESOURCE_PATH + "/revoke", items).json()["items"])
 
     def list(self, status: Optional[str] = None) -> SessionList:
         """`List all sessions in the current project. <https://docs.cognite.com/api/v1/#operation/listSessions>`_
@@ -234,5 +233,5 @@ class SessionsAPI(APIClient):
         Returns:
             SessionList: a list of sessions in the current project.
         """
-        filter = {"status": status} if status else None
-        return self._list(list_cls=self._LIST_CLASS, resource_cls=Session, method="GET", filter=filter)
+        filter = {"status": status} if status is not None else None
+        return self._list(list_cls=SessionList, resource_cls=Session, method="GET", filter=filter)

--- a/cognite/client/_api/templates.py
+++ b/cognite/client/_api/templates.py
@@ -332,7 +332,6 @@ class TemplateGroupVersionsAPI(APIClient):
 
 class TemplateInstancesAPI(APIClient):
     _RESOURCE_PATH = "/templategroups/{}/versions/{}/instances"
-    _LIST_CLASS = TemplateInstanceList
 
     def create(
         self, external_id: str, version: int, instances: Union[TemplateInstance, Sequence[TemplateInstance]]

--- a/cognite/client/_api/three_d.py
+++ b/cognite/client/_api/three_d.py
@@ -568,7 +568,6 @@ class ThreeDFilesAPI(APIClient):
 
 class ThreeDAssetMappingAPI(APIClient):
     _RESOURCE_PATH = "/3d/models/{}/revisions/{}/mappings"
-    _LIST_CLASS = ThreeDAssetMappingList
 
     def list(
         self,

--- a/cognite/client/_api/transformations/__init__.py
+++ b/cognite/client/_api/transformations/__init__.py
@@ -34,7 +34,6 @@ __all__ = [
 
 class TransformationsAPI(APIClient):
     _RESOURCE_PATH = "/transformations"
-    _LIST_CLASS = TransformationList
 
     def __init__(self, config: ClientConfig, api_version: Optional[str], cognite_client: CogniteClient) -> None:
         super().__init__(config, api_version, cognite_client)

--- a/cognite/client/_api/transformations/notifications.py
+++ b/cognite/client/_api/transformations/notifications.py
@@ -12,7 +12,6 @@ from cognite.client.utils._identifier import IdentifierSequence
 
 class TransformationNotificationsAPI(APIClient):
     _RESOURCE_PATH = "/transformations/notifications"
-    _LIST_CLASS = TransformationNotificationList
 
     def create(
         self, notification: Union[TransformationNotification, Sequence[TransformationNotification]]

--- a/cognite/client/_api/transformations/schedules.py
+++ b/cognite/client/_api/transformations/schedules.py
@@ -16,7 +16,6 @@ if TYPE_CHECKING:
 
 class TransformationSchedulesAPI(APIClient):
     _RESOURCE_PATH = "/transformations/schedules"
-    _LIST_CLASS = TransformationScheduleList
 
     def __init__(self, config: ClientConfig, api_version: Optional[str], cognite_client: CogniteClient) -> None:
         super().__init__(config, api_version, cognite_client)


### PR DESCRIPTION
## Description
`_LIST_CLASS` is a remnant from an earlier SDK version when the resource and list class were inferred automatically / implicitly used. These days we favor explicitness 😉 

Also adds `_RESOURCE_PATH` to `FunctionCallsAPI`.