### PR TITLE
Make dps test data always deterministic in xdist spawned workers

### DIFF
--- a/tests/utils.py
+++ b/tests/utils.py
@@ -41,7 +41,7 @@ def all_mock_children(mock, parent_name=()):
 
 
 @contextmanager
-def rng_context(seed: int):
+def rng_context(seed: int | str):
     """Temporarily override internal random state for deterministic behaviour without side-effects
 
     Idea stolen from pandas source `class RNGContext`.


### PR DESCRIPTION
## Description
A lot of the test data for DatapointsAPI are based on randomness, but when parallelizing workers with `pytest-xdist` we need to use a seed that makes this generation exactly equal across the 8(?) or so workers. Previously this was done by rounding `time.time()`, but ofc, that breaks every so often... https://github.com/cognitedata/cognite-sdk-python/actions/runs/5918418047/job/16047728671?pr=1322

This however, is a thing of the past as we change to using a unique identifier for each test run, provided by `pytest` itself.

## Checklist:
- [x] Tests added/updated.
