### PR TITLE
Annotations cleanup

### DIFF
--- a/cognite/client/_api/functions.py
+++ b/cognite/client/_api/functions.py
@@ -283,7 +283,7 @@ class FunctionsAPI(APIClient):
 
         return FunctionList._load(res.json()["items"], cognite_client=self._cognite_client)
 
-    def retrieve(self, id: int | None = None, external_id: str | None = None) -> FunctionList | Function | None:
+    def retrieve(self, id: int | None = None, external_id: str | None = None) -> Function | None:
         """`Retrieve a single function by id. <https://developer.cognite.com/api#tag/Functions/operation/byIdsFunctions>`_
 
         Args:
@@ -291,7 +291,7 @@ class FunctionsAPI(APIClient):
             external_id (str | None): External ID
 
         Returns:
-            FunctionList | Function | None: Requested function or None if it does not exist.
+            Function | None: Requested function or None if it does not exist.
 
         Examples:
 
@@ -305,10 +305,10 @@ class FunctionsAPI(APIClient):
 
                 >>> from cognite.client import CogniteClient
                 >>> c = CogniteClient()
-                >>> res = c.functions.retrieve(external_id="1")
+                >>> res = c.functions.retrieve(external_id="abc")
         """
-        identifiers = IdentifierSequence.load(ids=id, external_ids=external_id).as_singleton()
-        return self._retrieve_multiple(identifiers=identifiers, resource_cls=Function, list_cls=FunctionList)
+        identifier = IdentifierSequence.load(ids=id, external_ids=external_id).as_singleton()
+        return self._retrieve_multiple(identifiers=identifier, resource_cls=Function, list_cls=FunctionList)
 
     def retrieve_multiple(
         self, ids: Sequence[int] | None = None, external_ids: Sequence[str] | None = None
@@ -714,7 +714,7 @@ class FunctionCallsAPI(APIClient):
 
     def retrieve(
         self, call_id: int, function_id: int | None = None, function_external_id: str | None = None
-    ) -> FunctionCallList | FunctionCall | None:
+    ) -> FunctionCall | None:
         """`Retrieve a single function call by id. <https://developer.cognite.com/api#tag/Function-calls/operation/byIdsFunctionCalls>`_
 
         Args:
@@ -723,7 +723,7 @@ class FunctionCallsAPI(APIClient):
             function_external_id (str | None): External ID of the function on which the call was made.
 
         Returns:
-            FunctionCallList | FunctionCall | None: Requested function call.
+            FunctionCall | None: Requested function call or None if either call ID or function identifier is not found.
 
         Examples:
 
@@ -739,17 +739,15 @@ class FunctionCallsAPI(APIClient):
                 >>> c = CogniteClient()
                 >>> func = c.functions.retrieve(id=1)
                 >>> call = func.retrieve_call(id=2)
-
         """
         identifier = _get_function_identifier(function_id, function_external_id)
         function_id = _get_function_internal_id(self._cognite_client, identifier)
 
         resource_path = self._RESOURCE_PATH.format(function_id)
-        identifiers = IdentifierSequence.load(ids=call_id).as_singleton()
 
         return self._retrieve_multiple(
             resource_path=resource_path,
-            identifiers=identifiers,
+            identifiers=IdentifierSequence.load(ids=call_id).as_singleton(),
             resource_cls=FunctionCall,
             list_cls=FunctionCallList,
         )
@@ -832,14 +830,14 @@ class FunctionSchedulesAPI(APIClient):
         super().__init__(config, api_version, cognite_client)
         self._LIST_LIMIT_CEILING = 10_000
 
-    def retrieve(self, id: int) -> FunctionSchedule | FunctionSchedulesList | None:
+    def retrieve(self, id: int) -> FunctionSchedule | None:
         """`Retrieve a single function schedule by id. <https://developer.cognite.com/api#tag/Function-schedules/operation/byIdsFunctionSchedules>`_
 
         Args:
-            id (int): ID
+            id (int): Schedule ID
 
         Returns:
-            FunctionSchedule | FunctionSchedulesList | None: Requested function schedule.
+            FunctionSchedule | None: Requested function schedule or None if not found.
 
         Examples:
 
@@ -850,8 +848,9 @@ class FunctionSchedulesAPI(APIClient):
                 >>> res = c.functions.schedules.retrieve(id=1)
 
         """
+        identifier = IdentifierSequence.load(ids=id).as_singleton()
         return self._retrieve_multiple(
-            identifiers=IdentifierSequence.load(ids=id), resource_cls=FunctionSchedule, list_cls=FunctionSchedulesList
+            identifiers=identifier, resource_cls=FunctionSchedule, list_cls=FunctionSchedulesList
         )
 
     def list(

--- a/cognite/client/data_classes/functions.py
+++ b/cognite/client/data_classes/functions.py
@@ -143,14 +143,14 @@ class Function(CogniteResource):
 
         return (schedules_by_external_id + schedules_by_id)[:limit]
 
-    def retrieve_call(self, id: int) -> FunctionCall:
+    def retrieve_call(self, id: int) -> FunctionCall | None:
         """`Retrieve call by id. <https://docs.cognite.com/api/v1/#operation/getFunctionCall>`_
 
         Args:
             id (int): ID of the call.
 
         Returns:
-            FunctionCall: Function call.
+            FunctionCall | None: Requested function call or None if not found.
         """
         return self._cognite_client.functions.calls.retrieve(call_id=id, function_id=self.id)
 

--- a/cognite/client/data_classes/sequences.py
+++ b/cognite/client/data_classes/sequences.py
@@ -76,15 +76,15 @@ class Sequence(CogniteResource):
         self.data_set_id = data_set_id
         self._cognite_client = cast("CogniteClient", cognite_client)
 
-    def rows(self, start: int, end: int) -> list[dict]:
+    def rows(self, start: int, end: int | None) -> SequenceData:
         """Retrieves rows from this sequence.
 
         Args:
-            start (int): No description.
-            end (int): No description.
+            start (int): Row number to start from (inclusive).
+            end (int | None): Upper limit on the row number (exclusive). Set to None or -1 to get all rows until end of sequence.
 
         Returns:
-            list[dict]: List of sequence data.
+            SequenceData: List of sequence data.
         """
         identifier = Identifier.load(self.id, self.external_id).as_dict()
         return self._cognite_client.sequences.data.retrieve(**identifier, start=start, end=end)


### PR DESCRIPTION
## Description

- fix `Function.retrieve_call` return annot
- Fix wrong annots for `Sequence.rows`
- Fix retrieve (single) methods in `FunctionsAPI`
