### PR TITLE
Add `UserProfilesAPI`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ Changes are grouped as follows
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
+## [6.17.0] - 2023-09-01
+### Added
+- Support for the UserProfilesAPI with the implementation `client.iam.user_profiles`.
+
 ## [6.16.0] - 2023-09-01
 ### Added
 - Support for `ignore_unknown_ids` in `client.relationships.retrieve_multiple` method.

--- a/cognite/client/_api/iam.py
+++ b/cognite/client/_api/iam.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Sequence
 
+from cognite.client._api.user_profiles import UserProfilesAPI
 from cognite.client._api_client import APIClient
 from cognite.client._constants import LIST_LIMIT_DEFAULT
 from cognite.client.config import ClientConfig
@@ -29,6 +30,7 @@ class IAMAPI(APIClient):
         self.groups = GroupsAPI(config, api_version, cognite_client)
         self.security_categories = SecurityCategoriesAPI(config, api_version, cognite_client)
         self.sessions = SessionsAPI(config, api_version, cognite_client)
+        self.user_profiles = UserProfilesAPI(config, api_version, cognite_client)
         # TokenAPI only uses base_url, so we pass `api_version=None`:
         self.token = TokenAPI(config, api_version=None, cognite_client=cognite_client)
 

--- a/cognite/client/_api/user_profiles.py
+++ b/cognite/client/_api/user_profiles.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+from typing import Sequence
+
+from cognite.client._api_client import APIClient
+from cognite.client._constants import LIST_LIMIT_DEFAULT
+from cognite.client.data_classes.user_profiles import UserProfile, UserProfileList
+from cognite.client.utils._identifier import UserIdentifierSequence
+
+
+class UserProfilesAPI(APIClient):
+    _RESOURCE_PATH = "/profiles"
+
+    def me(self) -> UserProfile:
+        return UserProfile._load(self._get(self._RESOURCE_PATH + "/me").json())
+
+    def list(self, limit: int | None = LIST_LIMIT_DEFAULT, initial_cursor: str | None = None) -> UserProfileList:
+        return self._list(
+            "GET",
+            list_cls=UserProfileList,
+            resource_cls=UserProfile,
+            limit=limit,
+            initial_cursor=initial_cursor,
+        )
+
+    def retrieve(self, user_identifier: str) -> UserProfile | None:
+        identifier = UserIdentifierSequence.load(user_identifier).as_singleton()
+        return self._retrieve_multiple(
+            list_cls=UserProfileList,
+            resource_cls=UserProfile,
+            identifiers=identifier,
+        )
+
+    def retrieve_multiple(self, user_identifiers: Sequence[str]) -> UserProfileList:
+        identifiers = UserIdentifierSequence.load(user_identifiers)
+        return self._retrieve_multiple(
+            list_cls=UserProfileList,
+            resource_cls=UserProfile,
+            identifiers=identifiers,
+        )
+
+    def search(self, name: str, limit: int = 25) -> UserProfileList:
+        # prefix on name
+        return

--- a/cognite/client/_api/user_profiles.py
+++ b/cognite/client/_api/user_profiles.py
@@ -12,9 +12,46 @@ class UserProfilesAPI(APIClient):
     _RESOURCE_PATH = "/profiles"
 
     def me(self) -> UserProfile:
+        """`Retrieve your own user profile <https://developer.cognite.com/api#tag/User-profiles/paths/~1profiles~1me/get>`_
+
+        Retrieves the user profile of the principal issuing the request, i.e. the principal *this* CogniteClient was instantiated with.
+
+        Returns:
+            UserProfile: Your own user profile.
+
+        Raises:
+            CogniteAPIError: If this principal doesn't have a user profile, you get a not found (404) response code.
+
+        Examples:
+
+            Get your own user profile:
+
+                >>> from cognite.client import CogniteClient
+                >>> c = CogniteClient()
+                >>> res = c.iam.user_profiles.me()
+        """
         return UserProfile._load(self._get(self._RESOURCE_PATH + "/me").json())
 
     def list(self, limit: int | None = LIST_LIMIT_DEFAULT, initial_cursor: str | None = None) -> UserProfileList:
+        """`List user profiles <https://developer.cognite.com/api#tag/User-profiles/paths/~1profiles/get>`_
+
+        List all user profiles in the current CDF project. The results are ordered alphabetically by name.
+
+        Args:
+            limit (int | None): Maximum number of user profiles to return. Defaults to 25. Set to -1, float("inf") or None to return all.
+            initial_cursor (str | None): Start fetching from a specific cursor.
+
+        Returns:
+            UserProfileList: List of user profiles.
+
+        Examples:
+
+            List all user profiles:
+
+                >>> from cognite.client import CogniteClient
+                >>> c = CogniteClient()
+                >>> res = c.iam.user_profiles.list(limit=None)
+        """
         return self._list(
             "GET",
             list_cls=UserProfileList,
@@ -24,6 +61,24 @@ class UserProfilesAPI(APIClient):
         )
 
     def retrieve(self, user_identifier: str) -> UserProfile | None:
+        """`Retrieve a single user profile by user identifier. <https://developer.cognite.com/api#tag/User-profiles/paths/~1profiles~1byids/post>`_
+
+        Retrieves one user profile as indexed by the user identifier in the same CDF project.
+
+        Args:
+            user_identifier (str): The user identifier of the user profile to retrieve.
+
+        Returns:
+            UserProfile | None: The requested user profile or None if it doesn't exist.
+
+        Examples:
+
+            Get user profile by user identifier:
+
+                >>> from cognite.client import CogniteClient
+                >>> c = CogniteClient()
+                >>> res = c.iam.user_profiles.retrieve("foo")
+        """
         identifier = UserIdentifierSequence.load(user_identifier).as_singleton()
         return self._retrieve_multiple(
             list_cls=UserProfileList,
@@ -32,6 +87,27 @@ class UserProfilesAPI(APIClient):
         )
 
     def retrieve_multiple(self, user_identifiers: Sequence[str]) -> UserProfileList:
+        """`Retrieve multiple user profiles by user identifier. <https://developer.cognite.com/api#tag/User-profiles/paths/~1profiles~1byids/post>`_
+
+        Retrieves one or more user profiles indexed by the user identifier in the same CDF project.
+
+        Args:
+            user_identifiers (Sequence[str]): The list of user identifiers to retrieve.
+
+        Returns:
+            UserProfileList: The requested user profiles.
+
+        Raises:
+            CogniteNotFoundError: One or more user identifiers does not exist.
+
+        Examples:
+
+            Get user profiles by user identifier:
+
+                >>> from cognite.client import CogniteClient
+                >>> c = CogniteClient()
+                >>> res = c.iam.user_profiles.retrieve_multiple(["foo", "bar"])
+        """
         identifiers = UserIdentifierSequence.load(user_identifiers)
         return self._retrieve_multiple(
             list_cls=UserProfileList,
@@ -39,6 +115,28 @@ class UserProfilesAPI(APIClient):
             identifiers=identifiers,
         )
 
-    def search(self, name: str, limit: int = 25) -> UserProfileList:
-        # prefix on name
-        return
+    def search(self, name: str, limit: int = 100) -> UserProfileList:
+        """`Search for user profiles <https://developer.cognite.com/api#tag/User-profiles/paths/~1profiles~1search/post>`_
+        Primarily meant for human-centric use-cases and data exploration, not for programs, as the result set ordering and match criteria threshold may change over time.
+
+        Args:
+            name (str): Prefix search on name.
+            limit (int): Maximum number of results to return.
+
+        Returns:
+            UserProfileList: User profiles search result
+
+        Examples:
+
+            Search for users with first (or second...) name starting with "Alex":
+
+                >>> from cognite.client import CogniteClient
+                >>> c = CogniteClient()
+                >>> res = c.iam.user_profiles.search(name="Alex")
+        """
+        return self._search(
+            list_cls=UserProfileList,
+            search={"name": name},
+            filter={},
+            limit=limit,
+        )

--- a/cognite/client/_version.py
+++ b/cognite/client/_version.py
@@ -1,4 +1,4 @@
 from __future__ import annotations
 
-__version__ = "6.16.0"
+__version__ = "6.17.0"
 __api_subversion__ = "V20220125"

--- a/cognite/client/data_classes/__init__.py
+++ b/cognite/client/data_classes/__init__.py
@@ -208,6 +208,7 @@ from cognite.client.data_classes.transformations.schema import (
     TransformationSchemaColumn,
     TransformationSchemaColumnList,
 )
+from cognite.client.data_classes.user_profiles import UserProfile, UserProfileList
 
 __all__ = [
     "Annotation",
@@ -377,4 +378,6 @@ __all__ = [
     "FeatureTypeUpdateList",
     "CoordinateReferenceSystemList",
     "CoordinateReferenceSystem",
+    "UserProfile",
+    "UserProfileList",
 ]

--- a/cognite/client/data_classes/user_profiles.py
+++ b/cognite/client/data_classes/user_profiles.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, cast
+
+from cognite.client.data_classes._base import CogniteResource, CogniteResourceList
+
+if TYPE_CHECKING:
+    from cognite.client import CogniteClient
+
+
+class UserProfile(CogniteResource):
+    """User profiles is an authoritative source of core user profile information (email, name, job title, etc.)
+    for principals based on data from the identity provider configured for the CDF project.
+
+    Args:
+        user_identifier (str | None): Uniquely identifies the principal the profile is associated with. This property is guaranteed to be immutable.
+        given_name (str | None): The user's first name.
+        surname (str | None): The user's last name.
+        email (str | None): The user's email address (if any). The email address is is returned directly from the identity provider and not guaranteed
+            to be verified. Note that the email is mutable and can be updated in the identity provider. It should not be used to uniquely identify as a
+            user. Use the user_identifier property instead.
+        display_name (str | None): The display name for the user.
+        job_title (str | None): The user's job title.
+        last_updated_time (int | None): The number of milliseconds since 00:00:00 Thursday, 1 January 1970, Coordinated Universal Time (UTC), minus leap seconds.
+        cognite_client (CogniteClient | None): No description.
+    """
+
+    def __init__(
+        self,
+        user_identifier: str | None = None,
+        given_name: str | None = None,
+        surname: str | None = None,
+        email: str | None = None,
+        display_name: str | None = None,
+        job_title: str | None = None,
+        last_updated_time: int | None = None,
+        cognite_client: CogniteClient | None = None,
+    ) -> None:
+        self.user_identifier = user_identifier
+        self.given_name = given_name
+        self.surname = surname
+        self.email = email
+        self.display_name = display_name
+        self.job_title = job_title
+        self.last_updated_time = last_updated_time
+        self._cognite_client = cast("CogniteClient", cognite_client)
+
+
+class UserProfileList(CogniteResourceList[UserProfile]):
+    _RESOURCE = UserProfile

--- a/cognite/client/data_classes/user_profiles.py
+++ b/cognite/client/data_classes/user_profiles.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING, Sequence, cast
 
 from cognite.client.data_classes._base import CogniteResource, CogniteResourceList
 
@@ -48,3 +48,20 @@ class UserProfile(CogniteResource):
 
 class UserProfileList(CogniteResourceList[UserProfile]):
     _RESOURCE = UserProfile
+
+    def __init__(self, resources: Sequence[UserProfile], cognite_client: CogniteClient | None = None) -> None:
+        super().__init__(resources, cognite_client)
+
+        del self._id_to_item, self._external_id_to_item
+        self._user_identifier_to_item = {item.user_identifier: item for item in self.data or []}
+
+    def get(self, user_identifier: str) -> UserProfile | None:  # type: ignore [override]
+        """Get an item from this list by user_identifier.
+
+        Args:
+            user_identifier (str): The user_identifier of the item to get.
+
+        Returns:
+            UserProfile | None: The requested item or None if not found.
+        """
+        return self._user_identifier_to_item.get(user_identifier)

--- a/cognite/client/data_classes/user_profiles.py
+++ b/cognite/client/data_classes/user_profiles.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Sequence, cast
+import json
+from typing import TYPE_CHECKING, Any, Sequence, cast
 
 from cognite.client.data_classes._base import CogniteResource, CogniteResourceList
+from cognite.client.utils._text import to_camel_case
 
 if TYPE_CHECKING:
     from cognite.client import CogniteClient
@@ -13,37 +15,48 @@ class UserProfile(CogniteResource):
     for principals based on data from the identity provider configured for the CDF project.
 
     Args:
-        user_identifier (str | None): Uniquely identifies the principal the profile is associated with. This property is guaranteed to be immutable.
+        user_identifier (str): Uniquely identifies the principal the profile is associated with. This property is guaranteed to be immutable.
+        last_updated_time (int): The number of milliseconds since 00:00:00 Thursday, 1 January 1970, Coordinated Universal Time (UTC), minus leap seconds.
         given_name (str | None): The user's first name.
         surname (str | None): The user's last name.
-        email (str | None): The user's email address (if any). The email address is is returned directly from the identity provider and not guaranteed
-            to be verified. Note that the email is mutable and can be updated in the identity provider. It should not be used to uniquely identify as a
-            user. Use the user_identifier property instead.
+        email (str | None): The user's email address (if any). The email address is is returned directly from the identity provider and not guaranteed to be verified. Note that the email is mutable and can be updated in the identity provider. It should not be used to uniquely identify as a user. Use the user_identifier property instead.
         display_name (str | None): The display name for the user.
         job_title (str | None): The user's job title.
-        last_updated_time (int | None): The number of milliseconds since 00:00:00 Thursday, 1 January 1970, Coordinated Universal Time (UTC), minus leap seconds.
         cognite_client (CogniteClient | None): No description.
     """
 
     def __init__(
         self,
-        user_identifier: str | None = None,
+        user_identifier: str,
+        last_updated_time: int,
         given_name: str | None = None,
         surname: str | None = None,
         email: str | None = None,
         display_name: str | None = None,
         job_title: str | None = None,
-        last_updated_time: int | None = None,
         cognite_client: CogniteClient | None = None,
     ) -> None:
         self.user_identifier = user_identifier
+        self.last_updated_time = last_updated_time
         self.given_name = given_name
         self.surname = surname
         self.email = email
         self.display_name = display_name
         self.job_title = job_title
-        self.last_updated_time = last_updated_time
         self._cognite_client = cast("CogniteClient", cognite_client)
+
+    @classmethod
+    def _load(cls, resource: dict[str, Any] | str, cognite_client: CogniteClient | None = None) -> UserProfile:
+        if isinstance(resource, str):
+            resource = cast(dict[str, Any], json.loads(resource))
+        to_load = {
+            "user_identifier": resource["userIdentifier"],
+            "last_updated_time": resource["lastUpdatedTime"],
+        }
+        for param in ["given_name", "surname", "email", "display_name", "job_title"]:
+            if (value := resource.get(to_camel_case(param))) is not None:
+                to_load[param] = value
+        return cls(**to_load, cognite_client=cognite_client)
 
 
 class UserProfileList(CogniteResourceList[UserProfile]):
@@ -57,10 +70,8 @@ class UserProfileList(CogniteResourceList[UserProfile]):
 
     def get(self, user_identifier: str) -> UserProfile | None:  # type: ignore [override]
         """Get an item from this list by user_identifier.
-
         Args:
             user_identifier (str): The user_identifier of the item to get.
-
         Returns:
             UserProfile | None: The requested item or None if not found.
         """

--- a/cognite/client/testing.py
+++ b/cognite/client/testing.py
@@ -57,6 +57,7 @@ from cognite.client._api.transformations import (
     TransformationSchedulesAPI,
     TransformationSchemaAPI,
 )
+from cognite.client._api.user_profiles import UserProfilesAPI
 from cognite.client._api.vision import VisionAPI
 
 
@@ -115,6 +116,7 @@ class CogniteClientMock(MagicMock):
         self.iam.groups = MagicMock(spec_set=GroupsAPI)
         self.iam.security_categories = MagicMock(spec_set=SecurityCategoriesAPI)
         self.iam.sessions = MagicMock(spec_set=SessionsAPI)
+        self.iam.user_profiles = MagicMock(spec_set=UserProfilesAPI)
         self.iam.token = MagicMock(spec_set=TokenAPI)
 
         self.labels = MagicMock(spec_set=LabelsAPI)

--- a/cognite/client/utils/_identifier.py
+++ b/cognite/client/utils/_identifier.py
@@ -4,7 +4,6 @@ import numbers
 from abc import ABC
 from typing import (
     Generic,
-    Iterable,
     Literal,
     NoReturn,
     Protocol,
@@ -52,7 +51,7 @@ class Identifier(Generic[T_ID]):
         raise ValueError("At least one of id and external id must be specified")
 
     def name(self, camel_case: bool = False) -> str:
-        if isinstance(self.__value, int):
+        if self.is_id:
             return "id"
         return "externalId" if camel_case else "external_id"
 
@@ -61,17 +60,31 @@ class Identifier(Generic[T_ID]):
 
     @property
     def is_id(self) -> bool:
-        return isinstance(self.as_primitive(), int)
+        return isinstance(self.__value, int)
 
     @property
     def is_external_id(self) -> bool:
-        return isinstance(self.as_primitive(), str)
+        return isinstance(self.__value, str)
 
     def as_dict(self, camel_case: bool = True) -> dict[str, T_ID]:
         return {self.name(camel_case): self.__value}
 
     def as_tuple(self, camel_case: bool = True) -> tuple[str, T_ID]:
         return self.name(camel_case), self.__value
+
+
+class UserIdentifier:
+    def __init__(self, value: str) -> None:
+        self.__value: str = value
+
+    def name(self, camel_case: bool = False) -> str:
+        return "userIdentifier" if camel_case else "user_identifier"
+
+    def as_dict(self, camel_case: bool = True) -> dict[str, str]:
+        return {self.name(camel_case): self.__value}
+
+    def as_primitive(self) -> str:
+        return self.__value
 
 
 class DataModelingIdentifier:
@@ -137,7 +150,7 @@ class IdentifierSequenceCore(Generic[T_Identifier], ABC):
         self.assert_singleton()
         return cast(SingletonIdentifierSequence, self)
 
-    def chunked(self, chunk_size: int) -> Iterable[IdentifierSequence]:
+    def chunked(self, chunk_size: int) -> list[IdentifierSequence]:
         return [
             IdentifierSequence(chunk, is_singleton=self.is_singleton())
             for chunk in split_into_chunks(self._identifiers, chunk_size)
@@ -226,3 +239,31 @@ class SingletonIdentifierSequence(IdentifierSequenceCore[Identifier]):
 
 class DataModelingIdentifierSequence(IdentifierSequenceCore[DataModelingIdentifier]):
     ...
+
+
+class UserIdentifierSequence(IdentifierSequenceCore[UserIdentifier]):
+    @classmethod
+    def load(cls, user_identifiers: str | Sequence[str]) -> UserIdentifierSequence:
+        if isinstance(user_identifiers, str):
+            return cls(identifiers=[UserIdentifier(user_identifiers)], is_singleton=True)
+
+        elif isinstance(user_identifiers, Sequence):
+            return cls(identifiers=list(map(UserIdentifier, map(str, user_identifiers))), is_singleton=False)
+
+        raise TypeError(f"user_identifiers must be of type str or Sequence[str]. Found {type(user_identifiers)}")
+
+    def chunked(self, chunk_size: int) -> list[UserIdentifierSequence]:
+        return [
+            UserIdentifierSequence(chunk, is_singleton=self.is_singleton())
+            for chunk in split_into_chunks(self._identifiers, chunk_size)
+        ]
+
+    def assert_singleton(self) -> None:
+        if not self.is_singleton():
+            raise ValueError("Exactly one user identifier (string) must be specified")
+
+    def as_dicts(self) -> list[dict[str, str]]:
+        return super().as_dicts()
+
+    def as_primitives(self) -> list[str]:
+        return super().as_primitives()

--- a/cognite/client/utils/_identifier.py
+++ b/cognite/client/utils/_identifier.py
@@ -252,7 +252,7 @@ class UserIdentifierSequence(IdentifierSequenceCore[UserIdentifier]):
 
         raise TypeError(f"user_identifiers must be of type str or Sequence[str]. Found {type(user_identifiers)}")
 
-    def chunked(self, chunk_size: int) -> list[UserIdentifierSequence]:
+    def chunked(self, chunk_size: int) -> list[UserIdentifierSequence]:  # type: ignore [override]
         return [
             UserIdentifierSequence(chunk, is_singleton=self.is_singleton())
             for chunk in split_into_chunks(self._identifiers, chunk_size)
@@ -262,8 +262,8 @@ class UserIdentifierSequence(IdentifierSequenceCore[UserIdentifier]):
         if not self.is_singleton():
             raise ValueError("Exactly one user identifier (string) must be specified")
 
-    def as_dicts(self) -> list[dict[str, str]]:
-        return super().as_dicts()
+    def as_dicts(self) -> list[dict[str, str]]:  # type: ignore [override]
+        return [identifier.as_dict() for identifier in self._identifiers]
 
-    def as_primitives(self) -> list[str]:
-        return super().as_primitives()
+    def as_primitives(self) -> list[str]:  # type: ignore [override]
+        return [identifier.as_primitive() for identifier in self._identifiers]

--- a/docs/source/identity_and_access_management.rst
+++ b/docs/source/identity_and_access_management.rst
@@ -51,8 +51,35 @@ Revoke a session
 .. automethod:: cognite.client._api.iam.SessionsAPI.revoke
 
 
+User Profiles
+^^^^^^^^^^^^^^^^^^^
+Get my own user profile
+~~~~~~~~~~~~~~~~~~~~~~~~
+.. automethod:: cognite.client._api.iam.UserProfilesAPI.me
+
+List user profiles
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+.. automethod:: cognite.client._api.iam.UserProfilesAPI.list
+
+Retrieve a single user profile
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+.. automethod:: cognite.client._api.iam.UserProfilesAPI.retrieve
+
+Retrieve multiple user profiles
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+.. automethod:: cognite.client._api.iam.UserProfilesAPI.retrieve_multiple
+
+Search for user profiles
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+.. automethod:: cognite.client._api.iam.UserProfilesAPI.search
+
+
 Data classes
 ^^^^^^^^^^^^
 .. automodule:: cognite.client.data_classes.iam
+    :members:
+    :show-inheritance:
+
+.. automodule:: cognite.client.data_classes.user_profiles
     :members:
     :show-inheritance:

--- a/docs/source/identity_and_access_management.rst
+++ b/docs/source/identity_and_access_management.rst
@@ -61,13 +61,9 @@ List user profiles
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 .. automethod:: cognite.client._api.iam.UserProfilesAPI.list
 
-Retrieve a single user profile
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Retrieve one or more user profiles
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 .. automethod:: cognite.client._api.iam.UserProfilesAPI.retrieve
-
-Retrieve multiple user profiles
-~~~~~~~~~~~~~~~~~~~~~~~~~~
-.. automethod:: cognite.client._api.iam.UserProfilesAPI.retrieve_multiple
 
 Search for user profiles
 ~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "cognite-sdk"
 
-version = "6.16.0"
+version = "6.17.0"
 
 description = "Cognite Python SDK"
 readme = "README.md"

--- a/tests/tests_integration/test_api/test_transformations/test_schedules.py
+++ b/tests/tests_integration/test_api/test_transformations/test_schedules.py
@@ -72,7 +72,7 @@ def other_schedule(cognite_client, other_transformation):
 
 
 @pytest.mark.skipif(
-    os.environ.get("LOGIN_FLOW") != "client_credentials", reason="This test requires client_credentials auth"
+    os.getenv("LOGIN_FLOW") != "client_credentials", reason="This test requires client_credentials auth"
 )
 class TestTransformationSchedulesAPI:
     def test_create(self, new_schedule: TransformationSchedule):

--- a/tests/tests_integration/test_api/test_user_profiles.py
+++ b/tests/tests_integration/test_api/test_user_profiles.py
@@ -1,0 +1,57 @@
+import pytest
+
+# import os
+from cognite.client.data_classes import UserProfile, UserProfileList
+from cognite.client.exceptions import CogniteNotFoundError
+from cognite.client.utils._text import random_string
+
+
+# @pytest.mark.skipif(os.getenv("LOGIN_FLOW") != "interactive", reason="This test requires interactive auth")
+def test_user_profiles_api__get_my_own_profile(cognite_client):
+    profile = cognite_client.iam.user_profiles.me()
+    assert isinstance(profile, UserProfile)
+    # Only two required fields returned:
+    assert isinstance(profile.user_identifier, str)
+    assert isinstance(profile.last_updated_time, int)
+
+
+def test_user_profiles_api__list(cognite_client):
+    profiles = cognite_client.iam.user_profiles.list(limit=5)
+    assert 1 <= len(profiles) <= 5
+    assert isinstance(profiles, UserProfileList)
+    assert isinstance(profiles[0], UserProfile)
+    assert isinstance(profiles[0].user_identifier, str)
+
+
+def test_user_profiles_api__retrieve(cognite_client):
+    profile = cognite_client.iam.user_profiles.list(limit=1)[0]
+    assert isinstance(profile.user_identifier, str)
+
+    profile_retrieve = cognite_client.iam.user_profiles.retrieve(profile.user_identifier)
+    assert profile_retrieve is not None
+    assert profile == profile_retrieve
+
+
+def test_user_profiles_api__retrieve_not_exist(cognite_client):
+    assert cognite_client.iam.user_profiles.retrieve(random_string(10)) is None
+
+
+def test_user_profiles_api__retrieve_multiple(cognite_client):
+    profiles = cognite_client.iam.user_profiles.list(limit=5)
+    profiles_retrieve = cognite_client.iam.user_profiles.retrieve_multiple([p.user_identifier for p in profiles])
+
+    assert isinstance(profiles, UserProfileList)
+    assert isinstance(profiles_retrieve, UserProfileList)
+    assert profiles == profiles_retrieve
+
+
+def test_user_profiles_api__retrieve_multiple_str_input(cognite_client):
+    with pytest.raises(TypeError):
+        cognite_client.iam.user_profiles.retrieve_multiple("fooo")
+
+
+def test_user_profiles_api__retrieve_multiple_not_exist(cognite_client):
+    # Endpoint does not support 'ignore unknown ids'
+    with pytest.raises(CogniteNotFoundError) as err:
+        cognite_client.iam.user_profiles.retrieve_multiple([user_id := random_string(10)])
+    assert err.value.not_found == [{"userIdentifier": user_id}]

--- a/tests/tests_integration/test_api/test_user_profiles.py
+++ b/tests/tests_integration/test_api/test_user_profiles.py
@@ -7,6 +7,20 @@ from cognite.client.exceptions import CogniteNotFoundError
 from cognite.client.utils._text import random_string
 
 
+@pytest.fixture(scope="module")
+def profiles(cognite_client):
+    if profiles := cognite_client.iam.user_profiles.list(limit=5):
+        return profiles
+    pytest.skip("Can't test user profiles without any user profiles available", allow_module_level=True)
+
+
+def test_user_profiles_api__list(cognite_client, profiles):
+    assert 1 <= len(profiles) <= 5
+    assert isinstance(profiles, UserProfileList)
+    assert isinstance(profiles[0], UserProfile)
+    assert isinstance(profiles[0].user_identifier, str)
+
+
 @pytest.mark.skipif(os.getenv("LOGIN_FLOW") != "interactive", reason="This test requires interactive auth")
 def test_user_profiles_api__get_my_own_profile(cognite_client):
     profile = cognite_client.iam.user_profiles.me()
@@ -16,20 +30,11 @@ def test_user_profiles_api__get_my_own_profile(cognite_client):
     assert isinstance(profile.last_updated_time, int)
 
 
-def test_user_profiles_api__list(cognite_client):
-    profiles = cognite_client.iam.user_profiles.list(limit=5)
-    assert 1 <= len(profiles) <= 5
-    assert isinstance(profiles, UserProfileList)
-    assert isinstance(profiles[0], UserProfile)
-    assert isinstance(profiles[0].user_identifier, str)
-
-
-def test_user_profiles_api__retrieve(cognite_client):
-    profile = cognite_client.iam.user_profiles.list(limit=1)[0]
-    assert isinstance(profile.user_identifier, str)
-
+def test_user_profiles_api__retrieve_single(cognite_client, profiles):
+    profile = profiles[0]
     profile_retrieve = cognite_client.iam.user_profiles.retrieve(profile.user_identifier)
     assert profile_retrieve is not None
+    assert isinstance(profile, UserProfile)
     assert profile == profile_retrieve
 
 
@@ -37,17 +42,18 @@ def test_user_profiles_api__retrieve_not_exist(cognite_client):
     assert cognite_client.iam.user_profiles.retrieve(random_string(10)) is None
 
 
-def test_user_profiles_api__retrieve_multiple(cognite_client):
-    profiles = cognite_client.iam.user_profiles.list(limit=5)
-    profiles_retrieve = cognite_client.iam.user_profiles.retrieve_multiple([p.user_identifier for p in profiles])
+def test_user_profiles_api__retrieve_many(cognite_client, profiles):
+    profiles_retrieve = cognite_client.iam.user_profiles.retrieve([p.user_identifier for p in profiles])
 
     assert isinstance(profiles, UserProfileList)
     assert isinstance(profiles_retrieve, UserProfileList)
     assert profiles == profiles_retrieve
 
 
-def test_user_profiles_api__retrieve_multiple_not_exist(cognite_client):
+def test_user_profiles_api__retrieve_many_not_exist(cognite_client, profiles):
+    user_idents = [profiles[0].user_identifier, user_id := random_string(10)]
+
     # Endpoint does not support 'ignore unknown ids'
     with pytest.raises(CogniteNotFoundError) as err:
-        cognite_client.iam.user_profiles.retrieve_multiple([user_id := random_string(10)])
+        cognite_client.iam.user_profiles.retrieve(user_idents)
     assert err.value.not_found == [{"userIdentifier": user_id}]

--- a/tests/tests_integration/test_api/test_user_profiles.py
+++ b/tests/tests_integration/test_api/test_user_profiles.py
@@ -1,12 +1,13 @@
+import os
+
 import pytest
 
-# import os
 from cognite.client.data_classes import UserProfile, UserProfileList
 from cognite.client.exceptions import CogniteNotFoundError
 from cognite.client.utils._text import random_string
 
 
-# @pytest.mark.skipif(os.getenv("LOGIN_FLOW") != "interactive", reason="This test requires interactive auth")
+@pytest.mark.skipif(os.getenv("LOGIN_FLOW") != "interactive", reason="This test requires interactive auth")
 def test_user_profiles_api__get_my_own_profile(cognite_client):
     profile = cognite_client.iam.user_profiles.me()
     assert isinstance(profile, UserProfile)
@@ -43,11 +44,6 @@ def test_user_profiles_api__retrieve_multiple(cognite_client):
     assert isinstance(profiles, UserProfileList)
     assert isinstance(profiles_retrieve, UserProfileList)
     assert profiles == profiles_retrieve
-
-
-def test_user_profiles_api__retrieve_multiple_str_input(cognite_client):
-    with pytest.raises(TypeError):
-        cognite_client.iam.user_profiles.retrieve_multiple("fooo")
 
 
 def test_user_profiles_api__retrieve_multiple_not_exist(cognite_client):

--- a/tests/tests_unit/test_utils/test_identifier.py
+++ b/tests/tests_unit/test_utils/test_identifier.py
@@ -1,7 +1,7 @@
 import pytest
 
 from cognite.client._constants import MAX_VALID_INTERNAL_ID
-from cognite.client.utils._identifier import Identifier, IdentifierSequence
+from cognite.client.utils._identifier import Identifier, IdentifierSequence, UserIdentifier, UserIdentifierSequence
 
 
 class TestIdentifier:
@@ -83,3 +83,29 @@ class TestIdentifierSequence:
 
         seq = IdentifierSequence.of(external_ids)
         assert seq.is_singleton() is is_singleton
+
+
+class TestUserIdentifier:
+    def test_methods(self):
+        user_id = UserIdentifier("foo")
+        assert user_id.as_primitive() == "foo"
+        assert user_id.as_dict(camel_case=True) == {"userIdentifier": "foo"}
+        assert user_id.as_dict(camel_case=False) == {"user_identifier": "foo"}
+
+
+class TestUserIdentifierSequence:
+    @pytest.mark.parametrize(
+        "user_ids, exp_dcts, exp_primitives",
+        (
+            ("foo", [{"userIdentifier": "foo"}], ["foo"]),
+            (["foo", "bar"], [{"userIdentifier": "foo"}, {"userIdentifier": "bar"}], ["foo", "bar"]),
+        ),
+    )
+    def test_load_and_dump(self, user_ids, exp_dcts, exp_primitives):
+        user_id_seq = UserIdentifierSequence.load(user_ids)
+        assert user_id_seq.as_primitives() == exp_primitives
+        assert user_id_seq.as_dicts() == exp_dcts
+
+    def test_load_wrong_type(self):
+        with pytest.raises(TypeError):
+            UserIdentifierSequence.load(123)


### PR DESCRIPTION
## Description
Added the user profiles API.

See discission around `/byids` not returning in the same order: https://cognitedata.slack.com/archives/C85QG3UBU/p1693303250158219

# TODO:
- Documentation not added

## Checklist:
- [x] Tests added/updated.
- [ ] Documentation updated. Documentation is generated from docstrings - these must be updated according to your change.
  If a new method has been added it should be referenced in [cognite.rst](https://github.com/cognitedata/cognite-sdk-python/blob/master/docs/source/cognite.rst) in order to generate docs based on its docstring.
- [x] Changelog updated in [CHANGELOG.md](https://github.com/cognitedata/cognite-sdk-python/blob/master/CHANGELOG.md).
- [x] Version bumped. If triggering a new release is desired, bump the version number in [_version.py](https://github.com/cognitedata/cognite-sdk-python/blob/master/cognite/client/_version.py) and [pyproject.toml](https://github.com/cognitedata/cognite-sdk-python/blob/master/pyproject.toml) per [semantic versioning](https://semver.org/).
