### PR TITLE
Modify docstring formatter be lenient with "short" docstrings

### DIFF
--- a/cognite/client/_api/datapoint_tasks.py
+++ b/cognite/client/_api/datapoint_tasks.py
@@ -719,11 +719,7 @@ class SerialFetchSubtask(BaseDpsFetchSubtask):
 
 class SplittingFetchSubtask(SerialFetchSubtask):
     """Fetches data serially, but splits its time domain ("divide and conquer") based on the density
-    of returned datapoints. Stores data in parent
-
-    Args:
-        max_splitting_factor (int): No description.
-        **kwargs (Any): No description.
+    of returned datapoints. Stores data in parent.
     """
 
     def __init__(self, *, max_splitting_factor: int = 10, **kwargs: Any) -> None:

--- a/cognite/client/_api/datapoints.py
+++ b/cognite/client/_api/datapoints.py
@@ -320,9 +320,6 @@ class ChunkingDpsFetcher(DpsFetchStrategy):
     time series are chunked per request is dynamic and is decided by the overall number to fetch, their
     individual number of datapoints and whether raw- or aggregate datapoints are asked for since
     they are independent in requests - as long as the total number of time series does not exceed `_FETCH_TS_LIMIT`.
-
-    Args:
-        *args (Any): No description.
     """
 
     def __init__(self, *args: Any) -> None:

--- a/cognite/client/_http_client.py
+++ b/cognite/client/_http_client.py
@@ -173,12 +173,7 @@ class HTTPClient:
     ) -> bool:
         """requests does not use the "raise ... from ..." syntax, so we need to access the underlying exceptions using
         the __context__ attribute.
-
-        Args:
-            exc (BaseException): No description.
-            exc_types (tuple[type[BaseException], ...] | type[BaseException]): No description.
-        Returns:
-            bool: No description."""
+        """
         if isinstance(exc, exc_types):
             return True
         if exc.__context__ is None:

--- a/cognite/client/testing.py
+++ b/cognite/client/testing.py
@@ -65,10 +65,7 @@ class CogniteClientMock(MagicMock):
     """Mock for CogniteClient object
 
     All APIs are replaced with specced MagicMock objects.
-
-    Args:
-        *args (Any): No description.
-        **kwargs (Any): No description."""
+    """
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         if "parent" in kwargs:

--- a/cognite/client/utils/_concurrency.py
+++ b/cognite/client/utils/_concurrency.py
@@ -246,14 +246,7 @@ def execute_tasks(
     """
     Will use a default executor if one is not passed explicitly. The default executor type uses a thread pool but can
     be changed using ExecutorSettings.executor_type.
-
-    Args:
-        func (Callable[..., T_Result]): No description.
-        tasks (Sequence[tuple] | list[dict]): No description.
-        max_workers (int): No description.
-        executor (TaskExecutor | None): No description.
-    Returns:
-        TasksSummary: No description."""
+    """
     executor = executor or get_executor(max_workers)
     futures = []
     for task in tasks:

--- a/cognite/client/utils/_graph.py
+++ b/cognite/client/utils/_graph.py
@@ -2,16 +2,7 @@ from __future__ import annotations
 
 
 def find_all_cycles_with_elements(has_cycles: set[str], edges: dict) -> list[list[str]]:
-    """Given a set of connected nodes and a mapping between them (edges), find and return all cycles.
-
-    Raises:
-        KeyError: No loop found or edge does not exist.
-
-    Args:
-        has_cycles (set[str]): No description.
-        edges (dict): No description.
-    Returns:
-        list[list[str]]: No description."""
+    """Given a set of connected nodes and a mapping between them (edges), find and return all cycles."""
     cycles = []
     skip: set[str] = set()
     while has_cycles:
@@ -25,17 +16,7 @@ def find_all_cycles_with_elements(has_cycles: set[str], edges: dict) -> list[lis
 
 
 def find_extended_cycle(slow: str, edges: dict, skip: set[str]) -> tuple[set[str], list[str]]:
-    """Uses Floyd's cycle-finding algo with two pointers "slow" and "fast" moving at different speeds.
-
-    Raises:
-        KeyError: No loop found or edge does not exist.
-
-    Args:
-        slow (str): No description.
-        edges (dict): No description.
-        skip (set[str]): No description.
-    Returns:
-        tuple[set[str], list[str]]: No description."""
+    """Uses Floyd's cycle-finding algo with two pointers "slow" and "fast" moving at different speeds."""
     all_elements = {slow}
     fast = edges[slow]
     while slow != fast:

--- a/cognite/client/utils/_text.py
+++ b/cognite/client/utils/_text.py
@@ -45,11 +45,7 @@ def convert_all_keys_to_camel_case_recursive(dct: dict[str, Any]) -> dict[str, A
     """Converts all the dictionary keys from snake to camel cases included nested objects.
     >>> convert_all_keys_to_camel_case_recursive({"my_key": {"my_key": 1}})
     {'myKey': {'myKey': 1}}
-
-    Args:
-        dct (dict[str, Any]): No description.
-    Returns:
-        dict[str, Any]: No description."""
+    """
     return {
         to_camel_case(k): (convert_all_keys_to_camel_case_recursive(v) if isinstance(v, dict) else v)
         for k, v in dct.items()
@@ -60,12 +56,7 @@ def convert_all_keys_recursive(dct: dict[str, Any], camel_case: bool = False) ->
     """Converts all the dictionary keys from snake to camel cases included nested objects.
     >>> convert_all_keys_recursive({"my_key": {"my_key": 1}}, camel_case=True)
     {'myKey': {'myKey': 1}}
-
-    Args:
-        dct (dict[str, Any]): No description.
-        camel_case (bool): No description.
-    Returns:
-        dict[str, Any]: No description."""
+    """
     return {
         (to_camel_case(k) if camel_case else k): (
             convert_all_keys_recursive(v, camel_case) if isinstance(v, dict) else v

--- a/cognite/client/utils/_time.py
+++ b/cognite/client/utils/_time.py
@@ -268,11 +268,7 @@ class WeekAligner(DateTimeAligner):
         Ceils the date to the next monday
         >>> WeekAligner.ceil(datetime(2023, 4, 9 ))
         datetime.datetime(2023, 4, 10, 0, 0)
-
-        Args:
-            date (datetime): No description.
-        Returns:
-            datetime: No description."""
+        """
         date = cls.normalize(date)
         if (weekday := date.weekday()) != 0:
             return date + timedelta(days=7 - weekday)
@@ -284,11 +280,7 @@ class WeekAligner(DateTimeAligner):
         Floors the date to the nearest monday
         >>> WeekAligner.floor(datetime(2023, 4, 9))
         datetime.datetime(2023, 4, 3, 0, 0)
-
-        Args:
-            date (datetime): No description.
-        Returns:
-            datetime: No description."""
+        """
         date = cls.normalize(date)
         if (weekday := date.weekday()) != 0:
             return date - timedelta(days=weekday)
@@ -317,11 +309,7 @@ class MonthAligner(DateTimeAligner):
         datetime.datetime(2024, 1, 1, 0, 0)
         >>> MonthAligner.ceil(datetime(2024, 1, 10))
         datetime.datetime(2024, 2, 1, 0, 0)
-
-        Args:
-            date (datetime): No description.
-        Returns:
-            datetime: No description."""
+        """
         if date == datetime(year=date.year, month=date.month, day=1, tzinfo=date.tzinfo):
             return date
         extra, month = divmod(date.month + 1, 12)
@@ -353,11 +341,7 @@ class QuarterAligner(DateTimeAligner):
         datetime.datetime(2024, 1, 1, 0, 0)
         >>> QuarterAligner.ceil(datetime(2023, 1, 1))
         datetime.datetime(2023, 1, 1, 0, 0)
-
-        Args:
-            date (datetime): No description.
-        Returns:
-            datetime: No description."""
+        """
         if any(date == datetime(date.year, month, 1, tzinfo=date.tzinfo) for month in [1, 4, 7, 10]):
             return date
         month = 3 * ((date.month - 1) // 3 + 1) + 1
@@ -374,11 +358,7 @@ class QuarterAligner(DateTimeAligner):
         datetime.datetime(2023, 7, 1, 0, 0)
         >>> QuarterAligner.floor(datetime(2023, 12, 1))
         datetime.datetime(2023, 10, 1, 0, 0)
-
-        Args:
-            date (datetime): No description.
-        Returns:
-            datetime: No description."""
+        """
         month = 3 * ((date.month - 1) // 3) + 1
         return cls.normalize(date.replace(month=month, day=1))
 
@@ -559,14 +539,7 @@ def pandas_date_range_tz(start: datetime, end: datetime, freq: str, inclusive: s
     This function overcomes that limitation.
 
     Assumes that start and end have the same timezone.
-
-    Args:
-        start (datetime): No description.
-        end (datetime): No description.
-        freq (str): No description.
-        inclusive (str): No description.
-    Returns:
-        pandas.DatetimeIndex: No description."""
+    """
     pd = cast(Any, local_import("pandas"))
     # There is a bug in date_range which makes it fail to handle ambiguous timestamps when you use time zone aware
     # datetimes. This is a workaround by passing the time zone as an argument to the function.
@@ -600,12 +573,7 @@ def _timezones_are_equal(start_tz: tzinfo, end_tz: tzinfo) -> bool:
     Note:
         We do not consider timezones with different keys, but equal fixed offsets from UTC to be equal. An example
         would be Zulu Time (which is +00:00 ahead of UTC) and UTC.
-
-    Args:
-        start_tz (tzinfo): No description.
-        end_tz (tzinfo): No description.
-    Returns:
-        bool: No description."""
+    """
     if start_tz is end_tz:
         return True
     ZoneInfo, ZoneInfoNotFoundError = import_zoneinfo(), _import_zoneinfo_not_found_error()
@@ -662,12 +630,7 @@ def _unit_in_days(unit: str, ceil: bool = True) -> float:
     **Caveat** Should not be used for precise calculations, as month, quarter, and year
     do not have a precise timespan in days. Instead, the ceil argument is used to select between
     the maximum and minimum length of a year, quarter, and month.
-
-    Args:
-        unit (str): No description.
-        ceil (bool): No description.
-    Returns:
-        float: No description."""
+    """
     if unit in {"w", "d", "h", "m", "s"}:
         unit = GRANULARITY_IN_TIMEDELTA_UNIT[unit]
         arg = {unit: 1}

--- a/scripts/custom_checks/docstrings.py
+++ b/scripts/custom_checks/docstrings.py
@@ -148,6 +148,10 @@ class DocstrFormatter:
             raise ValueError("Missing return type annotation")
 
         for var_name, param in method_signature.parameters.items():
+            if not (isinstance(param.annotation, str) or param.annotation is inspect.Signature.empty):
+                # The file is probably missing '__from__future import annotations', we skip for now:
+                raise FalsePositiveDocstring
+
             if var_name in {"self", "cls"}:
                 continue
             if param.kind is param.VAR_POSITIONAL:

--- a/scripts/custom_checks/docstrings.py
+++ b/scripts/custom_checks/docstrings.py
@@ -202,6 +202,10 @@ class DocstrFormatter:
             elif len(first.split(self.RETURN_STRING)) > 1:
                 raise ValueError(f"'{self.RETURN_STRING}'-line contains additional text")
 
+        if self.line_args_group is self.line_return_group is None:
+            # Skip small docstrings; small as in the writer didnt specify args & return:
+            raise FalsePositiveDocstring
+
         self.add_space_after_args, self.add_space_after_returns = False, False
         if self.line_args_group is not None:
             self.parameters = list(map(Param, DocstrFormatter._parse_args_section(self.line_args_group, indentation)))


### PR DESCRIPTION
## Description

- Don't format short docstrings
- skip docfmt on non-stringified annots
- revert a few docstrings to short format
