### PR TITLE
Use same graphQl as Fusion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,8 @@ Changes are grouped as follows
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
-## [6.13.0] - 2023-08-02
+## [6.13.0] - 2023-08-03
+### Fixed
 - Changed the graphQl query used when updating DML models in `client.data_modeling.graphql.apply_dml` to ensure identical behaviour.
 
 ## [6.12.0] - 2023-07-26

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ Changes are grouped as follows
 
 ## [6.13.0] - 2023-08-03
 ### Fixed
-- Changed the graphQl query used when updating DML models in `client.data_modeling.graphql.apply_dml` to ensure identical behaviour.
+- Changed the graphQl query used when updating DML models in `client.data_modeling.graphql.apply_dml` to ensure identical behaviour as the Cognite Data Fusion UI.
 
 ## [6.12.0] - 2023-07-26
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ Changes are grouped as follows
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
-## [6.13.0] - 2023-08-03
+## [6.12.1] - 2023-08-03
 ### Fixed
 - Changed the structure of the GraphQL query used when updating DML models through `client.data_modeling.graphql.apply_dml` to properly handle (i.e. escape) all valid symbols/characters.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ Changes are grouped as follows
 
 ## [6.13.0] - 2023-08-03
 ### Fixed
-- Changed the graphQl query used when updating DML models in `client.data_modeling.graphql.apply_dml` to ensure identical behaviour as the Cognite Data Fusion UI.
+- Changed the structure of the GraphQL query used when updating DML models through `client.data_modeling.graphql.apply_dml` to properly handle (i.e. escape) all valid symbols/characters.
 
 ## [6.12.0] - 2023-07-26
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ Changes are grouped as follows
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
+## [6.13.0] - 2023-08-02
+- Changed the graphQl query used when updating DML models in `client.data_modeling.graphql.apply_dml` to ensure identical behaviour.
+
 ## [6.12.0] - 2023-07-26
 ### Added
 - Added option `expand_metadata` to `.to_pandas()` method for list resource types which converts the metadata (if any) into separate columns in the returned dataframe. Also added `metadata_prefix` to control the naming of these columns (default is "metadata.").

--- a/cognite/client/_api/data_modeling/graphql.py
+++ b/cognite/client/_api/data_modeling/graphql.py
@@ -14,9 +14,15 @@ class DataModelingGraphQLAPI(APIClient):
         res = self._post(url_path=url_path, json=json)
         json_res = res.json()
         if (errors := json_res.get("errors")) is not None:
-            raise CogniteGraphQLError([GraphQLErrorSpec.load(error) for error in errors])
-        if (errors := json_res.get("data").get("upsertGraphQlDmlVersion").get("errors")) is not None:
-            raise CogniteGraphQLError([GraphQLErrorSpec.load(error) for error in errors])
+            raise CogniteGraphQLError(
+                [GraphQLErrorSpec.load(error) for error in errors]
+            )
+        if (
+            errors := json_res.get("data").get("upsertGraphQlDmlVersion").get("errors")
+        ) is not None:
+            raise CogniteGraphQLError(
+                [GraphQLErrorSpec.load(error) for error in errors]
+            )
         return json_res["data"]
 
     def apply_dml(
@@ -89,9 +95,9 @@ class DataModelingGraphQLAPI(APIClient):
                     "previousVersion": previous_version,
                     "graphQlDml": dml,
                     "name": name,
-                    "description": description
+                    "description": description,
                 }
-            }
+            },
         }
 
         res = self._post_graphql(url_path="/dml/graphql", json=payload)

--- a/cognite/client/_api/data_modeling/graphql.py
+++ b/cognite/client/_api/data_modeling/graphql.py
@@ -15,7 +15,7 @@ class DataModelingGraphQLAPI(APIClient):
         json_res = res.json()
         if (errors := json_res.get("errors")) is not None:
             raise CogniteGraphQLError([GraphQLErrorSpec.load(error) for error in errors])
-        if (errors := json_res.get("data").get("upsertGraphQlDmlVersion").get("errors")) is not None:
+        if (errors := json_res["data"].get("upsertGraphQlDmlVersion", {}).get("errors")) is not None:
             raise CogniteGraphQLError([GraphQLErrorSpec.load(error) for error in errors])
         return json_res["data"]
 

--- a/cognite/client/_api/data_modeling/graphql.py
+++ b/cognite/client/_api/data_modeling/graphql.py
@@ -80,7 +80,7 @@ class DataModelingGraphQLAPI(APIClient):
             }
         """
         payload = {
-            "query": graphql_body,
+            "query": textwrap.dedent(graphql_body),
             "variables": {
                 "dmCreate": {
                     "space": data_model_id.space,

--- a/cognite/client/_api/data_modeling/graphql.py
+++ b/cognite/client/_api/data_modeling/graphql.py
@@ -8,11 +8,9 @@ from cognite.client.data_classes.data_modeling.graphql import DMLApplyResult
 from cognite.client.data_classes.data_modeling.ids import DataModelId
 from cognite.client.exceptions import CogniteGraphQLError, GraphQLErrorSpec
 
-import json
-
 
 class DataModelingGraphQLAPI(APIClient):
-    def _post_graphql(self, url_path: str, json: str) -> dict[str, Any]:
+    def _post_graphql(self, url_path: str, json: dict) -> dict[str, Any]:
         res = self._post(url_path=url_path, json=json)
         json_res = res.json()
         if (errors := json_res.get("errors")) is not None:

--- a/cognite/client/_api/data_modeling/graphql.py
+++ b/cognite/client/_api/data_modeling/graphql.py
@@ -16,8 +16,6 @@ class DataModelingGraphQLAPI(APIClient):
         json_res = res.json()
         if (errors := json_res.get("errors")) is not None:
             raise CogniteGraphQLError([GraphQLErrorSpec.load(error) for error in errors])
-        if (errors := json_res["data"].get("upsertGraphQlDmlVersion", {}).get("errors")) is not None:
-            raise CogniteGraphQLError([GraphQLErrorSpec.load(error) for error in errors])
         return json_res["data"]
 
     def apply_dml(
@@ -52,7 +50,6 @@ class DataModelingGraphQLAPI(APIClient):
                 ...     dml="type MyType { id: String! }"
                 ... )
         """
-        data_model_id = DataModelId.load(id)
         graphql_body = """
             mutation UpsertGraphQlDmlVersion($dmCreate: GraphQlDmlVersionUpsert!) {
                 upsertGraphQlDmlVersion(graphQlDmlVersion: $dmCreate) {
@@ -80,6 +77,7 @@ class DataModelingGraphQLAPI(APIClient):
                 }
             }
         """
+        data_model_id = DataModelId.load(id)
         payload = {
             "query": textwrap.dedent(graphql_body),
             "variables": {
@@ -94,6 +92,5 @@ class DataModelingGraphQLAPI(APIClient):
                 }
             },
         }
-
         res = self._post_graphql(url_path="/dml/graphql", json=payload)
         return DMLApplyResult.load(res["upsertGraphQlDmlVersion"]["result"])

--- a/cognite/client/_api/data_modeling/graphql.py
+++ b/cognite/client/_api/data_modeling/graphql.py
@@ -14,15 +14,9 @@ class DataModelingGraphQLAPI(APIClient):
         res = self._post(url_path=url_path, json=json)
         json_res = res.json()
         if (errors := json_res.get("errors")) is not None:
-            raise CogniteGraphQLError(
-                [GraphQLErrorSpec.load(error) for error in errors]
-            )
-        if (
-            errors := json_res.get("data").get("upsertGraphQlDmlVersion").get("errors")
-        ) is not None:
-            raise CogniteGraphQLError(
-                [GraphQLErrorSpec.load(error) for error in errors]
-            )
+            raise CogniteGraphQLError([GraphQLErrorSpec.load(error) for error in errors])
+        if (errors := json_res.get("data").get("upsertGraphQlDmlVersion").get("errors")) is not None:
+            raise CogniteGraphQLError([GraphQLErrorSpec.load(error) for error in errors])
         return json_res["data"]
 
     def apply_dml(

--- a/cognite/client/_api/data_modeling/graphql.py
+++ b/cognite/client/_api/data_modeling/graphql.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import textwrap
 from typing import Any, Optional
 
 from cognite.client._api_client import APIClient

--- a/cognite/client/_api/data_modeling/graphql.py
+++ b/cognite/client/_api/data_modeling/graphql.py
@@ -93,7 +93,6 @@ class DataModelingGraphQLAPI(APIClient):
                 }
             }
         }
-        print(payload)
 
         res = self._post_graphql(url_path="/dml/graphql", json=payload)
         return DMLApplyResult.load(res["upsertGraphQlDmlVersion"]["result"])

--- a/cognite/client/_version.py
+++ b/cognite/client/_version.py
@@ -1,4 +1,4 @@
 from __future__ import annotations
 
-__version__ = "6.13.0"
+__version__ = "6.12.1"
 __api_subversion__ = "V20220125"

--- a/cognite/client/_version.py
+++ b/cognite/client/_version.py
@@ -1,4 +1,4 @@
 from __future__ import annotations
 
-__version__ = "6.12.0"
+__version__ = "6.13.0"
 __api_subversion__ = "V20220125"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "cognite-sdk"
 
-version = "6.12.0"
+version = "6.13.0"
 
 description = "Cognite Python SDK"
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "cognite-sdk"
 
-version = "6.13.0"
+version = "6.12.1"
 
 description = "Cognite Python SDK"
 readme = "README.md"

--- a/tests/tests_integration/test_api/test_data_modeling/test_graphql.py
+++ b/tests/tests_integration/test_api/test_data_modeling/test_graphql.py
@@ -24,4 +24,4 @@ class TestDataModelingGraphQLAPI:
         with pytest.raises(CogniteGraphQLError) as exc:
             cognite_client.data_modeling.graphql.apply_dml(data_model.as_id(), "typ SomeType { someProp: String! }")
         assert exc.value.errors[0].message == "Invalid syntax in provided GraphQL schema"
-        assert exc.value.errors[0].locations == [{"column": 17, "line": 3}, {"column": 1, "line": 1}]
+        assert exc.value.errors[0].locations == [{"column": 5, "line": 3}, {"column": 1, "line": 1}]

--- a/tests/tests_integration/test_api/test_data_modeling/test_graphql.py
+++ b/tests/tests_integration/test_api/test_data_modeling/test_graphql.py
@@ -8,17 +8,16 @@ from cognite.client.exceptions import CogniteGraphQLError
 @pytest.fixture(scope="session")
 def data_model(cognite_client: CogniteClient, integration_test_space: Space) -> DataModel:
     data_model = cognite_client.data_modeling.data_models.apply(
-        DataModelApply(integration_test_space.space, "DataModelForDmlTest", "v1")
+        DataModelApply(integration_test_space.space, "DataModelForDmlTest", "1")
     )
     return data_model
 
 
 class TestDataModelingGraphQLAPI:
     def test_apply_dml(self, cognite_client: CogniteClient, data_model: DataModel) -> None:
-        res = cognite_client.data_modeling.graphql.apply_dml(
-            data_model.as_id(), "type SomeType { someProp: String! } type AnotherType { anotherProp: String! }"
-        )
-        assert res.version == "v1"
+        dml = "type SomeType { someProp: String! } type AnotherType { anotherProp: String! }"
+        res = cognite_client.data_modeling.graphql.apply_dml(data_model.as_id(), dml)
+        assert res.version == "1"
 
     def test_apply_dml_invalid(self, cognite_client: CogniteClient, data_model: DataModel) -> None:
         with pytest.raises(CogniteGraphQLError) as exc:


### PR DESCRIPTION
## Description
Use the same grapqhl query as Fusion UI when publishing DML models to make sure the same behaviour.

## Checklist:
- [x] Changelog updated in [CHANGELOG.md](https://github.com/cognitedata/cognite-sdk-python/blob/master/CHANGELOG.md).
- [x] Version bumped. If triggering a new release is desired, bump the version number in [_version.py](https://github.com/cognitedata/cognite-sdk-python/blob/master/cognite/client/_version.py) and [pyproject.toml](https://github.com/cognitedata/cognite-sdk-python/blob/master/pyproject.toml) per [semantic versioning](https://semver.org/).
