### PR TITLE
Fix space identifier unwrapping on errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,11 @@ Changes are grouped as follows
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
+## [6.5.5] - 2023-06-28
+### Fixed
+- A bug where we would raise the wrong exception when errors on occured on `data_modeling.spaces.delete`
+- A bug causing incosistent MRO in DataModelList
+
 ## [6.5.4] - 2023-06-28
 ### Added
 - Missing query parameters: 

--- a/cognite/client/_api/data_modeling/spaces.py
+++ b/cognite/client/_api/data_modeling/spaces.py
@@ -4,8 +4,8 @@ from typing import Iterator, Sequence, cast, overload
 
 from cognite.client._api_client import APIClient
 from cognite.client._constants import LIST_LIMIT_DEFAULT
+from cognite.client.data_classes.data_modeling.ids import _load_space_identifier
 from cognite.client.data_classes.data_modeling.spaces import Space, SpaceApply, SpaceList
-from cognite.client.utils._identifier import DataModelingIdentifierSequence
 
 
 class SpacesAPI(APIClient):
@@ -91,7 +91,7 @@ class SpacesAPI(APIClient):
                 >>> res = c.data_modeling.spaces.retrieve(spaces=["MySpace", "MyAwesomeSpace", "MyOtherSpace"])
 
         """
-        identifier = DataModelingIdentifierSequence.load_spaces(spaces=space)
+        identifier = _load_space_identifier(space)
         return self._retrieve_multiple(list_cls=SpaceList, resource_cls=Space, identifiers=identifier)
 
     def delete(self, space: str | Sequence[str]) -> list[str]:
@@ -111,9 +111,7 @@ class SpacesAPI(APIClient):
         """
         deleted_spaces = cast(
             list,
-            self._delete_multiple(
-                identifiers=DataModelingIdentifierSequence.load_spaces(spaces=space), wrap_ids=True, returns_items=True
-            ),
+            self._delete_multiple(identifiers=_load_space_identifier(space), wrap_ids=True, returns_items=True),
         )
         return [item["space"] for item in deleted_spaces]
 

--- a/cognite/client/_api/files.py
+++ b/cognite/client/_api/files.py
@@ -797,7 +797,7 @@ class FilesAPI(APIClient):
             self._process_file_download, tasks, max_workers=self._config.max_workers
         )
         tasks_summary.raise_compound_exception_if_failed_tasks(
-            task_unwrap_fn=lambda task: id_to_metadata[utils._auxiliary.unwrap_identifer(task[1])],
+            task_unwrap_fn=lambda task: id_to_metadata[IdentifierSequence.unwrap_identifier(task[1])],
             str_format_element_fn=lambda metadata: metadata.id,
         )
 
@@ -812,7 +812,7 @@ class FilesAPI(APIClient):
         identifier: Dict[str, Union[int, str]],
         id_to_metadata: Dict[Union[str, int], FileMetadata],
     ) -> None:
-        id = utils._auxiliary.unwrap_identifer(identifier)
+        id = IdentifierSequence.unwrap_identifier(identifier)
         file_metadata = id_to_metadata[id]
         file_path = (directory / cast(str, file_metadata.name)).resolve()
         file_is_in_download_directory = directory.resolve() in file_path.parents

--- a/cognite/client/_api_client.py
+++ b/cognite/client/_api_client.py
@@ -704,7 +704,7 @@ class APIClient:
         summary = utils._concurrency.execute_tasks(self._post, tasks, max_workers=self._config.max_workers)
         summary.raise_compound_exception_if_failed_tasks(
             task_unwrap_fn=lambda task: task["json"]["items"],
-            task_list_element_unwrap_fn=utils._auxiliary.unwrap_identifer,
+            task_list_element_unwrap_fn=identifiers.unwrap_identifier,
         )
         if returns_items:
             return summary.joined_results(lambda res: res.json()["items"])
@@ -775,7 +775,7 @@ class APIClient:
         tasks_summary = utils._concurrency.execute_tasks(self._post, tasks, max_workers=self._config.max_workers)
         tasks_summary.raise_compound_exception_if_failed_tasks(
             task_unwrap_fn=lambda task: task["json"]["items"],
-            task_list_element_unwrap_fn=lambda el: utils._auxiliary.unwrap_identifer(el),
+            task_list_element_unwrap_fn=lambda el: IdentifierSequenceCore.unwrap_identifier(el),
         )
         updated_items = tasks_summary.joined_results(lambda res: res.json()["items"])
 

--- a/cognite/client/_version.py
+++ b/cognite/client/_version.py
@@ -1,4 +1,4 @@
 from __future__ import annotations
 
-__version__ = "6.5.4"
+__version__ = "6.5.5"
 __api_subversion__ = "V20220125"

--- a/cognite/client/data_classes/data_modeling/data_models.py
+++ b/cognite/client/data_classes/data_modeling/data_models.py
@@ -176,7 +176,7 @@ class DataModelApplyList(CogniteResourceList[DataModelApply]):
     _RESOURCE = DataModelApply
 
 
-class DataModelList(Generic[T_View], CogniteResourceList[DataModel[T_View]]):
+class DataModelList(CogniteResourceList[DataModel[T_View]]):
     _RESOURCE = DataModel
 
     def to_data_model_apply_list(self) -> DataModelApplyList:

--- a/cognite/client/data_classes/data_modeling/ids.py
+++ b/cognite/client/data_classes/data_modeling/ids.py
@@ -151,8 +151,15 @@ EdgeIdentifier = Union[EdgeId, Tuple[str, str, str]]
 Id = Union[Tuple[str, str], Tuple[str, str, str], DataModelingId, VersionedDataModelingId, NodeId, EdgeId, InstanceId]
 
 
+def _load_space_identifier(ids: str | Sequence[str]) -> DataModelingIdentifierSequence:
+    spaces = [ids] if isinstance(ids, str) else ids
+    return DataModelingIdentifierSequence(
+        identifiers=[DataModelingIdentifier(space) for space in spaces], is_singleton=False
+    )
+
+
 def _load_identifier(
-    ids: Id | Sequence[Id], id_type: Literal["container", "view", "data_model", "node", "edge"]
+    ids: Id | Sequence[Id], id_type: Literal["container", "view", "data_model", "space", "node", "edge"]
 ) -> DataModelingIdentifierSequence:
     is_sequence = isinstance(ids, Sequence) and not (isinstance(ids, tuple) and isinstance(ids[0], str))
     is_view_or_data_model = id_type in {"view", "data_model"}

--- a/cognite/client/data_classes/data_modeling/ids.py
+++ b/cognite/client/data_classes/data_modeling/ids.py
@@ -152,9 +152,10 @@ Id = Union[Tuple[str, str], Tuple[str, str, str], DataModelingId, VersionedDataM
 
 
 def _load_space_identifier(ids: str | Sequence[str]) -> DataModelingIdentifierSequence:
+    is_sequence = isinstance(ids, Sequence) and not isinstance(ids, str)
     spaces = [ids] if isinstance(ids, str) else ids
     return DataModelingIdentifierSequence(
-        identifiers=[DataModelingIdentifier(space) for space in spaces], is_singleton=False
+        identifiers=[DataModelingIdentifier(space) for space in spaces], is_singleton=not is_sequence
     )
 
 

--- a/cognite/client/utils/_auxiliary.py
+++ b/cognite/client/utils/_auxiliary.py
@@ -93,32 +93,6 @@ def json_dump_default(x: Any) -> Any:
     raise TypeError(f"Object {x} of type {x.__class__} can't be serialized by the JSON encoder")
 
 
-@overload
-def unwrap_identifer(identifier: str) -> str:
-    ...
-
-
-@overload
-def unwrap_identifer(identifier: int) -> int:
-    ...
-
-
-@overload
-def unwrap_identifer(identifier: Dict) -> Union[str, int]:
-    ...
-
-
-def unwrap_identifer(identifier: Union[str, int, Dict]) -> Union[str, int]:
-    # TODO: Move to Identifier class?
-    if isinstance(identifier, (str, int)):
-        return identifier
-    if "externalId" in identifier:
-        return identifier["externalId"]
-    if "id" in identifier:
-        return identifier["id"]
-    raise ValueError(f"{identifier} does not contain 'id' or 'externalId'")
-
-
 def assert_type(var: Any, var_name: str, types: List[type], allow_none: bool = False) -> None:
     if var is None:
         if not allow_none:

--- a/cognite/client/utils/_identifier.py
+++ b/cognite/client/utils/_identifier.py
@@ -118,11 +118,9 @@ T_Identifier = TypeVar("T_Identifier", bound=IdentifierCore)
 
 
 class IdentifierSequenceCore(Generic[T_Identifier]):
-    _no_identifiers_error_message: str = ""
-
     def __init__(self, identifiers: List[T_Identifier], is_singleton: bool) -> None:
         if not identifiers:
-            raise ValueError(self._no_identifiers_error_message)
+            raise ValueError("No identifiers specified")
         self._identifiers = identifiers
         self.__is_singleton = is_singleton
 
@@ -160,8 +158,6 @@ class IdentifierSequenceCore(Generic[T_Identifier]):
 
 
 class IdentifierSequence(IdentifierSequenceCore[Identifier]):
-    _no_identifiers_error_message = "No ids or external_ids specified"
-
     @overload
     @classmethod
     def of(cls, *ids: List[Union[int, str]]) -> IdentifierSequence:
@@ -217,13 +213,7 @@ class IdentifierSequence(IdentifierSequenceCore[Identifier]):
 
 
 class DataModelingIdentifierSequence(IdentifierSequenceCore[DataModelingIdentifier]):
-    _no_identifiers_error_message = "No spaces specified."
-
-    @classmethod
-    def load_spaces(cls, spaces: str | Sequence[str]) -> DataModelingIdentifierSequence:
-        spaces = [spaces] if isinstance(spaces, str) else spaces
-
-        return cls(identifiers=[DataModelingIdentifier(space) for space in spaces], is_singleton=len(spaces) == 1)
+    ...
 
 
 class SingletonIdentifierSequence(IdentifierSequenceCore):

--- a/cognite/client/utils/_identifier.py
+++ b/cognite/client/utils/_identifier.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import numbers
+from abc import ABC
 from typing import (
     Dict,
     Generic,
@@ -117,7 +118,7 @@ class InternalId(Identifier[int]):
 T_Identifier = TypeVar("T_Identifier", bound=IdentifierCore)
 
 
-class IdentifierSequenceCore(Generic[T_Identifier]):
+class IdentifierSequenceCore(Generic[T_Identifier], ABC):
     def __init__(self, identifiers: List[T_Identifier], is_singleton: bool) -> None:
         if not identifiers:
             raise ValueError("No identifiers specified")
@@ -155,6 +156,18 @@ class IdentifierSequenceCore(Generic[T_Identifier]):
 
     def are_unique(self) -> bool:
         return len(self) == len(set(self.as_primitives()))
+
+    @staticmethod
+    def unwrap_identifier(identifier: Union[str, int, Dict]) -> Union[str, int]:
+        if isinstance(identifier, (str, int)):
+            return identifier
+        if "externalId" in identifier:
+            return identifier["externalId"]
+        if "id" in identifier:
+            return identifier["id"]
+        if "space" in identifier:
+            return identifier["space"]
+        raise ValueError(f"{identifier} does not contain 'id' or 'externalId' or 'space'")
 
 
 class IdentifierSequence(IdentifierSequenceCore[Identifier]):
@@ -212,9 +225,9 @@ class IdentifierSequence(IdentifierSequenceCore[Identifier]):
         return cls(identifiers=[Identifier(val) for val in all_identifiers], is_singleton=is_singleton)
 
 
-class DataModelingIdentifierSequence(IdentifierSequenceCore[DataModelingIdentifier]):
+class SingletonIdentifierSequence(IdentifierSequenceCore[Identifier]):
     ...
 
 
-class SingletonIdentifierSequence(IdentifierSequenceCore):
+class DataModelingIdentifierSequence(IdentifierSequenceCore[DataModelingIdentifier]):
     ...

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "cognite-sdk"
 
-version = "6.5.4"
+version = "6.5.5"
 
 description = "Cognite Python SDK"
 readme = "README.md"

--- a/tests/tests_unit/test_api/test_data_modeling/test_spaces.py
+++ b/tests/tests_unit/test_api/test_data_modeling/test_spaces.py
@@ -1,0 +1,26 @@
+import re
+
+import pytest
+from responses import RequestsMock
+
+from cognite.client import CogniteClient
+from cognite.client.exceptions import CogniteAPIError
+
+
+class TestSpaces:
+    @pytest.fixture
+    def mock_spaces_delete_raise_error(self, rsps: RequestsMock, cognite_client: CogniteClient) -> RequestsMock:
+        response_body = {"error": "smth"}
+        url_pattern = re.compile(
+            re.escape(cognite_client.data_modeling.spaces._get_base_url_with_base_path()) + "/models/spaces/delete"
+        )
+        rsps.add(rsps.POST, url_pattern, status=400, json=response_body)
+        yield rsps
+
+    def test_failed_delete_task(
+        self, cognite_client: CogniteClient, mock_spaces_delete_raise_error: RequestsMock
+    ) -> None:
+        some_space = "i-dont-actually-exist"
+        with pytest.raises(CogniteAPIError) as error:
+            cognite_client.data_modeling.spaces.delete(some_space)
+        assert error.value.code == 400

--- a/tests/tests_unit/test_api_client.py
+++ b/tests/tests_unit/test_api_client.py
@@ -337,7 +337,7 @@ class TestStandardRetrieveMultiple:
         assert 400 == e.value.code
 
     def test_ids_all_None(self, api_client_with_token):
-        with pytest.raises(ValueError, match="No ids or external_ids specified"):
+        with pytest.raises(ValueError, match="No identifiers specified"):
             api_client_with_token._retrieve_multiple(
                 list_cls=SomeResourceList,
                 resource_cls=SomeResource,

--- a/tests/tests_unit/test_data_classes/test_data_models/test_ids.py
+++ b/tests/tests_unit/test_data_classes/test_data_models/test_ids.py
@@ -65,7 +65,7 @@ class TestLoadIdentifier:
 
     @pytest.mark.parametrize(
         "ids, expected_dict, expected_is_singleton",
-        [("spaceId", [{"space": "spaceId"}], False), (["spaceId"], [{"space": "spaceId"}], False)],
+        [("spaceId", [{"space": "spaceId"}], True), (["spaceId"], [{"space": "spaceId"}], False)],
     )
     def test_load_space_identifier(
         self,

--- a/tests/tests_unit/test_data_classes/test_data_models/test_ids.py
+++ b/tests/tests_unit/test_data_classes/test_data_models/test_ids.py
@@ -4,7 +4,7 @@ from typing import Literal
 
 import pytest
 
-from cognite.client.data_classes.data_modeling.ids import ContainerId, ViewId, _load_identifier
+from cognite.client.data_classes.data_modeling.ids import ContainerId, ViewId, _load_identifier, _load_space_identifier
 
 
 class TestContainerReference:
@@ -28,6 +28,7 @@ class TestLoadIdentifier:
             (("space", "container"), "container", [{"space": "space", "externalId": "container"}], True),
             ([("space", "container")], "container", [{"space": "space", "externalId": "container"}], False),
             (("space", "view", "v1"), "view", [{"space": "space", "externalId": "view", "version": "v1"}], False),
+            ([("space", "view", "v1")], "view", [{"space": "space", "externalId": "view", "version": "v1"}], False),
             (
                 ("space", "myDataModel", "v1"),
                 "data_model",
@@ -56,6 +57,23 @@ class TestLoadIdentifier:
         expected_is_singleton: bool,
     ) -> None:
         identifier = _load_identifier(ids, id_type)
+
+        assert identifier.as_dicts() == expected_dict
+        assert (
+            identifier.is_singleton() == expected_is_singleton
+        ), f"Expected {expected_is_singleton} but got {identifier.is_singleton()}"
+
+    @pytest.mark.parametrize(
+        "ids, expected_dict, expected_is_singleton",
+        [("spaceId", [{"space": "spaceId"}], False), (["spaceId"], [{"space": "spaceId"}], False)],
+    )
+    def test_load_space_identifier(
+        self,
+        ids: tuple[str, str] | tuple[str, str, str],
+        expected_dict: list | dict,
+        expected_is_singleton: bool,
+    ) -> None:
+        identifier = _load_space_identifier(ids)
 
         assert identifier.as_dicts() == expected_dict
         assert (

--- a/tests/tests_unit/test_utils/test_identifier.py
+++ b/tests/tests_unit/test_utils/test_identifier.py
@@ -56,7 +56,7 @@ class TestIdentifierSequence:
 
     @pytest.mark.parametrize(
         "ids, external_ids, exception, match",
-        [(None, None, ValueError, "No ids or external_ids specified")],
+        [(None, None, ValueError, "No identifiers specified")],
     )
     def test_process_ids_fail(self, ids, external_ids, exception, match) -> None:
         with pytest.raises(exception, match=match):

--- a/tests/tests_unit/test_utils/test_identifier.py
+++ b/tests/tests_unit/test_utils/test_identifier.py
@@ -1,7 +1,7 @@
 import pytest
 
 from cognite.client._constants import MAX_VALID_INTERNAL_ID
-from cognite.client.utils._identifier import DataModelingIdentifierSequence, Identifier, IdentifierSequence
+from cognite.client.utils._identifier import Identifier, IdentifierSequence
 
 
 class TestIdentifier:
@@ -83,9 +83,3 @@ class TestIdentifierSequence:
 
         seq = IdentifierSequence.of(external_ids)
         assert seq.is_singleton() is is_singleton
-
-
-class TestDataModelingIdentifierSequence:
-    def test_load_spaces_bad_input(self):
-        with pytest.raises(ValueError, match="No spaces specified."):
-            DataModelingIdentifierSequence.load_spaces([])


### PR DESCRIPTION
- Handle all loading of dms identifiers in data_modeling/ids.py
- Move unwrap_identifier to IdentifierSequenceCore and handle 'space' identifiers
- Add test to make sure we correctly unwrap space identifiers when we err

## Description
Please describe the change you have made.

## Checklist:
- [ ] Tests added/updated.
- [ ] Documentation updated. Documentation is generated from docstrings - these must be updated according to your change.
  If a new method has been added it should be referenced in [cognite.rst](https://github.com/cognitedata/cognite-sdk-python/blob/master/docs/source/cognite.rst) in order to generate docs based on its docstring.
- [ ] Changelog updated in [CHANGELOG.md](https://github.com/cognitedata/cognite-sdk-python/blob/master/CHANGELOG.md).
- [ ] Version bumped. If triggering a new release is desired, bump the version number in [_version.py](https://github.com/cognitedata/cognite-sdk-python/blob/master/cognite/client/_version.py) and [pyproject.toml](https://github.com/cognitedata/cognite-sdk-python/blob/master/pyproject.toml) per [semantic versioning](https://semver.org/).
