### PR TITLE
Make `DatapointSubscriptionFilterProperties` properties immutable

### DIFF
--- a/cognite/client/data_classes/_base.py
+++ b/cognite/client/data_classes/_base.py
@@ -538,6 +538,11 @@ T_CogniteFilter = TypeVar("T_CogniteFilter", bound=CogniteFilter)
 
 
 class EnumProperty(Enum):
+    @staticmethod
+    def _generate_next_value_(name: str, *_: Any) -> str:
+        # Allows the use of enum.auto() for member values avoiding camelCase typos
+        return to_camel_case(name)
+
     def as_reference(self) -> list[str]:
         return [self.value]
 
@@ -668,9 +673,7 @@ class Sort:
                 nulls=data[2],  # type: ignore[misc]
             )
         elif isinstance(data, (str, list, EnumProperty)):
-            return cls(
-                property=data,
-            )
+            return cls(property=data)
         else:
             raise ValueError(f"Unable to load {cls.__name__} from {data}")
 
@@ -685,10 +688,7 @@ class Sort:
         else:
             raise ValueError(f"Unable to dump {type(self).__name__} with property {prop}")
 
-        output: dict[str, str | list[str]] = {
-            "property": prop,
-            "order": self.order,
-        }
+        output: dict[str, str | list[str]] = {"property": prop, "order": self.order}
         if self.nulls is not None:
             output["nulls"] = self.nulls
         return output

--- a/cognite/client/data_classes/datapoints_subscriptions.py
+++ b/cognite/client/data_classes/datapoints_subscriptions.py
@@ -2,7 +2,8 @@ from __future__ import annotations
 
 import json
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, Literal, Optional, Type
+from enum import auto
+from typing import TYPE_CHECKING, Any, Optional, Type
 
 from cognite.client.data_classes import Datapoints, filters
 from cognite.client.data_classes._base import (
@@ -11,6 +12,7 @@ from cognite.client.data_classes._base import (
     CogniteResource,
     CogniteResourceList,
     CogniteUpdate,
+    EnumProperty,
     PropertySpec,
     T_CogniteResource,
 )
@@ -365,58 +367,21 @@ class DatapointSubscriptionList(CogniteResourceList[DatapointSubscription]):
     _RESOURCE = DatapointSubscription
 
 
-class _DatapointSubscriptionFilterProperties:
-    @property
-    def description(self) -> list[Literal["description"]]:
-        return ["description"]
-
-    @property
-    def external_id(self) -> list[Literal["externalId"]]:
-        return ["externalId"]
-
-    @staticmethod
-    def metadata(key: str) -> list[str]:
-        return ["metadata", key]
-
-    @property
-    def name(self) -> list[Literal["name"]]:
-        return ["name"]
-
-    @property
-    def unit(self) -> list[Literal["unit"]]:
-        return ["unit"]
-
-    @property
-    def asset_id(self) -> list[Literal["assetId"]]:
-        return ["assetId"]
-
-    @property
-    def asset_root_id(self) -> list[Literal["assetRootId"]]:
-        return ["assetRootId"]
-
-    @property
-    def created_time(self) -> list[Literal["createdTime"]]:
-        return ["createdTime"]
-
-    @property
-    def data_set_id(self) -> list[Literal["dataSetId"]]:
-        return ["dataSetId"]
-
-    @property
-    def id(self) -> list[Literal["id"]]:
-        return ["id"]
-
-    @property
-    def last_updated_time(self) -> list[Literal["lastUpdatedTime"]]:
-        return ["lastUpdatedTime"]
-
-    @property
-    def is_step(self) -> list[Literal["isStep"]]:
-        return ["isStep"]
-
-    @property
-    def is_string(self) -> list[Literal["isString"]]:
-        return ["isString"]
+def _metadata(key: str) -> list[str]:
+    return ["metadata", key]
 
 
-DatapointSubscriptionFilterProperties = _DatapointSubscriptionFilterProperties()
+class DatapointSubscriptionFilterProperties(EnumProperty):
+    description = auto()
+    external_id = auto()
+    metadata = _metadata
+    name = auto()  # type: ignore [assignment]
+    unit = auto()
+    asset_id = auto()
+    asset_root_id = auto()
+    created_time = auto()
+    data_set_id = auto()
+    id = auto()
+    last_updated_time = auto()
+    is_step = auto()
+    is_string = auto()

--- a/cognite/client/data_classes/datapoints_subscriptions.py
+++ b/cognite/client/data_classes/datapoints_subscriptions.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import json
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, Optional, Type
+from typing import TYPE_CHECKING, Any, Literal, Optional, Type
 
 from cognite.client.data_classes import Datapoints, filters
 from cognite.client.data_classes._base import (
@@ -365,21 +365,58 @@ class DatapointSubscriptionList(CogniteResourceList[DatapointSubscription]):
     _RESOURCE = DatapointSubscription
 
 
-def _metadata(key: str) -> list[str]:
-    return ["metadata", key]
+class _DatapointSubscriptionFilterProperties:
+    @property
+    def description(self) -> list[Literal["description"]]:
+        return ["description"]
+
+    @property
+    def external_id(self) -> list[Literal["externalId"]]:
+        return ["externalId"]
+
+    @staticmethod
+    def metadata(key) -> list[str]:
+        return ["metadata", key]
+
+    @property
+    def name(self) -> list[Literal["name"]]:
+        return ["name"]
+
+    @property
+    def unit(self) -> list[Literal["unit"]]:
+        return ["unit"]
+
+    @property
+    def asset_id(self) -> list[Literal["assetId"]]:
+        return ["assetId"]
+
+    @property
+    def asset_root_id(self) -> list[Literal["assetRootId"]]:
+        return ["assetRootId"]
+
+    @property
+    def created_time(self) -> list[Literal["createdTime"]]:
+        return ["createdTime"]
+
+    @property
+    def data_set_id(self) -> list[Literal["dataSetId"]]:
+        return ["dataSetId"]
+
+    @property
+    def id(self) -> list[Literal["id"]]:
+        return ["id"]
+
+    @property
+    def last_updated_time(self) -> list[Literal["lastUpdatedTime"]]:
+        return ["lastUpdatedTime"]
+
+    @property
+    def is_step(self) -> list[Literal["isStep"]]:
+        return ["isStep"]
+
+    @property
+    def is_string(self) -> list[Literal["isString"]]:
+        return ["isString"]
 
 
-class DatapointSubscriptionFilterProperties:
-    description = ["description"]
-    external_id = ["externalId"]
-    metadata = _metadata
-    name = ["name"]
-    unit = ["unit"]
-    asset_id = ["assetId"]
-    asset_root_id = ["assetRootId"]
-    created_time = ["createdTime"]
-    data_set_id = ["dataSetId"]
-    id = ["id"]
-    last_updated_time = ["lastUpdatedTime"]
-    is_step = ["isStep"]
-    is_string = ["isString"]
+DatapointSubscriptionFilterProperties = _DatapointSubscriptionFilterProperties()

--- a/cognite/client/data_classes/datapoints_subscriptions.py
+++ b/cognite/client/data_classes/datapoints_subscriptions.py
@@ -375,7 +375,7 @@ class _DatapointSubscriptionFilterProperties:
         return ["externalId"]
 
     @staticmethod
-    def metadata(key) -> list[str]:
+    def metadata(key: str) -> list[str]:
         return ["metadata", key]
 
     @property

--- a/tests/tests_integration/test_api/test_datapoint_subscriptions.py
+++ b/tests/tests_integration/test_api/test_datapoint_subscriptions.py
@@ -129,9 +129,7 @@ class TestDatapointSubscriptions:
         # Arrange
         f = filters
         p = DatapointSubscriptionFilterProperties
-        numerical_timeseries = f.And(
-            f.Equals(p.is_string, False),
-        )
+        numerical_timeseries = f.And(f.Equals(p.is_string, False))
 
         new_subscription = DataPointSubscriptionCreate(
             external_id="PYSDKFilterDefinedDataPointSubscriptionUpdateTest",


### PR DESCRIPTION
## Description
A newer version of ruff forces these to be annotated with ClassVar... because they are mutable, which feels wrong to me, so I made them into properties.