### PR TITLE
Bugfix: Handle tuples in `sources` arg in `InstancesAPI.retrieve`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ Changes are grouped as follows
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
+## [6.14.1] - 2023-08-19
+### Fixed
+- Passing `sources` as a tuple no longer raises `ValueError` in `InstancesAPI.retrieve`.
+
 ## [6.14.0] - 2023-08-14
 ### Changed
 - Don't terminate client.timeseries.subscriptions.iterate_data() when `has_next=false` as more data

--- a/cognite/client/_api/data_modeling/instances.py
+++ b/cognite/client/_api/data_modeling/instances.py
@@ -68,8 +68,8 @@ class _NodeOrEdgeList(CogniteResourceList):
 
 
 class _NodeOrEdgeResourceAdapter:
-    @classmethod
-    def _load(cls, data: str | dict, cognite_client: Optional[CogniteClient] = None) -> Node | Edge:
+    @staticmethod
+    def _load(data: str | dict, cognite_client: Optional[CogniteClient] = None) -> Node | Edge:
         data = json.loads(data) if isinstance(data, str) else data
         if data["instanceType"] == "node":
             return Node.load(data)
@@ -95,10 +95,8 @@ class _NodeOrEdgeApplyResultList(CogniteResourceList):
 
 
 class _NodeOrEdgeApplyResultAdapter:
-    @classmethod
-    def _load(
-        cls, data: str | dict, cognite_client: Optional[CogniteClient] = None
-    ) -> NodeApplyResult | EdgeApplyResult:
+    @staticmethod
+    def _load(data: str | dict, cognite_client: Optional[CogniteClient] = None) -> NodeApplyResult | EdgeApplyResult:
         data = json.loads(data) if isinstance(data, str) else data
         if data["instanceType"] == "node":
             return NodeApplyResult.load(data)
@@ -106,8 +104,8 @@ class _NodeOrEdgeApplyResultAdapter:
 
 
 class _NodeOrEdgeApplyAdapter:
-    @classmethod
-    def _load(cls, data: str | dict, cognite_client: Optional[CogniteClient] = None) -> NodeApply | EdgeApply:
+    @staticmethod
+    def _load(data: str | dict, cognite_client: Optional[CogniteClient] = None) -> NodeApply | EdgeApply:
         data = json.loads(data) if isinstance(data, str) else data
         if data["instanceType"] == "node":
             return NodeApply.load(data)
@@ -395,16 +393,14 @@ class InstancesAPI(APIClient):
             other_params["instanceType"] = instance_type
         return other_params
 
-    @classmethod
-    def _dump_instance_source(
-        cls, sources: ViewIdentifier | Sequence[ViewIdentifier] | View | Sequence[View]
-    ) -> list[dict]:
+    @staticmethod
+    def _dump_instance_source(sources: ViewIdentifier | Sequence[ViewIdentifier] | View | Sequence[View]) -> list[dict]:
         return [
             {"source": ViewId.load(dct).dump(camel_case=True)} for dct in _load_identifier(sources, "view").as_dicts()
         ]
 
-    @classmethod
-    def _dump_instance_sort(cls, sort: InstanceSort | dict) -> dict:
+    @staticmethod
+    def _dump_instance_sort(sort: InstanceSort | dict) -> dict:
         return sort.dump(camel_case=True) if isinstance(sort, InstanceSort) else sort
 
     def apply(

--- a/cognite/client/_api/data_modeling/instances.py
+++ b/cognite/client/_api/data_modeling/instances.py
@@ -385,11 +385,7 @@ class InstancesAPI(APIClient):
     ) -> dict[str, Any]:
         other_params: dict[str, Any] = {"includeTyping": include_typing}
         if sources:
-            other_params["sources"] = (
-                [cls._dump_instance_source(source) for source in sources]
-                if isinstance(sources, Sequence)
-                else [cls._dump_instance_source(sources)]
-            )
+            other_params["sources"] = cls._dump_instance_source(sources)
         if sort:
             if isinstance(sort, (InstanceSort, dict)):
                 other_params["sort"] = [cls._dump_instance_sort(sort)]
@@ -400,13 +396,12 @@ class InstancesAPI(APIClient):
         return other_params
 
     @classmethod
-    def _dump_instance_source(cls, source: ViewIdentifier | View) -> dict:
-        instance_source: ViewIdentifier
-        if isinstance(source, View):
-            instance_source = source.as_id()
-        else:
-            instance_source = source
-        return {"source": ViewId.load(instance_source).dump(camel_case=True)}
+    def _dump_instance_source(
+        cls, sources: ViewIdentifier | Sequence[ViewIdentifier] | View | Sequence[View]
+    ) -> list[dict]:
+        return [
+            {"source": ViewId.load(dct).dump(camel_case=True)} for dct in _load_identifier(sources, "view").as_dicts()
+        ]
 
     @classmethod
     def _dump_instance_sort(cls, sort: InstanceSort | dict) -> dict:

--- a/cognite/client/_version.py
+++ b/cognite/client/_version.py
@@ -1,4 +1,4 @@
 from __future__ import annotations
 
-__version__ = "6.14.0"
+__version__ = "6.14.1"
 __api_subversion__ = "V20220125"

--- a/cognite/client/data_classes/data_modeling/ids.py
+++ b/cognite/client/data_classes/data_modeling/ids.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from abc import ABC
 from dataclasses import asdict, dataclass, field
-from typing import Any, ClassVar, Literal, Optional, Sequence, Tuple, Type, TypeVar, Union, cast
+from typing import Any, ClassVar, Literal, Optional, Protocol, Sequence, Tuple, Type, TypeVar, Union, cast
 
 from cognite.client.utils._auxiliary import rename_and_exclude_keys
 from cognite.client.utils._identifier import DataModelingIdentifier, DataModelingIdentifierSequence
@@ -142,13 +142,28 @@ class DataModelId(VersionedDataModelingId):
     _type = "datamodel"
 
 
+class IdLike(Protocol):
+    space: str
+    external_id: str
+    version: str
+
+
 ContainerIdentifier = Union[ContainerId, Tuple[str, str]]
 ViewIdentifier = Union[ViewId, Tuple[str, str], Tuple[str, str, str]]
 DataModelIdentifier = Union[DataModelId, Tuple[str, str], Tuple[str, str, str]]
 NodeIdentifier = Union[NodeId, Tuple[str, str, str]]
 EdgeIdentifier = Union[EdgeId, Tuple[str, str, str]]
 
-Id = Union[Tuple[str, str], Tuple[str, str, str], DataModelingId, VersionedDataModelingId, NodeId, EdgeId, InstanceId]
+Id = Union[
+    Tuple[str, str],
+    Tuple[str, str, str],
+    DataModelingId,
+    VersionedDataModelingId,
+    NodeId,
+    EdgeId,
+    InstanceId,
+    IdLike,
+]
 
 
 def _load_space_identifier(ids: str | Sequence[str]) -> DataModelingIdentifierSequence:

--- a/cognite/client/data_classes/data_modeling/ids.py
+++ b/cognite/client/data_classes/data_modeling/ids.py
@@ -2,11 +2,14 @@ from __future__ import annotations
 
 from abc import ABC
 from dataclasses import asdict, dataclass, field
-from typing import Any, ClassVar, Literal, Optional, Sequence, Tuple, Type, TypeVar, Union, cast
+from typing import TYPE_CHECKING, Any, ClassVar, Literal, Optional, Sequence, Tuple, Type, TypeVar, Union, cast
 
 from cognite.client.utils._auxiliary import rename_and_exclude_keys
 from cognite.client.utils._identifier import DataModelingIdentifier, DataModelingIdentifierSequence
 from cognite.client.utils._text import convert_all_keys_recursive, convert_all_keys_to_snake_case
+
+if TYPE_CHECKING:
+    from cognite.client.data_classes.data_modeling.views import View
 
 
 @dataclass(frozen=True)
@@ -148,7 +151,17 @@ DataModelIdentifier = Union[DataModelId, Tuple[str, str], Tuple[str, str, str]]
 NodeIdentifier = Union[NodeId, Tuple[str, str, str]]
 EdgeIdentifier = Union[EdgeId, Tuple[str, str, str]]
 
-Id = Union[Tuple[str, str], Tuple[str, str, str], DataModelingId, VersionedDataModelingId, NodeId, EdgeId, InstanceId]
+Id = Union[
+    Tuple[str, str],
+    Tuple[str, str, str],
+    DataModelingId,
+    VersionedDataModelingId,
+    "View",
+    ViewId,
+    NodeId,
+    EdgeId,
+    InstanceId,
+]
 
 
 def _load_space_identifier(ids: str | Sequence[str]) -> DataModelingIdentifierSequence:

--- a/cognite/client/data_classes/data_modeling/ids.py
+++ b/cognite/client/data_classes/data_modeling/ids.py
@@ -2,14 +2,11 @@ from __future__ import annotations
 
 from abc import ABC
 from dataclasses import asdict, dataclass, field
-from typing import TYPE_CHECKING, Any, ClassVar, Literal, Optional, Sequence, Tuple, Type, TypeVar, Union, cast
+from typing import Any, ClassVar, Literal, Optional, Sequence, Tuple, Type, TypeVar, Union, cast
 
 from cognite.client.utils._auxiliary import rename_and_exclude_keys
 from cognite.client.utils._identifier import DataModelingIdentifier, DataModelingIdentifierSequence
 from cognite.client.utils._text import convert_all_keys_recursive, convert_all_keys_to_snake_case
-
-if TYPE_CHECKING:
-    from cognite.client.data_classes.data_modeling.views import View
 
 
 @dataclass(frozen=True)
@@ -151,17 +148,7 @@ DataModelIdentifier = Union[DataModelId, Tuple[str, str], Tuple[str, str, str]]
 NodeIdentifier = Union[NodeId, Tuple[str, str, str]]
 EdgeIdentifier = Union[EdgeId, Tuple[str, str, str]]
 
-Id = Union[
-    Tuple[str, str],
-    Tuple[str, str, str],
-    DataModelingId,
-    VersionedDataModelingId,
-    "View",
-    ViewId,
-    NodeId,
-    EdgeId,
-    InstanceId,
-]
+Id = Union[Tuple[str, str], Tuple[str, str, str], DataModelingId, VersionedDataModelingId, NodeId, EdgeId, InstanceId]
 
 
 def _load_space_identifier(ids: str | Sequence[str]) -> DataModelingIdentifierSequence:

--- a/cognite/client/data_classes/data_modeling/ids.py
+++ b/cognite/client/data_classes/data_modeling/ids.py
@@ -143,9 +143,19 @@ class DataModelId(VersionedDataModelingId):
 
 
 class IdLike(Protocol):
-    space: str
-    external_id: str
-    version: str
+    @property
+    def space(self) -> str:
+        ...
+
+    @property
+    def external_id(self) -> str:
+        ...
+
+
+class VersionedIdLike(IdLike):
+    @property
+    def version(self) -> Optional[str]:
+        ...
 
 
 ContainerIdentifier = Union[ContainerId, Tuple[str, str]]
@@ -154,16 +164,7 @@ DataModelIdentifier = Union[DataModelId, Tuple[str, str], Tuple[str, str, str]]
 NodeIdentifier = Union[NodeId, Tuple[str, str, str]]
 EdgeIdentifier = Union[EdgeId, Tuple[str, str, str]]
 
-Id = Union[
-    Tuple[str, str],
-    Tuple[str, str, str],
-    DataModelingId,
-    VersionedDataModelingId,
-    NodeId,
-    EdgeId,
-    InstanceId,
-    IdLike,
-]
+Id = Union[Tuple[str, str], Tuple[str, str, str], IdLike, VersionedIdLike]
 
 
 def _load_space_identifier(ids: str | Sequence[str]) -> DataModelingIdentifierSequence:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "cognite-sdk"
 
-version = "6.14.0"
+version = "6.14.1"
 
 description = "Cognite Python SDK"
 readme = "README.md"

--- a/tests/tests_unit/test_api/test_data_modeling/test_instances.py
+++ b/tests/tests_unit/test_api/test_data_modeling/test_instances.py
@@ -1,0 +1,35 @@
+import pytest
+
+from cognite.client._api.data_modeling.instances import InstancesAPI
+from cognite.client.data_classes.data_modeling import View
+from cognite.client.data_classes.data_modeling.ids import ViewId
+
+SINGLE_SRC_DUMP = {"source": {"space": "a", "externalId": "b", "version": "c", "type": "view"}}
+SINGLE_SRC_DUMP_NO_VERSION = {"source": {"space": "a", "externalId": "b", "version": None, "type": "view"}}
+
+
+@pytest.mark.parametrize(
+    "sources, expected",
+    (
+        # Single
+        (("a", "b", "c"), [SINGLE_SRC_DUMP]),
+        (("a", "b"), [SINGLE_SRC_DUMP_NO_VERSION]),
+        (ViewId("a", "b", "c"), [SINGLE_SRC_DUMP]),
+        (ViewId("a", "b"), [SINGLE_SRC_DUMP_NO_VERSION]),
+        (View("a", "b", "c", created_time=1, properties={}, last_updated_time=2), [SINGLE_SRC_DUMP]),
+        # Multiple
+        ((("a", "b", "c"), ("a", "b", "c")), [SINGLE_SRC_DUMP, SINGLE_SRC_DUMP]),
+        ([("a", "b", "c"), ("a", "b")], [SINGLE_SRC_DUMP, SINGLE_SRC_DUMP_NO_VERSION]),
+        ((ViewId("a", "b"), ("a", "b", "c")), [SINGLE_SRC_DUMP_NO_VERSION, SINGLE_SRC_DUMP]),
+        ([ViewId("a", "b"), ViewId("a", "b", "c")], [SINGLE_SRC_DUMP_NO_VERSION, SINGLE_SRC_DUMP]),
+        (
+            [View("a", "b", None, created_time=1, properties={}, last_updated_time=2), ViewId("a", "b", "c")],
+            [SINGLE_SRC_DUMP_NO_VERSION, SINGLE_SRC_DUMP],
+        ),
+    ),
+)
+def test_instances_api_dump_instance_source(sources, expected):
+    # We need to support:
+    # ViewIdentifier = Union[ViewId, Tuple[str, str], Tuple[str, str, str]]
+    # ViewIdentifier | Sequence[ViewIdentifier] | View | Sequence[View]
+    assert expected == InstancesAPI._dump_instance_source(sources)


### PR DESCRIPTION
## Description
Passing the `sources` input as a `tuple` led to a `ValueError` being raised as it passed the `isinstance` check for `Sequence`.
```py
ValueError: Cannot load foo into <class 'cognite.client.data_classes.data_modeling.ids.ViewId'>, invalid type=<class 'str'>
```

## Checklist:
- [x] Tests added/updated.
- [ ] Documentation updated. Documentation is generated from docstrings - these must be updated according to your change.
  If a new method has been added it should be referenced in [cognite.rst](https://github.com/cognitedata/cognite-sdk-python/blob/master/docs/source/cognite.rst) in order to generate docs based on its docstring.
- [x] Changelog updated in [CHANGELOG.md](https://github.com/cognitedata/cognite-sdk-python/blob/master/CHANGELOG.md).
- [x] Version bumped. If triggering a new release is desired, bump the version number in [_version.py](https://github.com/cognitedata/cognite-sdk-python/blob/master/cognite/client/_version.py) and [pyproject.toml](https://github.com/cognitedata/cognite-sdk-python/blob/master/pyproject.toml) per [semantic versioning](https://semver.org/).
