### PR TITLE
Fix data_modeling handling non 200 status for apply endpoints.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,12 @@ Changes are grouped as follows
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
+## [6.4.8] - 2023-06-23
+### Fixed
+- Handling non 200 responses in `data_modeling.spaces.apply`, `data_modeling.data_models.apply`, 
+  `data_modeling.views.apply` and `data_modeling.containers.apply`
+
+
 ## [6.4.7] - 2023-06-22
 ### Fixed
 - Consistently return the correct id types in data modeling resource clients

--- a/cognite/client/_api/data_modeling/containers.py
+++ b/cognite/client/_api/data_modeling/containers.py
@@ -207,4 +207,6 @@ class ContainersAPI(APIClient):
                 >>> containers = [models.ContainerApply(space="mySpace",properties={"name": models.ContainerProperty(type=models.TextType, name="name")})]
                 >>> res = c.data_modeling.containers.apply(containers)
         """
-        return self._create_multiple(list_cls=ContainerList, resource_cls=Container, items=container)
+        return self._create_multiple(
+            list_cls=ContainerList, resource_cls=Container, items=container, input_resource_cls=ContainerApply
+        )

--- a/cognite/client/_api/data_modeling/data_models.py
+++ b/cognite/client/_api/data_modeling/data_models.py
@@ -212,4 +212,6 @@ class DataModelsAPI(APIClient):
                 ... DataModelApply(space="mySpace",external_id="myOtherDataModel",version="v1",is_global=,last_updated_time=)]
                 >>> res = c.data_modeling.data_models.apply(data_models)
         """
-        return self._create_multiple(list_cls=DataModelList, resource_cls=DataModel, items=data_model)
+        return self._create_multiple(
+            list_cls=DataModelList, resource_cls=DataModel, items=data_model, input_resource_cls=DataModelApply
+        )

--- a/cognite/client/_api/data_modeling/spaces.py
+++ b/cognite/client/_api/data_modeling/spaces.py
@@ -187,4 +187,4 @@ class SpacesAPI(APIClient):
                 ... SpaceApply(space="myOtherSpace", description="My second space", name="My Other Space")]
                 >>> res = c.data_modeling.spaces.apply(spaces)
         """
-        return self._create_multiple(list_cls=SpaceList, resource_cls=Space, items=space)
+        return self._create_multiple(list_cls=SpaceList, resource_cls=Space, items=space, input_resource_cls=SpaceApply)

--- a/cognite/client/_api/data_modeling/views.py
+++ b/cognite/client/_api/data_modeling/views.py
@@ -206,4 +206,4 @@ class ViewsAPI(APIClient):
                 ... models.ViewApply(space="mySpace",external_id="myOtherView",version="v1")]
                 >>> res = c.data_modeling.views.apply(views)
         """
-        return self._create_multiple(list_cls=ViewList, resource_cls=View, items=view)
+        return self._create_multiple(list_cls=ViewList, resource_cls=View, items=view, input_resource_cls=ViewApply)

--- a/cognite/client/_version.py
+++ b/cognite/client/_version.py
@@ -1,4 +1,4 @@
 from __future__ import annotations
 
-__version__ = "6.4.7"
+__version__ = "6.4.8"
 __api_subversion__ = "V20220125"

--- a/cognite/client/data_classes/data_modeling/data_models.py
+++ b/cognite/client/data_classes/data_modeling/data_models.py
@@ -40,6 +40,9 @@ class DataModelCore(DataModelingResource):
         self.name = name
         self.version = version
 
+    def as_id(self) -> DataModelId:
+        return DataModelId(space=self.space, external_id=self.external_id, version=self.version)
+
 
 class DataModelApply(DataModelCore):
     """A group of views. This is the write version of a Data Model.
@@ -159,9 +162,6 @@ class DataModel(DataModelCore):
             name=self.name,
             views=views,
         )
-
-    def as_id(self) -> DataModelId:
-        return DataModelId(space=self.space, external_id=self.external_id, version=self.version)
 
 
 class DataModelApplyList(CogniteResourceList[DataModelApply]):

--- a/cognite/client/data_classes/data_modeling/instances.py
+++ b/cognite/client/data_classes/data_modeling/instances.py
@@ -66,8 +66,13 @@ class NodeOrEdgeData:
 
     def dump(self, camel_case: bool = False) -> dict:
         output = asdict(self)
-        if self.source and isinstance(self.source, (ContainerId, ViewId)):
-            output["source"] = self.source.dump(camel_case)
+        if self.source:
+            if isinstance(self.source, (ContainerId, ViewId)):
+                output["source"] = self.source.dump(camel_case)
+            elif isinstance(self.source, dict):
+                output["source"] = self.source
+            else:
+                raise TypeError(f"source must be ContainerId, ViewId or a dict, but was {type(self.source)}")
         return convert_all_keys_to_camel_case_recursive(output) if camel_case else output
 
 

--- a/cognite/client/data_classes/data_modeling/instances.py
+++ b/cognite/client/data_classes/data_modeling/instances.py
@@ -66,7 +66,7 @@ class NodeOrEdgeData:
 
     def dump(self, camel_case: bool = False) -> dict:
         output = asdict(self)
-        if self.source:
+        if self.source and isinstance(self.source, (ContainerId, ViewId)):
             output["source"] = self.source.dump(camel_case)
         return convert_all_keys_to_camel_case_recursive(output) if camel_case else output
 

--- a/cognite/client/data_classes/data_modeling/spaces.py
+++ b/cognite/client/data_classes/data_modeling/spaces.py
@@ -24,6 +24,9 @@ class SpaceCore(DataModelingResource):
         self.description = description
         self.name = name
 
+    def as_id(self) -> str:
+        return self.space
+
 
 class SpaceApply(SpaceCore):
     """A workspace for data models and instances. This is the write version"""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "cognite-sdk"
 
-version = "6.4.7"
+version = "6.4.8"
 
 description = "Cognite Python SDK"
 readme = "README.md"

--- a/tests/tests_integration/test_api/test_data_modeling/test_containers.py
+++ b/tests/tests_integration/test_api/test_data_modeling/test_containers.py
@@ -137,14 +137,17 @@ class TestContainersAPI:
         )
         monkeypatch.setattr(cognite_client.data_modeling.containers, "_CREATE_LIMIT", 1)
 
-        with pytest.raises(CogniteAPIError) as error:
-            cognite_client.data_modeling.containers.apply([valid_container, invalid_container])
+        try:
+            # Act
+            with pytest.raises(CogniteAPIError) as error:
+                cognite_client.data_modeling.containers.apply([valid_container, invalid_container])
 
-        # Assert
-        assert "One or more spaces do not exist" in error.value.message
-        assert error.value.code == 400
-        assert len(error.value.successful) == 1
-        assert len(error.value.failed) == 1
+            # Assert
+            assert "One or more spaces do not exist" in error.value.message
+            assert error.value.code == 400
+            assert len(error.value.successful) == 1
+            assert len(error.value.failed) == 1
 
-        # Cleanup
-        cognite_client.data_modeling.instances.delete(valid_container.as_id())
+        finally:
+            # Cleanup
+            cognite_client.data_modeling.instances.delete(valid_container.as_id())

--- a/tests/tests_integration/test_api/test_data_modeling/test_data_models.py
+++ b/tests/tests_integration/test_api/test_data_modeling/test_data_models.py
@@ -153,13 +153,13 @@ class TestDataModelsAPI:
     ):
         # Arrange
         valid_data_model = dm.DataModelApply(
-            space="nonExistingSpace",
-            external_id="IntegrationTestDataModel",
+            space=integration_test_space.space,
+            external_id="IntegrationTestDataModel1",
             version="v1",
         )
         invalid_data_model = dm.DataModelApply(
             space="nonExistingSpace",
-            external_id="IntegrationTestDataModel",
+            external_id="IntegrationTestDataModel2",
             version="v1",
         )
         monkeypatch.setattr(cognite_client.data_modeling.data_models, "_CREATE_LIMIT", 1)

--- a/tests/tests_integration/test_api/test_data_modeling/test_instances.py
+++ b/tests/tests_integration/test_api/test_data_modeling/test_instances.py
@@ -320,3 +320,6 @@ class TestInstancesAPI:
         assert "invalidProperty" in error.value.message
         assert len(error.value.successful) == 1
         assert len(error.value.failed) == 1
+
+        # cleanup
+        cognite_client.data_modeling.instances.delete(valid_person.as_id())

--- a/tests/tests_integration/test_api/test_data_modeling/test_instances.py
+++ b/tests/tests_integration/test_api/test_data_modeling/test_instances.py
@@ -313,15 +313,16 @@ class TestInstancesAPI:
         )
         monkeypatch.setattr(cognite_client.data_modeling.instances, "_CREATE_LIMIT", 1)
 
-        # Act
-        with pytest.raises(CogniteAPIError) as error:
-            cognite_client.data_modeling.instances.apply(nodes=[valid_person, invalid_person])
+        try:
+            # Act
+            with pytest.raises(CogniteAPIError) as error:
+                cognite_client.data_modeling.instances.apply(nodes=[valid_person, invalid_person])
 
-        # Assert
-        assert "invalidProperty" in error.value.message
-        assert error.value.code == 400
-        assert len(error.value.successful) == 1
-        assert len(error.value.failed) == 1
-
-        # cleanup
-        cognite_client.data_modeling.instances.delete(valid_person.as_id())
+            # Assert
+            assert "invalidProperty" in error.value.message
+            assert error.value.code == 400
+            assert len(error.value.successful) == 1
+            assert len(error.value.failed) == 1
+        finally:
+            # Cleanup
+            cognite_client.data_modeling.instances.delete(valid_person.as_id())

--- a/tests/tests_integration/test_api/test_data_modeling/test_instances.py
+++ b/tests/tests_integration/test_api/test_data_modeling/test_instances.py
@@ -255,7 +255,7 @@ class TestInstancesAPI:
             assert isinstance(nodes, dm.NodeList)
             assert len(nodes) <= 2
 
-    def test_invalid_node_data(self, cognite_client: CogniteClient, person_view: dm.View):
+    def test_apply_invalid_node_data(self, cognite_client: CogniteClient, person_view: dm.View):
         # Arrange
         space = person_view.space
         person = dm.NodeApply(
@@ -278,6 +278,7 @@ class TestInstancesAPI:
             cognite_client.data_modeling.instances.apply(nodes=person)
 
         # Assert
+        assert error.value.code == 400
         assert "invalidProperty" in error.value.message
 
     def test_apply_failed_and_successful_task(self, cognite_client: CogniteClient, person_view: dm.View, monkeypatch):
@@ -318,6 +319,7 @@ class TestInstancesAPI:
 
         # Assert
         assert "invalidProperty" in error.value.message
+        assert error.value.code == 400
         assert len(error.value.successful) == 1
         assert len(error.value.failed) == 1
 

--- a/tests/tests_integration/test_api/test_data_modeling/test_views.py
+++ b/tests/tests_integration/test_api/test_data_modeling/test_views.py
@@ -1,7 +1,8 @@
 import pytest
 
-import cognite.client.data_classes.data_modeling as models
+import cognite.client.data_classes.data_modeling as dm
 from cognite.client import CogniteClient
+from cognite.client.exceptions import CogniteAPIError
 
 
 @pytest.fixture()
@@ -12,11 +13,9 @@ def cdf_views(cognite_client: CogniteClient):
 
 
 class TestViewsAPI:
-    def test_list(
-        self, cognite_client: CogniteClient, cdf_views: models.ViewList, integration_test_space: models.Space
-    ):
+    def test_list(self, cognite_client: CogniteClient, cdf_views: dm.ViewList, integration_test_space: dm.Space):
         # Arrange
-        expected_views = models.ViewList([v for v in cdf_views if v.space == integration_test_space.space])
+        expected_views = dm.ViewList([v for v in cdf_views if v.space == integration_test_space.space])
 
         # Act
         actual_views = cognite_client.data_modeling.views.list(space=integration_test_space.space, limit=-1)
@@ -25,17 +24,17 @@ class TestViewsAPI:
         assert sorted(actual_views, key=lambda v: v.external_id) == sorted(expected_views, key=lambda v: v.external_id)
         assert all(v.space == integration_test_space.space for v in actual_views)
 
-    def test_apply_retrieve_and_delete(self, cognite_client: CogniteClient, integration_test_space: models.Space):
+    def test_apply_retrieve_and_delete(self, cognite_client: CogniteClient, integration_test_space: dm.Space):
         # Arrange
-        new_view = models.ViewApply(
+        new_view = dm.ViewApply(
             space=integration_test_space.space,
             external_id="IntegrationTestView",
             version="v1",
             description="Integration test, should not persist",
             name="Create and delete view",
             properties={
-                "name": models.MappedApplyPropertyDefinition(
-                    container=models.ContainerId(
+                "name": dm.MappedApplyPropertyDefinition(
+                    container=dm.ContainerId(
                         space=integration_test_space.space,
                         external_id="Person",
                     ),
@@ -44,7 +43,7 @@ class TestViewsAPI:
                 ),
             },
         )
-        new_id = models.ViewId(new_view.space, new_view.external_id, new_view.version)
+        new_id = dm.ViewId(new_view.space, new_view.external_id, new_view.version)
 
         # Act
         created = cognite_client.data_modeling.views.apply(new_view)
@@ -64,19 +63,19 @@ class TestViewsAPI:
         assert deleted_id[0] == new_id
         assert not retrieved_deleted
 
-    def test_delete_non_existent(self, cognite_client: CogniteClient, integration_test_space: models.Space):
+    def test_delete_non_existent(self, cognite_client: CogniteClient, integration_test_space: dm.Space):
         space = integration_test_space.space
         assert (
             cognite_client.data_modeling.views.delete(
-                models.ViewId(space=space, external_id="DoesNotExists", version="v0")
+                dm.ViewId(space=space, external_id="DoesNotExists", version="v0")
             )
             == []
         )
 
-    def test_retrieve_multiple(self, cognite_client: CogniteClient, cdf_views: models.ViewList):
+    def test_retrieve_multiple(self, cognite_client: CogniteClient, cdf_views: dm.ViewList):
         assert len(cdf_views) >= 2, "Please add at least two views to the test environment"
         # Arrange
-        ids = [models.ViewId(v.space, v.external_id, v.version) for v in cdf_views]
+        ids = [dm.ViewId(v.space, v.external_id, v.version) for v in cdf_views]
 
         # Act
         retrieved = cognite_client.data_modeling.views.retrieve(ids)
@@ -84,11 +83,11 @@ class TestViewsAPI:
         # Assert
         assert [view.as_id() for view in retrieved] == ids
 
-    def test_retrieve_multiple_with_missing(self, cognite_client: CogniteClient, cdf_views: models.ViewList):
+    def test_retrieve_multiple_with_missing(self, cognite_client: CogniteClient, cdf_views: dm.ViewList):
         assert len(cdf_views) >= 2, "Please add at least two views to the test environment"
         # Arrange
         ids_without_missing = [v.as_id() for v in cdf_views]
-        ids_with_missing = [*ids_without_missing, models.ViewId("myNonExistingSpace", "myImaginaryView", "v0")]
+        ids_with_missing = [*ids_without_missing, dm.ViewId("myNonExistingSpace", "myImaginaryView", "v0")]
 
         # Act
         retrieved = cognite_client.data_modeling.views.retrieve(ids_with_missing)
@@ -99,8 +98,82 @@ class TestViewsAPI:
     def test_retrieve_non_existent(self, cognite_client: CogniteClient):
         assert not cognite_client.data_modeling.views.retrieve(("myNonExistingSpace", "myImaginaryView", "v0"))
 
-    def test_iterate(self, cognite_client: CogniteClient, integration_test_space: models.Space):
+    def test_iterate(self, cognite_client: CogniteClient, integration_test_space: dm.Space):
         for containers in cognite_client.data_modeling.views(
             chunk_size=2, limit=-1, space=integration_test_space.space
         ):
-            assert isinstance(containers, models.ViewList)
+            assert isinstance(containers, dm.ViewList)
+
+    def test_apply_invalid_view(self, cognite_client: CogniteClient, integration_test_space: dm.Space):
+        with pytest.raises(CogniteAPIError) as error:
+            cognite_client.data_modeling.views.apply(
+                dm.ViewApply(
+                    space="nonExistingSpace",
+                    external_id="myView",
+                    version="v1",
+                    properties={
+                        "name": dm.MappedApplyPropertyDefinition(
+                            container=dm.ContainerId(
+                                space=integration_test_space.space,
+                                external_id="Person",
+                            ),
+                            container_property_identifier="name",
+                            name="fullName",
+                        ),
+                    },
+                )
+            )
+
+        # Assert
+        assert error.value.code == 400
+        assert "One or more spaces do not exist" in error.value.message
+
+    def test_apply_failed_and_successful_task(
+        self, cognite_client: CogniteClient, integration_test_space: dm.Space, monkeypatch
+    ):
+        # Arrange
+        valid_view = dm.ViewApply(
+            space=integration_test_space.space,
+            external_id="myView",
+            version="v1",
+            properties={
+                "name": dm.MappedApplyPropertyDefinition(
+                    container=dm.ContainerId(
+                        space=integration_test_space.space,
+                        external_id="Person",
+                    ),
+                    container_property_identifier="name",
+                    name="fullName",
+                ),
+            },
+        )
+        invalid_view = dm.ViewApply(
+            space="nonExistingSpace",
+            external_id="myView",
+            version="v1",
+            properties={
+                "name": dm.MappedApplyPropertyDefinition(
+                    container=dm.ContainerId(
+                        space=integration_test_space.space,
+                        external_id="Person",
+                    ),
+                    container_property_identifier="name",
+                    name="fullName",
+                ),
+            },
+        )
+        monkeypatch.setattr(cognite_client.data_modeling.views, "_CREATE_LIMIT", 1)
+
+        try:
+            # Act
+            with pytest.raises(CogniteAPIError) as error:
+                cognite_client.data_modeling.views.apply([valid_view, invalid_view])
+
+            # Assert
+            assert "One or more spaces do not exist" in error.value.message
+            assert error.value.code == 400
+            assert len(error.value.successful) == 1
+            assert len(error.value.failed) == 1
+        finally:
+            # Cleanup
+            cognite_client.data_modeling.views.delete(valid_view.as_id())

--- a/tests/tests_integration/test_api/test_data_modeling/test_views.py
+++ b/tests/tests_integration/test_api/test_data_modeling/test_views.py
@@ -66,9 +66,7 @@ class TestViewsAPI:
     def test_delete_non_existent(self, cognite_client: CogniteClient, integration_test_space: dm.Space):
         space = integration_test_space.space
         assert (
-            cognite_client.data_modeling.views.delete(
-                dm.ViewId(space=space, external_id="DoesNotExists", version="v0")
-            )
+            cognite_client.data_modeling.views.delete(dm.ViewId(space=space, external_id="DoesNotExists", version="v0"))
             == []
         )
 


### PR DESCRIPTION
## Description
### Fixed
- Handling non 200 responses in `data_modeling.spaces.apply`, `data_modeling.data_models.apply`, 
  `data_modeling.views.apply` and `data_modeling.containers.apply`


## Checklist:
- [x] Tests added/updated.
- [x] Documentation updated. Documentation is generated from docstrings - these must be updated according to your change.
  If a new method has been added it should be referenced in [cognite.rst](https://github.com/cognitedata/cognite-sdk-python/blob/master/docs/source/cognite.rst) in order to generate docs based on its docstring.
- [x] Changelog updated in [CHANGELOG.md](https://github.com/cognitedata/cognite-sdk-python/blob/master/CHANGELOG.md).
- [x] Version bumped. If triggering a new release is desired, bump the version number in [_version.py](https://github.com/cognitedata/cognite-sdk-python/blob/master/cognite/client/_version.py) and [pyproject.toml](https://github.com/cognitedata/cognite-sdk-python/blob/master/pyproject.toml) per [semantic versioning](https://semver.org/).
