### PR TITLE
instances apply result fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ Changes are grouped as follows
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
+## [6.8.3] - 2023-07-12
+### Fixed
+- `last_updated_time` and `created_time` are no longer optional on InstanceApplyResult
+
 ## [6.8.2] - 2023-07-12
 ### Fixed
 - The `.dump()` method for `InstanceAggregationResult` caused an `AttributeError` when called.

--- a/cognite/client/_version.py
+++ b/cognite/client/_version.py
@@ -1,4 +1,4 @@
 from __future__ import annotations
 
-__version__ = "6.8.2"
+__version__ = "6.8.3"
 __api_subversion__ = "V20220125"

--- a/cognite/client/data_classes/data_modeling/instances.py
+++ b/cognite/client/data_classes/data_modeling/instances.py
@@ -299,8 +299,8 @@ class InstanceApplyResult(InstanceCore):
         external_id: str,
         version: str,
         was_modified: bool,
-        last_updated_time: int = None,
-        created_time: int = None,
+        last_updated_time: int,
+        created_time: int,
         **_: dict,
     ):
         super().__init__(space, external_id, instance_type)
@@ -471,8 +471,8 @@ class NodeApplyResult(InstanceApplyResult):
         external_id: str,
         version: str,
         was_modified: bool,
-        last_updated_time: int = None,
-        created_time: int = None,
+        last_updated_time: int,
+        created_time: int,
         **_: dict,
     ):
         super().__init__(
@@ -660,8 +660,8 @@ class EdgeApplyResult(InstanceApplyResult):
         external_id: str,
         version: str,
         was_modified: bool,
-        last_updated_time: int = None,
-        created_time: int = None,
+        last_updated_time: int,
+        created_time: int,
         **_: dict,
     ):
         super().__init__(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "cognite-sdk"
 
-version = "6.8.2"
+version = "6.8.3"
 
 description = "Cognite Python SDK"
 readme = "README.md"


### PR DESCRIPTION
- Make last_update_time and created_time not optional on InstanceApplyResults
- Bump version and update changelog

## Description
Please describe the change you have made.

## Checklist:
- [ ] Tests added/updated.
- [ ] Documentation updated. Documentation is generated from docstrings - these must be updated according to your change.
  If a new method has been added it should be referenced in [cognite.rst](https://github.com/cognitedata/cognite-sdk-python/blob/master/docs/source/cognite.rst) in order to generate docs based on its docstring.
- [ ] Changelog updated in [CHANGELOG.md](https://github.com/cognitedata/cognite-sdk-python/blob/master/CHANGELOG.md).
- [ ] Version bumped. If triggering a new release is desired, bump the version number in [_version.py](https://github.com/cognitedata/cognite-sdk-python/blob/master/cognite/client/_version.py) and [pyproject.toml](https://github.com/cognitedata/cognite-sdk-python/blob/master/pyproject.toml) per [semantic versioning](https://semver.org/).
