### PR TITLE
Fix `FilesAPI.upload` for pyodide users

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ Changes are grouped as follows
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
+## [6.15.3] - 2023-08-30
+### Fixed
+- Uploading files using `client.files.upload` now works when running with `pyodide`.
+
 ## [6.15.2] - 2023-08-29
 ### Improved
 - Improved error message for `CogniteMissingClientError`. Now includes the type of object missing the `CogniteClient` reference.

--- a/cognite/client/__init__.py
+++ b/cognite/client/__init__.py
@@ -1,15 +1,12 @@
 from __future__ import annotations
 
-import sys
-
 from cognite.client._cognite_client import CogniteClient
+from cognite.client._constants import _RUNNING_IN_BROWSER
 from cognite.client._version import __version__
 from cognite.client.config import ClientConfig, global_config
 from cognite.client.data_classes import data_modeling
 
 __all__ = ["ClientConfig", "CogniteClient", "__version__", "global_config", "data_modeling"]
-
-_RUNNING_IN_BROWSER = sys.platform == "emscripten" and "pyodide" in sys.modules
 
 if _RUNNING_IN_BROWSER:
     from cognite.client.utils._pyodide_helpers import patch_sdk_for_pyodide

--- a/cognite/client/_api/files.py
+++ b/cognite/client/_api/files.py
@@ -17,7 +17,7 @@ from typing import (
 
 from cognite.client import utils
 from cognite.client._api_client import APIClient
-from cognite.client._constants import LIST_LIMIT_DEFAULT
+from cognite.client._constants import _RUNNING_IN_BROWSER, LIST_LIMIT_DEFAULT
 from cognite.client.data_classes import (
     FileAggregate,
     FileMetadata,
@@ -485,8 +485,6 @@ class FilesAPI(APIClient):
         raise ValueError(f"The path '{path}' does not exist")
 
     def _upload_file_from_path(self, file: FileMetadata, file_path: str, overwrite: bool) -> FileMetadata:
-        from cognite.client import _RUNNING_IN_BROWSER
-
         fh: bytes | BufferedReader
         with open(file_path, "rb") as fh:
             if _RUNNING_IN_BROWSER:

--- a/cognite/client/_constants.py
+++ b/cognite/client/_constants.py
@@ -1,5 +1,9 @@
 from __future__ import annotations
 
+import sys
+
+_RUNNING_IN_BROWSER = sys.platform == "emscripten" and "pyodide" in sys.modules
+
 LIST_LIMIT_DEFAULT = 25
 # Max JavaScript-safe integer 2^53 - 1
 MAX_VALID_INTERNAL_ID = 9007199254740991

--- a/cognite/client/_version.py
+++ b/cognite/client/_version.py
@@ -1,4 +1,4 @@
 from __future__ import annotations
 
-__version__ = "6.15.2"
+__version__ = "6.15.3"
 __api_subversion__ = "V20220125"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "cognite-sdk"
 
-version = "6.15.2"
+version = "6.15.3"
 
 description = "Cognite Python SDK"
 readme = "README.md"


### PR DESCRIPTION
## Description
- Uploading files using `client.files.upload` now works when running with `pyodide`. Previously, the file handle would just be cast to string and uploaded.

## Checklist:
- [ ] Tests added/updated.
- [ ] Documentation updated. Documentation is generated from docstrings - these must be updated according to your change.
  If a new method has been added it should be referenced in [cognite.rst](https://github.com/cognitedata/cognite-sdk-python/blob/master/docs/source/cognite.rst) in order to generate docs based on its docstring.
- [x] Changelog updated in [CHANGELOG.md](https://github.com/cognitedata/cognite-sdk-python/blob/master/CHANGELOG.md).
- [x] Version bumped. If triggering a new release is desired, bump the version number in [_version.py](https://github.com/cognitedata/cognite-sdk-python/blob/master/cognite/client/_version.py) and [pyproject.toml](https://github.com/cognitedata/cognite-sdk-python/blob/master/pyproject.toml) per [semantic versioning](https://semver.org/).
