### PR TITLE
Fix unrecoverable state for request retries during token refresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,9 +17,15 @@ Changes are grouped as follows
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
-## [6.3.2] - 2023-06-07
+## [6.3.2] - 2023-06-08
 ### Fixed
 - Requests being retried around a token refresh cycle, no longer risk getting stuck with an outdated token.
+
+### Added
+- `CredentialProviders` subclassing `_OAuthCredentialProviderWithTokenRefresh`, now accepts a new parameter, `token_expiry_leeway_seconds`, controlling how early a token refresh request should be initiated (before it expires).
+
+### Changed
+- `CredentialProviders` subclassing `_OAuthCredentialProviderWithTokenRefresh` now uses a safer default of 15 seconds (up from 3 sec) to control how early a token refresh request should be initiated (before it expires).
 
 ## [6.3.1] - 2023-06-07
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,11 +17,13 @@ Changes are grouped as follows
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
+## [6.3.2] - 2023-06-07
+### Fixed
+- Requests being retried around a token refresh cycle, no longer gets stuck with an outdated token.
+
 ## [6.3.1] - 2023-06-07
 ### Fixed
-- Signature of `client.data_modeling.views.retrieve` and `client.data_modeling.data_models.retrieve` to always return
-  a list. 
-
+- Signature of `client.data_modeling.views.retrieve` and `client.data_modeling.data_models.retrieve` to always return a list.
 
 ## [6.3.0] - 2023-06-07
 ### Added
@@ -29,7 +31,7 @@ Changes are grouped as follows
 - Support for the view resource in the Data Modeling API with the implementation `client.data_modeling.views`.
 - Support for the data models resource in the Data Modeling API with the implementation `client.data_modeling.data_models`.
 
-### Changed
+### Removed
 - Removed `retrieve_multiple` from the `SpacesAPI` to have a consistent API with the `views`, `containers`, and `data_models`.
 
 ## [6.2.2] - 2023-06-05

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ Changes are grouped as follows
 
 ## [6.3.2] - 2023-06-07
 ### Fixed
-- Requests being retried around a token refresh cycle, no longer gets stuck with an outdated token.
+- Requests being retried around a token refresh cycle, no longer risk getting stuck with an outdated token.
 
 ## [6.3.1] - 2023-06-07
 ### Fixed

--- a/cognite/client/_api_client.py
+++ b/cognite/client/_api_client.py
@@ -100,6 +100,7 @@ class APIClient:
                 max_retries_status=global_config.max_retries,
             ),
             session=session,
+            refresh_auth_header=self._refresh_auth_header,
         )
         self._http_client_with_retry = HTTPClient(
             config=HTTPClientConfig(
@@ -112,6 +113,7 @@ class APIClient:
                 max_retries_status=global_config.max_retries,
             ),
             session=session,
+            refresh_auth_header=self._refresh_auth_header,
         )
 
     def _delete(
@@ -186,8 +188,7 @@ class APIClient:
     def _configure_headers(self, accept: str, additional_headers: Dict[str, str]) -> MutableMapping[str, Any]:
         headers: MutableMapping[str, Any] = CaseInsensitiveDict()
         headers.update(requests.utils.default_headers())
-        auth_header_name, auth_header_value = self._config.credentials.authorization_header()
-        headers[auth_header_name] = auth_header_value
+        self._refresh_auth_header(headers)
         headers["content-type"] = "application/json"
         headers["accept"] = accept
         headers["x-cdp-sdk"] = f"CognitePythonSDK:{utils._auxiliary.get_current_sdk_version()}"
@@ -199,6 +200,10 @@ class APIClient:
             headers["User-Agent"] = utils._auxiliary.get_user_agent()
         headers.update(additional_headers)
         return headers
+
+    def _refresh_auth_header(self, headers: MutableMapping[str, Any]) -> None:
+        auth_header_name, auth_header_value = self._config.credentials.authorization_header()
+        headers[auth_header_name] = auth_header_value
 
     def _resolve_url(self, method: str, url_path: str) -> Tuple[bool, str]:
         if not url_path.startswith("/"):

--- a/cognite/client/_http_client.py
+++ b/cognite/client/_http_client.py
@@ -96,8 +96,8 @@ class HTTPClient:
         self,
         config: HTTPClientConfig,
         session: requests.Session,
-        refresh_auth_header: Callable[[MutableMapping[str, Any]], None],
         retry_tracker_factory: Callable[[HTTPClientConfig], _RetryTracker] = _RetryTracker,
+        refresh_auth_header: Callable[[MutableMapping[str, Any]], None] | None = None,
     ):
         self.session = session
         self.config = config
@@ -128,7 +128,7 @@ class HTTPClient:
 
             # During a backoff loop, our credentials might expire, so we check and maybe refresh:
             time.sleep(retry_tracker.get_backoff_time())
-            if headers is not None:
+            if self.refresh_auth_header is not None and headers is not None:
                 # TODO: Refactoring needed to make this "prettier"
                 self.refresh_auth_header(headers)
 

--- a/cognite/client/_http_client.py
+++ b/cognite/client/_http_client.py
@@ -5,7 +5,7 @@ import random
 import socket
 import time
 from http import cookiejar
-from typing import Any, Callable, Optional, Set, Tuple, Type, Union
+from typing import Any, Callable, MutableMapping, Optional, Set, Tuple, Type, Union
 
 import requests
 import requests.adapters
@@ -96,14 +96,17 @@ class HTTPClient:
         self,
         config: HTTPClientConfig,
         session: requests.Session,
+        refresh_auth_header: Callable[[MutableMapping[str, Any]], None],
         retry_tracker_factory: Callable[[HTTPClientConfig], _RetryTracker] = _RetryTracker,
     ):
         self.session = session
         self.config = config
         self.retry_tracker_factory = retry_tracker_factory  # needed for tests
+        self.refresh_auth_header = refresh_auth_header
 
     def request(self, method: str, url: str, **kwargs: Any) -> requests.Response:
         retry_tracker = self.retry_tracker_factory(self.config)
+        headers = kwargs.get("headers")
         last_status = None
         while True:
             try:
@@ -122,7 +125,12 @@ class HTTPClient:
                 retry_tracker.connect += 1
                 if not retry_tracker.should_retry(status_code=last_status):
                     raise e
+
+            # During a backoff loop, our credentials might expire, so we check and maybe refresh:
             time.sleep(retry_tracker.get_backoff_time())
+            if headers is not None:
+                # TODO: Refactoring needed to make this "prettier"
+                self.refresh_auth_header(headers)
 
     def _do_request(self, method: str, url: str, **kwargs: Any) -> requests.Response:
         """requests/urllib3 adds 2 or 3 layers of exceptions on top of built-in networking exceptions.

--- a/cognite/client/_http_client.py
+++ b/cognite/client/_http_client.py
@@ -96,13 +96,13 @@ class HTTPClient:
         self,
         config: HTTPClientConfig,
         session: requests.Session,
+        refresh_auth_header: Callable[[MutableMapping[str, Any]], None],
         retry_tracker_factory: Callable[[HTTPClientConfig], _RetryTracker] = _RetryTracker,
-        refresh_auth_header: Callable[[MutableMapping[str, Any]], None] | None = None,
     ):
         self.session = session
         self.config = config
-        self.retry_tracker_factory = retry_tracker_factory  # needed for tests
         self.refresh_auth_header = refresh_auth_header
+        self.retry_tracker_factory = retry_tracker_factory  # needed for tests
 
     def request(self, method: str, url: str, **kwargs: Any) -> requests.Response:
         retry_tracker = self.retry_tracker_factory(self.config)
@@ -128,7 +128,7 @@ class HTTPClient:
 
             # During a backoff loop, our credentials might expire, so we check and maybe refresh:
             time.sleep(retry_tracker.get_backoff_time())
-            if self.refresh_auth_header is not None and headers is not None:
+            if headers is not None:
                 # TODO: Refactoring needed to make this "prettier"
                 self.refresh_auth_header(headers)
 

--- a/cognite/client/_version.py
+++ b/cognite/client/_version.py
@@ -1,4 +1,4 @@
 from __future__ import annotations
 
-__version__ = "6.3.1"
+__version__ = "6.3.2"
 __api_subversion__ = "V20220125"

--- a/cognite/client/credentials.py
+++ b/cognite/client/credentials.py
@@ -60,9 +60,6 @@ class Token(CredentialProvider):
 
 
 class _OAuthCredentialProviderWithTokenRefresh(CredentialProvider):
-    # This ensures we don't return a token which expires immediately, but within minimum 3 seconds.
-    __TOKEN_EXPIRY_LEEWAY_SECONDS = 3
-
     def __init__(self) -> None:
         self.__token_refresh_lock = threading.Lock()
         self.__access_token: Optional[str] = None
@@ -87,7 +84,7 @@ class _OAuthCredentialProviderWithTokenRefresh(CredentialProvider):
     @classmethod
     def __should_refresh_token(cls, token: Optional[str], expires_at: Optional[float]) -> bool:
         no_token = token is None
-        token_is_expired = expires_at is None or time.time() > expires_at - cls.__TOKEN_EXPIRY_LEEWAY_SECONDS
+        token_is_expired = expires_at is None or time.time() > expires_at
         return no_token or token_is_expired
 
     @staticmethod

--- a/cognite/client/credentials.py
+++ b/cognite/client/credentials.py
@@ -15,7 +15,7 @@ from requests_oauthlib import OAuth2Session
 
 from cognite.client.exceptions import CogniteAuthError
 
-_TOKEN_EXPIRY_LEEWAY_SECONDS_DEFAULT = 15
+_TOKEN_EXPIRY_LEEWAY_SECONDS_DEFAULT = 15  # Do not change without also updating all the docstrings using it
 
 
 class CredentialProvider(Protocol):
@@ -62,7 +62,7 @@ class Token(CredentialProvider):
 
 
 class _OAuthCredentialProviderWithTokenRefresh(CredentialProvider):
-    def __init__(self, token_expiry_leeway_seconds: int = _TOKEN_EXPIRY_LEEWAY_SECONDS) -> None:
+    def __init__(self, token_expiry_leeway_seconds: int = _TOKEN_EXPIRY_LEEWAY_SECONDS_DEFAULT) -> None:
         # This ensures we don't return a token which expires immediately:
         self.token_expiry_leeway_seconds = token_expiry_leeway_seconds
 
@@ -155,7 +155,7 @@ class OAuthDeviceCode(_OAuthCredentialProviderWithTokenRefresh, _WithMsalSeriali
         client_id (str): Your application's client id.
         scopes (List[str]): A list of scopes.
         token_cache_path (Path): Location to store token cache, defaults to os temp directory/cognitetokencache.{client_id}.bin.
-        token_expiry_leeway_seconds: (int): The token is refreshed at the earliest when this number of seconds is left before expiry.
+        token_expiry_leeway_seconds (int): The token is refreshed at the earliest when this number of seconds is left before expiry. Default: 15 sec
 
     Examples:
 
@@ -173,7 +173,7 @@ class OAuthDeviceCode(_OAuthCredentialProviderWithTokenRefresh, _WithMsalSeriali
         client_id: str,
         scopes: List[str],
         token_cache_path: Path = None,
-        token_expiry_leeway_seconds: int = _TOKEN_EXPIRY_LEEWAY_SECONDS,
+        token_expiry_leeway_seconds: int = _TOKEN_EXPIRY_LEEWAY_SECONDS_DEFAULT,
     ) -> None:
         super().__init__(token_expiry_leeway_seconds)
         self.__authority_url = authority_url
@@ -232,7 +232,7 @@ class OAuthInteractive(_OAuthCredentialProviderWithTokenRefresh, _WithMsalSerial
         scopes (List[str]): A list of scopes.
         redirect_port (List[str]): Redirect port defaults to 53000.
         token_cache_path (Path): Location to store token cache, defaults to os temp directory/cognitetokencache.{client_id}.bin.
-        token_expiry_leeway_seconds: (int): The token is refreshed at the earliest when this number of seconds is left before expiry.
+        token_expiry_leeway_seconds (int): The token is refreshed at the earliest when this number of seconds is left before expiry. Default: 15 sec
 
     Examples:
 
@@ -251,7 +251,7 @@ class OAuthInteractive(_OAuthCredentialProviderWithTokenRefresh, _WithMsalSerial
         scopes: List[str],
         redirect_port: int = 53000,
         token_cache_path: Path = None,
-        token_expiry_leeway_seconds: int = _TOKEN_EXPIRY_LEEWAY_SECONDS,
+        token_expiry_leeway_seconds: int = _TOKEN_EXPIRY_LEEWAY_SECONDS_DEFAULT,
     ) -> None:
 
         super().__init__(token_expiry_leeway_seconds)
@@ -306,7 +306,7 @@ class OAuthClientCredentials(_OAuthCredentialProviderWithTokenRefresh):
         client_id (str): Your application's client id.
         client_secret (str): Your application's client secret
         scopes (List[str]): A list of scopes.
-        token_expiry_leeway_seconds: (int): The token is refreshed at the earliest when this number of seconds is left before expiry.
+        token_expiry_leeway_seconds (int): The token is refreshed at the earliest when this number of seconds is left before expiry. Default: 15 sec
         **token_custom_args (Any): Optional additional arguments to pass as query parameters to the token fetch request.
 
     Examples:
@@ -329,7 +329,7 @@ class OAuthClientCredentials(_OAuthCredentialProviderWithTokenRefresh):
         client_id: str,
         client_secret: str,
         scopes: List[str],
-        token_expiry_leeway_seconds: int = _TOKEN_EXPIRY_LEEWAY_SECONDS,
+        token_expiry_leeway_seconds: int = _TOKEN_EXPIRY_LEEWAY_SECONDS_DEFAULT,
         **token_custom_args: Any,
     ):
         super().__init__(token_expiry_leeway_seconds)
@@ -411,7 +411,7 @@ class OAuthClientCertificate(_OAuthCredentialProviderWithTokenRefresh):
         cert_thumbprint (str): Your certificate's thumbprint. You get it when you upload your certificate to Azure AD.
         certificate (str): Your private certificate, typically read from a .pem file
         scopes (List[str]): A list of scopes.
-        token_expiry_leeway_seconds: (int): The token is refreshed at the earliest when this number of seconds is left before expiry.
+        token_expiry_leeway_seconds (int): The token is refreshed at the earliest when this number of seconds is left before expiry. Default: 15 sec
 
     Examples:
 
@@ -433,7 +433,7 @@ class OAuthClientCertificate(_OAuthCredentialProviderWithTokenRefresh):
         cert_thumbprint: str,
         certificate: str,
         scopes: List[str],
-        token_expiry_leeway_seconds: int = _TOKEN_EXPIRY_LEEWAY_SECONDS,
+        token_expiry_leeway_seconds: int = _TOKEN_EXPIRY_LEEWAY_SECONDS_DEFAULT,
     ):
         super().__init__(token_expiry_leeway_seconds)
         self.__authority_url = authority_url

--- a/cognite/client/credentials.py
+++ b/cognite/client/credentials.py
@@ -15,7 +15,7 @@ from requests_oauthlib import OAuth2Session
 
 from cognite.client.exceptions import CogniteAuthError
 
-_TOKEN_EXPIRY_LEEWAY_SECONDS = 15
+_TOKEN_EXPIRY_LEEWAY_SECONDS_DEFAULT = 15
 
 
 class CredentialProvider(Protocol):

--- a/cognite/client/credentials.py
+++ b/cognite/client/credentials.py
@@ -60,6 +60,9 @@ class Token(CredentialProvider):
 
 
 class _OAuthCredentialProviderWithTokenRefresh(CredentialProvider):
+    # This ensures we don't return a token which expires immediately, but within minimum 3 seconds.
+    __TOKEN_EXPIRY_LEEWAY_SECONDS = 3
+
     def __init__(self) -> None:
         self.__token_refresh_lock = threading.Lock()
         self.__access_token: Optional[str] = None
@@ -84,7 +87,7 @@ class _OAuthCredentialProviderWithTokenRefresh(CredentialProvider):
     @classmethod
     def __should_refresh_token(cls, token: Optional[str], expires_at: Optional[float]) -> bool:
         no_token = token is None
-        token_is_expired = expires_at is None or time.time() > expires_at
+        token_is_expired = expires_at is None or time.time() > expires_at - cls.__TOKEN_EXPIRY_LEEWAY_SECONDS
         return no_token or token_is_expired
 
     @staticmethod

--- a/cognite/client/credentials.py
+++ b/cognite/client/credentials.py
@@ -15,6 +15,8 @@ from requests_oauthlib import OAuth2Session
 
 from cognite.client.exceptions import CogniteAuthError
 
+_TOKEN_EXPIRY_LEEWAY_SECONDS = 15
+
 
 class CredentialProvider(Protocol):
     @abstractmethod
@@ -60,10 +62,10 @@ class Token(CredentialProvider):
 
 
 class _OAuthCredentialProviderWithTokenRefresh(CredentialProvider):
-    # This ensures we don't return a token which expires immediately, but within minimum 3 seconds.
-    __TOKEN_EXPIRY_LEEWAY_SECONDS = 3
+    def __init__(self, token_expiry_leeway_seconds: int = _TOKEN_EXPIRY_LEEWAY_SECONDS) -> None:
+        # This ensures we don't return a token which expires immediately:
+        self.token_expiry_leeway_seconds = token_expiry_leeway_seconds
 
-    def __init__(self) -> None:
         self.__token_refresh_lock = threading.Lock()
         self.__access_token: Optional[str] = None
         self.__access_token_expires_at: Optional[float] = None
@@ -84,10 +86,9 @@ class _OAuthCredentialProviderWithTokenRefresh(CredentialProvider):
         """This method should return the access_token and expiry time"""
         raise NotImplementedError
 
-    @classmethod
-    def __should_refresh_token(cls, token: Optional[str], expires_at: Optional[float]) -> bool:
+    def __should_refresh_token(self, token: Optional[str], expires_at: Optional[float]) -> bool:
         no_token = token is None
-        token_is_expired = expires_at is None or time.time() > expires_at - cls.__TOKEN_EXPIRY_LEEWAY_SECONDS
+        token_is_expired = expires_at is None or time.time() > expires_at - self.token_expiry_leeway_seconds
         return no_token or token_is_expired
 
     @staticmethod
@@ -153,8 +154,8 @@ class OAuthDeviceCode(_OAuthCredentialProviderWithTokenRefresh, _WithMsalSeriali
         authority_url (str): OAuth authority url
         client_id (str): Your application's client id.
         scopes (List[str]): A list of scopes.
-        token_cache_path (Path): Location to store token cache, defaults to
-                                 os temp directory/cognitetokencache.{client_id}.bin.
+        token_cache_path (Path): Location to store token cache, defaults to os temp directory/cognitetokencache.{client_id}.bin.
+        token_expiry_leeway_seconds: (int): The token is refreshed at the earliest when this number of seconds is left before expiry.
 
     Examples:
 
@@ -172,8 +173,9 @@ class OAuthDeviceCode(_OAuthCredentialProviderWithTokenRefresh, _WithMsalSeriali
         client_id: str,
         scopes: List[str],
         token_cache_path: Path = None,
+        token_expiry_leeway_seconds: int = _TOKEN_EXPIRY_LEEWAY_SECONDS,
     ) -> None:
-        super().__init__()
+        super().__init__(token_expiry_leeway_seconds)
         self.__authority_url = authority_url
         self.__client_id = client_id
         self.__scopes = scopes
@@ -229,8 +231,8 @@ class OAuthInteractive(_OAuthCredentialProviderWithTokenRefresh, _WithMsalSerial
         client_id (str): Your application's client id.
         scopes (List[str]): A list of scopes.
         redirect_port (List[str]): Redirect port defaults to 53000.
-        token_cache_path (Path): Location to store token cache, defaults to
-                                 os temp directory/cognitetokencache.{client_id}.bin.
+        token_cache_path (Path): Location to store token cache, defaults to os temp directory/cognitetokencache.{client_id}.bin.
+        token_expiry_leeway_seconds: (int): The token is refreshed at the earliest when this number of seconds is left before expiry.
 
     Examples:
 
@@ -249,9 +251,10 @@ class OAuthInteractive(_OAuthCredentialProviderWithTokenRefresh, _WithMsalSerial
         scopes: List[str],
         redirect_port: int = 53000,
         token_cache_path: Path = None,
+        token_expiry_leeway_seconds: int = _TOKEN_EXPIRY_LEEWAY_SECONDS,
     ) -> None:
 
-        super().__init__()
+        super().__init__(token_expiry_leeway_seconds)
         self.__authority_url = authority_url
         self.__client_id = client_id
         self.__scopes = scopes
@@ -303,6 +306,7 @@ class OAuthClientCredentials(_OAuthCredentialProviderWithTokenRefresh):
         client_id (str): Your application's client id.
         client_secret (str): Your application's client secret
         scopes (List[str]): A list of scopes.
+        token_expiry_leeway_seconds: (int): The token is refreshed at the earliest when this number of seconds is left before expiry.
         **token_custom_args (Any): Optional additional arguments to pass as query parameters to the token fetch request.
 
     Examples:
@@ -325,9 +329,10 @@ class OAuthClientCredentials(_OAuthCredentialProviderWithTokenRefresh):
         client_id: str,
         client_secret: str,
         scopes: List[str],
+        token_expiry_leeway_seconds: int = _TOKEN_EXPIRY_LEEWAY_SECONDS,
         **token_custom_args: Any,
     ):
-        super().__init__()
+        super().__init__(token_expiry_leeway_seconds)
         self.__token_url = token_url
         self.__client_id = client_id
         self.__client_secret = client_secret
@@ -406,6 +411,7 @@ class OAuthClientCertificate(_OAuthCredentialProviderWithTokenRefresh):
         cert_thumbprint (str): Your certificate's thumbprint. You get it when you upload your certificate to Azure AD.
         certificate (str): Your private certificate, typically read from a .pem file
         scopes (List[str]): A list of scopes.
+        token_expiry_leeway_seconds: (int): The token is refreshed at the earliest when this number of seconds is left before expiry.
 
     Examples:
 
@@ -420,8 +426,16 @@ class OAuthClientCertificate(_OAuthCredentialProviderWithTokenRefresh):
             ... )
     """
 
-    def __init__(self, authority_url: str, client_id: str, cert_thumbprint: str, certificate: str, scopes: List[str]):
-        super().__init__()
+    def __init__(
+        self,
+        authority_url: str,
+        client_id: str,
+        cert_thumbprint: str,
+        certificate: str,
+        scopes: List[str],
+        token_expiry_leeway_seconds: int = _TOKEN_EXPIRY_LEEWAY_SECONDS,
+    ):
+        super().__init__(token_expiry_leeway_seconds)
         self.__authority_url = authority_url
         self.__client_id = client_id
         self.__cert_thumbprint = cert_thumbprint

--- a/cognite/client/utils/_pyodide_helpers.py
+++ b/cognite/client/utils/_pyodide_helpers.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import os
 import warnings
-from typing import TYPE_CHECKING, Callable, Dict, Optional, Tuple
+from typing import TYPE_CHECKING, Any, Callable, Dict, MutableMapping, Optional, Tuple
 
 import cognite.client as cc
 from cognite.client._http_client import _RetryTracker
@@ -62,11 +62,12 @@ def http_client__init__(
     self: HTTPClient,
     config: HTTPClientConfig,
     session: Session,
+    refresh_auth_header: Callable[[MutableMapping[str, Any]], None],
     retry_tracker_factory: Callable[[HTTPClientConfig], _RetryTracker] = _RetryTracker,
 ) -> None:
     import pyodide_http  # type: ignore [import]
 
-    self._old__init__(config, session, retry_tracker_factory)  # type: ignore [attr-defined]
+    self._old__init__(config, session, refresh_auth_header, retry_tracker_factory)  # type: ignore [attr-defined]
     self.session.mount("https://", pyodide_http._requests.PyodideHTTPAdapter())
     self.session.mount("http://", pyodide_http._requests.PyodideHTTPAdapter())
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "cognite-sdk"
 
-version = "6.3.1"
+version = "6.3.2"
 
 description = "Cognite Python SDK"
 readme = "README.md"

--- a/tests/tests_unit/test_api_client.py
+++ b/tests/tests_unit/test_api_client.py
@@ -1214,9 +1214,7 @@ def test_worker_in_backoff_loop_gets_new_token(rsps):
         if call_count < 1:
             call_count += 1
             return "outdated-token"
-
-        while True:
-            return "valid-token"
+        return "valid-token"
 
     client = CogniteClient(ClientConfig(client_name="a", credentials=Token(token_callable), project="c"))
     assert client.assets.retrieve(id=1).id == 123

--- a/tests/tests_unit/test_api_client.py
+++ b/tests/tests_unit/test_api_client.py
@@ -1200,3 +1200,26 @@ class TestConnectionPooling:
             == c1._api_client._http_client_with_retry.session
             == c2._api_client._http_client_with_retry.session
         )
+
+
+def test_worker_in_backoff_loop_gets_new_token(rsps):
+    url = "https://api.cognitedata.com/api/v1/projects/c/assets/byids"
+    rsps.add(rsps.POST, url, status=429, json={"error": "Backoff plz"})
+    rsps.add(rsps.POST, url, status=200, json={"items": [{"id": 123}]})
+
+    call_count = 0
+
+    def token_callable():
+        nonlocal call_count
+        if call_count < 1:
+            call_count += 1
+            return "outdated-token"
+
+        while True:
+            return "valid-token"
+
+    client = CogniteClient(ClientConfig(client_name="a", credentials=Token(token_callable), project="c"))
+    assert client.assets.retrieve(id=1).id == 123
+    assert call_count > 0
+    assert rsps.calls[0].request.headers["Authorization"] == "Bearer outdated-token"
+    assert rsps.calls[1].request.headers["Authorization"] == "Bearer valid-token"

--- a/tests/tests_unit/test_http_client.py
+++ b/tests/tests_unit/test_http_client.py
@@ -81,6 +81,7 @@ class TestHTTPClient:
         retry_tracker = _RetryTracker(cnf)
         c = HTTPClient(
             config=cnf,
+            refresh_auth_header=lambda headers: None,
             retry_tracker_factory=lambda _: retry_tracker,
             session=MagicMock(
                 request=MagicMock(
@@ -104,6 +105,7 @@ class TestHTTPClient:
         retry_tracker = _RetryTracker(cnf)
         c = HTTPClient(
             config=cnf,
+            refresh_auth_header=lambda headers: None,
             retry_tracker_factory=lambda _: retry_tracker,
             session=MagicMock(
                 request=MagicMock(
@@ -126,6 +128,7 @@ class TestHTTPClient:
         retry_tracker = _RetryTracker(cnf)
         c = HTTPClient(
             config=cnf,
+            refresh_auth_header=lambda headers: None,
             retry_tracker_factory=lambda _: retry_tracker,
             session=MagicMock(
                 request=MagicMock(
@@ -147,6 +150,7 @@ class TestHTTPClient:
         retry_tracker = _RetryTracker(cnf)
         c = HTTPClient(
             config=cnf,
+            refresh_auth_header=lambda headers: None,
             retry_tracker_factory=lambda _: retry_tracker,
             session=MagicMock(request=MagicMock(return_value=MagicMock(status_code=429))),
         )


### PR DESCRIPTION
## Description
During a "token refresh cycle", it is quite likely, _especially in concurrent scenarios_, that worker threads get stuck with an outdated token. This is an **unrecoverable** state and thus always leads to an exception being raised once the "retry budget is spent".

## Checklist:
- [ ] Tests added/updated.
- [ ] Documentation updated. Documentation is generated from docstrings - these must be updated according to your change.
  If a new method has been added it should be referenced in [cognite.rst](https://github.com/cognitedata/cognite-sdk-python/blob/master/docs/source/cognite.rst) in order to generate docs based on its docstring.
- [x] Changelog updated in [CHANGELOG.md](https://github.com/cognitedata/cognite-sdk-python/blob/master/CHANGELOG.md).
- [x] Version bumped. If triggering a new release is desired, bump the version number in [_version.py](https://github.com/cognitedata/cognite-sdk-python/blob/master/cognite/client/_version.py) and [pyproject.toml](https://github.com/cognitedata/cognite-sdk-python/blob/master/pyproject.toml) per [semantic versioning](https://semver.org/).
