### PR TITLE
Fix `Index.load` to ignore unknown fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,11 @@ Changes are grouped as follows
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
+## [6.13.2] - 2023-08-11
+### Fixed
+- Fixed bug in `Index.load` that would raise `TypeError` when trying to loading `indexes`, when an unexpected field was
+  encountered (e.g. during a call to `client.data_modeling.container.list`).
+
 ## [6.13.1] - 2023-08-09
 ### Fixed
 - Fixed bug when calling a `retrieve`, `list`, or `create` in `client.data_modeling.container` raised a `TypeError`.
@@ -26,16 +31,16 @@ Changes are grouped as follows
 ### Fixed
 - Fixed a bug raising a `KeyError` when calling `client.data_modeling.graphql.apply_dml` with an invalid `DataModelingId`.
 - Fixed a bug raising `AttributeError` in `SpaceList.to_space_apply_list`, `DataModelList.to_data_model_apply_list`,
-  `ViewList.to_view_apply`. These methods have also been renamed to `.as_apply` for consistency 
+  `ViewList.to_view_apply`. These methods have also been renamed to `.as_apply` for consistency
   with the other data modeling resources.
 
 ### Removed
 - The method `.as_apply` from `ContainerApplyList` as this method should be on the `ContainerList` instead.
 
 ### Added
-- Missing `as_ids()` for `DataModelApplyList`, `ContainerList`, `ContainerApplyList`, `SpaceApplyList`, `SpaceList`, 
+- Missing `as_ids()` for `DataModelApplyList`, `ContainerList`, `ContainerApplyList`, `SpaceApplyList`, `SpaceList`,
   `ViewApplyList`, `ViewList`.
-- Added helper method `.as_id` to `DMLApplyResult`. 
+- Added helper method `.as_id` to `DMLApplyResult`.
 - Added helper method `.latest_version` to `DataModelList`.
 - Added helper method `.as_apply` to `ContainerList`.
 - Added container classes `NodeApplyList`, `EdgeApplyList`, and `InstancesApply`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ Changes are grouped as follows
 
 ## [6.13.2] - 2023-08-11
 ### Fixed
-- Fixed bug in `Index.load` that would raise `TypeError` when trying to loading `indexes`, when an unexpected field was
+- Fixed bug in `Index.load` that would raise `TypeError` when trying to load `indexes`, when an unexpected field was
   encountered (e.g. during a call to `client.data_modeling.container.list`).
 
 ## [6.13.1] - 2023-08-09

--- a/cognite/client/_version.py
+++ b/cognite/client/_version.py
@@ -1,4 +1,4 @@
 from __future__ import annotations
 
-__version__ = "6.13.1"
+__version__ = "6.13.2"
 __api_subversion__ = "V20220125"

--- a/cognite/client/data_classes/data_modeling/containers.py
+++ b/cognite/client/data_classes/data_modeling/containers.py
@@ -293,10 +293,15 @@ class UniquenessConstraintDefinition(Constraint):
 class Index:
     properties: list[str]
     index_type: Literal["btree"] | str = "btree"
+    cursorable: bool = False
 
     @classmethod
     def load(cls, data: dict[str, Any]) -> Index:
-        return cls(**convert_all_keys_to_snake_case(data))
+        data = convert_all_keys_to_snake_case(data)
+        # We want to avoid repeating the default values here (e.g. cursorable = False):
+        for key in set(data) - set(cls.__dataclass_fields__):
+            del data[key]
+        return cls(**data)
 
     def dump(self, camel_case: bool = False) -> dict[str, str | dict]:
         output = asdict(self)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "cognite-sdk"
 
-version = "6.13.1"
+version = "6.13.2"
 
 description = "Cognite Python SDK"
 readme = "README.md"

--- a/tests/tests_unit/test_data_classes/test_data_models/test_containers.py
+++ b/tests/tests_unit/test_data_classes/test_data_models/test_containers.py
@@ -20,7 +20,21 @@ class TestConstraintIdentifier:
 
 
 class TestIndexIdentifier:
-    @pytest.mark.parametrize("data", [{"properties": ["name", "fullName"], "indexType": "btree"}])
+    @pytest.mark.parametrize("data", [{"properties": ["name", "fullName"], "indexType": "btree", "cursorable": True}])
     def test_load_dump(self, data: dict) -> None:
         actual = Index.load(data).dump(camel_case=True)
+        assert data == actual
+
+    @pytest.mark.parametrize("data", [{"properties": ["name"]}])
+    def test_load_dump__default_values_are_used(self, data: dict) -> None:
+        actual = Index.load(data).dump(camel_case=False)
+        data.update(index_type="btree", cursorable=False)
+        assert data == actual
+
+    @pytest.mark.parametrize(
+        "data", [{"this-key-is-new-sooo-new": 42, "properties": ["name"], "indexType": "best-tree", "cursorable": True}]
+    )
+    def test_load_dump__no_fail_on_unseen_key(self, data: dict) -> None:
+        actual = Index.load(data).dump(camel_case=True)
+        data.pop("this-key-is-new-sooo-new")
         assert data == actual


### PR DESCRIPTION
## Description
- `Index.load` will no longer complain on new, unexpected keys.
- Add `cursorable` to `Index`

## Checklist:
- [x] Tests added/updated.
- [ ] Documentation updated. Documentation is generated from docstrings - these must be updated according to your change.
  If a new method has been added it should be referenced in [cognite.rst](https://github.com/cognitedata/cognite-sdk-python/blob/master/docs/source/cognite.rst) in order to generate docs based on its docstring.
- [x] Changelog updated in [CHANGELOG.md](https://github.com/cognitedata/cognite-sdk-python/blob/master/CHANGELOG.md).
- [x] Version bumped. If triggering a new release is desired, bump the version number in [_version.py](https://github.com/cognitedata/cognite-sdk-python/blob/master/cognite/client/_version.py) and [pyproject.toml](https://github.com/cognitedata/cognite-sdk-python/blob/master/pyproject.toml) per [semantic versioning](https://semver.org/).
