### PR TITLE
fix: When token cache is invalid, don't raise `TypeError`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ Changes are grouped as follows
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
+## [6.28.1] - 2023-09-26
+### Fixed
+- If you have en expired token you got the error message `TypeError: argument of type 'NoneType' is not iterable`
+
 ## [6.28.0] - 2023-09-26
 ### Added
 - Support for the WorkflowOrchestrationAPI with the implementation `client.workflows`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,8 @@ Changes are grouped as follows
 
 ## [6.28.1] - 2023-09-26
 ### Fixed
-- If you have en expired token you got the error message `TypeError: argument of type 'NoneType' is not iterable`
+- If you have en expired token you got the error message `TypeError: argument of type 'NoneType' is not iterable`. 
+  The SDK will now try to refresh your token instead.
 
 ## [6.28.0] - 2023-09-26
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,8 +19,8 @@ Changes are grouped as follows
 
 ## [6.28.2] - 2023-10-02
 ### Fixed
-- If you have en expired token you got the error message `TypeError: argument of type 'NoneType' is not iterable`. 
-  The SDK will now try to refresh your token instead.
+- When cache lookup did not yield a token for `CredentialProvider`s like `OAuthDeviceCode` or `OAuthInteractive`, a
+  `TypeError` could be raised instead of initiating their authentication flow.
 
 ## [6.28.1] - 2023-09-30
 ### Improved
@@ -32,7 +32,7 @@ Changes are grouped as follows
 
 ## [6.27.0] - 2023-09-13
 ### Changed
-- Reduce concurrency in data modeling client to 1 
+- Reduce concurrency in data modeling client to 1
 
 ## [6.26.0] - 2023-09-22
 ### Added

--- a/cognite/client/_version.py
+++ b/cognite/client/_version.py
@@ -1,4 +1,4 @@
 from __future__ import annotations
 
-__version__ = "6.28.1"
+__version__ = "6.28.2"
 __api_subversion__ = "V20220125"

--- a/cognite/client/_version.py
+++ b/cognite/client/_version.py
@@ -1,4 +1,4 @@
 from __future__ import annotations
 
-__version__ = "6.28.0"
+__version__ = "6.28.1"
 __api_subversion__ = "V20220125"

--- a/cognite/client/credentials.py
+++ b/cognite/client/credentials.py
@@ -209,9 +209,13 @@ class OAuthDeviceCode(_OAuthCredentialProviderWithTokenRefresh, _WithMsalSeriali
     def _refresh_access_token(self) -> tuple[str, float]:
         # First check if there is a serialized token cached on disk.
         if accounts := self.__app.get_accounts():
-            credentials = self.__app.acquire_token_silent(scopes=self.__scopes, account=accounts[0])
-        # If not, we acquire a new token using device code auth flow:
+            credentials = self.__app.acquire_token_silent_with_error(scopes=self.__scopes, account=accounts[0])
         else:
+            credentials = {}
+
+        # If not, we acquire a new token using device code auth flow:
+        # or the token might be expired, so we try to refresh it.
+        if not accounts or "error" in credentials:
             device_flow = self.__app.initiate_device_flow(scopes=self.__scopes)
             # print device code user instructions to screen
             print(f"Device code: {device_flow['message']}")  # noqa: T201

--- a/cognite/client/credentials.py
+++ b/cognite/client/credentials.py
@@ -288,7 +288,10 @@ class OAuthInteractive(_OAuthCredentialProviderWithTokenRefresh, _WithMsalSerial
     def _refresh_access_token(self) -> tuple[str, float]:
         # First check if there is a serialized token cached on disk.
         if accounts := self.__app.get_accounts():
-            credentials = self.__app.acquire_token_silent(scopes=self.__scopes, account=accounts[0])
+            credentials = self.__app.acquire_token_silent_with_error(scopes=self.__scopes, account=accounts[0])
+            if "error" in credentials:
+                # The token might be expired, so we try to refresh it
+                credentials = self.__app.acquire_token_interactive(scopes=self.__scopes, port=self.__redirect_port)
         # If not, we acquire a new token interactively
         else:
             credentials = self.__app.acquire_token_interactive(scopes=self.__scopes, port=self.__redirect_port)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "cognite-sdk"
 
-version = "6.28.0"
+version = "6.28.1"
 description = "Cognite Python SDK"
 readme = "README.md"
 documentation = "https://cognite-sdk-python.readthedocs-hosted.com"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "cognite-sdk"
 
-version = "6.28.1"
+version = "6.28.2"
 description = "Cognite Python SDK"
 readme = "README.md"
 documentation = "https://cognite-sdk-python.readthedocs-hosted.com"


### PR DESCRIPTION
## Description
Please describe the change you have made.

## Checklist:
- [ ] Tests added/updated.
- [ ] Documentation updated. Documentation is generated from docstrings - these must be updated according to your change.
  If a new method has been added it should be referenced in [cognite.rst](https://github.com/cognitedata/cognite-sdk-python/blob/master/docs/source/cognite.rst) in order to generate docs based on its docstring.
- [x] Changelog updated in [CHANGELOG.md](https://github.com/cognitedata/cognite-sdk-python/blob/master/CHANGELOG.md).
- [x] Version bumped. If triggering a new release is desired, bump the version number in [_version.py](https://github.com/cognitedata/cognite-sdk-python/blob/master/cognite/client/_version.py) and [pyproject.toml](https://github.com/cognitedata/cognite-sdk-python/blob/master/pyproject.toml) per [semantic versioning](https://semver.org/).
