### PR TITLE
Don't terminate iterate_data when has_next=false

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,13 +17,19 @@ Changes are grouped as follows
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
+## [6.14.0] - 2023-08-14
+### Changed
+- Don't terminate client.timeseries.subscriptions.iterate_data() when `has_next=false` as more data
+may be returned in the future. Instead we return the `has_next` field in the batch, and let the user
+decide whether to terminate iteration. This is a breaking change, but this particular API is still
+in beta and thus we reserve the right to break it without bumping the major version.
+
 ## [6.13.3] - 2023-08-14
 ### Fixed
 - Fixed bug in `ViewApply.properties` had type hint `ConnectionDefinition` instead of `ConnectionDefinitionApply`.
 - Fixed bug in `dump` methods of `ViewApply.properties` causing the return code `400` with message
   `Request had 1 constraint violations. Please fix the request and try again. [type must not be null]` to be returned
   from the CDF API.
-
 
 ## [6.13.2] - 2023-08-11
 ### Fixed

--- a/cognite/client/_api/datapoints_subscriptions.py
+++ b/cognite/client/_api/datapoints_subscriptions.py
@@ -15,7 +15,7 @@ from cognite.client.data_classes.datapoints_subscriptions import (
     DatapointSubscriptionList,
     DatapointSubscriptionPartition,
     DataPointSubscriptionUpdate,
-    _DatapointSubscriptionBatch,
+    _DatapointSubscriptionBatchWithPartitions,
 )
 from cognite.client.utils._identifier import IdentifierSequence
 
@@ -243,7 +243,7 @@ class DatapointsSubscriptionAPI(APIClient):
             start = None
 
             res = self._post(url_path=self._RESOURCE_PATH + "/data/list", json=body)
-            batch = _DatapointSubscriptionBatch._load(res.json())
+            batch = _DatapointSubscriptionBatchWithPartitions._load(res.json())
 
             yield DatapointSubscriptionBatch(batch.updates, batch.subscription_changes, batch.has_next)
 

--- a/cognite/client/_api/datapoints_subscriptions.py
+++ b/cognite/client/_api/datapoints_subscriptions.py
@@ -10,12 +10,11 @@ from cognite.client._constants import (
 )
 from cognite.client.data_classes.datapoints_subscriptions import (
     DatapointSubscription,
+    DatapointSubscriptionBatch,
     DataPointSubscriptionCreate,
     DatapointSubscriptionList,
     DatapointSubscriptionPartition,
     DataPointSubscriptionUpdate,
-    DatapointsUpdate,
-    SubscriptionTimeSeriesUpdate,
     _DatapointSubscriptionBatch,
 )
 from cognite.client.utils._identifier import IdentifierSequence
@@ -186,8 +185,8 @@ class DatapointsSubscriptionAPI(APIClient):
         external_id: str,
         start: str | None = None,
         limit: int = DATAPOINT_SUBSCRIPTION_DATA_LIST_LIMIT_DEFAULT,
-    ) -> Iterator[tuple[list[DatapointsUpdate], SubscriptionTimeSeriesUpdate]]:
-        """`Fetch the next batch of data from a given subscription and partition(s). <https://pr-2221.specs.preview.cogniteapp.com/20230101-beta.json.html#tag/Data-point-subscriptions/operation/listSubscriptionData>`_
+    ) -> Iterator[DatapointSubscriptionBatch]:
+        """`Iterate over data from a given subscription. <https://pr-2221.specs.preview.cogniteapp.com/20230101-beta.json.html#tag/Data-point-subscriptions/operation/listSubscriptionData>`_
 
         Data can be ingested datapoints and time ranges where data is deleted. This endpoint will also return changes to
         the subscription itself, that is, if time series are added or removed from the subscription.
@@ -205,7 +204,7 @@ class DatapointsSubscriptionAPI(APIClient):
             limit (int): Approximate number of results to return across all partitions.
 
         Yields:
-           Iterator[tuple[list[DatapointUpdate], Optional[SubscriptionTimeSeriesUpdate]]]: A tuple of list datapoint updates and timeseries updates.
+           Iterator[DatapointSubscriptionBatch]: Changes to the subscription and data in the subscribed time series.
 
         Examples:
 
@@ -213,19 +212,19 @@ class DatapointsSubscriptionAPI(APIClient):
 
             >>> from cognite.client import CogniteClient
             >>> c = CogniteClient()
-            >>> for changed_data, changed_timeseries in c.time_series.subscriptions.iterate_data("my_subscription"):
-            ...     print(f"Added {len(changed_timeseries.added)} timeseries")
-            ...     print(f"Removed {len(changed_timeseries.removed)} timeseries")
-            ...     print(f"Changed data in {len(changed_data)} timeseries")
+            >>> for batch in c.time_series.subscriptions.iterate_data("my_subscription"):
+            ...     print(f"Added {len(batch.subscription_changes.added)} timeseries")
+            ...     print(f"Removed {len(batch.subscription_changes.removed)} timeseries")
+            ...     print(f"Changed data in {len(batch.updates)} timeseries")
 
         Iterate over all changes in the subscripted timeseries the last 3 days:
 
             >>> from cognite.client import CogniteClient
             >>> c = CogniteClient()
-            >>> for changed_data, changed_timeseries in c.time_series.subscriptions.iterate_data("my_subscription", "3d-ago"):
-            ...     print(f"Added {len(changed_timeseries.added)} timeseries")
-            ...     print(f"Removed {len(changed_timeseries.removed)} timeseries")
-            ...     print(f"Changed data in {len(changed_data)} timeseries")
+            >>> for batch in c.time_series.subscriptions.iterate_data("my_subscription", "3d-ago"):
+            ...     print(f"Added {len(batch.subscription_changes.added)} timeseries")
+            ...     print(f"Removed {len(batch.subscription_changes.removed)} timeseries")
+            ...     print(f"Changed data in {len(batch.updates)} timeseries")
 
         """
         self._experimental_warning()
@@ -246,9 +245,8 @@ class DatapointsSubscriptionAPI(APIClient):
             res = self._post(url_path=self._RESOURCE_PATH + "/data/list", json=body)
             batch = _DatapointSubscriptionBatch._load(res.json())
 
-            yield batch.updates, batch.subscription_changes
-            if not batch.has_next:
-                return
+            yield DatapointSubscriptionBatch(batch.updates, batch.subscription_changes, batch.has_next)
+
             current_partitions = batch.partitions
 
     def list(self, limit: int = DATAPOINT_SUBSCRIPTIONS_LIST_LIMIT_DEFAULT) -> DatapointSubscriptionList:

--- a/cognite/client/_version.py
+++ b/cognite/client/_version.py
@@ -1,4 +1,4 @@
 from __future__ import annotations
 
-__version__ = "6.13.3"
+__version__ = "6.14.0"
 __api_subversion__ = "V20220125"

--- a/cognite/client/data_classes/datapoints_subscriptions.py
+++ b/cognite/client/data_classes/datapoints_subscriptions.py
@@ -369,6 +369,13 @@ class _DatapointSubscriptionBatch:
         return resource
 
 
+@dataclass
+class DatapointSubscriptionBatch:
+    updates: list[DatapointsUpdate]
+    subscription_changes: SubscriptionTimeSeriesUpdate
+    has_next: bool
+
+
 class DatapointSubscriptionList(CogniteResourceList[DatapointSubscription]):
     _RESOURCE = DatapointSubscription
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "cognite-sdk"
 
-version = "6.13.3"
+version = "6.14.0"
 
 description = "Cognite Python SDK"
 readme = "README.md"

--- a/tests/tests_integration/test_api/test_datapoint_subscriptions.py
+++ b/tests/tests_integration/test_api/test_datapoint_subscriptions.py
@@ -172,20 +172,18 @@ class TestDatapointSubscriptions:
 
         try:
             cognite_client.time_series.subscriptions.create(new_subscription)
-            subscription = iter(cognite_client.time_series.subscriptions.iterate_data(new_subscription.external_id))
+            subscription = cognite_client.time_series.subscriptions.iterate_data(new_subscription.external_id)
 
-            # Act
-            _, time_series = next(subscription)
+            batch = next(subscription)
 
-            # Assert
             assert (
-                len(time_series.added) > 0
+                len(batch.subscription_changes.added) > 0
             ), "The subscription used for testing datapoint subscriptions must have at least one time series"
 
-            # Act
-            for next_data, next_timeseries in subscription:
-                # Assert
-                assert len(next_timeseries.added) == 0, "There should be no more timeseries in the subsequent batches"
+            batch = next(subscription)
+            assert (
+                len(batch.subscription_changes.added) == 0
+            ), "There should be no more timeseries in the subsequent batches"
         finally:
             cognite_client.time_series.subscriptions.delete(new_subscription.external_id, ignore_unknown_ids=True)
 
@@ -204,12 +202,12 @@ class TestDatapointSubscriptions:
             created = cognite_client.time_series.subscriptions.create(new_subscription)
 
             # Act
-            subscription = iter(cognite_client.time_series.subscriptions.iterate_data(new_subscription.external_id))
-            data, timeseries = next(subscription)
+            subscription = cognite_client.time_series.subscriptions.iterate_data(new_subscription.external_id)
+            batch = next(subscription)
 
             # Assert
-            assert timeseries.added[0].external_id == time_series_external_ids[0]
-            assert len(data) == 0
+            assert batch.subscription_changes.added[0].external_id == time_series_external_ids[0]
+            assert len(batch.updates) == 0
 
             # Arrange
             update = (
@@ -220,15 +218,15 @@ class TestDatapointSubscriptions:
 
             # Act
             cognite_client.time_series.subscriptions.update(update)
-            data, timeseries = next(cognite_client.time_series.subscriptions.iterate_data(new_subscription.external_id))
+            batch = next(cognite_client.time_series.subscriptions.iterate_data(new_subscription.external_id))
 
             # Assert
-            assert {a.external_id for a in timeseries.added} == {
+            assert {a.external_id for a in batch.subscription_changes.added} == {
                 time_series_external_ids[1],
                 time_series_external_ids[0],
             }
-            assert {a.external_id for a in timeseries.removed} == {time_series_external_ids[0]}
-            assert len(data) == 0
+            assert {a.external_id for a in batch.subscription_changes.removed} == {time_series_external_ids[0]}
+            assert len(batch.updates) == 0
         finally:
             if created:
                 cognite_client.time_series.subscriptions.delete(new_subscription.external_id, ignore_unknown_ids=True)
@@ -250,10 +248,10 @@ class TestDatapointSubscriptions:
             assert created.created_time
 
             # Act
-            _, timeseries = next(cognite_client.time_series.subscriptions.iterate_data(new_subscription.external_id))
+            batch = next(cognite_client.time_series.subscriptions.iterate_data(new_subscription.external_id))
 
             # Assert
-            assert timeseries.added[0].external_id == time_series_external_ids[0]
+            assert batch.subscription_changes.added[0].external_id == time_series_external_ids[0]
 
             # Arrange
             existing_data = cognite_client.time_series.data.retrieve_dataframe(external_id=time_series_external_ids[0])
@@ -265,22 +263,20 @@ class TestDatapointSubscriptions:
 
             # Act
             cognite_client.time_series.data.insert_dataframe(new_data)
-            retrieved_data, timeseries = next(
-                cognite_client.time_series.subscriptions.iterate_data(new_subscription.external_id)
-            )
+            batch = next(cognite_client.time_series.subscriptions.iterate_data(new_subscription.external_id))
 
             # Assert
-            assert timeseries
+            assert batch.updates
             assert (
                 sum(
                     abs(actual.value - expected)
-                    for actual, expected in zip(retrieved_data[0].upserts, new_data[time_series_external_ids[0]].values)
+                    for actual, expected in zip(batch.updates[0].upserts, new_data[time_series_external_ids[0]].values)
                 )
                 < 1e-6
             ), "The values of the retrieved data should be the same as the inserted data"
             assert all(
                 (actual.timestamp == expected)
-                for actual, expected in zip(retrieved_data[0].upserts, new_data.index.astype("int64") // 10**6)
+                for actual, expected in zip(batch.updates[0].upserts, new_data.index.astype("int64") // 10**6)
             ), "The timestamps of the retrieved data should be the same as the inserted data"
         finally:
             if created:
@@ -307,13 +303,15 @@ class TestDatapointSubscriptions:
             assert created.created_time
 
             # Act
-            for changed_data, timeseries in cognite_client.time_series.subscriptions.iterate_data(
+            for batch in cognite_client.time_series.subscriptions.iterate_data(
                 new_subscription.external_id, start="now"
             ):
                 # Assert
-                assert len(changed_data) == 0
-                assert len(timeseries.added) == 0
-                assert len(timeseries.removed) == 0
+                assert len(batch.updates) == 0
+                assert len(batch.subscription_changes.added) == 0
+                assert len(batch.subscription_changes.removed) == 0
+                if not batch.has_next:
+                    break
 
         finally:
             if created:
@@ -322,20 +320,11 @@ class TestDatapointSubscriptions:
     def test_iterate_data_subscription_start_1m_ago(
         self, cognite_client: CogniteClient, subscription: DatapointSubscription
     ):
-        # Arrange
-        added_count = 0
-        for changed_data, timeseries in cognite_client.time_series.subscriptions.iterate_data(subscription.external_id):
-            added_count += len(timeseries.added)
-        assert added_count >= 0
-
-        # Act
         added_last_minute = 0
-        for changed_data, timeseries in cognite_client.time_series.subscriptions.iterate_data(
-            subscription.external_id, start="1m-ago"
-        ):
-            added_last_minute += len(timeseries.added)
-
-        # Assert
+        for batch in cognite_client.time_series.subscriptions.iterate_data(subscription.external_id, start="1m-ago"):
+            added_last_minute += len(batch.subscription_changes.added)
+            if not batch.has_next:
+                break
         assert added_last_minute == 0, "There should be no timeseries added in the last minute"
 
     @pytest.mark.skip(reason="This test is flaky")
@@ -364,8 +353,10 @@ class TestDatapointSubscriptions:
 
             # Act
             initial_added_count = 0
-            for _, timeseries in cognite_client.time_series.subscriptions.iterate_data(new_subscription.external_id):
-                initial_added_count += len(timeseries.added)
+            for batch in cognite_client.time_series.subscriptions.iterate_data(new_subscription.external_id):
+                initial_added_count += len(batch.subscription_changes.added)
+                if not batch.has_next:
+                    break
 
             # Assert
             assert initial_added_count > 0, "There should be at least one numerical timeseries added"
@@ -385,8 +376,10 @@ class TestDatapointSubscriptions:
 
             # Act
             updated_added_count = 0
-            for _, timeseries in cognite_client.time_series.subscriptions.iterate_data(new_subscription.external_id):
-                updated_added_count += len(timeseries.added)
+            for batch in cognite_client.time_series.subscriptions.iterate_data(new_subscription.external_id):
+                updated_added_count += len(batch.subscription_changes.added)
+                if not batch.has_next:
+                    break
 
             # Assert
             assert (


### PR DESCRIPTION
## Description
Please describe the change you have made.

## Checklist:
- [ ] Tests added/updated.
- [ ] Documentation updated. Documentation is generated from docstrings - these must be updated according to your change.
  If a new method has been added it should be referenced in [cognite.rst](https://github.com/cognitedata/cognite-sdk-python/blob/master/docs/source/cognite.rst) in order to generate docs based on its docstring.
- [ ] Changelog updated in [CHANGELOG.md](https://github.com/cognitedata/cognite-sdk-python/blob/master/CHANGELOG.md).
- [ ] Version bumped. If triggering a new release is desired, bump the version number in [_version.py](https://github.com/cognitedata/cognite-sdk-python/blob/master/cognite/client/_version.py) and [pyproject.toml](https://github.com/cognitedata/cognite-sdk-python/blob/master/pyproject.toml) per [semantic versioning](https://semver.org/).
