### PR TITLE
Reduce the number of available threads in the Data Modeling pool to 1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ Changes are grouped as follows
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
+## [6.27.0] - 2023-09-13
+### Changed
+- Reduce concurrency in data modeling client to 1 
+
 ## [6.26.0] - 2023-09-22
 ### Added
 - Support `partition` and `cursor` parameters on `time_series.subscriptions.iterate_data`
@@ -77,7 +81,7 @@ data modeling query and receive updates through a provided callback.
 ### Added
 - Supporting pattern mode and extra configuration for diagram detect in beta.
 
-## [6.20.0] - 2023-09-06
+## [6.20.0] - 2023-09-05
 ### Fixed
 - When creating functions with `client.functions.create` using the `folder` argument, a trial-import is executed as part of
   the verification process. This could leave leftover modules still in scope, possibly affecting subsequent calls. This is

--- a/cognite/client/_api/data_modeling/_data_modeling_executor.py
+++ b/cognite/client/_api/data_modeling/_data_modeling_executor.py
@@ -6,7 +6,7 @@ from cognite.client.utils._concurrency import ConcurrencySettings, MainThreadExe
 
 _THREAD_POOL_EXECUTOR_SINGLETON: ThreadPoolExecutor
 _MAIN_THREAD_EXECUTOR_SINGLETON = MainThreadExecutor()
-_MAX_WORKERS = 2
+_MAX_WORKERS = 1
 
 
 def get_data_modeling_executor() -> TaskExecutor:

--- a/cognite/client/_version.py
+++ b/cognite/client/_version.py
@@ -1,4 +1,4 @@
 from __future__ import annotations
 
-__version__ = "6.26.0"
+__version__ = "6.27.0"
 __api_subversion__ = "V20220125"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "cognite-sdk"
 
-version = "6.26.0"
+version = "6.27.0"
 
 description = "Cognite Python SDK"
 readme = "README.md"


### PR DESCRIPTION
## Description
Please describe the change you have made.

## Checklist:
- [ ] Tests added/updated.
- [ ] Documentation updated. Documentation is generated from docstrings - these must be updated according to your change.
  If a new method has been added it should be referenced in [cognite.rst](https://github.com/cognitedata/cognite-sdk-python/blob/master/docs/source/cognite.rst) in order to generate docs based on its docstring.
- [ ] Changelog updated in [CHANGELOG.md](https://github.com/cognitedata/cognite-sdk-python/blob/master/CHANGELOG.md).
- [ ] Version bumped. If triggering a new release is desired, bump the version number in [_version.py](https://github.com/cognitedata/cognite-sdk-python/blob/master/cognite/client/_version.py) and [pyproject.toml](https://github.com/cognitedata/cognite-sdk-python/blob/master/pyproject.toml) per [semantic versioning](https://semver.org/).
