### PR TITLE
Fix HasData filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ Changes are grouped as follows
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
+## [6.24.1] - 2023-09-12
+### Fixed
+- Using the `HasData` filter would raise an API error in CDF.
+
 ## [6.24.0] - 2023-09-12
 ### Fixed
 - Bugfix for `FilesAPI.upload` and `FilesAPI.upload_bytes` not raising an error on file contents upload failure. Now `CogniteFileUploadError` is raised based on upload response.

--- a/cognite/client/_version.py
+++ b/cognite/client/_version.py
@@ -1,4 +1,4 @@
 from __future__ import annotations
 
-__version__ = "6.24.0"
+__version__ = "6.24.1"
 __api_subversion__ = "V20220125"

--- a/cognite/client/data_classes/filters.py
+++ b/cognite/client/data_classes/filters.py
@@ -90,7 +90,14 @@ class Filter(ABC):
         elif filter_name == MatchAll._filter_name:
             return MatchAll()
         elif filter_name == HasData._filter_name:
-            return HasData(containers=filter_body.get("containers"), views=filter_body.get("views"))
+            containers = []
+            views = []
+            for view_or_space in filter_body:
+                if view_or_space["type"] == "container":
+                    containers.append((view_or_space["space"], view_or_space["externalId"]))
+                else:
+                    views.append((view_or_space["space"], view_or_space["externalId"], view_or_space.get("version")))
+            return HasData(containers=containers, views=views)
         elif filter_name == Range._filter_name:
             return Range(
                 property=filter_body["property"],
@@ -283,7 +290,7 @@ class HasData(Filter):
         self.__containers: list[ContainerId] = [ContainerId.load(container) for container in (containers or [])]
         self.__views: list[ViewId] = [ViewId.load(view) for view in (views or [])]
 
-    def _filter_body(self, camel_case_property: bool) -> dict:
+    def _filter_body(self, camel_case_property: bool) -> list:
         views = [v.as_tuple() for v in self.__views]
         filter_body_views = [
             {"type": "view", "space": space, "externalId": externalId, "version": version}

--- a/cognite/client/data_classes/filters.py
+++ b/cognite/client/data_classes/filters.py
@@ -284,10 +284,16 @@ class HasData(Filter):
         self.__views: list[ViewId] = [ViewId.load(view) for view in (views or [])]
 
     def _filter_body(self, camel_case_property: bool) -> dict:
-        return {
-            "views": [view.as_tuple() for view in self.__views],
-            "containers": [container.as_tuple() for container in self.__containers],
-        }
+        views = [v.as_tuple() for v in self.__views]
+        filter_body_views = [
+            {"type": "view", "space": space, "externalId": externalId, "version": version}
+            for space, externalId, version in views
+        ]
+        containers = [c.as_tuple() for c in self.__containers]
+        filter_body_containers = [
+            {"type": "container", "space": space, "externalId": externalId} for space, externalId in containers
+        ]
+        return filter_body_views + filter_body_containers
 
 
 @final

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "cognite-sdk"
 
-version = "6.24.0"
+version = "6.24.1"
 
 description = "Cognite Python SDK"
 readme = "README.md"

--- a/tests/tests_unit/test_data_classes/test_data_models/test_filters.py
+++ b/tests/tests_unit/test_data_classes/test_data_models/test_filters.py
@@ -54,7 +54,7 @@ def load_and_dump_equals_data() -> Iterator[ParameterSet]:
                         "lte": "2021-01-01T00:00:00Z",
                     }
                 },
-                {"hasData": {"views": [("space", "viewExternalId", "v1")], "containers": []}},
+                {"hasData": [{"type": "view", "space": "space", "externalId": "viewExternalId", "version": "v1"}]},
             ]
         },
         id="And hasData and overlaps",

--- a/tests/tests_unit/test_data_classes/test_data_models/test_filters.py
+++ b/tests/tests_unit/test_data_classes/test_data_models/test_filters.py
@@ -138,7 +138,7 @@ def dump_filter_test_data() -> Iterator[ParameterSet]:
             },
             {
                 "or": [
-                    {"hasData": {"views": [], "containers": [("space", "container")]}},
+                    {"hasData": [{"type": "container", "space": "space", "externalId": "container"}]},
                     {
                         "overlaps": {
                             "startProperty": ("space", "container", "prop1"),


### PR DESCRIPTION
## Description
The HasData filter does not work:

`CogniteAPIError: Invalid field - hasdata - expected an array but got an object | code: 400 | X-Request-ID: 6c0eca6b-da6f-93fd-8086-a40c502b4aee`

Change it to conform with https://api-docs.cognite.com/20230101/tag/Instances/operation/queryContent

## Checklist:
- [x] Tests added/updated.
- [ ] Documentation updated. Documentation is generated from docstrings - these must be updated according to your change.
  If a new method has been added it should be referenced in [cognite.rst](https://github.com/cognitedata/cognite-sdk-python/blob/master/docs/source/cognite.rst) in order to generate docs based on its docstring.
- [x] Changelog updated in [CHANGELOG.md](https://github.com/cognitedata/cognite-sdk-python/blob/master/CHANGELOG.md).
- [x] Version bumped. If triggering a new release is desired, bump the version number in [_version.py](https://github.com/cognitedata/cognite-sdk-python/blob/master/cognite/client/_version.py) and [pyproject.toml](https://github.com/cognitedata/cognite-sdk-python/blob/master/pyproject.toml) per [semantic versioning](https://semver.org/).
