### PR TITLE
fixed_docstrings

### DIFF
--- a/cognite/client/_api/data_modeling/containers.py
+++ b/cognite/client/_api/data_modeling/containers.py
@@ -202,7 +202,7 @@ class ContainersAPI(APIClient):
             Create new containers:
 
                 >>> from cognite.client import CogniteClient
-                >>> import cognite.client.data_classes.data_modeling as models
+                >>> from cognite.client import data_modeling as models
                 >>> c = CogniteClient()
                 >>> containers = [models.ContainerApply(space="mySpace",properties={"name": models.ContainerProperty(type=models.TextType, name="name")})]
                 >>> res = c.data_modeling.containers.apply(containers)

--- a/cognite/client/_api/data_modeling/data_models.py
+++ b/cognite/client/_api/data_modeling/data_models.py
@@ -206,7 +206,7 @@ class DataModelsAPI(APIClient):
             Create new data model::
 
                 >>> from cognite.client import CogniteClient
-                >>> import cognite.client.data_classes.data_modeling as models
+                >>> from cognite.client import data_modeling as models
                 >>> c = CogniteClient()
                 >>> data_models = [models.DataModelApply(space="mySpace",external_id="myDataModel",version="v1",is_global=,last_updated_time=),
                 ... DataModelApply(space="mySpace",external_id="myOtherDataModel",version="v1",is_global=,last_updated_time=)]

--- a/cognite/client/_api/data_modeling/instances.py
+++ b/cognite/client/_api/data_modeling/instances.py
@@ -243,7 +243,7 @@ class InstancesAPI(APIClient):
             Retrieve nodes an edges using the built in data class
 
                 >>> from cognite.client import CogniteClient
-                >>> import cognite.client.data_modeling as dm
+                >>> from cognite.client import data_modeling as dm
                 >>> c = CogniteClient()
                 >>> res = c.data_modeling.instances.retrieve(dm.NodeId("mySpace", "myNode"),
                 ...                                          dm.EdgeId("mySpace", "myEdge"),
@@ -253,7 +253,7 @@ class InstancesAPI(APIClient):
             Retrieve nodes an edges using the the view object as source
 
                 >>> from cognite.client import CogniteClient
-                >>> import cognite.client.data_modeling as dm
+                >>> from cognite.client import data_modeling as dm
                 >>> c = CogniteClient()
                 >>> res = c.data_modeling.instances.retrieve(dm.NodeId("mySpace", "myNode"),
                 ...                                          dm.EdgeId("mySpace", "myEdge"),
@@ -330,7 +330,7 @@ class InstancesAPI(APIClient):
             Delete nodes and edges using the built in data class
 
                 >>> from cognite.client import CogniteClient
-                >>> import cognite.client.data_modeling as dm
+                >>> from cognite.client import data_modeling as dm
                 >>> c = CogniteClient()
                 >>> c.data_modeling.instances.delete(dm.NodeId('mySpace', 'myNode'), dm.EdgeId('mySpace', 'myEdge'))
         """
@@ -415,7 +415,7 @@ class InstancesAPI(APIClient):
             Create new node without data:
 
                 >>> from cognite.client import CogniteClient
-                >>> import cognite.client.data_modeling as dm
+                >>> from cognite.client import data_modeling as dm
                 >>> c = CogniteClient()
                 >>> nodes = [dm.ApplyNode("mySpace", "myNodeId")]
                 >>> res = c.data_modeling.instances.apply(nodes)
@@ -423,7 +423,7 @@ class InstancesAPI(APIClient):
             Create two nodes with data with an one to many edge, and a one to one edge
 
                 >>> from cognite.client import CogniteClient
-                >>> import cognite.client.data_modeling as dm
+                >>> from cognite.client import data_modeling as dm
                 >>> person = dm.NodeApply("mySpace", "person:arnold_schwarzenegger", sources=[
                 ...                        dm.NodeOrEdgeData(
                 ...                               dm.ViewId("mySpace", "PersonView", "v1"),
@@ -449,7 +449,7 @@ class InstancesAPI(APIClient):
             Create new edge an automatically create end nodes.
 
                 >>> from cognite.client import CogniteClient
-                >>> import cognite.client.data_modeling as dm
+                >>> from cognite.client import data_modeling as dm
                 >>> c = CogniteClient()
                 >>> edge = dm.EdgeApply(space="mySpace",
                 ...                            external_id="relation:sylvester_stallone:actor",

--- a/cognite/client/_api/data_modeling/views.py
+++ b/cognite/client/_api/data_modeling/views.py
@@ -200,7 +200,7 @@ class ViewsAPI(APIClient):
             Create new views::
 
                 >>> from cognite.client import CogniteClient
-                >>> import cognite.client.data_classes.data_modeling as models
+                >>> from cognite.client import data_modeling as models
                 >>> c = CogniteClient()
                 >>> views = [models.ViewApply(space="mySpace",external_id="myView",version="v1"),
                 ... models.ViewApply(space="mySpace",external_id="myOtherView",version="v1")]


### PR DESCRIPTION
## Description
Fixed docstrings in data modelling to use "from cognite.client import data_modeling" In addition to the wrong import statements, I also changed the ones using the full data-classes path for consistency. I did not change the alias naming to be consistent as that would probably several other changes. 

## Checklist:
- [x] Tests added/updated.
- [x] Documentation updated. Documentation is generated from docstrings - these must be updated according to your change.
  If a new method has been added it should be referenced in [cognite.rst](https://github.com/cognitedata/cognite-sdk-python/blob/master/docs/source/cognite.rst) in order to generate docs based on its docstring.
- [x] Changelog updated in [CHANGELOG.md](https://github.com/cognitedata/cognite-sdk-python/blob/master/CHANGELOG.md).
- [x] Version bumped. If triggering a new release is desired, bump the version number in [_version.py](https://github.com/cognitedata/cognite-sdk-python/blob/master/cognite/client/_version.py) and [pyproject.toml](https://github.com/cognitedata/cognite-sdk-python/blob/master/pyproject.toml) per [semantic versioning](https://semver.org/).
