### PR TITLE
Bugfix Select.load (InstanceSort._load), update CogniteFilter/Sort

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ Changes are grouped as follows
 
 ## [6.15.1] - 2023-08-28
 ### Fixed
-- Bugfix for `InstanceSort._load` that always raised `TypeError` (now public, `.load`). Also and indirect fix for `Select.load` for non-empty `sort`.
+- Bugfix for `InstanceSort._load` that always raised `TypeError` (now public, `.load`). Also, indirect fix for `Select.load` for non-empty `sort`.
 
 ## [6.15.0] - 2023-08-23
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,11 @@ Changes are grouped as follows
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
-## [6.15.0] - 2023-08-18
+## [6.15.1] - 2023-08-28
+### Fixed
+- Bugfix for `InstanceSort._load` that always raised `TypeError` (now public, `.load`). Also and indirect fix for `Select.load` for non-empty `sort`.
+
+## [6.15.0] - 2023-08-23
 ### Added
 - Support for the DocumentsAPI with the implementation `client.documents`.
 - Support for advanced filtering for `Events`, `TimeSeries`, `Assets` and `Sequences`. This is available through the

--- a/cognite/client/_version.py
+++ b/cognite/client/_version.py
@@ -1,4 +1,4 @@
 from __future__ import annotations
 
-__version__ = "6.15.0"
+__version__ = "6.15.1"
 __api_subversion__ = "V20220125"

--- a/cognite/client/data_classes/_base.py
+++ b/cognite/client/data_classes/_base.py
@@ -502,25 +502,6 @@ class CogniteFilter:
     def __repr__(self) -> str:
         return str(self)
 
-    def __getattribute__(self, item: Any) -> Any:
-        attr = super().__getattribute__(item)
-        if item == "_cognite_client" and attr is None:
-            raise CogniteMissingClientError
-        return attr
-
-    @classmethod
-    def _load(cls: type[T_CogniteFilter], resource: dict | str) -> T_CogniteFilter:
-        if isinstance(resource, str):
-            return cls._load(json.loads(resource))
-        elif isinstance(resource, Dict):
-            instance = cls()
-            for key, value in resource.items():
-                snake_case_key = to_snake_case(key)
-                if hasattr(instance, snake_case_key):
-                    setattr(instance, snake_case_key, value)
-            return instance
-        raise TypeError(f"Resource must be json str or dict, not {type(resource)}")
-
     def dump(self, camel_case: bool = False) -> dict[str, Any]:
         """Dump the instance into a json serializable Python data type.
 

--- a/cognite/client/data_classes/_base.py
+++ b/cognite/client/data_classes/_base.py
@@ -10,7 +10,6 @@ from typing import (
     TYPE_CHECKING,
     Any,
     Collection,
-    Dict,
     Generic,
     Iterator,
     List,
@@ -128,7 +127,7 @@ class CogniteResource:
     ) -> T_CogniteResource:
         if isinstance(resource, str):
             return cls._load(json.loads(resource), cognite_client=cognite_client)
-        elif isinstance(resource, Dict):
+        elif isinstance(resource, dict):
             instance = cls(cognite_client=cognite_client)
             for key, value in resource.items():
                 snake_case_key = to_snake_case(key)
@@ -612,7 +611,7 @@ class Geometry(dict):
 SortableProperty: TypeAlias = Union[str, List[str], EnumProperty]
 
 
-class Sort:
+class CogniteSort:
     def __init__(
         self,
         property: SortableProperty,
@@ -623,15 +622,21 @@ class Sort:
         self.order = order
         self.nulls = nulls
 
+    def __str__(self) -> str:
+        return json.dumps(self.dump(), default=utils._auxiliary.json_dump_default, indent=4)
+
+    def __repr__(self) -> str:
+        return str(self)
+
     @classmethod
     def load(
-        cls: type[T_Sort],
+        cls: type[T_CogniteSort],
         data: dict[str, Any]
         | tuple[SortableProperty, Literal["asc", "desc"]]
         | tuple[SortableProperty, Literal["asc", "desc"], Literal["auto", "first", "last"]]
         | SortableProperty
-        | T_Sort,
-    ) -> T_Sort:
+        | T_CogniteSort,
+    ) -> T_CogniteSort:
         if isinstance(data, cls):
             return data
         elif isinstance(data, dict):
@@ -671,7 +676,7 @@ class Sort:
         return output
 
 
-T_Sort = TypeVar("T_Sort", bound=Sort)
+T_CogniteSort = TypeVar("T_CogniteSort", bound=CogniteSort)
 
 
 class HasExternalAndInternalId(Protocol):

--- a/cognite/client/data_classes/assets.py
+++ b/cognite/client/data_classes/assets.py
@@ -449,7 +449,6 @@ class AssetFilter(CogniteFilter):
         external_id_prefix (str | None): Filter by this (case-sensitive) prefix for the external ID.
         labels (LabelFilter | None): Return only the resource matching the specified label constraints.
         geo_location (GeoLocationFilter | None): Only include files matching the specified geographic relation.
-        cognite_client (CogniteClient | None): The client to associate with this object.
     """
 
     def __init__(
@@ -467,7 +466,6 @@ class AssetFilter(CogniteFilter):
         external_id_prefix: str | None = None,
         labels: LabelFilter | None = None,
         geo_location: GeoLocationFilter | None = None,
-        cognite_client: CogniteClient | None = None,
     ) -> None:
         self.name = name
         self.parent_ids = parent_ids
@@ -482,20 +480,9 @@ class AssetFilter(CogniteFilter):
         self.external_id_prefix = external_id_prefix
         self.labels = labels
         self.geo_location = geo_location
-        self._cognite_client = cast("CogniteClient", cognite_client)
 
         if labels is not None and not isinstance(labels, LabelFilter):
             raise TypeError("AssetFilter.labels must be of type LabelFilter")
-
-    @classmethod
-    def _load(cls, resource: dict | str) -> AssetFilter:
-        instance = super()._load(resource)
-        if isinstance(resource, Dict):
-            if instance.created_time is not None:
-                instance.created_time = TimestampRange(**instance.created_time)
-            if instance.last_updated_time is not None:
-                instance.last_updated_time = TimestampRange(**instance.last_updated_time)
-        return instance
 
     def dump(self, camel_case: bool = False) -> dict[str, Any]:
         result = super().dump(camel_case)

--- a/cognite/client/data_classes/assets.py
+++ b/cognite/client/data_classes/assets.py
@@ -35,11 +35,11 @@ from cognite.client.data_classes._base import (
     CognitePropertyClassUtil,
     CogniteResource,
     CogniteResourceList,
+    CogniteSort,
     CogniteUpdate,
     EnumProperty,
     IdTransformerMixin,
     PropertySpec,
-    Sort,
 )
 from cognite.client.data_classes.labels import Label, LabelDefinition, LabelFilter
 from cognite.client.data_classes.shared import GeoLocation, GeoLocationFilter, TimestampRange
@@ -909,7 +909,7 @@ class SortableAssetProperty(EnumProperty):
 SortableAssetPropertyLike: TypeAlias = Union[SortableAssetProperty, str, List[str]]
 
 
-class AssetSort(Sort):
+class AssetSort(CogniteSort):
     def __init__(
         self,
         property: SortableAssetProperty,

--- a/cognite/client/data_classes/data_modeling/_core.py
+++ b/cognite/client/data_classes/data_modeling/_core.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
 import json
-from typing import TYPE_CHECKING, TypeVar
+from typing import TYPE_CHECKING, Any, Literal, TypeVar
 
-from cognite.client.data_classes._base import CogniteResource
+from cognite.client.data_classes._base import CogniteResource, basic_instance_dump
+from cognite.client.utils._auxiliary import json_dump_default
 from cognite.client.utils._text import convert_all_keys_to_snake_case
 
 if TYPE_CHECKING:
@@ -38,3 +39,40 @@ class DataModelingResource(CogniteResource):
 
 
 T_DataModelingResource = TypeVar("T_DataModelingResource", bound=DataModelingResource)
+
+
+class DataModelingSort:
+    def __init__(
+        self,
+        property: str | list[str] | tuple[str, ...],
+        direction: Literal["ascending", "descending"] = "ascending",
+        nulls_first: bool = False,
+    ) -> None:
+        self.property = property
+        self.direction = direction
+        self.nulls_first = nulls_first
+
+    def __str__(self) -> str:
+        return json.dumps(self.dump(), default=json_dump_default, indent=4)
+
+    def __repr__(self) -> str:
+        return str(self)
+
+    @classmethod
+    def load(cls: type[T_DataModelingSort], resource: dict) -> T_DataModelingSort:
+        if not isinstance(resource, dict):
+            raise TypeError(f"Resource must be mapping, not {type(resource)}")
+
+        instance = cls(property=resource["property"])
+        if "direction" in resource:
+            instance.direction = resource["direction"]
+        if "nulls_first" in resource:
+            instance.nulls_first = resource["nullsFirst"]
+
+        return instance
+
+    def dump(self, camel_case: bool = False) -> dict[str, Any]:
+        return basic_instance_dump(self, camel_case=camel_case)
+
+
+T_DataModelingSort = TypeVar("T_DataModelingSort", bound=DataModelingSort)

--- a/cognite/client/data_classes/data_modeling/_core.py
+++ b/cognite/client/data_classes/data_modeling/_core.py
@@ -66,7 +66,7 @@ class DataModelingSort:
         instance = cls(property=resource["property"])
         if "direction" in resource:
             instance.direction = resource["direction"]
-        if "nulls_first" in resource:
+        if "nullsFirst" in resource:
             instance.nulls_first = resource["nullsFirst"]
 
         return instance

--- a/cognite/client/data_classes/data_modeling/_core.py
+++ b/cognite/client/data_classes/data_modeling/_core.py
@@ -52,6 +52,9 @@ class DataModelingSort:
         self.direction = direction
         self.nulls_first = nulls_first
 
+    def __eq__(self, other: Any) -> bool:
+        return type(other) is type(self) and self.dump() == other.dump()
+
     def __str__(self) -> str:
         return json.dumps(self.dump(), default=json_dump_default, indent=4)
 

--- a/cognite/client/data_classes/data_modeling/data_models.py
+++ b/cognite/client/data_classes/data_modeling/data_models.py
@@ -4,11 +4,8 @@ import json
 from operator import attrgetter
 from typing import Any, Generic, Literal, TypeVar, Union, cast
 
-from cognite.client.data_classes._base import (
-    CogniteFilter,
-    CogniteResourceList,
-)
-from cognite.client.data_classes.data_modeling._core import DataModelingResource
+from cognite.client.data_classes._base import CogniteFilter, CogniteResourceList
+from cognite.client.data_classes.data_modeling._core import DataModelingResource, DataModelingSort
 from cognite.client.data_classes.data_modeling._validation import validate_data_modeling_identifier
 from cognite.client.data_classes.data_modeling.ids import DataModelId, ViewId
 from cognite.client.data_classes.data_modeling.views import View, ViewApply
@@ -250,7 +247,7 @@ class DataModelFilter(CogniteFilter):
         self.include_global = include_global
 
 
-class DataModelsSort(CogniteFilter):
+class DataModelsSort(DataModelingSort):
     def __init__(
         self,
         property: Literal[
@@ -259,6 +256,4 @@ class DataModelsSort(CogniteFilter):
         direction: Literal["ascending", "descending"] = "ascending",
         nulls_first: bool = False,
     ) -> None:
-        self.property = property
-        self.direction = direction
-        self.nulls_first = nulls_first
+        super().__init__(property, direction, nulls_first)

--- a/cognite/client/data_classes/data_modeling/instances.py
+++ b/cognite/client/data_classes/data_modeling/instances.py
@@ -24,12 +24,9 @@ from typing import (
     overload,
 )
 
-from cognite.client.data_classes._base import (
-    CogniteFilter,
-    CogniteResourceList,
-)
+from cognite.client.data_classes._base import CogniteResourceList
 from cognite.client.data_classes.aggregations import AggregatedNumberedValue
-from cognite.client.data_classes.data_modeling._core import DataModelingResource
+from cognite.client.data_classes.data_modeling._core import DataModelingResource, DataModelingSort
 from cognite.client.data_classes.data_modeling._validation import validate_data_modeling_identifier
 from cognite.client.data_classes.data_modeling.data_types import (
     DirectRelationReference,
@@ -758,16 +755,14 @@ class InstancesApply:
     edges: EdgeApplyList
 
 
-class InstanceSort(CogniteFilter):
+class InstanceSort(DataModelingSort):
     def __init__(
         self,
         property: list[str] | tuple[str, ...],
         direction: Literal["ascending", "descending"] = "ascending",
         nulls_first: bool = False,
     ) -> None:
-        self.property = property
-        self.direction = direction
-        self.nulls_first = nulls_first
+        super().__init__(property, direction, nulls_first)
 
 
 @dataclass

--- a/cognite/client/data_classes/data_modeling/query.py
+++ b/cognite/client/data_classes/data_modeling/query.py
@@ -62,7 +62,7 @@ class Select:
         data = json.loads(data) if isinstance(data, str) else data
         return cls(
             sources=[SourceSelector.load(source) for source in data.get("sources", [])],
-            sort=[InstanceSort._load(s) for s in data.get("sort", [])],
+            sort=[InstanceSort.load(s) for s in data.get("sort", [])],
             limit=data.get("limit"),
         )
 

--- a/cognite/client/data_classes/data_sets.py
+++ b/cognite/client/data_classes/data_sets.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Dict, cast
+from typing import TYPE_CHECKING, Any, cast
 
 from cognite.client.data_classes._base import (
     CogniteFilter,

--- a/cognite/client/data_classes/data_sets.py
+++ b/cognite/client/data_classes/data_sets.py
@@ -68,7 +68,6 @@ class DataSetFilter(CogniteFilter):
         last_updated_time (dict[str, Any] | TimestampRange | None): Range between two timestamps.
         external_id_prefix (str | None): Filter by this (case-sensitive) prefix for the external ID.
         write_protected (bool | None): No description.
-        cognite_client (CogniteClient | None): The client to associate with this object.
     """
 
     def __init__(
@@ -78,24 +77,12 @@ class DataSetFilter(CogniteFilter):
         last_updated_time: dict[str, Any] | TimestampRange | None = None,
         external_id_prefix: str | None = None,
         write_protected: bool | None = None,
-        cognite_client: CogniteClient | None = None,
     ) -> None:
         self.metadata = metadata
         self.created_time = created_time
         self.last_updated_time = last_updated_time
         self.external_id_prefix = external_id_prefix
         self.write_protected = write_protected
-        self._cognite_client = cast("CogniteClient", cognite_client)
-
-    @classmethod
-    def _load(cls, resource: dict | str) -> DataSetFilter:
-        instance = super()._load(resource)
-        if isinstance(resource, Dict):
-            if instance.created_time is not None:
-                instance.created_time = TimestampRange(**instance.created_time)
-            if instance.last_updated_time is not None:
-                instance.last_updated_time = TimestampRange(**instance.last_updated_time)
-        return instance
 
 
 class DataSetUpdate(CogniteUpdate):

--- a/cognite/client/data_classes/documents.py
+++ b/cognite/client/data_classes/documents.py
@@ -9,9 +9,9 @@ from typing_extensions import TypeAlias
 from cognite.client.data_classes._base import (
     CogniteResource,
     CogniteResourceList,
+    CogniteSort,
     EnumProperty,
     IdTransformerMixin,
-    Sort,
 )
 from cognite.client.data_classes.aggregations import UniqueResult
 from cognite.client.data_classes.labels import Label, LabelDefinition
@@ -328,7 +328,7 @@ class DocumentProperty(EnumProperty):
 SortableProperty: TypeAlias = Union[SortableSourceFileProperty, SortableDocumentProperty, str, List[str]]
 
 
-class DocumentSort(Sort):
+class DocumentSort(CogniteSort):
     def __init__(self, property: SortableProperty, order: Literal["asc", "desc"] = "asc"):
         super().__init__(property, order)
 

--- a/cognite/client/data_classes/events.py
+++ b/cognite/client/data_classes/events.py
@@ -119,7 +119,6 @@ class EventFilter(CogniteFilter):
         created_time (dict[str, Any] | TimestampRange | None): Range between two timestamps.
         last_updated_time (dict[str, Any] | TimestampRange | None): Range between two timestamps.
         external_id_prefix (str | None): Filter by this (case-sensitive) prefix for the external ID.
-        cognite_client (CogniteClient | None): The client to associate with this object.
     """
 
     def __init__(
@@ -138,7 +137,6 @@ class EventFilter(CogniteFilter):
         created_time: dict[str, Any] | TimestampRange | None = None,
         last_updated_time: dict[str, Any] | TimestampRange | None = None,
         external_id_prefix: str | None = None,
-        cognite_client: CogniteClient | None = None,
     ) -> None:
         self.start_time = start_time
         self.end_time = end_time
@@ -154,23 +152,6 @@ class EventFilter(CogniteFilter):
         self.created_time = created_time
         self.last_updated_time = last_updated_time
         self.external_id_prefix = external_id_prefix
-        self._cognite_client = cast("CogniteClient", cognite_client)
-
-    @classmethod
-    def _load(cls, resource: dict | str) -> EventFilter:
-        instance = super()._load(resource)
-        if isinstance(resource, Dict):
-            if instance.start_time is not None:
-                instance.start_time = TimestampRange(**instance.start_time)
-            if instance.end_time is not None:
-                instance.end_time = EndTimeFilter(**instance.end_time)
-            if instance.active_at_time is not None:
-                instance.active_at_time = TimestampRange(**instance.active_at_time)
-            if instance.created_time is not None:
-                instance.created_time = TimestampRange(**instance.created_time)
-            if instance.last_updated_time is not None:
-                instance.last_updated_time = TimestampRange(**instance.last_updated_time)
-        return instance
 
 
 class EventUpdate(CogniteUpdate):

--- a/cognite/client/data_classes/events.py
+++ b/cognite/client/data_classes/events.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Dict, List, Literal, Sequence, Union, cast
+from typing import TYPE_CHECKING, Any, List, Literal, Sequence, Union, cast
 
 from typing_extensions import TypeAlias
 
@@ -13,11 +13,11 @@ from cognite.client.data_classes._base import (
     CognitePropertyClassUtil,
     CogniteResource,
     CogniteResourceList,
+    CogniteSort,
     CogniteUpdate,
     EnumProperty,
     IdTransformerMixin,
     PropertySpec,
-    Sort,
 )
 from cognite.client.data_classes.shared import TimestampRange
 
@@ -298,7 +298,7 @@ class SortableEventProperty(EnumProperty):
 SortableEventPropertyLike: TypeAlias = Union[SortableEventProperty, str, List[str]]
 
 
-class EventSort(Sort):
+class EventSort(CogniteSort):
     def __init__(
         self,
         property: SortableEventPropertyLike,

--- a/cognite/client/data_classes/extractionpipelines.py
+++ b/cognite/client/data_classes/extractionpipelines.py
@@ -290,7 +290,6 @@ class ExtractionPipelineRunFilter(CogniteFilter):
         statuses (Sequence[str] | None): success/failure/seen.
         message (StringFilter | None): message filter.
         created_time (dict[str, Any] | TimestampRange | None): Range between two timestamps.
-        cognite_client (CogniteClient | None): The client to associate with this object.
     """
 
     def __init__(
@@ -299,21 +298,11 @@ class ExtractionPipelineRunFilter(CogniteFilter):
         statuses: Sequence[str] | None = None,
         message: StringFilter | None = None,
         created_time: dict[str, Any] | TimestampRange | None = None,
-        cognite_client: CogniteClient | None = None,
     ) -> None:
         self.external_id = external_id
         self.statuses = statuses
         self.message = message
         self.created_time = created_time
-        self._cognite_client = cast("CogniteClient", cognite_client)
-
-    @classmethod
-    def _load(cls, resource: dict | str) -> ExtractionPipelineRunFilter:
-        instance = super()._load(resource)
-        if isinstance(resource, Dict):
-            if instance.created_time is not None:
-                instance.created_time = TimestampRange(**instance.created_time)
-        return instance
 
 
 class ExtractionPipelineConfigRevision(CogniteResource):

--- a/cognite/client/data_classes/extractionpipelines.py
+++ b/cognite/client/data_classes/extractionpipelines.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Dict, Sequence, cast
+from typing import TYPE_CHECKING, Any, Sequence, cast
 
 from cognite.client.data_classes._base import (
     CogniteFilter,

--- a/cognite/client/data_classes/files.py
+++ b/cognite/client/data_classes/files.py
@@ -122,7 +122,6 @@ class FileMetadataFilter(CogniteFilter):
         external_id_prefix (str | None): Filter by this (case-sensitive) prefix for the external ID.
         directory_prefix (str | None): Filter by this (case-sensitive) prefix for the directory provided by the client.
         uploaded (bool | None): Whether or not the actual file is uploaded. This field is returned only by the API, it has no effect in a post body.
-        cognite_client (CogniteClient | None): The client to associate with this object.
     """
 
     def __init__(
@@ -145,7 +144,6 @@ class FileMetadataFilter(CogniteFilter):
         external_id_prefix: str | None = None,
         directory_prefix: str | None = None,
         uploaded: bool | None = None,
-        cognite_client: CogniteClient | None = None,
     ) -> None:
         self.name = name
         self.mime_type = mime_type
@@ -165,28 +163,11 @@ class FileMetadataFilter(CogniteFilter):
         self.external_id_prefix = external_id_prefix
         self.directory_prefix = directory_prefix
         self.uploaded = uploaded
-        self._cognite_client = cast("CogniteClient", cognite_client)
 
         if labels is not None and not isinstance(labels, LabelFilter):
             raise TypeError("FileMetadataFilter.labels must be of type LabelFilter")
         if geo_location is not None and not isinstance(geo_location, GeoLocationFilter):
             raise TypeError("FileMetadata.geo_location should be of type GeoLocationFilter")
-
-    @classmethod
-    def _load(cls, resource: dict | str) -> FileMetadataFilter:
-        instance = super()._load(resource)
-        if isinstance(resource, Dict):
-            if instance.created_time is not None:
-                instance.created_time = TimestampRange(**instance.created_time)
-            if instance.last_updated_time is not None:
-                instance.last_updated_time = TimestampRange(**instance.last_updated_time)
-            if instance.uploaded_time is not None:
-                instance.uploaded_time = TimestampRange(**instance.uploaded_time)
-            if instance.labels is not None:
-                instance.labels = LabelFilter._load(instance.labels)
-            if instance.geo_location is not None:
-                instance.geo_location = GeoLocationFilter._load(**instance.geo_location)
-        return instance
 
     def dump(self, camel_case: bool = False) -> dict[str, Any]:
         result = super().dump(camel_case)

--- a/cognite/client/data_classes/files.py
+++ b/cognite/client/data_classes/files.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Dict, Sequence, cast
+from typing import TYPE_CHECKING, Any, Sequence, cast
 
 from cognite.client.data_classes._base import (
     CogniteFilter,

--- a/cognite/client/data_classes/relationships.py
+++ b/cognite/client/data_classes/relationships.py
@@ -138,7 +138,6 @@ class RelationshipFilter(CogniteFilter):
         created_time (dict[str, int] | None): Range to filter the field for (inclusive).
         active_at_time (dict[str, int] | None): Limits results to those active at any point within the given time range, i.e. if there is any overlap in the intervals [activeAtTime.min, activeAtTime.max] and [startTime, endTime], where both intervals are inclusive. If a relationship does not have a startTime, it is regarded as active from the begining of time by this filter. If it does not have an endTime is will be regarded as active until the end of time. Similarly, if a min is not supplied to the filter, the min will be implicitly set to the beginning of time, and if a max is not supplied, the max will be implicitly set to the end of time.
         labels (LabelFilter | None): Return only the resource matching the specified label constraints.
-        cognite_client (CogniteClient | None): The client to associate with this object.
     """
 
     def __init__(
@@ -155,7 +154,6 @@ class RelationshipFilter(CogniteFilter):
         created_time: dict[str, int] | None = None,
         active_at_time: dict[str, int] | None = None,
         labels: LabelFilter | None = None,
-        cognite_client: CogniteClient | None = None,
     ) -> None:
         self.source_external_ids = source_external_ids
         self.source_types = source_types
@@ -169,7 +167,6 @@ class RelationshipFilter(CogniteFilter):
         self.created_time = created_time
         self.active_at_time = active_at_time
         self.labels = labels
-        self._cognite_client = cast("CogniteClient", cognite_client)
 
     def dump(self, camel_case: bool = False) -> dict[str, Any]:
         result = super().dump(camel_case)

--- a/cognite/client/data_classes/sequences.py
+++ b/cognite/client/data_classes/sequences.py
@@ -122,7 +122,6 @@ class SequenceFilter(CogniteFilter):
         created_time (dict[str, Any] | TimestampRange | None): Range between two timestamps.
         last_updated_time (dict[str, Any] | TimestampRange | None): Range between two timestamps.
         data_set_ids (SequenceType[dict[str, Any]] | None): Only include sequences that belong to these datasets.
-        cognite_client (CogniteClient | None): The client to associate with this object.
     """
 
     def __init__(
@@ -135,7 +134,6 @@ class SequenceFilter(CogniteFilter):
         created_time: dict[str, Any] | TimestampRange | None = None,
         last_updated_time: dict[str, Any] | TimestampRange | None = None,
         data_set_ids: SequenceType[dict[str, Any]] | None = None,
-        cognite_client: CogniteClient | None = None,
     ) -> None:
         self.name = name
         self.external_id_prefix = external_id_prefix
@@ -145,17 +143,6 @@ class SequenceFilter(CogniteFilter):
         self.created_time = created_time
         self.last_updated_time = last_updated_time
         self.data_set_ids = data_set_ids
-        self._cognite_client = cast("CogniteClient", cognite_client)
-
-    @classmethod
-    def _load(cls, resource: dict | str) -> SequenceFilter:
-        instance = super()._load(resource)
-        if isinstance(resource, Dict):
-            if instance.created_time is not None:
-                instance.created_time = TimestampRange(**instance.created_time)
-            if instance.last_updated_time is not None:
-                instance.last_updated_time = TimestampRange(**instance.last_updated_time)
-        return instance
 
 
 class SequenceColumnUpdate(CogniteUpdate):

--- a/cognite/client/data_classes/sequences.py
+++ b/cognite/client/data_classes/sequences.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import json
 import math
-from typing import TYPE_CHECKING, Any, Dict, Iterator, List, Literal, Union, cast
+from typing import TYPE_CHECKING, Any, Iterator, List, Literal, Union, cast
 from typing import Sequence as SequenceType
 
 from typing_extensions import TypeAlias
@@ -17,11 +17,11 @@ from cognite.client.data_classes._base import (
     CognitePropertyClassUtil,
     CogniteResource,
     CogniteResourceList,
+    CogniteSort,
     CogniteUpdate,
     EnumProperty,
     IdTransformerMixin,
     PropertySpec,
-    Sort,
 )
 from cognite.client.data_classes.shared import TimestampRange
 from cognite.client.utils._identifier import Identifier
@@ -513,7 +513,7 @@ class SortableSequenceProperty(EnumProperty):
 SortableSequencePropertyLike: TypeAlias = Union[SortableSequenceProperty, str, List[str]]
 
 
-class SequenceSort(Sort):
+class SequenceSort(CogniteSort):
     def __init__(
         self,
         property: SortableSequenceProperty,

--- a/cognite/client/data_classes/time_series.py
+++ b/cognite/client/data_classes/time_series.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from datetime import datetime
-from typing import TYPE_CHECKING, Any, Dict, List, Literal, Sequence, Union, cast
+from typing import TYPE_CHECKING, Any, List, Literal, Sequence, Union, cast
 
 from typing_extensions import TypeAlias
 
@@ -14,11 +14,11 @@ from cognite.client.data_classes._base import (
     CognitePropertyClassUtil,
     CogniteResource,
     CogniteResourceList,
+    CogniteSort,
     CogniteUpdate,
     EnumProperty,
     IdTransformerMixin,
     PropertySpec,
-    Sort,
 )
 from cognite.client.data_classes.shared import TimestampRange
 from cognite.client.utils._identifier import Identifier
@@ -344,7 +344,7 @@ class SortableTimeSeriesProperty(EnumProperty):
 SortableTimeSeriesPropertyLike: TypeAlias = Union[SortableTimeSeriesProperty, str, List[str]]
 
 
-class TimeSeriesSort(Sort):
+class TimeSeriesSort(CogniteSort):
     def __init__(
         self,
         property: SortableTimeSeriesProperty,

--- a/cognite/client/data_classes/time_series.py
+++ b/cognite/client/data_classes/time_series.py
@@ -163,7 +163,6 @@ class TimeSeriesFilter(CogniteFilter):
         external_id_prefix (str | None): Filter by this (case-sensitive) prefix for the external ID.
         created_time (dict[str, Any] | TimestampRange | None): Range between two timestamps.
         last_updated_time (dict[str, Any] | TimestampRange | None): Range between two timestamps.
-        cognite_client (CogniteClient | None): The client to associate with this object.
     """
 
     def __init__(
@@ -180,7 +179,6 @@ class TimeSeriesFilter(CogniteFilter):
         external_id_prefix: str | None = None,
         created_time: dict[str, Any] | TimestampRange | None = None,
         last_updated_time: dict[str, Any] | TimestampRange | None = None,
-        cognite_client: CogniteClient | None = None,
     ) -> None:
         self.name = name
         self.unit = unit
@@ -194,17 +192,6 @@ class TimeSeriesFilter(CogniteFilter):
         self.external_id_prefix = external_id_prefix
         self.created_time = created_time
         self.last_updated_time = last_updated_time
-        self._cognite_client = cast("CogniteClient", cognite_client)
-
-    @classmethod
-    def _load(cls, resource: dict | str) -> TimeSeriesFilter:
-        instance = super()._load(resource)
-        if isinstance(resource, Dict):
-            if instance.created_time is not None:
-                instance.created_time = TimestampRange(**instance.created_time)
-            if instance.last_updated_time is not None:
-                instance.last_updated_time = TimestampRange(**instance.last_updated_time)
-        return instance
 
 
 class TimeSeriesUpdate(CogniteUpdate):

--- a/cognite/client/data_classes/transformations/__init__.py
+++ b/cognite/client/data_classes/transformations/__init__.py
@@ -488,16 +488,6 @@ class TransformationFilter(CogniteFilter):
         self.data_set_ids = data_set_ids
         self.tags = tags
 
-    @classmethod
-    def _load(cls, resource: dict | str) -> TransformationFilter:
-        instance = super()._load(resource)
-        if isinstance(resource, Dict):
-            if instance.created_time is not None:
-                instance.created_time = TimestampRange(**instance.created_time)
-            if instance.last_updated_time is not None:
-                instance.last_updated_time = TimestampRange(**instance.last_updated_time)
-        return instance
-
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         obj = super().dump(camel_case=camel_case)
         if obj.get("includePublic") is not None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "cognite-sdk"
 
-version = "6.15.0"
+version = "6.15.1"
 
 description = "Cognite Python SDK"
 readme = "README.md"

--- a/tests/tests_unit/test_api/test_signatures.py
+++ b/tests/tests_unit/test_api/test_signatures.py
@@ -54,7 +54,6 @@ class TestListAndIterSignatures:
             del list_parameters[name]
 
         filter_parameters = dict(inspect.signature(filter.__init__).parameters)
-        del filter_parameters["cognite_client"]
 
         iter_parameters = {v.name for _, v in iter_parameters.items()}
         filter_parameters = {v.name for _, v in filter_parameters.items()}

--- a/tests/tests_unit/test_base.py
+++ b/tests/tests_unit/test_base.py
@@ -108,13 +108,9 @@ class LabelUpdate(CogniteLabelUpdate):
 
 
 class MyFilter(CogniteFilter):
-    def __init__(self, var_a=None, var_b=None, cognite_client=None):
+    def __init__(self, var_a=None, var_b=None):
         self.var_a = var_a
         self.var_b = var_b
-        self._cognite_client = cognite_client
-
-    def use(self):
-        return self._cognite_client
 
 
 class MyResourceList(CogniteResourceList):
@@ -392,7 +388,6 @@ class TestCogniteFilter:
 
     def test_eq(self):
         assert MyFilter(1, 2) == MyFilter(1, 2)
-        assert MyFilter(1, 2) == MyFilter(1, 2, cognite_client=mock.MagicMock())
         assert MyFilter(1) != MyFilter(1, 2)
         assert MyFilter() == MyFilter()
 
@@ -402,11 +397,6 @@ class TestCogniteFilter:
 
     def test_repr(self):
         assert json.dumps({"var_a": 1}, indent=4) == repr(MyFilter(1))
-
-    def test_use_method_which_requires_cognite_client__client_not_set(self):
-        mr = MyFilter()
-        with pytest.raises(CogniteMissingClientError):
-            mr.use()
 
 
 class TestCogniteUpdate:

--- a/tests/tests_unit/test_data_classes/test_data_models/test_queries.py
+++ b/tests/tests_unit/test_data_classes/test_data_models/test_queries.py
@@ -4,7 +4,7 @@ import pytest
 from _pytest.mark import ParameterSet
 
 from cognite.client.data_classes import filters as f
-from cognite.client.data_classes.data_modeling import ViewId
+from cognite.client.data_classes.data_modeling import InstanceSort, ViewId
 from cognite.client.data_classes.data_modeling import query as q
 
 
@@ -86,10 +86,18 @@ def select_load_and_dump_equals_data() -> Iterator[ParameterSet]:
                 "properties": ["title"],
                 "source": {"externalId": "Movie", "space": "IntegrationTestsImmutable", "type": "view", "version": "2"},
             }
-        ]
+        ],
+        "sort": [
+            {
+                "property": ("IntegrationTestSpace", "Person", "name"),
+                "direction": "descending",
+                "nullsFirst": True,
+            }
+        ],
     }
     loaded = q.Select(
-        [q.SourceSelector(ViewId(space="IntegrationTestsImmutable", external_id="Movie", version="2"), ["title"])]
+        [q.SourceSelector(ViewId(space="IntegrationTestsImmutable", external_id="Movie", version="2"), ["title"])],
+        [InstanceSort(("IntegrationTestSpace", "Person", "name"), direction="descending", nulls_first=True)],
     )
     yield pytest.param(raw, loaded, id="Select single property")
 


### PR DESCRIPTION
## Description
- `CogniteFilter` shouldn't have `_load` or `CogniteClient` reference
- Change the base of `InstanceSort` and `DataModelsSort` to a new `DataModelingSort`.
- Bugfix `Select.load` of `InstanceSort`; bad inheritance from `CogniteFilter`
- remove `_load` and `__getattribute__` from `CogniteFilter`
- rename `Sort` -> `CogniteSort`


```py
>>> inst_srt = InstanceSort(
...     property=["a"], direction="descending", nulls_first=True,
... ).dump(camel_case=True)
>>> # {'property': ['a'], 'direction': 'descending', 'nullsFirst': True}


>>> Select.load({"sort": [inst_srt]})
# TypeError: InstanceSort.__init__() missing 1 required positional argument: 'property'
```

## Checklist:
- [x] Tests added/updated.
- [ ] Documentation updated. Documentation is generated from docstrings - these must be updated according to your change.
  If a new method has been added it should be referenced in [cognite.rst](https://github.com/cognitedata/cognite-sdk-python/blob/master/docs/source/cognite.rst) in order to generate docs based on its docstring.
- [x] Changelog updated in [CHANGELOG.md](https://github.com/cognitedata/cognite-sdk-python/blob/master/CHANGELOG.md).
- [x] Version bumped. If triggering a new release is desired, bump the version number in [_version.py](https://github.com/cognitedata/cognite-sdk-python/blob/master/cognite/client/_version.py) and [pyproject.toml](https://github.com/cognitedata/cognite-sdk-python/blob/master/pyproject.toml) per [semantic versioning](https://semver.org/).
