### PR TITLE
Support an 'all_versions' flag on retrieving views

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,14 @@ Changes are grouped as follows
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
+## [6.7.1] - 2023-07-07
+### Fixed
+- Needless function "as_id" on View as it was already inherited
+### Added
+- Flag "all_versions" on data_modeling.data_models.retrieve() to retrieve all versions of a data model or only the latest one
+- Extra documentation on how to delete edges and nodes.
+- Support for using full Node and Edge objects when deleting instances.
+
 ## [6.7.0] - 2023-07-07
 ### Added
 - Support for applying graphql dml using `client.data_modeling.graphql.apply_dml()`.
@@ -30,7 +38,6 @@ Changes are grouped as follows
 ### Fixed
 - Support for query and sync endpoints across instances in the Data Modeling API with the implementation 
   `client.data_modeling.instances`, the methods `query` and `sync`.
-
 
 ## [6.5.8] - 2023-06-30
 ### Fixed

--- a/cognite/client/_api/data_modeling/instances.py
+++ b/cognite/client/_api/data_modeling/instances.py
@@ -296,13 +296,15 @@ class InstancesAPI(APIClient):
         nodes: NodeId | Sequence[NodeId] | tuple[str, str] | Sequence[tuple[str, str]] | None,
         edges: EdgeId | Sequence[EdgeId] | tuple[str, str] | Sequence[tuple[str, str]] | None,
     ) -> DataModelingIdentifierSequence:
+        nodes_seq: Sequence[NodeId | tuple[str, str]]
         if isinstance(nodes, NodeId) or (isinstance(nodes, tuple) and isinstance(nodes[0], str)):
-            nodes_seq: Sequence[NodeId | tuple[str, str]] = [nodes]  # type: ignore[list-item]
+            nodes_seq = [nodes]  # type: ignore[list-item]
         else:
             nodes_seq = nodes  # type: ignore[assignment]
 
+        edges_seq: Sequence[EdgeId | tuple[str, str]]
         if isinstance(edges, EdgeId) or (isinstance(edges, tuple) and isinstance(edges[0], str)):
-            edges_seq: Sequence[EdgeId | tuple[str, str]] = [edges]  # type: ignore[list-item]
+            edges_seq = [edges]  # type: ignore[list-item]
         else:
             edges_seq = edges  # type: ignore[assignment]
 
@@ -336,7 +338,7 @@ class InstancesAPI(APIClient):
 
                 >>> from cognite.client import CogniteClient
                 >>> c = CogniteClient()
-                >>> c.data_modeling.instances.delete(nodes=("myNode", "mySpace"))
+                >>> c.data_modeling.instances.delete(nodes=("mySpace", "myNode"))
 
             Delete nodes and edges using the built in data class
 
@@ -344,6 +346,15 @@ class InstancesAPI(APIClient):
                 >>> from cognite.client.data_classes.data_modeling import NodeId, EdgeId
                 >>> c = CogniteClient()
                 >>> c.data_modeling.instances.delete(NodeId('mySpace', 'myNode'), EdgeId('mySpace', 'myEdge'))
+
+            Delete all nodes from a NodeList
+
+                >>> from cognite.client import CogniteClient
+                >>> from cognite.client.data_classes.data_modeling import NodeId, EdgeId
+                >>> c = CogniteClient()
+                >>> my_view = c.data_modeling.views.retrieve('mySpace', 'myView')
+                >>> my_nodes = c.data_modeling.instances.list(instance_type='node', sources=my_view, limit=None)
+                >>> c.data_modeling.instances.delete(nodes=my_nodes.as_ids())
         """
         identifiers = self._load_node_and_edge_ids(nodes, edges)
         deleted_instances = cast(List, self._delete_multiple(identifiers, wrap_ids=True, returns_items=True))

--- a/cognite/client/_version.py
+++ b/cognite/client/_version.py
@@ -1,4 +1,4 @@
 from __future__ import annotations
 
-__version__ = "6.7.0"
+__version__ = "6.7.1"
 __api_subversion__ = "V20220125"

--- a/cognite/client/data_classes/data_modeling/views.py
+++ b/cognite/client/data_classes/data_modeling/views.py
@@ -204,14 +204,6 @@ class View(ViewCore):
             properties=properties,
         )
 
-    def as_id(self) -> ViewId:
-        """Convert to a view id.
-
-        Returns:
-            ViewId: The view id.
-        """
-        return ViewId(space=self.space, external_id=self.external_id, version=self.version)
-
 
 class ViewList(CogniteResourceList[View]):
     _RESOURCE = View

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "cognite-sdk"
 
-version = "6.7.0"
+version = "6.7.1"
 
 description = "Cognite Python SDK"
 readme = "README.md"

--- a/tests/tests_unit/test_api/test_data_modeling/test_views.py
+++ b/tests/tests_unit/test_api/test_data_modeling/test_views.py
@@ -1,0 +1,67 @@
+import pytest
+
+from cognite.client.data_classes.data_modeling import View
+
+
+@pytest.fixture
+def view1():
+    return View(space="mySpace", external_id="myView", version="v1", created_time=1, properties={}, last_updated_time=9)
+
+
+@pytest.fixture
+def view2():
+    return View(space="mySpace", external_id="myView", version="v2", created_time=2, properties={}, last_updated_time=9)
+
+
+@pytest.fixture
+def view3():
+    return View(
+        space="mySpace", external_id="myOtherView", version="v1", created_time=1, properties={}, last_updated_time=9
+    )
+
+
+@pytest.fixture
+def view4():
+    return View(
+        space="mySpace", external_id="myOtherView", version="v2", created_time=3, properties={}, last_updated_time=9
+    )
+
+
+@pytest.fixture
+def view5():
+    return View(
+        space="myOtherSpace", external_id="myView", version="v1", created_time=1, properties={}, last_updated_time=9
+    )
+
+
+@pytest.fixture
+def view6():
+    return View(
+        space="myOtherSpace", external_id="myView", version="v2", created_time=2, properties={}, last_updated_time=9
+    )
+
+
+class TestViewsRetrieveLatest:
+    def test_view_nr_same_view(self, cognite_client, view1, view2):
+        views = [view1, view2]
+
+        result = cognite_client.data_modeling.views._get_latest_views(views)
+        assert len(result) == 1
+
+    def test_view_nr_different_views(self, cognite_client, view1, view2, view3, view4):
+        views = [view1, view2, view3, view4]
+
+        result = cognite_client.data_modeling.views._get_latest_views(views)
+        assert len(result) == 2
+
+    def test_view_nr_different_spaces_views(self, cognite_client, view1, view2, view3, view4, view5, view6):
+        views = [view1, view2, view3, view4, view5, view6]
+
+        result = cognite_client.data_modeling.views._get_latest_views(views)
+        assert len(result) == 3
+
+    def test_view_get_latest(self, cognite_client, view1, view2):
+        views = [view1, view2]
+
+        result = cognite_client.data_modeling.views._get_latest_views(views)
+        assert result[0].version == "v2"

--- a/tests/tests_unit/test_api/test_data_modeling/test_views.py
+++ b/tests/tests_unit/test_api/test_data_modeling/test_views.py
@@ -3,65 +3,29 @@ import pytest
 from cognite.client.data_classes.data_modeling import View
 
 
-@pytest.fixture
-def view1():
-    return View(space="mySpace", external_id="myView", version="v1", created_time=1, properties={}, last_updated_time=9)
-
-
-@pytest.fixture
-def view2():
-    return View(space="mySpace", external_id="myView", version="v2", created_time=2, properties={}, last_updated_time=9)
-
-
-@pytest.fixture
-def view3():
-    return View(
-        space="mySpace", external_id="myOtherView", version="v1", created_time=1, properties={}, last_updated_time=9
-    )
-
-
-@pytest.fixture
-def view4():
-    return View(
-        space="mySpace", external_id="myOtherView", version="v2", created_time=3, properties={}, last_updated_time=9
-    )
-
-
-@pytest.fixture
-def view5():
-    return View(
-        space="myOtherSpace", external_id="myView", version="v1", created_time=1, properties={}, last_updated_time=9
-    )
-
-
-@pytest.fixture
-def view6():
-    return View(
-        space="myOtherSpace", external_id="myView", version="v2", created_time=2, properties={}, last_updated_time=9
-    )
-
-
 class TestViewsRetrieveLatest:
-    def test_view_nr_same_view(self, cognite_client, view1, view2):
-        views = [view1, view2]
+    @pytest.fixture
+    def views(self):
+        return [
+            View("mySpace", "myView", "v1", created_time=1, properties={}, last_updated_time=9),
+            View("mySpace", "myView", "v2", created_time=2, properties={}, last_updated_time=9),
+            View("mySpace", "myOtherView", "v1", created_time=1, properties={}, last_updated_time=9),
+            View("mySpace", "myOtherView", "v2", created_time=3, properties={}, last_updated_time=9),
+            View("myOtherSpace", "myView", "v1", created_time=1, properties={}, last_updated_time=9),
+            View("myOtherSpace", "myView", "v2", created_time=2, properties={}, last_updated_time=9),
+        ]
+
+    def test_different_versions(self, cognite_client, views):
+        views = (views[0], views[1])
+        result = cognite_client.data_modeling.views._get_latest_views(views)
+        assert result == [views[1]]
+
+    def test_different_external_ids(self, cognite_client, views):
+        views = [views[0], views[1], views[2], views[3]]
 
         result = cognite_client.data_modeling.views._get_latest_views(views)
-        assert len(result) == 1
+        assert result == [views[1], views[3]]
 
-    def test_view_nr_different_views(self, cognite_client, view1, view2, view3, view4):
-        views = [view1, view2, view3, view4]
-
+    def test_different_spaces(self, cognite_client, views):
         result = cognite_client.data_modeling.views._get_latest_views(views)
-        assert len(result) == 2
-
-    def test_view_nr_different_spaces_views(self, cognite_client, view1, view2, view3, view4, view5, view6):
-        views = [view1, view2, view3, view4, view5, view6]
-
-        result = cognite_client.data_modeling.views._get_latest_views(views)
-        assert len(result) == 3
-
-    def test_view_get_latest(self, cognite_client, view1, view2):
-        views = [view1, view2]
-
-        result = cognite_client.data_modeling.views._get_latest_views(views)
-        assert result[0].version == "v2"
+        assert result == [views[1], views[3], views[5]]


### PR DESCRIPTION
## Description
- Deleted unnecessary  "as_id" function on View, as it is inherited already.
- Added "all_versions" flag on data_model.views.retrieve so that one can choose to only get latest version
- data_mode.instance.delete now accepts full Edge and Node objects, not only IDs

## Checklist:
- [x] Tests added/updated.
- [x] Documentation updated. Documentation is generated from docstrings - these must be updated according to your change.
  If a new method has been added it should be referenced in [cognite.rst](https://github.com/cognitedata/cognite-sdk-python/blob/master/docs/source/cognite.rst) in order to generate docs based on its docstring.
- [x] Changelog updated in [CHANGELOG.md](https://github.com/cognitedata/cognite-sdk-python/blob/master/CHANGELOG.md).
- [x] Version bumped. If triggering a new release is desired, bump the version number in [_version.py](https://github.com/cognitedata/cognite-sdk-python/blob/master/cognite/client/_version.py) and [pyproject.toml](https://github.com/cognitedata/cognite-sdk-python/blob/master/pyproject.toml) per [semantic versioning](https://semver.org/).
