### PR TITLE
annotations reverse lookup with test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ Changes are grouped as follows
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
+## [6.8.0] - 2023-07-07
+### Added
+- Support for annotations reverse lookup.
+
 ## [6.7.1] - 2023-07-07
 ### Fixed
 - Needless function "as_id" on View as it was already inherited

--- a/cognite/client/_api/annotations.py
+++ b/cognite/client/_api/annotations.py
@@ -7,6 +7,8 @@ from cognite.client._api_client import APIClient
 from cognite.client._constants import LIST_LIMIT_DEFAULT
 from cognite.client.data_classes import Annotation, AnnotationFilter, AnnotationList, AnnotationUpdate
 from cognite.client.data_classes._base import CogniteResource
+from cognite.client.data_classes.annotations import AnnotationReverseLookupFilter
+from cognite.client.data_classes.contextualization import ResourceReference, ResourceReferenceList
 from cognite.client.utils._auxiliary import assert_type
 from cognite.client.utils._identifier import IdentifierSequence
 from cognite.client.utils._text import to_camel_case
@@ -169,3 +171,25 @@ class AnnotationsAPI(APIClient):
         """
         identifiers = IdentifierSequence.load(ids=id, external_ids=None).as_singleton()
         return self._retrieve_multiple(list_cls=AnnotationList, resource_cls=Annotation, identifiers=identifiers)
+
+    def reverse_lookup(self, filter: AnnotationReverseLookupFilter, limit: int | None = None) -> ResourceReferenceList:
+        """Reverse lookup annotations
+
+        Args:
+            filter (AnnotationReverseLookupFilter): Filter to apply
+            limit (int, optional): Maximum number of results to return. Defaults to None.
+
+        Returns:
+            ResourceReferenceList: List of resource references
+        """
+        assert_type(filter, "filter", types=[AnnotationReverseLookupFilter], allow_none=False)
+        assert_type(limit, "limit", [int, type(None)], allow_none=True)
+
+        return self._list(
+            list_cls=ResourceReferenceList,
+            resource_cls=ResourceReference,
+            method="POST",
+            limit=limit,
+            filter=filter.dump(camel_case=True),
+            url_path=self._RESOURCE_PATH + "/reverselookup",
+        )

--- a/cognite/client/_api/annotations.py
+++ b/cognite/client/_api/annotations.py
@@ -173,7 +173,7 @@ class AnnotationsAPI(APIClient):
         return self._retrieve_multiple(list_cls=AnnotationList, resource_cls=Annotation, identifiers=identifiers)
 
     def reverse_lookup(self, filter: AnnotationReverseLookupFilter, limit: int | None = None) -> ResourceReferenceList:
-        """Reverse lookup annotations
+        """Reverse lookup annotated resources based on having annotations matching the filter.
 
         Args:
             filter (AnnotationReverseLookupFilter): Filter to apply

--- a/cognite/client/_version.py
+++ b/cognite/client/_version.py
@@ -1,4 +1,4 @@
 from __future__ import annotations
 
-__version__ = "6.7.1"
+__version__ = "6.8.0"
 __api_subversion__ = "V20220125"

--- a/cognite/client/data_classes/annotations.py
+++ b/cognite/client/data_classes/annotations.py
@@ -100,7 +100,51 @@ class Annotation(CogniteResource):
         return result
 
 
-class AnnotationFilter(CogniteFilter):
+class AnnotationReverseLookupFilter(CogniteFilter):
+    """Filter on annotations with various criteria
+
+    Args:
+       annotated_resource_type (str): The type of the CDF resource that is annotated, e.g. "file".
+       status (str, optional): Status of annotations to filter for, e.g. "suggested", "approved", "rejected".
+       creating_user (str, optional): Name of the user who created the annotations to filter for. Can be set explicitly to "None" to filter for annotations created by a service.
+       creating_app (str, optional): Name of the app from which the annotations to filter for where created.
+       creating_app_version (str, optional): Version of the app from which the annotations to filter for were created.
+       annotation_type(str, optional): Type name of the annotations.
+       data(Dict[str, Any], optional): The annotation data to filter by. Example format: {"label": "cat", "confidence": 0.9}
+    """
+
+    def __init__(
+        self,
+        annotated_resource_type: str,
+        status: Optional[str] = None,
+        creating_user: Optional[str] = "",  # None means filtering for a service
+        creating_app: Optional[str] = None,
+        creating_app_version: Optional[str] = None,
+        annotation_type: Optional[str] = None,
+        data: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        self.annotated_resource_type = annotated_resource_type
+        self.status = status
+        self.creating_user = creating_user
+        self.creating_app = creating_app
+        self.creating_app_version = creating_app_version
+        self.annotation_type = annotation_type
+        self.data = data
+
+    def dump(self, camel_case: bool = False) -> Dict[str, Any]:
+        result = super().dump(camel_case=camel_case)
+        # Special handling for creating_user, which has a valid None value
+        key = "creatingUser" if camel_case else "creating_user"
+        # Remove creating_user if it is an empty string
+        if self.creating_user == "":
+            del result[key]
+        # dump creating_user if it is None
+        elif self.creating_user is None:
+            result[key] = None
+        return result
+
+
+class AnnotationFilter(AnnotationReverseLookupFilter):
     """Filter on annotations with various criteria
 
     Args:
@@ -125,26 +169,17 @@ class AnnotationFilter(CogniteFilter):
         annotation_type: Optional[str] = None,
         data: Optional[Dict[str, Any]] = None,
     ) -> None:
-        self.annotated_resource_type = annotated_resource_type
-        self.annotated_resource_ids = annotated_resource_ids
-        self.status = status
-        self.creating_user = creating_user
-        self.creating_app = creating_app
-        self.creating_app_version = creating_app_version
-        self.annotation_type = annotation_type
-        self.data = data
 
-    def dump(self, camel_case: bool = False) -> Dict[str, Any]:
-        result = super().dump(camel_case=camel_case)
-        # Special handling for creating_user, which has a valid None value
-        key = "creatingUser" if camel_case else "creating_user"
-        # Remove creating_user if it is an empty string
-        if self.creating_user == "":
-            del result[key]
-        # dump creating_user if it is None
-        elif self.creating_user is None:
-            result[key] = None
-        return result
+        self.annotated_resource_ids = annotated_resource_ids
+        super().__init__(
+            annotated_resource_type=annotated_resource_type,
+            status=status,
+            creating_user=creating_user,
+            creating_app=creating_app,
+            creating_app_version=creating_app_version,
+            annotation_type=annotation_type,
+            data=data,
+        )
 
 
 class AnnotationUpdate(CogniteUpdate):

--- a/cognite/client/data_classes/contextualization.py
+++ b/cognite/client/data_classes/contextualization.py
@@ -844,3 +844,16 @@ class VisionExtractJob(VisionJob):
         raise CogniteException(
             "Extract job is not completed. If the job is queued or running, wait for completion and try again"
         )
+
+
+class ResourceReference(CogniteResource):
+    def __init__(
+        self, id: int | None = None, external_id: str | None = None, cognite_client: None | CogniteClient = None
+    ):
+        self.id = id
+        self.external_id = external_id
+        self._cognite_client: CogniteClient = cast("CogniteClient", None)  # Read only
+
+
+class ResourceReferenceList(CogniteResourceList[ResourceReference]):
+    _RESOURCE = ResourceReference

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "cognite-sdk"
 
-version = "6.7.1"
+version = "6.8.0"
 
 description = "Cognite Python SDK"
 readme = "README.md"

--- a/tests/tests_integration/test_api/test_annotations.py
+++ b/tests/tests_integration/test_api/test_annotations.py
@@ -74,7 +74,7 @@ def file_id(cognite_client: CogniteClient) -> int:
     cognite_client.files.delete(id=file.id)
 
 
-@pytest.fixture
+@pytest.fixture(scope="session")
 def permanent_file_id(cognite_client: CogniteClient) -> int:
     # Create a test file
     external_id = "annotation_unit_test_file_permanent"
@@ -113,7 +113,7 @@ def base_suggest_annotation(base_annotation: Annotation) -> Annotation:
     return ann
 
 
-@pytest.fixture
+@pytest.fixture(scope="session")
 def asset_link_annotation(permanent_file_id: int, cognite_client: CogniteClient) -> Annotation:
     annotation = Annotation(
         annotation_type="diagrams.AssetLink",


### PR DESCRIPTION
## Description
Added a reverse lookup method to the annotations client, and a resource type "ResourceReference", since this is what the endpoint returns. (Objects only containing id/external_id. Could maybe consider combining with byIds endpoints and resolve the resources at some point)


## Checklist:
- [x] Tests added/updated.
- [x] Documentation updated. Documentation is generated from docstrings - these must be updated according to your change.
  If a new method has been added it should be referenced in [cognite.rst](https://github.com/cognitedata/cognite-sdk-python/blob/master/docs/source/cognite.rst) in order to generate docs based on its docstring.
- [x] Changelog updated in [CHANGELOG.md](https://github.com/cognitedata/cognite-sdk-python/blob/master/CHANGELOG.md).
- [x] Version bumped. If triggering a new release is desired, bump the version number in [_version.py](https://github.com/cognitedata/cognite-sdk-python/blob/master/cognite/client/_version.py) and [pyproject.toml](https://github.com/cognitedata/cognite-sdk-python/blob/master/pyproject.toml) per [semantic versioning](https://semver.org/).
