### PR TITLE
Add meta-test to ensure all `.py` files follow PEP 563

### DIFF
--- a/cognite/client/_api/__init__.py
+++ b/cognite/client/_api/__init__.py
@@ -1,0 +1,1 @@
+from __future__ import annotations

--- a/cognite/client/_api/data_modeling/_data_modeling_executor.py
+++ b/cognite/client/_api/data_modeling/_data_modeling_executor.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from concurrent.futures import ThreadPoolExecutor
 
 from cognite.client.utils._concurrency import ConcurrencySettings, MainThreadExecutor, TaskExecutor

--- a/cognite/client/data_classes/__init__.py
+++ b/cognite/client/data_classes/__init__.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from cognite.client.data_classes.annotations import (
     Annotation,
     AnnotationFilter,

--- a/cognite/client/data_classes/annotation_types/__init__.py
+++ b/cognite/client/data_classes/annotation_types/__init__.py
@@ -1,0 +1,1 @@
+from __future__ import annotations

--- a/cognite/client/data_classes/data_modeling/__init__.py
+++ b/cognite/client/data_classes/data_modeling/__init__.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from cognite.client.data_classes import filters
 from cognite.client.data_classes.data_modeling import aggregations, query
 from cognite.client.data_classes.data_modeling.aggregations import AggregatedValue, Aggregation

--- a/cognite/client/utils/_auxiliary.py
+++ b/cognite/client/utils/_auxiliary.py
@@ -1,9 +1,3 @@
-"""Utilities for Cognite API SDK
-
-This module provides helper methods and different utilities for the Cognite API Python SDK.
-
-This module is protected and should not be used by end-users.
-"""
 from __future__ import annotations
 
 import functools

--- a/cognite/client/utils/_graph.py
+++ b/cognite/client/utils/_graph.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Dict, List, Set, Tuple
 
 

--- a/tests/tests_unit/test_meta.py
+++ b/tests/tests_unit/test_meta.py
@@ -9,3 +9,20 @@ def test_assert_no_root_init_file():
     # or uses a pkgutil-style __init__.py. If any distribution does not, it will cause the namespace logic to
     # fail and the other sub-packages will not be importable"
     assert not Path("cognite/__init__.py").exists()
+
+
+def test_ensure_all_files_use_future_annots():
+    def keep(path):
+        skip_list = [
+            "_pb2.py",  # Auto-generated, dislikes changes ;)
+            "cognite/client/utils/_priority_tpe.py",  # Module docstring at the top takes priority
+        ]
+        return all(skip not in str(path) for skip in skip_list)
+
+    all_filepaths = [Path(p) for p in Path("cognite/client/").glob("**/*.py") if keep(p)]
+    err_msg = "File: '{}' is missing 'from __future__ import annotations' at line=0"
+
+    for filepath in all_filepaths:
+        with filepath.open("r") as file:
+            # We just read the first line from each file:
+            assert file.readline() == "from __future__ import annotations\n", err_msg.format(filepath)

--- a/tests/tests_unit/test_meta.py
+++ b/tests/tests_unit/test_meta.py
@@ -17,9 +17,9 @@ def test_ensure_all_files_use_future_annots():
             "_pb2.py",  # Auto-generated, dislikes changes ;)
             "cognite/client/utils/_priority_tpe.py",  # Module docstring at the top takes priority
         ]
-        return all(skip not in str(path) for skip in skip_list)
+        return all(skip not in str(path.as_posix()) for skip in skip_list)
 
-    all_filepaths = [Path(p) for p in Path("cognite/client/").glob("**/*.py") if keep(p)]
+    all_filepaths = filter(keep, Path("cognite/client/").glob("**/*.py"))
     err_msg = "File: '{}' is missing 'from __future__ import annotations' at line=0"
 
     for filepath in all_filepaths:


### PR DESCRIPTION
## Description
Add meta-test to ensure all `.py` files follow PEP 563 – **_Postponed Evaluation of Annotations_**

- Also removed a "dated" module docstring in `cognite/client/utils/_auxiliary.py`

Needed for #1314 🤓 

## Checklist:
- [x] Tests added/updated.
- [ ] Documentation updated. Documentation is generated from docstrings - these must be updated according to your change.
  If a new method has been added it should be referenced in [cognite.rst](https://github.com/cognitedata/cognite-sdk-python/blob/master/docs/source/cognite.rst) in order to generate docs based on its docstring.
- [ ] Changelog updated in [CHANGELOG.md](https://github.com/cognitedata/cognite-sdk-python/blob/master/CHANGELOG.md).
- [ ] Version bumped. If triggering a new release is desired, bump the version number in [_version.py](https://github.com/cognitedata/cognite-sdk-python/blob/master/cognite/client/_version.py) and [pyproject.toml](https://github.com/cognitedata/cognite-sdk-python/blob/master/pyproject.toml) per [semantic versioning](https://semver.org/).
