### PR TITLE
Add some more ergonomics to instance syncing along with sqlite example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,12 @@ Changes are grouped as follows
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
+## [6.22.0] - 2023-09-08
+### Added
+- `client.data_modeling.instances.subscribe` which lets you subscribe to a given
+data modeling query and receive updates through a provided callback.
+- Example on how to use the subscribe method to sync nodes to a local sqlite db.
+
 ## [6.21.1] - 2023-09-07
 ### Fixed
 - Concurrent usage of the `CogniteClient` could result in API calls being made with the wrong value for `api_subversion`.

--- a/cognite/client/_version.py
+++ b/cognite/client/_version.py
@@ -1,4 +1,4 @@
 from __future__ import annotations
 
-__version__ = "6.21.1"
+__version__ = "6.22.0"
 __api_subversion__ = "V20220125"

--- a/cognite/client/data_classes/data_modeling/instances.py
+++ b/cognite/client/data_classes/data_modeling/instances.py
@@ -691,9 +691,11 @@ class NodeList(CogniteResourceList[Node]):
 
 
 class NodeListWithCursor(NodeList):
-    def __init__(self, resources: Collection[Any], cognite_client: CogniteClient | None = None) -> None:
+    def __init__(
+        self, resources: Collection[Any], cursor: str | None, cognite_client: CogniteClient | None = None
+    ) -> None:
         super().__init__(resources, cognite_client)
-        self.cursor: str | None = None
+        self.cursor = cursor
 
 
 class EdgeApplyResultList(CogniteResourceList[EdgeApplyResult]):
@@ -736,9 +738,11 @@ class EdgeList(CogniteResourceList[Edge]):
 
 
 class EdgeListWithCursor(EdgeList):
-    def __init__(self, resources: Collection[Any], cognite_client: CogniteClient | None = None) -> None:
+    def __init__(
+        self, resources: Collection[Any], cursor: str | None, cognite_client: CogniteClient | None = None
+    ) -> None:
         super().__init__(resources, cognite_client)
-        self.cursor: str | None = None
+        self.cursor = cursor
 
 
 @dataclass

--- a/cognite/client/data_classes/data_modeling/instances.py
+++ b/cognite/client/data_classes/data_modeling/instances.py
@@ -4,6 +4,7 @@ import json
 from abc import abstractmethod
 from collections import defaultdict
 from dataclasses import dataclass
+from datetime import datetime
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -813,3 +814,13 @@ class InstancesDeleteResult:
 
     nodes: list[NodeId]
     edges: list[EdgeId]
+
+
+@dataclass
+class SubscriptionContext:
+    last_successful_sync: datetime | None = None
+    last_successful_callback: datetime | None = None
+    _canceled: bool = False
+
+    def cancel(self) -> None:
+        self._canceled = True

--- a/cognite/client/utils/_retry.py
+++ b/cognite/client/utils/_retry.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+from random import uniform
+from typing import Iterator
+
+
+class Backoff(Iterator[float]):
+    """Iterator that emits how long to wait, according to the "Full Jitter" approach
+    described in this post: https://aws.amazon.com/blogs/architecture/exponential-backoff-and-jitter/
+
+    Args:
+        multiplier (float): No description.
+        max_wait (float): No description.
+        base (int): No description."""
+
+    def __init__(self, multiplier: float = 0.5, max_wait: float = 60.0, base: int = 2) -> None:
+        self._multiplier = multiplier
+        self._max_wait = max_wait
+        self._base = base
+        self._past_attempts = 0
+
+    def __next__(self) -> float:
+        # 100 is an arbitrary limit at which point most sensible parameters are likely to
+        # be capped by max anyway.
+        wait = uniform(0, min(self._multiplier * (self._base ** min(100, self._past_attempts)), self._max_wait))
+        self._past_attempts += 1
+        return wait
+
+    def reset(self) -> None:
+        self._past_attempts = 0
+
+    def has_progressed(self) -> bool:
+        return self._past_attempts > 0

--- a/docs/source/data_modeling.rst
+++ b/docs/source/data_modeling.rst
@@ -126,6 +126,112 @@ Query instances
 Sync instances
 ^^^^^^^^^^^^^^^^^
 .. automethod:: cognite.client._api.data_modeling.instances.InstancesAPI.sync
+.. automethod:: cognite.client._api.data_modeling.instances.InstancesAPI.subscribe
+
+Example on syncing instances to local sqlite
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+.. code:: python
+
+    import json
+    import time
+    import sqlite3
+
+    from cognite.client import CogniteClient
+    from cognite.client.data_classes.data_modeling.instances import (
+        SubscriptionContext,
+    )
+    from cognite.client.data_classes.data_modeling.query import (
+        QueryResult,
+        Query,
+        NodeResultSetExpression,
+        Select,
+    )
+    from cognite.client.data_classes.filters import Equals
+
+    c = CogniteClient()
+
+
+    def sqlite_connection(db_name: str) -> sqlite3.Connection:
+        return sqlite3.connect(db_name, check_same_thread=False)
+
+
+    def bootstrap_sqlite(db_name: str) -> None:
+        with sqlite_connection(db_name) as connection:
+            connection.execute(
+                """
+                CREATE TABLE IF NOT EXISTS instance (
+                    space TEXT,
+                    external_id TEXT,
+                    data JSON,
+                    PRIMARY KEY(space, external_id)
+                )
+                """
+            )
+            connection.execute("CREATE TABLE IF NOT EXISTS cursor (cursor TEXT)")
+
+
+    def sync_space_to_sqlite(
+        db_name: str, space_to_sync: str
+    ) -> SubscriptionContext:
+        with sqlite_connection(db_name) as connection:
+            existing_cursor = connection.execute(
+                "SELECT cursor FROM cursor"
+            ).fetchone()
+            if existing_cursor:
+                print("Found existing cursor, using that")
+
+        query = Query(
+            with_={
+                "nodes": NodeResultSetExpression(
+                    filter=Equals(property=["node", "space"], value=space_to_sync)
+                )
+            },
+            select={"nodes": Select()},
+            cursors={"nodes": existing_cursor[0] if existing_cursor else None},
+        )
+
+        def _sync_batch_to_sqlite(result: QueryResult):
+            with sqlite_connection(db_name) as connection:
+                inserts = []
+                deletes = []
+                for node in result["nodes"]:
+                    if node.deleted_time is None:
+                        inserts.append(
+                            (node.space, node.external_id, json.dumps(node.dump()))
+                        )
+                    else:
+                        deletes.append((node.space, node.external_id))
+                # Updates must be done in the same transaction as persisting the cursor.
+                # A transaction is implicitly started by sqlite here.
+                #
+                # It is also important that deletes happen first as the same (space, external_id)
+                # may appear as several tombstones and then a new instance, which must result in
+                # the instance being saved.
+                connection.executemany(
+                    "DELETE FROM instance WHERE space=? AND external_id=?", deletes
+                )
+                connection.executemany(
+                    "INSERT INTO instance VALUES (?, ?, ?) ON CONFLICT DO UPDATE SET data=excluded.data",
+                    inserts,
+                )
+                connection.execute(
+                    "INSERT INTO cursor VALUES (?)", [result.cursors["nodes"]]
+                )
+                connection.commit()
+            print(f"Wrote {len(inserts)} nodes and deleted {len(deletes)} nodes")
+
+        return c.data_modeling.instances.subscribe(query, _sync_batch_to_sqlite)
+
+
+    if __name__ == "__main__":
+        SQLITE_DB_NAME = "test.db"
+        SPACE_TO_SYNC = "mytestspace"
+        bootstrap_sqlite(db_name=SQLITE_DB_NAME)
+        sync_space_to_sqlite(db_name=SQLITE_DB_NAME, space_to_sync=SPACE_TO_SYNC)
+        while True:
+            # Keep main thread alive
+            time.sleep(10)
+
 
 Delete instances
 ^^^^^^^^^^^^^^^^^^

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "cognite-sdk"
 
-version = "6.21.1"
+version = "6.22.0"
 
 description = "Cognite Python SDK"
 readme = "README.md"

--- a/tests/tests_integration/test_api/test_data_modeling/test_instances.py
+++ b/tests/tests_integration/test_api/test_data_modeling/test_instances.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
 import json
-from typing import Any, cast
+import time
+from typing import Any, ClassVar, cast
 
 import pytest
 
@@ -32,6 +33,13 @@ from cognite.client.data_classes.data_modeling import (
     aggregations,
     filters,
     query,
+)
+from cognite.client.data_classes.data_modeling.query import (
+    NodeResultSetExpression,
+    Query,
+    QueryResult,
+    Select,
+    SourceSelector,
 )
 from cognite.client.exceptions import CogniteAPIError
 
@@ -542,18 +550,18 @@ class TestInstancesAPI:
         assert all(actor.properties.get(actor_id, {}).get("wonOscar") for actor in result["actors"])
         assert result["actors"] == sorted(result["actors"], key=lambda x: x.external_id)
 
+
+class TestInstancesSync:
     def test_sync_movies_released_in_1994(self, cognite_client: CogniteClient, movie_view: View) -> None:
-        # Arrange
         movie_id = movie_view.as_id()
-        q = query
-        f = filters
-        movies_released_1994 = q.NodeResultSetExpression(filter=f.Equals(movie_id.as_property_ref("releaseYear"), 1994))
-        my_query = q.Query(
+        movies_released_1994 = NodeResultSetExpression(
+            filter=filters.Equals(movie_id.as_property_ref("releaseYear"), 1994)
+        )
+        my_query = Query(
             with_={"movies": movies_released_1994},
-            select={"movies": q.Select([q.SourceSelector(movie_id, ["title", "releaseYear"])])},
+            select={"movies": Select([SourceSelector(movie_id, ["title", "releaseYear"])])},
         )
 
-        # Act
         result = cognite_client.data_modeling.instances.sync(my_query)
         assert len(result["movies"]) > 0, "Add at least one movie released in 1994"
 
@@ -580,5 +588,67 @@ class TestInstancesAPI:
             # Assert
             assert len(new_result["movies"]) == 1, "Only the new movie should be returned"
             assert new_result["movies"][0].external_id == new_1994_movie.external_id
+        finally:
+            cognite_client.data_modeling.instances.delete(new_1994_movie.as_id())
+
+    def test_subscribe_to_movies_released_in_1994(self, cognite_client: CogniteClient, movie_view: View) -> None:
+        # Arrange
+        movie_id = movie_view.as_id()
+        movies_released_1994 = NodeResultSetExpression(
+            filter=filters.Equals(movie_id.as_property_ref("releaseYear"), 1994)
+        )
+        my_query = Query(
+            with_={"movies": movies_released_1994},
+            select={"movies": Select([SourceSelector(movie_id, [".*"])])},
+        )
+
+        class State:
+            invocation_count: ClassVar[int] = 0
+
+        def callback(result: QueryResult) -> None:
+            State.invocation_count += 1
+
+        new_1994_movie = NodeApply(
+            space=movie_view.space,
+            external_id="movie:forrest_gump",
+            sources=[
+                NodeOrEdgeData(
+                    source=movie_id,
+                    properties={
+                        "title": "Forrest Gump",
+                        "releaseYear": 1994,
+                        "runTimeMinutes": 142,
+                    },
+                )
+            ],
+        )
+
+        updated_1994_movie = NodeApply(
+            space=movie_view.space,
+            external_id="movie:forrest_gump",
+            sources=[
+                NodeOrEdgeData(
+                    source=movie_id,
+                    properties={
+                        "runTimeMinutes": 200,
+                    },
+                )
+            ],
+        )
+
+        def wait_for_invocation_count_to_have_value(value: int) -> None:
+            max_wait_seconds = 5
+            start_time = time.time()
+            while State.invocation_count != value and (abs(time.time() - start_time) > max_wait_seconds):
+                time.sleep(0.1)
+
+        cognite_client.data_modeling.instances.subscribe(my_query, callback)
+
+        try:
+            cognite_client.data_modeling.instances.apply(nodes=new_1994_movie)
+            wait_for_invocation_count_to_have_value(1)
+
+            cognite_client.data_modeling.instances.apply(nodes=updated_1994_movie)
+            wait_for_invocation_count_to_have_value(2)
         finally:
             cognite_client.data_modeling.instances.delete(new_1994_movie.as_id())


### PR DESCRIPTION
- Add backoff utilitiy
- Add callback-based method for subscribing to a given dms query
- Add docs along with example on how to sync to local sqlite
