### PR TITLE
Accept direct relations as tuples in EdgeApply

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ Changes are grouped as follows
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
+## [6.4.3] - 2023-06-15
+### Added
+- Accept direct relation values as tuples in `EdgeApply`
+
 ## [6.4.2] - 2023-06-15
 ### Changed
 - When providing ids as tuples in `instances.retrieve` and `instances.delete` you should not 

--- a/cognite/client/_api/data_modeling/instances.py
+++ b/cognite/client/_api/data_modeling/instances.py
@@ -362,6 +362,7 @@ class InstancesAPI(APIClient):
         edges: EdgeApply | Sequence[EdgeApply] | None = None,
         auto_create_start_nodes: bool = False,
         auto_create_end_nodes: bool = False,
+        auto_create_direct_relations: bool = True,
         skip_on_version_conflict: bool = False,
         replace: bool = False,
     ) -> InstancesApplyResult:
@@ -374,6 +375,7 @@ class InstancesAPI(APIClient):
                                             the start node of an edge must exist before it can be ingestested.
             auto_create_end_nodes (bool): Whether to create missing end nodes for edges when ingesting. By default,
                                           the end node of an edge must exist before it can be ingestested.
+            auto_create_direct_relations (bool): Whether to create missing direct relation targets when ingesting.
             skip_on_version_conflict (bool): If existingVersion is specified on any of the nodes/edges in the input,
                                              the default behaviour is that the entire ingestion will fail when version
                                              conflicts occur. If skipOnVersionConflict is set to true, items with
@@ -439,6 +441,7 @@ class InstancesAPI(APIClient):
         other_parameters = {
             "autoCreateStartNodes": auto_create_start_nodes,
             "autoCreateEndNodes": auto_create_end_nodes,
+            "autoCreateDirectRelations": auto_create_direct_relations,
             "skipOnVersionConflict": skip_on_version_conflict,
             "replace": replace,
         }

--- a/cognite/client/_version.py
+++ b/cognite/client/_version.py
@@ -1,4 +1,4 @@
 from __future__ import annotations
 
-__version__ = "6.4.2"
+__version__ = "6.4.3"
 __api_subversion__ = "V20220125"

--- a/cognite/client/data_classes/data_modeling/data_types.py
+++ b/cognite/client/data_classes/data_modeling/data_types.py
@@ -22,8 +22,13 @@ class DirectRelationReference:
         return convert_all_keys_recursive(output, camel_case)
 
     @classmethod
-    def load(cls, data: dict) -> DirectRelationReference:
-        return cls(**convert_all_keys_to_snake_case(rename_and_exclude_keys(data, exclude={"type"})))
+    def load(cls, data: dict | tuple[str, str]) -> DirectRelationReference:
+        if isinstance(data, dict):
+            return cls(**convert_all_keys_to_snake_case(rename_and_exclude_keys(data, exclude={"type"})))
+        elif isinstance(data, tuple) and len(data) == 2:
+            return cls(data[0], data[1])
+        else:
+            raise ValueError("Invalid data provided to load method. Must be dict or tuple with two elements.")
 
     def as_tuple(self) -> tuple[str, str]:
         return self.space, self.external_id

--- a/cognite/client/data_classes/data_modeling/instances.py
+++ b/cognite/client/data_classes/data_modeling/instances.py
@@ -360,16 +360,20 @@ class EdgeApply(InstanceApply):
         self,
         space: str,
         external_id: str,
-        type: DirectRelationReference,
-        start_node: DirectRelationReference,
-        end_node: DirectRelationReference,
+        type: DirectRelationReference | tuple[str, str],
+        start_node: DirectRelationReference | tuple[str, str],
+        end_node: DirectRelationReference | tuple[str, str],
         existing_version: int = None,
         sources: list[NodeOrEdgeData] = None,
     ):
         super().__init__(space, external_id, "edge", existing_version, sources)
-        self.type = type
-        self.start_node = start_node
-        self.end_node = end_node
+        self.type = type if isinstance(type, DirectRelationReference) else DirectRelationReference.load(type)
+        self.start_node = (
+            start_node if isinstance(start_node, DirectRelationReference) else DirectRelationReference.load(start_node)
+        )
+        self.end_node = (
+            end_node if isinstance(end_node, DirectRelationReference) else DirectRelationReference.load(end_node)
+        )
 
     def as_id(self) -> EdgeId:
         return EdgeId(space=self.space, external_id=self.external_id)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "cognite-sdk"
 
-version = "6.4.2"
+version = "6.4.3"
 
 description = "Cognite Python SDK"
 readme = "README.md"

--- a/tests/tests_integration/test_api/test_data_modeling/test_instances.py
+++ b/tests/tests_integration/test_api/test_data_modeling/test_instances.py
@@ -152,7 +152,7 @@ class TestInstancesAPI:
             space=space,
             external_id="relation:arnold_schwarzenegger:actor",
             type=dm.DirectRelationReference(space, person_view.properties["roles"].type.external_id),
-            start_node=dm.DirectRelationReference(space, person.external_id),
+            start_node=(space, person.external_id),
             end_node=dm.DirectRelationReference(space, actor.external_id),
         )
         new_nodes = [person, actor]


### PR DESCRIPTION
- Accept direct relation values as tuples in EdgeApply
- Bump version and update changelog

## Description
Please describe the change you have made.

## Checklist:
- [ ] Tests added/updated.
- [ ] Documentation updated. Documentation is generated from docstrings - these must be updated according to your change.
  If a new method has been added it should be referenced in [cognite.rst](https://github.com/cognitedata/cognite-sdk-python/blob/master/docs/source/cognite.rst) in order to generate docs based on its docstring.
- [ ] Changelog updated in [CHANGELOG.md](https://github.com/cognitedata/cognite-sdk-python/blob/master/CHANGELOG.md).
- [ ] Version bumped. If triggering a new release is desired, bump the version number in [_version.py](https://github.com/cognitedata/cognite-sdk-python/blob/master/cognite/client/_version.py) and [pyproject.toml](https://github.com/cognitedata/cognite-sdk-python/blob/master/pyproject.toml) per [semantic versioning](https://semver.org/).
