### PR TITLE
Fix debug logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ Changes are grouped as follows
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
+## [6.5.6] - 2023-06-29
+### Fixed
+- A bug causing `ClientConfig(debug=True)` to raise an AttributeError 
+
 ## [6.5.5] - 2023-06-28
 ### Fixed
 - A bug where we would raise the wrong exception when errors on occured on `data_modeling.spaces.delete`

--- a/cognite/client/_version.py
+++ b/cognite/client/_version.py
@@ -1,4 +1,4 @@
 from __future__ import annotations
 
-__version__ = "6.5.5"
+__version__ = "6.5.6"
 __api_subversion__ = "V20220125"

--- a/cognite/client/config.py
+++ b/cognite/client/config.py
@@ -4,7 +4,6 @@ import pprint
 from contextlib import suppress
 from typing import Dict, Optional, Set
 
-from cognite.client import utils
 from cognite.client._version import __api_subversion__
 from cognite.client.credentials import CredentialProvider
 
@@ -87,11 +86,15 @@ class ClientConfig:
         self.debug = debug
 
         if debug:
-            utils._logging._configure_logger_for_debug_mode()
+            from cognite.client.utils._logging import _configure_logger_for_debug_mode
+
+            _configure_logger_for_debug_mode()
 
         if not global_config.disable_pypi_version_check:
             with suppress(Exception):  # PyPI might be unreachable, if so, skip version check
-                utils._auxiliary._check_client_has_newest_major_version()
+                from cognite.client.utils._auxiliary import _check_client_has_newest_major_version
+
+                _check_client_has_newest_major_version()
 
     def __str__(self) -> str:
         return pprint.pformat(self.__dict__, indent=4)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "cognite-sdk"
 
-version = "6.5.5"
+version = "6.5.6"
 
 description = "Cognite Python SDK"
 readme = "README.md"


### PR DESCRIPTION
Was raising attribute error when debug=True, due to _logging module not being explicitly exported. There's also some circular imports going on, so needed local imports to fix it.

```
Traceback (most recent call last):
  File "/Users/erlendvollset/git/cognite-sdk-python/test.py", line 8, in <module>
    c = CogniteClient(ClientConfig(project="haha", credentials=Token("hehe"), client_name="nono", debug=True))
  File "/Users/erlendvollset/git/cognite-sdk-python/cognite/client/config.py", line 90, in __init__
    utils._logging._configure_logger_for_debug_mode()
AttributeError: module 'cognite.client.utils' has no attribute '_logging'
```