### PR TITLE
Don't allow Histogram on instances.aggregate()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,11 @@ Changes are grouped as follows
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
-## [6.5.0] - 2023-06-13
+## [6.5.1] - 2023-06-27
+### Fixed
+- Fix typehints on `data_modeling.instances.aggregate()` to not allow Histogram aggregate.
+
+## [6.5.0] - 2023-06-27
 ### Added
 - Support for searching and aggregating across instances in the Data Modeling API with the implementation 
   `client.data_modeling.instances`, the methods `search`, `histogram` and `aggregate`.

--- a/cognite/client/_api/data_modeling/instances.py
+++ b/cognite/client/_api/data_modeling/instances.py
@@ -6,7 +6,12 @@ from typing import TYPE_CHECKING, Any, Dict, Iterator, List, Literal, Sequence, 
 from cognite.client._api_client import APIClient
 from cognite.client._constants import INSTANCES_LIST_LIMIT_DEFAULT
 from cognite.client.data_classes._base import CogniteResourceList
-from cognite.client.data_classes.data_modeling.aggregations import Aggregation, Histogram, HistogramValue
+from cognite.client.data_classes.data_modeling.aggregations import (
+    Aggregation,
+    Histogram,
+    HistogramValue,
+    MetricAggregation,
+)
 from cognite.client.data_classes.data_modeling.filters import Filter
 from cognite.client.data_classes.data_modeling.ids import (
     EdgeId,
@@ -575,7 +580,7 @@ class InstancesAPI(APIClient):
     def aggregate(
         self,
         view: ViewId,
-        aggregates: Aggregation | dict | Sequence[Aggregation | dict],
+        aggregates: MetricAggregation | dict | Sequence[MetricAggregation | dict],
         instance_type: Literal["node", "edge"] = "node",
         group_by: Sequence[str] | None = None,
         query: str | None = None,
@@ -587,7 +592,7 @@ class InstancesAPI(APIClient):
 
         Args:
             view (ViewId): View to to aggregate over.
-            aggregates (Aggregation | dict | Sequence[Aggregation | dict]):  The properties to aggregate over.
+            aggregates (MetricAggregation | dict | Sequence[MetricAggregation | dict]):  The properties to aggregate over.
             instance_type (Literal["node", "edge"]): Whether to search for nodes or edges.
             group_by (Optional[Sequence[str]]): The selection of fields to group the results by when doing aggregations.
                                   You can specify up to 5 items to group by.

--- a/cognite/client/_version.py
+++ b/cognite/client/_version.py
@@ -1,4 +1,4 @@
 from __future__ import annotations
 
-__version__ = "6.5.0"
+__version__ = "6.5.1"
 __api_subversion__ = "V20220125"

--- a/cognite/client/data_classes/data_modeling/aggregations.py
+++ b/cognite/client/data_classes/data_modeling/aggregations.py
@@ -39,33 +39,38 @@ class Aggregation(ABC):
         return output
 
 
+@dataclass
+class MetricAggregation(Aggregation):
+    ...
+
+
 @final
 @dataclass
-class Avg(Aggregation):
+class Avg(MetricAggregation):
     _aggregation_name = "avg"
 
 
 @final
 @dataclass
-class Count(Aggregation):
+class Count(MetricAggregation):
     _aggregation_name = "count"
 
 
 @final
 @dataclass
-class Max(Aggregation):
+class Max(MetricAggregation):
     _aggregation_name = "max"
 
 
 @final
 @dataclass
-class Min(Aggregation):
+class Min(MetricAggregation):
     _aggregation_name = "min"
 
 
 @final
 @dataclass
-class Sum(Aggregation):
+class Sum(MetricAggregation):
     _aggregation_name = "sum"
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "cognite-sdk"
 
-version = "6.5.0"
+version = "6.5.1"
 
 description = "Cognite Python SDK"
 readme = "README.md"


### PR DESCRIPTION
- Only allow metric aggregations in the instances.aggregate() method
- Update changelog and version

## Description
Please describe the change you have made.

## Checklist:
- [ ] Tests added/updated.
- [ ] Documentation updated. Documentation is generated from docstrings - these must be updated according to your change.
  If a new method has been added it should be referenced in [cognite.rst](https://github.com/cognitedata/cognite-sdk-python/blob/master/docs/source/cognite.rst) in order to generate docs based on its docstring.
- [ ] Changelog updated in [CHANGELOG.md](https://github.com/cognitedata/cognite-sdk-python/blob/master/CHANGELOG.md).
- [ ] Version bumped. If triggering a new release is desired, bump the version number in [_version.py](https://github.com/cognitedata/cognite-sdk-python/blob/master/cognite/client/_version.py) and [pyproject.toml](https://github.com/cognitedata/cognite-sdk-python/blob/master/pyproject.toml) per [semantic versioning](https://semver.org/).
