### PR TITLE
Make calls to API endpoints in beta thread safe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ Changes are grouped as follows
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
+## [6.21.1] - 2023-09-07
+### Fixed
+- Concurrent usage of the `CogniteClient` could result in API calls being made with the wrong value for `api_subversion`.
+
 ## [6.21.0] - 2023-09-06
 ### Added
 - Supporting pattern mode and extra configuration for diagram detect in beta.

--- a/cognite/client/_api/sequences.py
+++ b/cognite/client/_api/sequences.py
@@ -249,17 +249,12 @@ class SequencesAPI(APIClient):
 
         """
         self._validate_filter(advanced_filter)
-
-        api_version = self._api_subversion
-        try:
-            self._api_subversion = "beta"
-            return self._advanced_aggregate(
-                "count",
-                filter=filter,
-                advanced_filter=advanced_filter,
-            )
-        finally:
-            self._api_subversion = api_version
+        return self._advanced_aggregate(
+            "count",
+            filter=filter,
+            advanced_filter=advanced_filter,
+            api_subversion="beta",
+        )
 
     def aggregate_cardinality_values(
         self,
@@ -303,20 +298,14 @@ class SequencesAPI(APIClient):
                 ...     aggregate_filter=not_america)
         """
         self._validate_filter(advanced_filter)
-
-        api_version = self._api_subversion
-
-        try:
-            self._api_subversion = "beta"
-            return self._advanced_aggregate(
-                "cardinalityValues",
-                properties=property,
-                filter=filter,
-                advanced_filter=advanced_filter,
-                aggregate_filter=aggregate_filter,
-            )
-        finally:
-            self._api_subversion = api_version
+        return self._advanced_aggregate(
+            "cardinalityValues",
+            properties=property,
+            filter=filter,
+            advanced_filter=advanced_filter,
+            aggregate_filter=aggregate_filter,
+            api_subversion="beta",
+        )
 
     def aggregate_cardinality_properties(
         self,
@@ -346,19 +335,14 @@ class SequencesAPI(APIClient):
                 >>> count = c.sequences.aggregate_cardinality_values(SequenceProperty.metadata)
         """
         self._validate_filter(advanced_filter)
-        api_version = self._api_subversion
-
-        try:
-            self._api_subversion = "beta"
-            return self._advanced_aggregate(
-                "cardinalityProperties",
-                path=path,
-                filter=filter,
-                advanced_filter=advanced_filter,
-                aggregate_filter=aggregate_filter,
-            )
-        finally:
-            self._api_subversion = api_version
+        return self._advanced_aggregate(
+            "cardinalityProperties",
+            path=path,
+            filter=filter,
+            advanced_filter=advanced_filter,
+            aggregate_filter=aggregate_filter,
+            api_subversion="beta",
+        )
 
     def aggregate_unique_values(
         self,
@@ -413,29 +397,23 @@ class SequencesAPI(APIClient):
                 >>> print(result.unique)
         """
         self._validate_filter(advanced_filter)
-
-        api_version = self._api_subversion
-
-        try:
-            self._api_subversion = "beta"
-            if property == ["metadata"] or property is SequenceProperty.metadata:
-                return self._advanced_aggregate(
-                    aggregate="uniqueProperties",
-                    path=property,
-                    filter=filter,
-                    advanced_filter=advanced_filter,
-                    aggregate_filter=aggregate_filter,
-                )
-            else:
-                return self._advanced_aggregate(
-                    aggregate="uniqueValues",
-                    properties=property,
-                    filter=filter,
-                    advanced_filter=advanced_filter,
-                    aggregate_filter=aggregate_filter,
-                )
-        finally:
-            self._api_subversion = api_version
+        if property == ["metadata"] or property is SequenceProperty.metadata:
+            return self._advanced_aggregate(
+                aggregate="uniqueProperties",
+                path=property,
+                api_subversion="beta",
+                filter=filter,
+                advanced_filter=advanced_filter,
+                aggregate_filter=aggregate_filter,
+            )
+        return self._advanced_aggregate(
+            aggregate="uniqueValues",
+            properties=property,
+            api_subversion="beta",
+            filter=filter,
+            advanced_filter=advanced_filter,
+            aggregate_filter=aggregate_filter,
+        )
 
     def aggregate_unique_properties(
         self,
@@ -465,20 +443,14 @@ class SequencesAPI(APIClient):
                 >>> result = c.sequences.aggregate_unique_properties(SequenceProperty.metadata)
         """
         self._validate_filter(advanced_filter)
-
-        api_version = self._api_subversion
-
-        try:
-            self._api_subversion = "beta"
-            return self._advanced_aggregate(
-                aggregate="uniqueProperties",
-                path=path,
-                filter=filter,
-                advanced_filter=advanced_filter,
-                aggregate_filter=aggregate_filter,
-            )
-        finally:
-            self._api_subversion = api_version
+        return self._advanced_aggregate(
+            aggregate="uniqueProperties",
+            path=path,
+            filter=filter,
+            advanced_filter=advanced_filter,
+            aggregate_filter=aggregate_filter,
+            api_subversion="beta",
+        )
 
     @overload
     def create(self, sequence: Sequence) -> Sequence:
@@ -800,20 +772,15 @@ class SequencesAPI(APIClient):
         elif not isinstance(sort, list):
             sort = [sort]
 
-        api_version = self._api_subversion
-
-        try:
-            self._api_subversion = "beta"
-            return self._list(
-                list_cls=SequenceList,
-                resource_cls=Sequence,
-                method="POST",
-                limit=limit,
-                advanced_filter=filter.dump(camel_case=True) if isinstance(filter, Filter) else filter,
-                sort=[SequenceSort.load(item).dump(camel_case=True) for item in sort],
-            )
-        finally:
-            self._api_subversion = api_version
+        return self._list(
+            list_cls=SequenceList,
+            resource_cls=Sequence,
+            method="POST",
+            limit=limit,
+            advanced_filter=filter.dump(camel_case=True) if isinstance(filter, Filter) else filter,
+            sort=[SequenceSort.load(item).dump(camel_case=True) for item in sort],
+            api_subversion="beta",
+        )
 
     def _validate_filter(self, filter: Filter | dict | None) -> None:
         _validate_filter(filter, _FILTERS_SUPPORTED, type(self).__name__)

--- a/cognite/client/_api/sequences.py
+++ b/cognite/client/_api/sequences.py
@@ -401,18 +401,18 @@ class SequencesAPI(APIClient):
             return self._advanced_aggregate(
                 aggregate="uniqueProperties",
                 path=property,
-                api_subversion="beta",
                 filter=filter,
                 advanced_filter=advanced_filter,
                 aggregate_filter=aggregate_filter,
+                api_subversion="beta",
             )
         return self._advanced_aggregate(
             aggregate="uniqueValues",
             properties=property,
-            api_subversion="beta",
             filter=filter,
             advanced_filter=advanced_filter,
             aggregate_filter=aggregate_filter,
+            api_subversion="beta",
         )
 
     def aggregate_unique_properties(

--- a/cognite/client/_api/time_series.py
+++ b/cognite/client/_api/time_series.py
@@ -261,17 +261,12 @@ class TimeSeriesAPI(APIClient):
 
         """
         self._validate_filter(advanced_filter)
-
-        api_version = self._api_subversion
-        try:
-            self._api_subversion = "beta"
-            return self._advanced_aggregate(
-                "count",
-                filter=filter,
-                advanced_filter=advanced_filter,
-            )
-        finally:
-            self._api_subversion = api_version
+        return self._advanced_aggregate(
+            "count",
+            filter=filter,
+            advanced_filter=advanced_filter,
+            api_subversion="beta",
+        )
 
     def aggregate_cardinality_values(
         self,
@@ -315,20 +310,14 @@ class TimeSeriesAPI(APIClient):
 
         """
         self._validate_filter(advanced_filter)
-
-        api_version = self._api_subversion
-
-        try:
-            self._api_subversion = "beta"
-            return self._advanced_aggregate(
-                "cardinalityValues",
-                properties=property,
-                filter=filter,
-                advanced_filter=advanced_filter,
-                aggregate_filter=aggregate_filter,
-            )
-        finally:
-            self._api_subversion = api_version
+        return self._advanced_aggregate(
+            "cardinalityValues",
+            properties=property,
+            filter=filter,
+            advanced_filter=advanced_filter,
+            api_subversion="beta",
+            aggregate_filter=aggregate_filter,
+        )
 
     def aggregate_cardinality_properties(
         self,
@@ -357,20 +346,14 @@ class TimeSeriesAPI(APIClient):
                 >>> key_count = c.time_series.aggregate_cardinality_properties(TimeSeriesProperty.metadata)
         """
         self._validate_filter(advanced_filter)
-
-        api_version = self._api_subversion
-
-        try:
-            self._api_subversion = "beta"
-            return self._advanced_aggregate(
-                "cardinalityProperties",
-                path=path,
-                filter=filter,
-                advanced_filter=advanced_filter,
-                aggregate_filter=aggregate_filter,
-            )
-        finally:
-            self._api_subversion = api_version
+        return self._advanced_aggregate(
+            "cardinalityProperties",
+            path=path,
+            filter=filter,
+            advanced_filter=advanced_filter,
+            api_subversion="beta",
+            aggregate_filter=aggregate_filter,
+        )
 
     def aggregate_unique_values(
         self,
@@ -425,20 +408,14 @@ class TimeSeriesAPI(APIClient):
                 >>> print(result.unique)
         """
         self._validate_filter(advanced_filter)
-
-        api_version = self._api_subversion
-
-        try:
-            self._api_subversion = "beta"
-            return self._advanced_aggregate(
-                aggregate="uniqueValues",
-                properties=property,
-                filter=filter,
-                advanced_filter=advanced_filter,
-                aggregate_filter=aggregate_filter,
-            )
-        finally:
-            self._api_subversion = api_version
+        return self._advanced_aggregate(
+            aggregate="uniqueValues",
+            properties=property,
+            filter=filter,
+            advanced_filter=advanced_filter,
+            api_subversion="beta",
+            aggregate_filter=aggregate_filter,
+        )
 
     def aggregate_unique_properties(
         self,
@@ -468,20 +445,14 @@ class TimeSeriesAPI(APIClient):
                 >>> result = c.time_series.aggregate_unique_values(TimeSeriesProperty.metadata)
         """
         self._validate_filter(advanced_filter)
-
-        api_version = self._api_subversion
-
-        try:
-            self._api_subversion = "beta"
-            return self._advanced_aggregate(
-                aggregate="uniqueProperties",
-                path=path,
-                filter=filter,
-                advanced_filter=advanced_filter,
-                aggregate_filter=aggregate_filter,
-            )
-        finally:
-            self._api_subversion = api_version
+        return self._advanced_aggregate(
+            aggregate="uniqueProperties",
+            path=path,
+            filter=filter,
+            advanced_filter=advanced_filter,
+            api_subversion="beta",
+            aggregate_filter=aggregate_filter,
+        )
 
     @overload
     def create(self, time_series: Sequence[TimeSeries]) -> TimeSeriesList:
@@ -717,20 +688,15 @@ class TimeSeriesAPI(APIClient):
         elif not isinstance(sort, list):
             sort = [sort]
 
-        api_version = self._api_subversion
-
-        try:
-            self._api_subversion = "beta"
-            return self._list(
-                list_cls=TimeSeriesList,
-                resource_cls=TimeSeries,
-                method="POST",
-                limit=limit,
-                advanced_filter=filter.dump(camel_case=True) if isinstance(filter, Filter) else filter,
-                sort=[TimeSeriesSort.load(item).dump(camel_case=True) for item in sort],
-            )
-        finally:
-            self._api_subversion = api_version
+        return self._list(
+            list_cls=TimeSeriesList,
+            resource_cls=TimeSeries,
+            method="POST",
+            limit=limit,
+            advanced_filter=filter.dump(camel_case=True) if isinstance(filter, Filter) else filter,
+            sort=[TimeSeriesSort.load(item).dump(camel_case=True) for item in sort],
+            api_subversion="beta",
+        )
 
     def _validate_filter(self, filter: Filter | dict | None) -> None:
         _validate_filter(filter, _FILTERS_SUPPORTED, type(self).__name__)

--- a/cognite/client/_api/time_series.py
+++ b/cognite/client/_api/time_series.py
@@ -315,8 +315,8 @@ class TimeSeriesAPI(APIClient):
             properties=property,
             filter=filter,
             advanced_filter=advanced_filter,
-            api_subversion="beta",
             aggregate_filter=aggregate_filter,
+            api_subversion="beta",
         )
 
     def aggregate_cardinality_properties(
@@ -351,8 +351,8 @@ class TimeSeriesAPI(APIClient):
             path=path,
             filter=filter,
             advanced_filter=advanced_filter,
-            api_subversion="beta",
             aggregate_filter=aggregate_filter,
+            api_subversion="beta",
         )
 
     def aggregate_unique_values(
@@ -413,8 +413,8 @@ class TimeSeriesAPI(APIClient):
             properties=property,
             filter=filter,
             advanced_filter=advanced_filter,
-            api_subversion="beta",
             aggregate_filter=aggregate_filter,
+            api_subversion="beta",
         )
 
     def aggregate_unique_properties(
@@ -450,8 +450,8 @@ class TimeSeriesAPI(APIClient):
             path=path,
             filter=filter,
             advanced_filter=advanced_filter,
-            api_subversion="beta",
             aggregate_filter=aggregate_filter,
+            api_subversion="beta",
         )
 
     @overload

--- a/cognite/client/_api_client.py
+++ b/cognite/client/_api_client.py
@@ -667,6 +667,7 @@ class APIClient:
         advanced_filter: Filter | dict | None = None,
         aggregate_filter: AggregationFilter | dict | None = None,
         limit: int | None = None,
+        api_subversion: str | None = None,
     ) -> int:
         ...
 
@@ -685,6 +686,7 @@ class APIClient:
         advanced_filter: Filter | dict | None = None,
         aggregate_filter: AggregationFilter | dict | None = None,
         limit: int | None = None,
+        api_subversion: str | None = None,
     ) -> UniqueResultList:
         ...
 

--- a/cognite/client/_version.py
+++ b/cognite/client/_version.py
@@ -1,4 +1,4 @@
 from __future__ import annotations
 
-__version__ = "6.21.0"
+__version__ = "6.21.1"
 __api_subversion__ = "V20220125"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,8 +1,7 @@
 [tool.poetry]
 name = "cognite-sdk"
 
-version = "6.21.0"
-
+version = "6.21.1"
 
 description = "Cognite Python SDK"
 readme = "README.md"


### PR DESCRIPTION
## Description
`api_subversion` is now passed explicitly per call, making sure concurrent usage of the client is safe.

## Checklist:
- [x] Changelog updated in [CHANGELOG.md](https://github.com/cognitedata/cognite-sdk-python/blob/master/CHANGELOG.md).
- [x] Version bumped. If triggering a new release is desired, bump the version number in [_version.py](https://github.com/cognitedata/cognite-sdk-python/blob/master/cognite/client/_version.py) and [pyproject.toml](https://github.com/cognitedata/cognite-sdk-python/blob/master/pyproject.toml) per [semantic versioning](https://semver.org/).
