### PR TITLE
Make Iterator[foo] default return annot (again) for generators

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,7 +13,7 @@ repos:
           - --fixable=E,W,F,I,T,RUF,TID,UP
           - --target-version=py38
           - --exclude=cognite/client/_proto,cognite/client/_proto_legacy
-    rev: v0.0.285
+    rev: v0.0.286
 
   - repo: https://github.com/psf/black
     rev: 23.7.0
@@ -57,7 +57,7 @@ repos:
         require_serial: true  # avoid possible race conditions
 
   - repo: https://github.com/jsh9/pydoclint  # Run after 'custom-checks' as these may auto-fix
-    rev: 0.2.4
+    rev: 0.3.0
     hooks:
       - id: pydoclint
         require_serial: true  # Spammy in run-all scenarios (more than fast enough already)

--- a/cognite/client/_api/datapoint_tasks.py
+++ b/cognite/client/_api/datapoint_tasks.py
@@ -15,7 +15,6 @@ from typing import (
     Any,
     Callable,
     Dict,
-    Generator,
     Generic,
     Hashable,
     Iterator,
@@ -740,7 +739,7 @@ class SplittingFetchSubtask(SerialFetchSubtask):
             return self._split_self_into_new_subtasks_if_needed(last_ts)
         return None
 
-    def _create_subtasks_idxs(self, n_new_tasks: int) -> Generator[tuple[float, ...], None, None]:
+    def _create_subtasks_idxs(self, n_new_tasks: int) -> Iterator[tuple[float, ...]]:
         # Since this task may decide to split itself multiple times, we count backwards to keep order
         # (we rely on tuple sorting logic). Example using `self.subtask_idx=(4,)`:
         # - First split into e.g. 3 parts: (4,-3), (4,-2), (4,-1)

--- a/cognite/client/_api/datapoints_subscriptions.py
+++ b/cognite/client/_api/datapoints_subscriptions.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Generator, Sequence
+from typing import TYPE_CHECKING, Iterator, Sequence
 from warnings import warn
 
 from cognite.client._api_client import APIClient
@@ -178,7 +178,7 @@ class DatapointsSubscriptionAPI(APIClient):
         external_id: str,
         start: str | None = None,
         limit: int = DATAPOINT_SUBSCRIPTION_DATA_LIST_LIMIT_DEFAULT,
-    ) -> Generator[DatapointSubscriptionBatch, None, None]:
+    ) -> Iterator[DatapointSubscriptionBatch]:
         """`Iterate over data from a given subscription. <https://pr-2221.specs.preview.cogniteapp.com/20230101-beta.json.html#tag/Data-point-subscriptions/operation/listSubscriptionData>`_
 
         Data can be ingested datapoints and time ranges where data is deleted. This endpoint will also return changes to

--- a/cognite/client/_api/geospatial.py
+++ b/cognite/client/_api/geospatial.py
@@ -4,7 +4,7 @@ import json as complexjson
 import numbers
 import urllib.parse
 import warnings
-from typing import Any, Generator, Sequence, cast, overload
+from typing import Any, Iterator, Sequence, cast, overload
 
 from requests.exceptions import ChunkedEncodingError
 
@@ -700,7 +700,7 @@ class GeospatialAPI(APIClient):
         filter: dict[str, Any] | None = None,
         properties: dict[str, Any] | None = None,
         allow_crs_transformation: bool = False,
-    ) -> Generator[Feature, None, None]:
+    ) -> Iterator[Feature]:
         """`Stream features`
         <https://developer.cognite.com/api#tag/Geospatial/operation/searchFeaturesStreaming>
 

--- a/cognite/client/data_classes/sequences.py
+++ b/cognite/client/data_classes/sequences.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import json
 import math
-from typing import TYPE_CHECKING, Any, Dict, Generator, List, Literal, Union, cast
+from typing import TYPE_CHECKING, Any, Dict, Iterator, List, Literal, Union, cast
 from typing import Sequence as SequenceType
 
 from typing_extensions import TypeAlias
@@ -396,7 +396,7 @@ class SequenceData(CogniteResource):
             )
         return [r[ix] for r in self.values]
 
-    def items(self) -> Generator[tuple[int, list[int | str | float]], None, None]:
+    def items(self) -> Iterator[tuple[int, list[int | str | float]]]:
         """Returns an iterator over tuples of (row number, values)."""
         for row, values in zip(self.row_numbers, self.values):
             yield row, list(values)

--- a/cognite/client/testing.py
+++ b/cognite/client/testing.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from contextlib import contextmanager
-from typing import Any, Generator
+from typing import Any, Iterator
 from unittest.mock import MagicMock
 
 from cognite.client import CogniteClient
@@ -156,7 +156,7 @@ class CogniteClientMock(MagicMock):
 
 
 @contextmanager
-def monkeypatch_cognite_client() -> Generator[CogniteClientMock, None, None]:
+def monkeypatch_cognite_client() -> Iterator[CogniteClientMock]:
     """Context manager for monkeypatching the CogniteClient.
 
     Will patch all clients and replace them with specced MagicMock objects.

--- a/scripts/custom_checks/docstrings.py
+++ b/scripts/custom_checks/docstrings.py
@@ -109,11 +109,14 @@ class DocstrFormatter:
     def _extract_yields_return_annot(string):
         # Example:
         #   A return annotation like 'Generator[tuple[float, ...], list[str, int], int | float]'
-        #   should be marked as yielding: 'tuple[float, ...]'
+        #   should be marked as yielding: 'tuple[float, ...]', and similarly, Iterator[int] --> int.
         # TODO: With 3.9 this gets much easier: get_args(get_type_hints(method)["return"])[0]
 
+        if string.startswith("Iterator["):
+            return string[9:-1]
+
         if not string.startswith("Generator["):
-            raise ValueError("All generators must be annotated using 'typing.Generator'")
+            raise ValueError("All generators must be annotated using 'Generator' or 'Iterator'")
 
         bracket_count, letters = 0, []
         for char in string[10:]:


### PR DESCRIPTION
## Description
With the release of `pydoclint` v0.3.0, Iterators are back in the game.