### PR TITLE
Data Modeling Validate Only Write Classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,11 @@ Changes are grouped as follows
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
+## [6.5.3] - 2023-06-28
+### Fixed
+- Only validate `space` and `external_id` for write methods in `data_modeling` classes.
+
+
 ## [6.5.2] - 2023-06-27
 ### Fixed
 - Added missing `metadata` attribute to `iam.Group`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ Changes are grouped as follows
 
 ## [6.5.3] - 2023-06-28
 ### Fixed
-- Only validate `space` and `external_id` for write methods in `data_modeling` classes.
+- Only validate `space` and `external_id` for `data_modeling` write classes.
 
 
 ## [6.5.2] - 2023-06-27

--- a/cognite/client/_version.py
+++ b/cognite/client/_version.py
@@ -1,4 +1,4 @@
 from __future__ import annotations
 
-__version__ = "6.5.2"
+__version__ = "6.5.3"
 __api_subversion__ = "V20220125"

--- a/cognite/client/data_classes/data_modeling/containers.py
+++ b/cognite/client/data_classes/data_modeling/containers.py
@@ -10,6 +10,7 @@ from cognite.client.data_classes._base import (
     CogniteResourceList,
 )
 from cognite.client.data_classes.data_modeling._core import DataModelingResource
+from cognite.client.data_classes.data_modeling._validation import validate_data_modeling_identifier
 from cognite.client.data_classes.data_modeling.data_types import (
     DirectRelation,
     PropertyType,
@@ -45,7 +46,6 @@ class ContainerCore(DataModelingResource):
         indexes: dict[str, Index] = None,
         **_: dict,
     ):
-        # validate_data_modeling_identifier(space, external_id)
         self.space = space
         self.external_id = external_id
         self.description = description
@@ -106,6 +106,7 @@ class ContainerApply(ContainerCore):
         constraints: dict[str, Constraint] = None,
         indexes: dict[str, Index] = None,
     ):
+        validate_data_modeling_identifier(space, external_id)
         super().__init__(space, external_id, properties, description, name, used_for, constraints, indexes)
 
 

--- a/cognite/client/data_classes/data_modeling/containers.py
+++ b/cognite/client/data_classes/data_modeling/containers.py
@@ -10,7 +10,6 @@ from cognite.client.data_classes._base import (
     CogniteResourceList,
 )
 from cognite.client.data_classes.data_modeling._core import DataModelingResource
-from cognite.client.data_classes.data_modeling._validation import validate_data_modeling_identifier
 from cognite.client.data_classes.data_modeling.data_types import (
     DirectRelation,
     PropertyType,
@@ -46,7 +45,7 @@ class ContainerCore(DataModelingResource):
         indexes: dict[str, Index] = None,
         **_: dict,
     ):
-        validate_data_modeling_identifier(space, external_id)
+        # validate_data_modeling_identifier(space, external_id)
         self.space = space
         self.external_id = external_id
         self.description = description

--- a/cognite/client/data_classes/data_modeling/data_models.py
+++ b/cognite/client/data_classes/data_modeling/data_models.py
@@ -33,7 +33,6 @@ class DataModelCore(DataModelingResource):
         name: str = None,
         **_: dict,
     ):
-        validate_data_modeling_identifier(space, external_id)
         self.space = space
         self.external_id = external_id
         self.description = description
@@ -65,6 +64,7 @@ class DataModelApply(DataModelCore):
         name: str = None,
         views: list[ViewId | ViewApply] = None,
     ):
+        validate_data_modeling_identifier(space, external_id)
         super().__init__(space, external_id, version, description, name)
         self.views = views
 

--- a/cognite/client/data_classes/data_modeling/instances.py
+++ b/cognite/client/data_classes/data_modeling/instances.py
@@ -86,7 +86,6 @@ class InstanceCore(DataModelingResource):
     """
 
     def __init__(self, space: str, external_id: str, instance_type: Literal["node", "edge"] = "node"):
-        validate_data_modeling_identifier(space, external_id)
         self.instance_type = instance_type
         self.space = space
         self.external_id = external_id
@@ -117,6 +116,7 @@ class InstanceApply(InstanceCore):
         existing_version: int = None,
         sources: list[NodeOrEdgeData] = None,
     ):
+        validate_data_modeling_identifier(space, external_id)
         super().__init__(space, external_id, instance_type)
         self.existing_version = existing_version
         self.sources = sources

--- a/cognite/client/data_classes/data_modeling/spaces.py
+++ b/cognite/client/data_classes/data_modeling/spaces.py
@@ -19,7 +19,6 @@ class SpaceCore(DataModelingResource):
     """
 
     def __init__(self, space: str, description: str = None, name: str = None):
-        validate_data_modeling_identifier(space)
         self.space = space
         self.description = description
         self.name = name
@@ -29,9 +28,23 @@ class SpaceCore(DataModelingResource):
 
 
 class SpaceApply(SpaceCore):
-    """A workspace for data models and instances. This is the write version"""
+    """A workspace for data models and instances. This is the write version
 
-    ...
+    Args:
+        space (str): A unique identifier for space.
+        description (str): Textual description of the space
+        name (str): Human readable name for the space.
+    """
+
+    def __init__(
+        self,
+        space: str,
+        description: str = None,
+        name: str = None,
+        **_: Any,
+    ):
+        validate_data_modeling_identifier(space)
+        super().__init__(space, description, name)
 
 
 class Space(SpaceCore):

--- a/cognite/client/data_classes/data_modeling/views.py
+++ b/cognite/client/data_classes/data_modeling/views.py
@@ -36,7 +36,6 @@ class ViewCore(DataModelingResource):
         implements: list[ViewId] = None,
         **_: dict,
     ):
-        validate_data_modeling_identifier(space, external_id)
         self.space = space
         self.external_id = external_id
         self.description = description
@@ -97,6 +96,7 @@ class ViewApply(ViewCore):
         implements: list[ViewId] = None,
         properties: dict[str, MappedPropertyApply | ConnectionDefinition] = None,
     ):
+        validate_data_modeling_identifier(space, external_id)
         super().__init__(space, external_id, version, description, name, filter, implements)
         self.properties = properties
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "cognite-sdk"
 
-version = "6.5.2"
+version = "6.5.3"
 
 description = "Cognite Python SDK"
 readme = "README.md"


### PR DESCRIPTION
## Description

We had some old containers, and views which we are unable to delete as space and external id is validated upon creating the read classes. Moved that validation to only apply for the write classes, so that we can download these old containers, and deletl them. 

## Checklist:
- [ ] Tests added/updated.
- [ ] Documentation updated. Documentation is generated from docstrings - these must be updated according to your change.
  If a new method has been added it should be referenced in [cognite.rst](https://github.com/cognitedata/cognite-sdk-python/blob/master/docs/source/cognite.rst) in order to generate docs based on its docstring.
- [ ] Changelog updated in [CHANGELOG.md](https://github.com/cognitedata/cognite-sdk-python/blob/master/CHANGELOG.md).
- [ ] Version bumped. If triggering a new release is desired, bump the version number in [_version.py](https://github.com/cognitedata/cognite-sdk-python/blob/master/cognite/client/_version.py) and [pyproject.toml](https://github.com/cognitedata/cognite-sdk-python/blob/master/pyproject.toml) per [semantic versioning](https://semver.org/).
