### PR TITLE
docs: Removed outdated docs

### DIFF
--- a/cognite/client/_api/datapoints_subscriptions.py
+++ b/cognite/client/_api/datapoints_subscriptions.py
@@ -192,8 +192,6 @@ class DatapointsSubscriptionAPI(APIClient):
         Data can be ingested datapoints and time ranges where data is deleted. This endpoint will also return changes to
         the subscription itself, that is, if time series are added or removed from the subscription.
 
-        Current implementation is limited to always start from the beginning of the subscription histroy.
-
         Args:
             external_id (str): The external ID of the subscription.
             start (str, optional): When to start the iteration. If set to None, the iteration will start from the beginning.


### PR DESCRIPTION
## Description
Fix outdated docs

## Checklist:
- [ ] Tests added/updated.
- [ ] Documentation updated. Documentation is generated from docstrings - these must be updated according to your change.
  If a new method has been added it should be referenced in [cognite.rst](https://github.com/cognitedata/cognite-sdk-python/blob/master/docs/source/cognite.rst) in order to generate docs based on its docstring.
- [ ] Changelog updated in [CHANGELOG.md](https://github.com/cognitedata/cognite-sdk-python/blob/master/CHANGELOG.md).
- [ ] Version bumped. If triggering a new release is desired, bump the version number in [_version.py](https://github.com/cognitedata/cognite-sdk-python/blob/master/cognite/client/_version.py) and [pyproject.toml](https://github.com/cognitedata/cognite-sdk-python/blob/master/pyproject.toml) per [semantic versioning](https://semver.org/).
