### PR TITLE
add mixin class for `CogniteClient` reference handling

### DIFF
--- a/cognite/client/_api/functions.py
+++ b/cognite/client/_api/functions.py
@@ -522,7 +522,7 @@ class FunctionsAPI(APIClient):
 def _create_session_and_return_nonce(
     client: CogniteClient,
     client_credentials: dict | ClientCredentials | None = None,
-) -> str | None:
+) -> str:
     if client_credentials is None:
         if isinstance(client._config.credentials, OAuthClientCertificate):
             raise CogniteAuthError("Client certificate credentials is not supported with the Functions API")

--- a/cognite/client/_api_client.py
+++ b/cognite/client/_api_client.py
@@ -991,7 +991,7 @@ class APIClient:
             result = self._update_multiple(items, list_cls, resource_cls, update_cls, mode=mode)
         except CogniteNotFoundError as not_found_error:
             items_by_external_id = {item.external_id: item for item in items if item.external_id is not None}  # type: ignore [attr-defined]
-            items_by_id = {item.id: item for item in items if hasattr(item, "id") and item.id is not None}  # type: ignore [attr-defined]
+            items_by_id = {item.id: item for item in items if hasattr(item, "id") and item.id is not None}
             # Not found must have an external id as they do not exist in CDF:
             try:
                 missing_external_ids = {entry["externalId"] for entry in not_found_error.not_found}

--- a/cognite/client/data_classes/_base.py
+++ b/cognite/client/data_classes/_base.py
@@ -4,6 +4,7 @@ import json
 from abc import ABC, abstractmethod
 from collections import UserList
 from collections.abc import Iterable
+from contextlib import suppress
 from dataclasses import dataclass
 from enum import Enum
 from typing import (
@@ -16,7 +17,6 @@ from typing import (
     Literal,
     Protocol,
     Sequence,
-    SupportsIndex,
     TypeVar,
     Union,
     cast,
@@ -57,12 +57,6 @@ class CogniteResponse:
     def __eq__(self, other: Any) -> bool:
         return type(other) is type(self) and other.dump() == self.dump()
 
-    def __getattribute__(self, item: Any) -> Any:
-        attr = super().__getattribute__(item)
-        if item == "_cognite_client" and attr is None:
-            raise CogniteMissingClientError(self)
-        return attr
-
     def dump(self, camel_case: bool = False) -> dict[str, Any]:
         """Dump the instance into a json serializable Python data type.
 
@@ -85,15 +79,35 @@ class CogniteResponse:
 T_CogniteResponse = TypeVar("T_CogniteResponse", bound=CogniteResponse)
 
 
-class CogniteResource:
-    _cognite_client: Any
+class _WithClientMixin:
+    @property
+    def _cognite_client(self) -> CogniteClient:
+        with suppress(AttributeError):
+            if self.__cognite_client is not None:
+                return self.__cognite_client
+        raise CogniteMissingClientError(self)
 
-    def __new__(cls, *args: Any, **kwargs: Any) -> CogniteResource:
-        obj = super().__new__(cls)
-        obj._cognite_client = None
-        if "cognite_client" in kwargs:
-            obj._cognite_client = kwargs["cognite_client"]
-        return obj
+    @_cognite_client.setter
+    def _cognite_client(self, value: CogniteClient | None) -> None:
+        from cognite.client import CogniteClient
+
+        if value is None or isinstance(value, CogniteClient):
+            self.__cognite_client = value
+        else:
+            raise AttributeError(
+                "Can't set the CogniteClient reference to anything else than a CogniteClient instance or None"
+            )
+
+    def _get_cognite_client(self) -> CogniteClient | None:
+        """Get Cognite client reference without raising (when missing)"""
+        return self.__cognite_client
+
+
+class CogniteResource(_WithClientMixin):
+    __cognite_client: CogniteClient | None
+
+    def __init__(self, cognite_client: CogniteClient | None = None) -> None:
+        raise NotImplementedError
 
     def __eq__(self, other: Any) -> bool:
         return type(self) is type(other) and self.dump() == other.dump()
@@ -101,12 +115,6 @@ class CogniteResource:
     def __str__(self) -> str:
         item = convert_time_attributes_to_datetime(self.dump())
         return json.dumps(item, default=utils._auxiliary.json_dump_default, indent=4)
-
-    def __getattribute__(self, item: Any) -> Any:
-        attr = super().__getattribute__(item)
-        if item == "_cognite_client" and attr is None:
-            raise CogniteMissingClientError(self)
-        return attr
 
     def dump(self, camel_case: bool = False) -> dict[str, Any]:
         """Dump the instance into a json serializable Python data type.
@@ -188,8 +196,9 @@ class CognitePropertyClassUtil:
             self[schema_name] = value
 
 
-class CogniteResourceList(UserList, Generic[T_CogniteResource]):
-    _RESOURCE: type[CogniteResource]
+class CogniteResourceList(UserList, Generic[T_CogniteResource], _WithClientMixin):
+    _RESOURCE: type[T_CogniteResource]
+    __cognite_client: CogniteClient | None
 
     def __init__(self, resources: Collection[Any], cognite_client: CogniteClient | None = None) -> None:
         for resource in resources:
@@ -209,34 +218,26 @@ class CogniteResourceList(UserList, Generic[T_CogniteResource]):
             if hasattr(self.data[0], "id"):
                 self._id_to_item = {item.id: item for item in self.data if item.id is not None}
 
-    def __getattribute__(self, item: Any) -> Any:
-        attr = super().__getattribute__(item)
-        if item == "_cognite_client" and attr is None:
-            raise CogniteMissingClientError(self)
-        return attr
-
     def pop(self, i: int = -1) -> T_CogniteResource:
         return super().pop(i)
 
     def __iter__(self) -> Iterator[T_CogniteResource]:
         return super().__iter__()
 
-    @overload
-    def __getitem__(self, item: SupportsIndex) -> T_CogniteResource:
+    @overload  # type: ignore [override]
+    # Generic[T] + UserList does not like this overload:
+    def __getitem__(self: T_CogniteResourceList, item: int) -> T_CogniteResource:
         ...
 
     @overload
-    def __getitem__(self, item: slice) -> CogniteResourceList[T_CogniteResource]:
+    def __getitem__(self: T_CogniteResourceList, item: slice) -> T_CogniteResourceList:
         ...
 
-    def __getitem__(self, item: Any) -> Any:
-        value = super().__getitem__(item)
+    def __getitem__(self: T_CogniteResourceList, item: int | slice) -> T_CogniteResource | T_CogniteResourceList:
+        value = self.data[item]
         if isinstance(item, slice):
-            c = None
-            if super().__getattribute__("_cognite_client") is not None:
-                c = self._cognite_client
-            return self.__class__(value, cognite_client=c)
-        return value
+            return type(self)(value, cognite_client=self._get_cognite_client())
+        return cast(T_CogniteResource, value)
 
     def __str__(self) -> str:
         item = convert_time_attributes_to_datetime(self.dump())

--- a/cognite/client/data_classes/_base.py
+++ b/cognite/client/data_classes/_base.py
@@ -17,6 +17,7 @@ from typing import (
     Literal,
     Protocol,
     Sequence,
+    SupportsIndex,
     TypeVar,
     Union,
     cast,
@@ -224,16 +225,17 @@ class CogniteResourceList(UserList, Generic[T_CogniteResource], _WithClientMixin
     def __iter__(self) -> Iterator[T_CogniteResource]:
         return super().__iter__()
 
-    @overload  # type: ignore [override]
-    # Generic[T] + UserList does not like this overload:
-    def __getitem__(self: T_CogniteResourceList, item: int) -> T_CogniteResource:
+    @overload
+    def __getitem__(self: T_CogniteResourceList, item: SupportsIndex) -> T_CogniteResource:
         ...
 
     @overload
     def __getitem__(self: T_CogniteResourceList, item: slice) -> T_CogniteResourceList:
         ...
 
-    def __getitem__(self: T_CogniteResourceList, item: int | slice) -> T_CogniteResource | T_CogniteResourceList:
+    def __getitem__(
+        self: T_CogniteResourceList, item: SupportsIndex | slice
+    ) -> T_CogniteResource | T_CogniteResourceList:
         value = self.data[item]
         if isinstance(item, slice):
             return type(self)(value, cognite_client=self._get_cognite_client())

--- a/cognite/client/data_classes/assets.py
+++ b/cognite/client/data_classes/assets.py
@@ -174,14 +174,14 @@ class Asset(CogniteResource):
         return hash(self.external_id)
 
     def parent(self) -> Asset:
-        """Returns this assets parent.
+        """Returns this asset's parent.
 
         Returns:
             Asset: The parent asset.
         """
         if self.parent_id is None:
-            raise ValueError("parent_id is None")
-        return self._cognite_client.assets.retrieve(id=self.parent_id)
+            raise ValueError("parent_id is None, is this a root asset?")
+        return cast(Asset, self._cognite_client.assets.retrieve(id=self.parent_id))
 
     def children(self) -> AssetList:
         """Returns the children of this asset.
@@ -189,6 +189,7 @@ class Asset(CogniteResource):
         Returns:
             AssetList: The requested assets
         """
+        assert self.id is not None
         return self._cognite_client.assets.list(parent_ids=[self.id], limit=None)
 
     def subtree(self, depth: int | None = None) -> AssetList:
@@ -200,6 +201,7 @@ class Asset(CogniteResource):
         Returns:
             AssetList: The requested assets sorted topologically.
         """
+        assert self.id is not None
         return self._cognite_client.assets.retrieve_subtree(id=self.id, depth=depth)
 
     def time_series(self, **kwargs: Any) -> TimeSeriesList:
@@ -210,6 +212,7 @@ class Asset(CogniteResource):
         Returns:
             TimeSeriesList: All time series related to this asset.
         """
+        assert self.id is not None
         return self._cognite_client.time_series.list(asset_ids=[self.id], **kwargs)
 
     def sequences(self, **kwargs: Any) -> SequenceList:
@@ -220,6 +223,7 @@ class Asset(CogniteResource):
         Returns:
             SequenceList: All sequences related to this asset.
         """
+        assert self.id is not None
         return self._cognite_client.sequences.list(asset_ids=[self.id], **kwargs)
 
     def events(self, **kwargs: Any) -> EventList:
@@ -230,7 +234,7 @@ class Asset(CogniteResource):
         Returns:
             EventList: All events related to this asset.
         """
-
+        assert self.id is not None
         return self._cognite_client.events.list(asset_ids=[self.id], **kwargs)
 
     def files(self, **kwargs: Any) -> FileMetadataList:
@@ -241,6 +245,7 @@ class Asset(CogniteResource):
         Returns:
             FileMetadataList: Metadata about all files related to this asset.
         """
+        assert self.id is not None
         return self._cognite_client.files.list(asset_ids=[self.id], **kwargs)
 
     def dump(self, camel_case: bool = False) -> dict[str, Any]:

--- a/cognite/client/data_classes/data_modeling/_core.py
+++ b/cognite/client/data_classes/data_modeling/_core.py
@@ -14,14 +14,15 @@ if TYPE_CHECKING:
 class DataModelingResource(CogniteResource):
     def __repr__(self) -> str:
         args = []
+        # TODO: Need newer mypy version to understand the below hasattr's:
         if hasattr(self, "space"):
-            space = self.space
+            space = self.space  # type: ignore [attr-defined]
             args.append(f"{space=}")
         if hasattr(self, "external_id"):
-            external_id = self.external_id
+            external_id = self.external_id  # type: ignore [attr-defined]
             args.append(f"{external_id=}")
         if hasattr(self, "version"):
-            version = self.version
+            version = self.version  # type: ignore [attr-defined]
             args.append(f"{version=}")
 
         return f"<{type(self).__qualname__}({', '.join(args)}) at {id(self):#x}>"

--- a/cognite/client/data_classes/data_modeling/_core.py
+++ b/cognite/client/data_classes/data_modeling/_core.py
@@ -14,15 +14,14 @@ if TYPE_CHECKING:
 class DataModelingResource(CogniteResource):
     def __repr__(self) -> str:
         args = []
-        # TODO: Need newer mypy version to understand the below hasattr's:
         if hasattr(self, "space"):
-            space = self.space  # type: ignore [attr-defined]
+            space = self.space
             args.append(f"{space=}")
         if hasattr(self, "external_id"):
-            external_id = self.external_id  # type: ignore [attr-defined]
+            external_id = self.external_id
             args.append(f"{external_id=}")
         if hasattr(self, "version"):
-            version = self.version  # type: ignore [attr-defined]
+            version = self.version
             args.append(f"{version=}")
 
         return f"<{type(self).__qualname__}({', '.join(args)}) at {id(self):#x}>"

--- a/cognite/client/data_classes/data_modeling/ids.py
+++ b/cognite/client/data_classes/data_modeling/ids.py
@@ -12,7 +12,7 @@ from cognite.client.utils._text import convert_all_keys_recursive, convert_all_k
 @dataclass(frozen=True)
 class AbstractDataclass(ABC):
     def __new__(cls, *args: Any, **kwargs: Any) -> Any:
-        if cls == AbstractDataclass or cls.__bases__[0] == AbstractDataclass:
+        if cls is AbstractDataclass or cls.__bases__[0] is AbstractDataclass:
             raise TypeError("Cannot instantiate abstract class.")
         return super().__new__(cls)
 

--- a/cognite/client/data_classes/documents.py
+++ b/cognite/client/data_classes/documents.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import json
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, List, Literal, Union
+from typing import TYPE_CHECKING, Any, List, Literal, Union, cast
 
 from typing_extensions import TypeAlias
 
@@ -72,7 +72,7 @@ class SourceFile(CogniteResource):
         self.dataset_id = dataset_id
         self.security_categories = security_categories
         self.metadata: dict[str, str] = metadata or {}
-        self._cognite_client = cognite_client
+        self._cognite_client = cast("CogniteClient", cognite_client)
 
     @classmethod
     def _load(cls, resource: dict | str, cognite_client: CogniteClient | None = None) -> SourceFile:
@@ -163,7 +163,7 @@ class Document(CogniteResource):
         self.asset_ids: list[int] = asset_ids or []
         self.labels: list[Label] = Label._load_list(labels) or []
         self.geo_location = geo_location
-        self._cognite_client = cognite_client
+        self._cognite_client = cast("CogniteClient", cognite_client)
 
     @classmethod
     def _load(cls, resource: dict | str, cognite_client: CogniteClient | None = None) -> Document:

--- a/cognite/client/data_classes/extractionpipelines.py
+++ b/cognite/client/data_classes/extractionpipelines.py
@@ -328,7 +328,7 @@ class ExtractionPipelineConfigRevision(CogniteResource):
         self.revision = revision
         self.description = description
         self.created_time = created_time
-        self._cognite_client = cognite_client
+        self._cognite_client = cast("CogniteClient", cognite_client)
 
 
 class ExtractionPipelineConfig(ExtractionPipelineConfigRevision):

--- a/cognite/client/data_classes/functions.py
+++ b/cognite/client/data_classes/functions.py
@@ -312,11 +312,11 @@ class FunctionCall(CogniteResource):
         self.function_id = function_id
         self._cognite_client = cast("CogniteClient", cognite_client)
 
-    def get_response(self) -> dict:
+    def get_response(self) -> dict | None:
         """Retrieve the response from this function call.
 
         Returns:
-            dict: Response from the function call.
+            dict | None: Response from the function call.
         """
         if self.id is None or self.function_id is None:
             raise ValueError("FunctionCall is missing one or more of: [id, function_id]")

--- a/cognite/client/data_classes/iam.py
+++ b/cognite/client/data_classes/iam.py
@@ -146,16 +146,13 @@ class CreatedSession(CogniteResponse):
 
     @classmethod
     def _load(cls, response: dict[str, Any]) -> CreatedSession:
-        to_load = {
-            "id": response["id"],
-            "status": response["status"],
-            "nonce": response["nonce"],
-        }
-        if "type" in response:
-            to_load["type"] = response["type"]
-        if "clientId" in response:
-            to_load["client_id"] = response["clientId"]
-        return cls(**to_load)
+        return cls(
+            id=response["id"],
+            status=response["status"],
+            nonce=response["nonce"],
+            type=response.get("type"),
+            client_id=response.get("clientId"),
+        )
 
 
 class Session(CogniteResource):

--- a/cognite/client/data_classes/iam.py
+++ b/cognite/client/data_classes/iam.py
@@ -119,32 +119,43 @@ class TokenInspection(CogniteResponse):
         return dumped
 
 
-class CreatedSession(CogniteResource):
+class CreatedSession(CogniteResponse):
     """Session creation related information
 
     Args:
-        id (int | None): ID of the created session.
+        id (int): ID of the created session.
+        status (str): Current status of the session.
+        nonce (str): Nonce to be passed to the internal service that will bind the session
         type (str | None): Credentials kind used to create the session.
-        status (str | None): Current status of the session.
-        nonce (str | None): Nonce to be passed to the internal service that will bind the session
         client_id (str | None): Client ID in identity provider. Returned only if the session was created using client credentials
-        cognite_client (CogniteClient | None): No description.
     """
 
     def __init__(
         self,
-        id: int | None = None,
+        id: int,
+        status: str,
+        nonce: str,
         type: str | None = None,
-        status: str | None = None,
-        nonce: str | None = None,
         client_id: str | None = None,
-        cognite_client: CogniteClient | None = None,
     ) -> None:
         self.id = id
-        self.type = type
         self.status = status
         self.nonce = nonce
+        self.type = type
         self.client_id = client_id
+
+    @classmethod
+    def _load(cls, response: dict[str, Any]) -> CreatedSession:
+        to_load = {
+            "id": response["id"],
+            "status": response["status"],
+            "nonce": response["nonce"],
+        }
+        if "type" in response:
+            to_load["type"] = response["type"]
+        if "clientId" in response:
+            to_load["client_id"] = response["clientId"]
+        return cls(**to_load)
 
 
 class Session(CogniteResource):

--- a/cognite/client/data_classes/raw.py
+++ b/cognite/client/data_classes/raw.py
@@ -83,7 +83,7 @@ class Table(CogniteResource):
         ...
 
     @overload
-    def rows(self, key: None, limit: int | None = None) -> RowList:
+    def rows(self, key: None = None, limit: int | None = None) -> RowList:
         ...
 
     def rows(self, key: str | None = None, limit: int | None = None) -> Row | RowList | None:

--- a/cognite/client/data_classes/raw.py
+++ b/cognite/client/data_classes/raw.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections import OrderedDict
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING, Any, cast, overload
 
 from cognite.client import utils
 from cognite.client.data_classes._base import CogniteResource, CogniteResourceList
@@ -78,7 +78,15 @@ class Table(CogniteResource):
 
         self._db_name: str | None = None
 
-    def rows(self, key: str | None = None, limit: int | None = None) -> Row | RowList:
+    @overload
+    def rows(self, key: str, limit: int | None = None) -> Row | None:
+        ...
+
+    @overload
+    def rows(self, key: None, limit: int | None = None) -> RowList:
+        ...
+
+    def rows(self, key: str | None = None, limit: int | None = None) -> Row | RowList | None:
         """Get the rows in this table.
 
         Args:
@@ -86,9 +94,14 @@ class Table(CogniteResource):
             limit (int | None): The number of rows to return.
 
         Returns:
-            Row | RowList: List of tables in this database.
+            Row | RowList | None: List of tables in this database.
         """
-        if key:
+        if self._db_name is None:
+            raise ValueError("Table is not linked to a database, did you instantiate it yourself?")
+        elif self.name is None:
+            raise ValueError("Table 'name' is missing")
+
+        if key is not None:
             return self._cognite_client.raw.rows.retrieve(db_name=self._db_name, table_name=self.name, key=key)
         return self._cognite_client.raw.rows.list(db_name=self._db_name, table_name=self.name, limit=limit)
 
@@ -125,6 +138,8 @@ class Database(CogniteResource):
         Returns:
             TableList: List of tables in this database.
         """
+        if self.name is None:
+            raise ValueError("Unable to list tables, 'name' is not set on instance")
         return self._cognite_client.raw.tables.list(db_name=self.name, limit=limit)
 
 

--- a/cognite/client/data_classes/sequences.py
+++ b/cognite/client/data_classes/sequences.py
@@ -87,7 +87,7 @@ class Sequence(CogniteResource):
             SequenceData: List of sequence data.
         """
         identifier = Identifier.load(self.id, self.external_id).as_dict()
-        return self._cognite_client.sequences.data.retrieve(**identifier, start=start, end=end)
+        return cast(SequenceData, self._cognite_client.sequences.data.retrieve(**identifier, start=start, end=end))
 
     @property
     def column_external_ids(self) -> list[str]:

--- a/cognite/client/data_classes/time_series.py
+++ b/cognite/client/data_classes/time_series.py
@@ -105,7 +105,7 @@ class TimeSeries(CogniteResource):
         dps = self._cognite_client.time_series.data.retrieve(
             **identifier, start=MIN_TIMESTAMP_MS, end=MAX_TIMESTAMP_MS + 1, aggregates="count", granularity="100d"
         )
-        return sum(dps.count)
+        return sum(dps.count)  # type: ignore [union-attr, arg-type]
 
     def latest(self, before: int | str | datetime | None = None) -> Datapoint | None:
         """Returns the latest datapoint in this time series. If empty, returns None.
@@ -117,7 +117,7 @@ class TimeSeries(CogniteResource):
         """
         identifier = Identifier.load(self.id, self.external_id).as_dict()
         if dps := self._cognite_client.time_series.data.retrieve_latest(**identifier, before=before):
-            return dps[0]
+            return dps[0]  # type: ignore [return-value]
         return None
 
     def first(self) -> Datapoint | None:
@@ -131,7 +131,7 @@ class TimeSeries(CogniteResource):
             **identifier, start=MIN_TIMESTAMP_MS, end=MAX_TIMESTAMP_MS + 1, limit=1
         )
         if dps:
-            return dps[0]
+            return dps[0]  # type: ignore [return-value]
         return None
 
     def asset(self) -> Asset:
@@ -144,7 +144,7 @@ class TimeSeries(CogniteResource):
         """
         if self.asset_id is None:
             raise ValueError("asset_id is None")
-        return self._cognite_client.assets.retrieve(id=self.asset_id)
+        return cast(Asset, self._cognite_client.assets.retrieve(id=self.asset_id))
 
 
 class TimeSeriesFilter(CogniteFilter):

--- a/cognite/client/data_classes/time_series.py
+++ b/cognite/client/data_classes/time_series.py
@@ -144,7 +144,7 @@ class TimeSeries(CogniteResource):
         """
         if self.asset_id is None:
             raise ValueError("asset_id is None")
-        return cast(Asset, self._cognite_client.assets.retrieve(id=self.asset_id))
+        return cast("Asset", self._cognite_client.assets.retrieve(id=self.asset_id))
 
 
 class TimeSeriesFilter(CogniteFilter):

--- a/cognite/client/data_classes/transformations/__init__.py
+++ b/cognite/client/data_classes/transformations/__init__.py
@@ -215,7 +215,7 @@ class Transformation(CogniteResource):
                 else:
                     credentials = None
                 try:
-                    session = self._cognite_client.iam.sessions.create(credentials, project=project)
+                    session = self._cognite_client.iam.sessions.create(credentials)
                     ret = NonceCredentials(session.id, session.nonce, project)
                     sessions_cache[key] = ret
                 except Exception:
@@ -223,13 +223,13 @@ class Transformation(CogniteResource):
             return ret
 
         if self.source_nonce is None and self.source_oidc_credentials:
-            project = self.source_oidc_credentials.cdf_project_name or self._cognite_client.project
+            project = self.source_oidc_credentials.cdf_project_name or self._cognite_client.config.project
             self.source_nonce = try_get_or_create_nonce(self.source_oidc_credentials, project)
             if self.source_nonce:
                 self.source_oidc_credentials = None
 
         if self.destination_nonce is None and self.destination_oidc_credentials:
-            project = self.destination_oidc_credentials.cdf_project_name or self._cognite_client.project
+            project = self.destination_oidc_credentials.cdf_project_name or self._cognite_client.config.project
             self.destination_nonce = try_get_or_create_nonce(self.destination_oidc_credentials, project)
             if self.destination_nonce:
                 self.destination_oidc_credentials = None

--- a/cognite/client/data_classes/transformations/jobs.py
+++ b/cognite/client/data_classes/transformations/jobs.py
@@ -113,7 +113,13 @@ class TransformationJob(CogniteResource):
 
     def update(self) -> None:
         """`Get updated job status.`"""
+        if self.id is None:
+            raise ValueError("Unable to update, TransformationJob is missing 'id'")
+
         updated = self._cognite_client.transformations.jobs.retrieve(id=self.id)
+        if updated is None:
+            raise RuntimeError("Unable to update the transformation. Has it been deleted?")
+
         self.status = updated.status
         self.error = updated.error
         self.started_time = updated.started_time

--- a/tests/tests_integration/test_api/test_transformations/test_transformations.py
+++ b/tests/tests_integration/test_api/test_transformations/test_transformations.py
@@ -102,6 +102,7 @@ class TestTransformationsAPI:
         ts = cognite_client.transformations.create(transform)
         cognite_client.transformations.delete(id=ts.id)
 
+    @pytest.mark.skip(reason="Awaiting access to an additional CDF project")
     def test_create_asset_with_source_destination_oidc_transformation(self, cognite_client):
         prefix = random_string(6, string.ascii_letters)
         transform = Transformation(

--- a/tests/tests_unit/test_api/test_functions.py
+++ b/tests/tests_unit/test_api/test_functions.py
@@ -131,7 +131,7 @@ def mock_sessions_with_client_credentials(rsps, cognite_client_with_client_crede
         rsps.POST,
         url=url,
         status=200,
-        json={"items": [{"nonce": "aabbccdd"}]},
+        json={"items": [{"nonce": "aabbccdd", "id": 123, "status": "mocky"}]},
         match=[post_body_matcher({"items": [{"clientId": creds.client_id, "clientSecret": creds.client_secret}]})],
     )
 
@@ -146,7 +146,7 @@ def mock_sessions_with_token_exchange(rsps, cognite_client):
         rsps.POST,
         url=url,
         status=200,
-        json={"items": [{"nonce": "aabbccdd"}]},
+        json={"items": [{"nonce": "aabbccdd", "id": 123, "status": "mocky"}]},
         match=[post_body_matcher({"items": [{"tokenExchange": True}]})],
     )
 
@@ -784,7 +784,12 @@ def mock_filter_function_schedules_response(rsps, cognite_client):
 @pytest.fixture
 def mock_function_schedules_response(rsps, cognite_client):
     # Creating a new schedule first needs a session (to pass the nonce):
-    rsps.add(rsps.POST, full_url(cognite_client, "/sessions"), status=200, json={"items": [{"nonce": "very noncy"}]})
+    rsps.add(
+        rsps.POST,
+        full_url(cognite_client, "/sessions"),
+        status=200,
+        json={"items": [{"nonce": "very noncy", "id": 123, "status": "mocky"}]},
+    )
 
     url = full_url(cognite_client, "/functions/schedules")
     rsps.assert_all_requests_are_fired = False
@@ -797,7 +802,12 @@ def mock_function_schedules_response(rsps, cognite_client):
 @pytest.fixture
 def mock_function_schedules_response_xid_not_valid_with_oidc(rsps, cognite_client):
     # Creating a new schedule first needs a session (to pass the nonce):
-    rsps.add(rsps.POST, full_url(cognite_client, "/sessions"), status=200, json={"items": [{"nonce": "very noncy"}]})
+    rsps.add(
+        rsps.POST,
+        full_url(cognite_client, "/sessions"),
+        status=200,
+        json={"items": [{"nonce": "very noncy", "id": 123, "status": "mocky"}]},
+    )
     rsps.add(
         rsps.POST,
         full_url(cognite_client, "/functions/schedules"),
@@ -820,7 +830,7 @@ def mock_function_schedules_response_oidc_client_credentials(rsps, cognite_clien
         rsps.POST,
         session_url,
         status=200,
-        json={"items": [{"nonce": "aaabbb"}]},
+        json={"items": [{"nonce": "aaabbb", "id": 123, "status": "mocky"}]},
         match=[post_body_matcher({"items": [{"clientId": "aabbccdd", "clientSecret": "xxyyzz"}]})],
     )
 

--- a/tests/tests_unit/test_api/test_functions.py
+++ b/tests/tests_unit/test_api/test_functions.py
@@ -1107,7 +1107,7 @@ class TestFunctionCallsAPI:
 
 @pytest.fixture
 def fns_api_with_mock_client(cognite_client):
-    cognite_client.functions._cognite_client = MagicMock(spec_set=CogniteClient)
+    cognite_client.functions._cognite_client = MagicMock()
     return cognite_client.functions
 
 

--- a/tests/tests_unit/test_api/test_functions.py
+++ b/tests/tests_unit/test_api/test_functions.py
@@ -1107,7 +1107,7 @@ class TestFunctionCallsAPI:
 
 @pytest.fixture
 def fns_api_with_mock_client(cognite_client):
-    cognite_client.functions._cognite_client = MagicMock()
+    cognite_client.functions._cognite_client = MagicMock(spec_set=CogniteClient)
     return cognite_client.functions
 
 

--- a/tests/tests_unit/test_base.py
+++ b/tests/tests_unit/test_base.py
@@ -146,7 +146,7 @@ class TestCogniteResource:
 
     def test_eq(self):
         assert MyResource(1, "s") == MyResource(1, "s")
-        assert MyResource(1, "s") == MyResource(1, "s", cognite_client=MagicMock(spec_set=CogniteClient))
+        assert MyResource(1, "s") == MyResource(1, "s", cognite_client=MagicMock(spec=CogniteClient))
         assert MyResource() == MyResource()
         assert MyResource(1, "s") != MyResource(1)
         assert MyResource(1, "s") != MyResource(2, "t")
@@ -280,7 +280,7 @@ class TestCogniteResourceList:
         assert isinstance(resource_list[:], MyResourceList)
 
     def test_slice_list_client_remains(self):
-        rl = MyResourceList([MyResource(1, 2)], cognite_client=MagicMock(spec_set=CogniteClient))
+        rl = MyResourceList([MyResource(1, 2)], cognite_client=MagicMock(spec=CogniteClient))
         rl_sliced = rl[:]
         assert rl._cognite_client == rl_sliced._cognite_client
 

--- a/tests/tests_unit/test_base.py
+++ b/tests/tests_unit/test_base.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import json
 from decimal import Decimal
 from typing import Any
-from unittest import mock
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -24,13 +24,6 @@ from cognite.client.data_classes._base import (
 from cognite.client.data_classes.events import Event, EventList
 from cognite.client.exceptions import CogniteMissingClientError
 from tests.utils import all_subclasses
-
-
-@pytest.fixture
-def simple_mock_client():
-    # We allow the mock to pass isinstance checks
-    (client := mock.MagicMock()).__class__ = CogniteClient
-    return client
 
 
 class MyResource(CogniteResource):
@@ -151,9 +144,9 @@ class TestCogniteResource:
     def test_load_object_attr(self):
         assert {"var_a": 1, "var_b": {"camelCase": 1}} == MyResource._load({"varA": 1, "varB": {"camelCase": 1}}).dump()
 
-    def test_eq(self, simple_mock_client):
+    def test_eq(self):
         assert MyResource(1, "s") == MyResource(1, "s")
-        assert MyResource(1, "s") == MyResource(1, "s", cognite_client=simple_mock_client)
+        assert MyResource(1, "s") == MyResource(1, "s", cognite_client=MagicMock(spec_set=CogniteClient))
         assert MyResource() == MyResource()
         assert MyResource(1, "s") != MyResource(1)
         assert MyResource(1, "s") != MyResource(2, "t")
@@ -286,8 +279,8 @@ class TestCogniteResourceList:
         assert MyResourceList([MyResource(1, 2), MyResource(2, 3)]) == resource_list[:]
         assert isinstance(resource_list[:], MyResourceList)
 
-    def test_slice_list_client_remains(self, simple_mock_client):
-        rl = MyResourceList([MyResource(1, 2)], cognite_client=simple_mock_client)
+    def test_slice_list_client_remains(self):
+        rl = MyResourceList([MyResource(1, 2)], cognite_client=MagicMock(spec_set=CogniteClient))
         rl_sliced = rl[:]
         assert rl._cognite_client == rl_sliced._cognite_client
 

--- a/tests/tests_unit/test_data_classes/test_assets.py
+++ b/tests/tests_unit/test_data_classes/test_assets.py
@@ -11,6 +11,7 @@ from unittest.mock import call
 
 import pytest
 
+from cognite.client import CogniteClient
 from cognite.client.data_classes import (
     Asset,
     AssetHierarchy,
@@ -116,7 +117,8 @@ class TestAssetList:
         resources_a2 = resource_list_class([r2, r3])
         resources_a3 = resource_list_class([r2, r3])
 
-        mock_cognite_client = mock.MagicMock()
+        # Make a mock that pass isinstance checks for 'CogniteClient':
+        (mock_cognite_client := mock.MagicMock()).__class__ = CogniteClient
         mock_method = getattr(mock_cognite_client, method)
         mock_method.list.side_effect = [resources_a1, resources_a2, resources_a3]
         mock_method._config = mock.Mock(max_workers=3)

--- a/tests/tests_unit/test_data_classes/test_assets.py
+++ b/tests/tests_unit/test_data_classes/test_assets.py
@@ -117,8 +117,7 @@ class TestAssetList:
         resources_a2 = resource_list_class([r2, r3])
         resources_a3 = resource_list_class([r2, r3])
 
-        # Make a mock that pass isinstance checks for 'CogniteClient':
-        (mock_cognite_client := mock.MagicMock()).__class__ = CogniteClient
+        mock_cognite_client = mock.MagicMock(spec_set=CogniteClient)
         mock_method = getattr(mock_cognite_client, method)
         mock_method.list.side_effect = [resources_a1, resources_a2, resources_a3]
         mock_method._config = mock.Mock(max_workers=3)

--- a/tests/tests_unit/test_data_classes/test_functions.py
+++ b/tests/tests_unit/test_data_classes/test_functions.py
@@ -3,17 +3,24 @@ from unittest.mock import MagicMock, call
 
 import pytest
 
+from cognite.client import CogniteClient
 from cognite.client.data_classes import Function, FunctionSchedule
 from tests.utils import jsgz_load
 
 
 @pytest.fixture
-def empty_function():
-    return Function(id=123, cognite_client=MagicMock())
+def mock_client():
+    (mock_client := MagicMock()).__class__ = CogniteClient
+    return mock_client
 
 
 @pytest.fixture
-def function():
+def empty_function(mock_client):
+    return Function(id=123, cognite_client=mock_client)
+
+
+@pytest.fixture
+def function(mock_client):
     return Function(
         id=123,
         name="my-function",
@@ -25,19 +32,19 @@ def function():
         function_path="handler.py",
         created_time="2020-06-19 08:49:37",
         secrets={},
-        cognite_client=MagicMock(),
+        cognite_client=mock_client,
     )
 
 
 @pytest.fixture
-def function_schedules():
+def function_schedules(mock_client):
     schedule_1 = FunctionSchedule(
         name="my-schedule-1",
         function_id=123,
         description="my schedule 1",
         created_time=12345,
         cron_expression="* * * * *",
-        cognite_client=MagicMock(),
+        cognite_client=mock_client,
     )
     schedule_2 = FunctionSchedule(
         name="my-schedule-2",
@@ -45,7 +52,7 @@ def function_schedules():
         description="my schedule 2",
         created_time=12345,
         cron_expression="* * * * *",
-        cognite_client=MagicMock(),
+        cognite_client=mock_client,
     )
     return [schedule_1, schedule_2]
 

--- a/tests/tests_unit/test_data_classes/test_functions.py
+++ b/tests/tests_unit/test_data_classes/test_functions.py
@@ -10,8 +10,7 @@ from tests.utils import jsgz_load
 
 @pytest.fixture
 def mock_client():
-    (mock_client := MagicMock()).__class__ = CogniteClient
-    return mock_client
+    return MagicMock(spec_set=CogniteClient)
 
 
 @pytest.fixture

--- a/tests/tests_unit/test_data_classes/test_functions.py
+++ b/tests/tests_unit/test_data_classes/test_functions.py
@@ -10,7 +10,9 @@ from tests.utils import jsgz_load
 
 @pytest.fixture
 def mock_client():
-    return MagicMock(spec_set=CogniteClient)
+    # We allow the mock to pass isinstance checks
+    (client := MagicMock()).__class__ = CogniteClient
+    return client
 
 
 @pytest.fixture


### PR DESCRIPTION
## Description
- Add mixin class for `CogniteClient` reference handling.
- Remove `__new__`
- Remove `__getattribute__`

Solves #1342

***

### Bonus (performance notes)
...also worth noting, the removal of `__getattribute__` comes with a nice 600 % speed increase for attribute access(-es) 😉 

<img width="690" alt="image" src="https://github.com/cognitedata/cognite-sdk-python/assets/8521241/e67dac49-4f4f-4b77-acd2-a6001f5b72c4">
 
 ***

Object instantiation without our custom `__new__` is ~50% faster:

<img width="771" alt="image" src="https://github.com/cognitedata/cognite-sdk-python/assets/8521241/db6adbb1-cd4e-4037-82b0-d79a5ea1726e">

***

## Checklist:
- [x] Tests added/updated.
- [ ] Documentation updated. Documentation is generated from docstrings - these must be updated according to your change.
  If a new method has been added it should be referenced in [cognite.rst](https://github.com/cognitedata/cognite-sdk-python/blob/master/docs/source/cognite.rst) in order to generate docs based on its docstring.
- [ ] Changelog updated in [CHANGELOG.md](https://github.com/cognitedata/cognite-sdk-python/blob/master/CHANGELOG.md).
- [ ] Version bumped. If triggering a new release is desired, bump the version number in [_version.py](https://github.com/cognitedata/cognite-sdk-python/blob/master/cognite/client/_version.py) and [pyproject.toml](https://github.com/cognitedata/cognite-sdk-python/blob/master/pyproject.toml) per [semantic versioning](https://semver.org/).
