### PR TITLE
Make CogniteResourceList generic on inner type

### DIFF
--- a/cognite/client/_api/files.py
+++ b/cognite/client/_api/files.py
@@ -778,10 +778,11 @@ class FilesAPI(APIClient):
 
         files_metadata = self.retrieve_multiple(ids=ids, external_ids=external_ids)
 
-        id_to_metadata = {}
+        id_to_metadata: dict[str | int, FileMetadata] = {}
         for f in files_metadata:
-            id_to_metadata[f.id] = f
-            id_to_metadata[f.external_id] = f
+            id_to_metadata[cast(int, f.id)] = f
+            if f.external_id is not None:
+                id_to_metadata[f.external_id] = f
 
         return id_to_metadata
 

--- a/cognite/client/data_classes/_base.py
+++ b/cognite/client/data_classes/_base.py
@@ -2,7 +2,23 @@ from __future__ import annotations
 
 import json
 from collections import UserList
-from typing import TYPE_CHECKING, Any, Collection, Dict, Generic, List, Optional, Sequence, Type, TypeVar, Union, cast
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Collection,
+    Dict,
+    Generic,
+    Iterator,
+    List,
+    Optional,
+    Sequence,
+    SupportsIndex,
+    Type,
+    TypeVar,
+    Union,
+    cast,
+    overload,
+)
 
 from cognite.client import utils
 from cognite.client.exceptions import CogniteMissingClientError
@@ -173,7 +189,7 @@ class CognitePropertyClassUtil:
             self[schema_name] = value
 
 
-class CogniteResourceList(UserList):
+class CogniteResourceList(UserList, Generic[T_CogniteResource]):
     _RESOURCE: Type[CogniteResource]
 
     def __init__(self, resources: Collection[Any], cognite_client: CogniteClient = None):
@@ -199,6 +215,20 @@ class CogniteResourceList(UserList):
         if item == "_cognite_client" and attr is None:
             raise CogniteMissingClientError
         return attr
+
+    def pop(self, i: int = -1) -> T_CogniteResource:
+        return super().pop(i)
+
+    def __iter__(self) -> Iterator[T_CogniteResource]:
+        return super().__iter__()
+
+    @overload
+    def __getitem__(self, item: SupportsIndex) -> T_CogniteResource:
+        ...
+
+    @overload
+    def __getitem__(self, item: slice) -> CogniteResourceList[T_CogniteResource]:
+        ...
 
     def __getitem__(self, item: Any) -> Any:
         value = super().__getitem__(item)
@@ -234,7 +264,7 @@ class CogniteResourceList(UserList):
         """
         return [resource.dump(camel_case) for resource in self.data]
 
-    def get(self, id: int = None, external_id: str = None) -> Optional[CogniteResource]:
+    def get(self, id: int = None, external_id: str = None) -> Optional[T_CogniteResource]:
         """Get an item from this list by id or exernal_id.
 
         Args:

--- a/cognite/client/data_classes/annotations.py
+++ b/cognite/client/data_classes/annotations.py
@@ -194,5 +194,5 @@ class AnnotationUpdate(CogniteUpdate):
         return AnnotationUpdate._StrUpdate(self, "annotationType")
 
 
-class AnnotationList(CogniteResourceList):
+class AnnotationList(CogniteResourceList[Annotation]):
     _RESOURCE = Annotation

--- a/cognite/client/data_classes/assets.py
+++ b/cognite/client/data_classes/assets.py
@@ -332,7 +332,7 @@ class AssetUpdate(CogniteUpdate):
         return AssetUpdate._PrimitiveAssetUpdate(self, "geoLocation")
 
 
-class AssetList(CogniteResourceList):
+class AssetList(CogniteResourceList[Asset]):
     _RESOURCE = Asset
 
     def __init__(self, resources: Collection[Any], cognite_client: CogniteClient = None):

--- a/cognite/client/data_classes/contextualization.py
+++ b/cognite/client/data_classes/contextualization.py
@@ -164,7 +164,7 @@ class ContextualizationJob(CogniteResource):
 T_ContextualizationJob = TypeVar("T_ContextualizationJob", bound=ContextualizationJob)
 
 
-class ContextualizationJobList(CogniteResourceList):
+class ContextualizationJobList(CogniteResourceList[ContextualizationJob]):
     _RESOURCE = ContextualizationJob
 
 
@@ -326,7 +326,7 @@ class EntityMatchingModelUpdate(CogniteUpdate):
         return EntityMatchingModelUpdate._PrimitiveUpdate(self, "description")
 
 
-class EntityMatchingModelList(CogniteResourceList):
+class EntityMatchingModelList(CogniteResourceList[EntityMatchingModel]):
     _RESOURCE = EntityMatchingModel
 
 
@@ -368,7 +368,7 @@ class DiagramConvertPage(CogniteResource):
         self._cognite_client = cast("CogniteClient", cognite_client)
 
 
-class DiagramConvertPageList(CogniteResourceList):
+class DiagramConvertPageList(CogniteResourceList[DiagramConvertPage]):
     _RESOURCE = DiagramConvertPage
 
 

--- a/cognite/client/data_classes/data_modeling/containers.py
+++ b/cognite/client/data_classes/data_modeling/containers.py
@@ -160,11 +160,11 @@ class Container(ContainerCore):
         )
 
 
-class ContainerList(CogniteResourceList):
+class ContainerList(CogniteResourceList[Container]):
     _RESOURCE = Container
 
 
-class ContainerApplyList(CogniteResourceList):
+class ContainerApplyList(CogniteResourceList[ContainerApply]):
     _RESOURCE = ContainerApply
 
     def as_apply(self) -> ContainerApplyList:

--- a/cognite/client/data_classes/data_modeling/data_models.py
+++ b/cognite/client/data_classes/data_modeling/data_models.py
@@ -162,11 +162,11 @@ class DataModel(DataModelCore):
         )
 
 
-class DataModelApplyList(CogniteResourceList):
+class DataModelApplyList(CogniteResourceList[DataModelApply]):
     _RESOURCE = DataModelApply
 
 
-class DataModelList(CogniteResourceList):
+class DataModelList(CogniteResourceList[DataModel]):
     _RESOURCE = DataModel
 
     def to_data_model_apply_list(self) -> DataModelApplyList:

--- a/cognite/client/data_classes/data_modeling/spaces.py
+++ b/cognite/client/data_classes/data_modeling/spaces.py
@@ -69,11 +69,11 @@ class Space(SpaceCore):
         )
 
 
-class SpaceApplyList(CogniteResourceList):
+class SpaceApplyList(CogniteResourceList[SpaceApply]):
     _RESOURCE = SpaceApply
 
 
-class SpaceList(CogniteResourceList):
+class SpaceList(CogniteResourceList[Space]):
     _RESOURCE = Space
 
     def to_space_apply_list(self) -> SpaceApplyList:

--- a/cognite/client/data_classes/data_modeling/views.py
+++ b/cognite/client/data_classes/data_modeling/views.py
@@ -209,7 +209,7 @@ class View(ViewCore):
         )
 
 
-class ViewList(CogniteResourceList):
+class ViewList(CogniteResourceList[View]):
     _RESOURCE = View
 
     def to_view_apply(self) -> ViewApplyList:
@@ -221,7 +221,7 @@ class ViewList(CogniteResourceList):
         return ViewApplyList(resources=[v.as_apply() for v in self.items])
 
 
-class ViewApplyList(CogniteResourceList):
+class ViewApplyList(CogniteResourceList[ViewApply]):
     _RESOURCE = ViewApply
 
 

--- a/cognite/client/data_classes/data_sets.py
+++ b/cognite/client/data_classes/data_sets.py
@@ -170,5 +170,5 @@ class DataSetAggregate(dict):
     count = CognitePropertyClassUtil.declare_property("count")
 
 
-class DataSetList(CogniteResourceList):
+class DataSetList(CogniteResourceList[DataSet]):
     _RESOURCE = DataSet

--- a/cognite/client/data_classes/datapoints.py
+++ b/cognite/client/data_classes/datapoints.py
@@ -641,7 +641,7 @@ class Datapoints(CogniteResource):
         return notebook_display_with_fallback(self, include_errors=is_synthetic_dps)
 
 
-class DatapointsArrayList(CogniteResourceList):
+class DatapointsArrayList(CogniteResourceList[DatapointsArray]):
     _RESOURCE = DatapointsArray
 
     def __init__(self, resources: Collection[Any], cognite_client: CogniteClient = None):
@@ -760,7 +760,7 @@ class DatapointsArrayList(CogniteResourceList):
         return [dps.dump(camel_case, convert_timestamps) for dps in self]
 
 
-class DatapointsList(CogniteResourceList):
+class DatapointsList(CogniteResourceList[Datapoints]):
     _RESOURCE = Datapoints
 
     def __init__(self, resources: Collection[Any], cognite_client: CogniteClient = None):

--- a/cognite/client/data_classes/events.py
+++ b/cognite/client/data_classes/events.py
@@ -244,5 +244,5 @@ class EventUpdate(CogniteUpdate):
         return EventUpdate._PrimitiveEventUpdate(self, "subtype")
 
 
-class EventList(CogniteResourceList):
+class EventList(CogniteResourceList[Event]):
     _RESOURCE = Event

--- a/cognite/client/data_classes/extractionpipelines.py
+++ b/cognite/client/data_classes/extractionpipelines.py
@@ -193,7 +193,7 @@ class ExtractionPipelineUpdate(CogniteUpdate):
         return ExtractionPipelineUpdate._ListExtractionPipelineUpdate(self, "contacts")
 
 
-class ExtractionPipelineList(CogniteResourceList):
+class ExtractionPipelineList(CogniteResourceList[ExtractionPipeline]):
     _RESOURCE = ExtractionPipeline
 
 
@@ -248,7 +248,7 @@ class ExtractionPipelineRun(CogniteResource):
         return dct
 
 
-class ExtractionPipelineRunList(CogniteResourceList):
+class ExtractionPipelineRunList(CogniteResourceList[ExtractionPipelineRun]):
     _RESOURCE = ExtractionPipelineRun
 
 
@@ -354,5 +354,5 @@ class ExtractionPipelineConfig(ExtractionPipelineConfigRevision):
         self.config = config
 
 
-class ExtractionPipelineConfigRevisionList(CogniteResourceList):
+class ExtractionPipelineConfigRevisionList(CogniteResourceList[ExtractionPipelineConfigRevision]):
     _RESOURCE = ExtractionPipelineConfigRevision

--- a/cognite/client/data_classes/files.py
+++ b/cognite/client/data_classes/files.py
@@ -295,5 +295,5 @@ class FileAggregate(dict):
     count = CognitePropertyClassUtil.declare_property("count")
 
 
-class FileMetadataList(CogniteResourceList):
+class FileMetadataList(CogniteResourceList[FileMetadata]):
     _RESOURCE = FileMetadata

--- a/cognite/client/data_classes/functions.py
+++ b/cognite/client/data_classes/functions.py
@@ -264,11 +264,11 @@ class FunctionSchedulesFilter(CogniteFilter):
         self.cron_expression = cron_expression
 
 
-class FunctionSchedulesList(CogniteResourceList):
+class FunctionSchedulesList(CogniteResourceList[FunctionSchedule]):
     _RESOURCE = FunctionSchedule
 
 
-class FunctionList(CogniteResourceList):
+class FunctionList(CogniteResourceList[Function]):
     _RESOURCE = Function
 
 
@@ -341,7 +341,7 @@ class FunctionCall(CogniteResource):
             time.sleep(1.0)
 
 
-class FunctionCallList(CogniteResourceList):
+class FunctionCallList(CogniteResourceList[FunctionCall]):
     _RESOURCE = FunctionCall
 
 
@@ -364,7 +364,7 @@ class FunctionCallLogEntry(CogniteResource):
         self._cognite_client = cast("CogniteClient", cognite_client)
 
 
-class FunctionCallLog(CogniteResourceList):
+class FunctionCallLog(CogniteResourceList[FunctionCallLogEntry]):
     _RESOURCE = FunctionCallLogEntry
 
 

--- a/cognite/client/data_classes/geospatial.py
+++ b/cognite/client/data_classes/geospatial.py
@@ -49,7 +49,7 @@ class FeatureType(CogniteResource):
         return instance
 
 
-class FeatureTypeList(CogniteResourceList):
+class FeatureTypeList(CogniteResourceList[FeatureType]):
     _RESOURCE = FeatureType
 
 
@@ -173,7 +173,7 @@ def _to_feature_property_name(property_name: str) -> str:
     return to_snake_case(property_name) if property_name in RESERVED_PROPERTIES else property_name
 
 
-class FeatureList(CogniteResourceList):
+class FeatureList(CogniteResourceList[Feature]):
     _RESOURCE = Feature
 
     def to_geopandas(self, geometry: str, camel_case: bool = False) -> geopandas.GeoDataFrame:
@@ -301,7 +301,7 @@ class FeatureAggregate(CogniteResource):
         return instance
 
 
-class FeatureAggregateList(CogniteResourceList):
+class FeatureAggregateList(CogniteResourceList[FeatureAggregate]):
     _RESOURCE = FeatureAggregate
 
 
@@ -329,7 +329,7 @@ class CoordinateReferenceSystem(CogniteResource):
         return instance
 
 
-class CoordinateReferenceSystemList(CogniteResourceList):
+class CoordinateReferenceSystemList(CogniteResourceList[CoordinateReferenceSystem]):
     _RESOURCE = CoordinateReferenceSystem
 
 
@@ -416,7 +416,7 @@ class GeospatialComputedItem(CogniteResource):
         return instance
 
 
-class GeospatialComputedItemList(CogniteResourceList):
+class GeospatialComputedItemList(CogniteResourceList[GeospatialComputedItem]):
     "A list of items computed from geospatial."
     _RESOURCE = GeospatialComputedItem
 

--- a/cognite/client/data_classes/iam.py
+++ b/cognite/client/data_classes/iam.py
@@ -41,7 +41,7 @@ class Group(CogniteResource):
         self._cognite_client = cast("CogniteClient", cognite_client)
 
 
-class GroupList(CogniteResourceList):
+class GroupList(CogniteResourceList[Group]):
     _RESOURCE = Group
 
 
@@ -60,7 +60,7 @@ class SecurityCategory(CogniteResource):
         self._cognite_client = cast("CogniteClient", cognite_client)
 
 
-class SecurityCategoryList(CogniteResourceList):
+class SecurityCategoryList(CogniteResourceList[SecurityCategory]):
     _RESOURCE = SecurityCategory
 
 
@@ -171,7 +171,7 @@ class Session(CogniteResource):
         self.client_id = client_id
 
 
-class SessionList(CogniteResourceList):
+class SessionList(CogniteResourceList[Session]):
     _RESOURCE = Session
 
 

--- a/cognite/client/data_classes/labels.py
+++ b/cognite/client/data_classes/labels.py
@@ -66,7 +66,7 @@ class LabelDefinitionFilter(CogniteFilter):
         self._cognite_client = cast("CogniteClient", cognite_client)
 
 
-class LabelDefinitionList(CogniteResourceList):
+class LabelDefinitionList(CogniteResourceList[LabelDefinition]):
     _RESOURCE = LabelDefinition
 
 

--- a/cognite/client/data_classes/raw.py
+++ b/cognite/client/data_classes/raw.py
@@ -44,7 +44,7 @@ class Row(CogniteResource):
         return pd.DataFrame([self.columns], [self.key])
 
 
-class RowList(CogniteResourceList):
+class RowList(CogniteResourceList[Row]):
     _RESOURCE = Row
 
     def to_pandas(self) -> pandas.DataFrame:  # type: ignore[override]
@@ -88,7 +88,7 @@ class Table(CogniteResource):
         return self._cognite_client.raw.rows.list(db_name=self._db_name, table_name=self.name, limit=limit)
 
 
-class TableList(CogniteResourceList):
+class TableList(CogniteResourceList[Table]):
     _RESOURCE = Table
 
 
@@ -118,5 +118,5 @@ class Database(CogniteResource):
         return self._cognite_client.raw.tables.list(db_name=self.name, limit=limit)
 
 
-class DatabaseList(CogniteResourceList):
+class DatabaseList(CogniteResourceList[Database]):
     _RESOURCE = Database

--- a/cognite/client/data_classes/relationships.py
+++ b/cognite/client/data_classes/relationships.py
@@ -233,5 +233,5 @@ class RelationshipUpdate(CogniteUpdate):
         return RelationshipUpdate._LabelRelationshipUpdate(self, "labels")
 
 
-class RelationshipList(CogniteResourceList):
+class RelationshipList(CogniteResourceList[Relationship]):
     _RESOURCE = Relationship

--- a/cognite/client/data_classes/sequences.py
+++ b/cognite/client/data_classes/sequences.py
@@ -290,7 +290,7 @@ class SequenceAggregate(dict):
     count = CognitePropertyClassUtil.declare_property("count")
 
 
-class SequenceList(CogniteResourceList):
+class SequenceList(CogniteResourceList[Sequence]):
     _RESOURCE = Sequence
 
 
@@ -438,7 +438,7 @@ class SequenceData(CogniteResource):
         return [cast(str, c.get("valueType")) for c in self.columns]
 
 
-class SequenceDataList(CogniteResourceList):
+class SequenceDataList(CogniteResourceList[SequenceData]):
     _RESOURCE = SequenceData
 
     def __str__(self) -> str:

--- a/cognite/client/data_classes/templates.py
+++ b/cognite/client/data_classes/templates.py
@@ -51,7 +51,7 @@ class TemplateGroup(CogniteResource):
         self._cognite_client = cast("CogniteClient", cognite_client)
 
 
-class TemplateGroupList(CogniteResourceList):
+class TemplateGroupList(CogniteResourceList[TemplateGroup]):
     _RESOURCE = TemplateGroup
 
 
@@ -87,7 +87,7 @@ class TemplateGroupVersion(CogniteResource):
         self._cognite_client = cast("CogniteClient", cognite_client)
 
 
-class TemplateGroupVersionList(CogniteResourceList):
+class TemplateGroupVersionList(CogniteResourceList[TemplateGroupVersion]):
     _RESOURCE = TemplateGroupVersion
 
 
@@ -433,13 +433,13 @@ class GraphQlResponse(CogniteResource):
         self._cognite_client = cast("CogniteClient", cognite_client)
 
 
-class TemplateInstanceList(CogniteResourceList):
+class TemplateInstanceList(CogniteResourceList[TemplateInstance]):
     _RESOURCE = TemplateInstance
 
 
-class ViewList(CogniteResourceList):
+class ViewList(CogniteResourceList[View]):
     _RESOURCE = View
 
 
-class ViewResolveList(CogniteResourceList):
+class ViewResolveList(CogniteResourceList[ViewResolveItem]):
     _RESOURCE = ViewResolveItem

--- a/cognite/client/data_classes/three_d.py
+++ b/cognite/client/data_classes/three_d.py
@@ -124,7 +124,7 @@ class ThreeDModelUpdate(CogniteUpdate):
         return ThreeDModelUpdate._ObjectThreeDModelUpdate(self, "metadata")
 
 
-class ThreeDModelList(CogniteResourceList):
+class ThreeDModelList(CogniteResourceList[ThreeDModel]):
     _RESOURCE = ThreeDModel
 
 
@@ -238,7 +238,7 @@ class ThreeDModelRevisionUpdate(CogniteUpdate):
         return ThreeDModelRevisionUpdate._ObjectThreeDModelRevisionUpdate(self, "metadata")
 
 
-class ThreeDModelRevisionList(CogniteResourceList):
+class ThreeDModelRevisionList(CogniteResourceList[ThreeDModelRevision]):
     _RESOURCE = ThreeDModelRevision
 
 
@@ -288,7 +288,7 @@ class ThreeDNode(CogniteResource):
         return instance
 
 
-class ThreeDNodeList(CogniteResourceList):
+class ThreeDNodeList(CogniteResourceList[ThreeDNode]):
     _RESOURCE = ThreeDNode
 
 
@@ -318,5 +318,5 @@ class ThreeDAssetMapping(CogniteResource):
         self._cognite_client = cast("CogniteClient", cognite_client)
 
 
-class ThreeDAssetMappingList(CogniteResourceList):
+class ThreeDAssetMappingList(CogniteResourceList[ThreeDAssetMapping]):
     _RESOURCE = ThreeDAssetMapping

--- a/cognite/client/data_classes/time_series.py
+++ b/cognite/client/data_classes/time_series.py
@@ -287,5 +287,5 @@ class TimeSeriesAggregate(dict):
     count = CognitePropertyClassUtil.declare_property("count")
 
 
-class TimeSeriesList(CogniteResourceList):
+class TimeSeriesList(CogniteResourceList[TimeSeries]):
     _RESOURCE = TimeSeries

--- a/cognite/client/data_classes/transformations/jobs.py
+++ b/cognite/client/data_classes/transformations/jobs.py
@@ -48,7 +48,7 @@ class TransformationJobMetric(CogniteResource):
         return instance
 
 
-class TransformationJobMetricList(CogniteResourceList):
+class TransformationJobMetricList(CogniteResourceList[TransformationJobMetric]):
     _RESOURCE = TransformationJobMetric
 
 
@@ -256,7 +256,7 @@ class TransformationJob(CogniteResource):
         return hash(self.id)
 
 
-class TransformationJobList(CogniteResourceList):
+class TransformationJobList(CogniteResourceList[TransformationJob]):
     _RESOURCE = TransformationJob
 
 

--- a/cognite/client/data_classes/transformations/notifications.py
+++ b/cognite/client/data_classes/transformations/notifications.py
@@ -43,7 +43,7 @@ class TransformationNotification(CogniteResource):
         return hash(self.id)
 
 
-class TransformationNotificationList(CogniteResourceList):
+class TransformationNotificationList(CogniteResourceList[TransformationNotification]):
     _RESOURCE = TransformationNotification
 
 

--- a/cognite/client/data_classes/transformations/schedules.py
+++ b/cognite/client/data_classes/transformations/schedules.py
@@ -69,5 +69,5 @@ class TransformationScheduleUpdate(CogniteUpdate):
         return TransformationScheduleUpdate._PrimitiveTransformationScheduleUpdate(self, "isPaused")
 
 
-class TransformationScheduleList(CogniteResourceList):
+class TransformationScheduleList(CogniteResourceList[TransformationSchedule]):
     _RESOURCE = TransformationSchedule

--- a/cognite/client/data_classes/transformations/schema.py
+++ b/cognite/client/data_classes/transformations/schema.py
@@ -69,5 +69,5 @@ class TransformationSchemaColumn(CogniteResource):
         return instance
 
 
-class TransformationSchemaColumnList(CogniteResourceList):
+class TransformationSchemaColumnList(CogniteResourceList[TransformationSchemaColumn]):
     _RESOURCE = TransformationSchemaColumn


### PR DESCRIPTION
Inner types would be inferred as Any previous to this. Now we get correct type information when accessing inner elements.
```
from cognite.client import CogniteClient

c = CogniteClient()

a = c.data_modeling.container.list()[0]
reveal_type(a) # reveals Container

for a in c.data_modeling.container.list():
    reveal_type(a) # reveals Container
```
