### PR TITLE
Factory method for client config and credentials

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,11 @@ Changes are grouped as follows
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
+## [6.6.1] - 2023-07-07
+### Improved
+- Added convenience function to instantiate a `CogniteClient.default(...)` to save the users from typing the 
+  default URLs.
+
 ## [6.6.0] - 2023-07-06
 ### Fixed
 - Support for query and sync endpoints across instances in the Data Modeling API with the implementation 

--- a/cognite/client/_cognite_client.py
+++ b/cognite/client/_cognite_client.py
@@ -174,7 +174,7 @@ class CogniteClient:
             A CogniteClient instance with default configurations.
         """
 
-        credentials = OAuthClientCredentials.default_azure_project(tenant_id, client_id, client_secret, cdf_cluster)
+        credentials = OAuthClientCredentials.default_for_azure_ad(tenant_id, client_id, client_secret, cdf_cluster)
 
         return cls.default(project, cdf_cluster, credentials, client_name)
 
@@ -208,5 +208,5 @@ class CogniteClient:
         Returns:
             A CogniteClient instance with default configurations.
         """
-        credentials = OAuthInteractive.default_azure_project(tenant_id, client_id, cdf_cluster)
+        credentials = OAuthInteractive.default_for_azure_ad(tenant_id, client_id, cdf_cluster)
         return cls.default(project, cdf_cluster, credentials, client_name)

--- a/cognite/client/_version.py
+++ b/cognite/client/_version.py
@@ -1,4 +1,4 @@
 from __future__ import annotations
 
-__version__ = "6.6.0"
+__version__ = "6.6.1"
 __api_subversion__ = "V20220125"

--- a/cognite/client/config.py
+++ b/cognite/client/config.py
@@ -104,7 +104,7 @@ class ClientConfig:
         return str(self)
 
     @classmethod
-    def create_default(
+    def default(
         cls, project: str, cdf_cluster: str, credentials: CredentialProvider, client_name: str = None
     ) -> ClientConfig:
         """

--- a/cognite/client/config.py
+++ b/cognite/client/config.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import getpass
 import pprint
 from contextlib import suppress
 from typing import Dict, Optional, Set
@@ -101,3 +102,28 @@ class ClientConfig:
 
     def _repr_html_(self) -> str:
         return str(self)
+
+    @classmethod
+    def create_default(
+        cls, project: str, cdf_cluster: str, credentials: CredentialProvider, client_name: str = None
+    ) -> ClientConfig:
+        """
+        Create a default client config object.
+
+        Args:
+            project: CDF Project name.
+            cdf_cluster: The CDF cluster where the CDF project is located.
+            credentials: Credentials. e.g. Token, ClientCredentials.
+            client_name: A user-defined name for the client. Used to identify number of unique applications/scripts
+            running on top of CDF. Defaults to the current user.
+
+        Returns:
+            ClientConfig: A default client config object.
+        """
+
+        return cls(
+            client_name=client_name or getpass.getuser(),
+            project=project,
+            credentials=credentials,
+            base_url=f"https://{cdf_cluster}.cognitedata.com/",
+        )

--- a/cognite/client/config.py
+++ b/cognite/client/config.py
@@ -114,8 +114,9 @@ class ClientConfig:
             project: CDF Project name.
             cdf_cluster: The CDF cluster where the CDF project is located.
             credentials: Credentials. e.g. Token, ClientCredentials.
-            client_name: A user-defined name for the client. Used to identify number of unique applications/scripts
-            running on top of CDF. Defaults to the current user.
+            client_name: A user-defined name for the client. Used to identify the number of unique applications/scripts
+                         running on top of CDF. If this is not set, the getpass.getuser() is used instead, meaning
+                         the username you are logged in with is used.
 
         Returns:
             ClientConfig: A default client config object.

--- a/cognite/client/credentials.py
+++ b/cognite/client/credentials.py
@@ -297,6 +297,36 @@ class OAuthInteractive(_OAuthCredentialProviderWithTokenRefresh, _WithMsalSerial
         self._verify_credentials(credentials)
         return credentials["access_token"], time.time() + credentials["expires_in"]
 
+    @classmethod
+    def default_azure_project(
+        cls,
+        tenant_id: str,
+        client_id: str,
+        cdf_cluster: str,
+        token_expiry_leeway_seconds: int = _TOKEN_EXPIRY_LEEWAY_SECONDS_DEFAULT,
+        **token_custom_args: Any,
+    ) -> OAuthInteractive:
+        """
+        Create an OAuthClientCredentials instance for Azure with default token URL and scopes.
+
+        Args:
+            tenant_id: The Azure tenant id
+            cdf_cluster: The CDF cluster where the CDF project is located.
+            client_id: Your application's client id.
+            token_expiry_leeway_seconds: The token is refreshed at the earliest when this number of seconds is left before expiry. Default: 15 sec
+            **token_custom_args: Optional additional arguments to pass as query parameters to the token fetch request.
+
+        Returns:
+            An OAuthInteractive instance
+        """
+        return cls(
+            authority_url=f"https://login.microsoftonline.com/{tenant_id}",
+            client_id=client_id,
+            scopes=[f"https://{cdf_cluster}.cognitedata.com/.default"],
+            token_expiry_leeway_seconds=token_expiry_leeway_seconds,
+            **token_custom_args,
+        )
+
 
 class OAuthClientCredentials(_OAuthCredentialProviderWithTokenRefresh):
     """OAuth credential provider for the "Client Credentials" flow.

--- a/cognite/client/credentials.py
+++ b/cognite/client/credentials.py
@@ -309,6 +309,11 @@ class OAuthInteractive(_OAuthCredentialProviderWithTokenRefresh, _WithMsalSerial
         """
         Create an OAuthClientCredentials instance for Azure with default token URL and scopes.
 
+        The default configuration creates the URLs based on the tenant id and cluster:
+
+        * Authority URL: "https://login.microsoftonline.com/{tenant_id}"
+        * Scopes: [f"https://{cdf_cluster}.cognitedata.com/.default"]
+
         Args:
             tenant_id: The Azure tenant id
             cdf_cluster: The CDF cluster where the CDF project is located.
@@ -443,6 +448,11 @@ class OAuthClientCredentials(_OAuthCredentialProviderWithTokenRefresh):
     ) -> OAuthClientCredentials:
         """
         Create an OAuthClientCredentials instance for Azure with default token URL and scopes.
+
+        The default configuration creates the URLs based on the tenant id and cluster/oauth2/v2.0/token:
+
+        * Token URL: "https://login.microsoftonline.com/{tenant_id}"
+        * Scopes: [f"https://{cdf_cluster}.cognitedata.com/.default"]
 
         Args:
             tenant_id: The Azure tenant id

--- a/cognite/client/credentials.py
+++ b/cognite/client/credentials.py
@@ -298,7 +298,7 @@ class OAuthInteractive(_OAuthCredentialProviderWithTokenRefresh, _WithMsalSerial
         return credentials["access_token"], time.time() + credentials["expires_in"]
 
     @classmethod
-    def default_azure_project(
+    def default_for_azure_ad(
         cls,
         tenant_id: str,
         client_id: str,
@@ -437,7 +437,7 @@ class OAuthClientCredentials(_OAuthCredentialProviderWithTokenRefresh):
             ) from oauth_err
 
     @classmethod
-    def default_azure_project(
+    def default_for_azure_ad(
         cls,
         tenant_id: str,
         client_id: str,

--- a/cognite/client/credentials.py
+++ b/cognite/client/credentials.py
@@ -401,6 +401,39 @@ class OAuthClientCredentials(_OAuthCredentialProviderWithTokenRefresh):
                 f"Error generating access token: {oauth_err.error}, {oauth_err.status_code}, {oauth_err.description}"
             ) from oauth_err
 
+    @classmethod
+    def default_azure_project(
+        cls,
+        tenant_id: str,
+        client_id: str,
+        client_secret: str,
+        cdf_cluster: str,
+        token_expiry_leeway_seconds: int = _TOKEN_EXPIRY_LEEWAY_SECONDS_DEFAULT,
+        **token_custom_args: Any,
+    ) -> OAuthClientCredentials:
+        """
+        Create an OAuthClientCredentials instance for Azure with default token URL and scopes.
+
+        Args:
+            tenant_id: The Azure tenant id
+            cdf_cluster: The CDF cluster where the CDF project is located.
+            client_id: Your application's client id.
+            client_secret: Your application's client secret.
+            token_expiry_leeway_seconds: The token is refreshed at the earliest when this number of seconds is left before expiry. Default: 15 sec
+            **token_custom_args: Optional additional arguments to pass as query parameters to the token fetch request.
+
+        Returns:
+            An OAuthClientCredentials instance
+        """
+        return cls(
+            token_url=f"https://login.microsoftonline.com/{tenant_id}/oauth2/v2.0/token",
+            client_id=client_id,
+            client_secret=client_secret,
+            scopes=[f"https://{cdf_cluster}.cognitedata.com/.default"],
+            token_expiry_leeway_seconds=token_expiry_leeway_seconds,
+            **token_custom_args,
+        )
+
 
 class OAuthClientCertificate(_OAuthCredentialProviderWithTokenRefresh):
     """OAuth credential provider for authenticating with a client certificate.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "cognite-sdk"
 
-version = "6.6.0"
+version = "6.6.1"
 
 description = "Cognite Python SDK"
 readme = "README.md"


### PR DESCRIPTION
## Description
I see these URLs copied around all over in solutions. Suggest to instead just include them in the SDK. 

## Checklist:
- [ ] Tests added/updated.
- [x] Documentation updated. Documentation is generated from docstrings - these must be updated according to your change.
  If a new method has been added it should be referenced in [cognite.rst](https://github.com/cognitedata/cognite-sdk-python/blob/master/docs/source/cognite.rst) in order to generate docs based on its docstring.
- [x] Changelog updated in [CHANGELOG.md](https://github.com/cognitedata/cognite-sdk-python/blob/master/CHANGELOG.md).
- [x] Version bumped. If triggering a new release is desired, bump the version number in [_version.py](https://github.com/cognitedata/cognite-sdk-python/blob/master/cognite/client/_version.py) and [pyproject.toml](https://github.com/cognitedata/cognite-sdk-python/blob/master/pyproject.toml) per [semantic versioning](https://semver.org/).
