### PR TITLE
Fix slow `DataFrame` creation in `CogniteResource.to_pandas`

### DIFF
--- a/cognite/client/data_classes/_base.py
+++ b/cognite/client/data_classes/_base.py
@@ -165,8 +165,7 @@ class CogniteResource(_WithClientMixin):
                 else:
                     raise AssertionError(f"Could not expand attribute '{key}'")
 
-        data = [{"value": value} for name, value in dumped.items()]
-        df = pd.DataFrame(data, index=dumped.keys())
+        df = pd.DataFrame.from_dict(dumped, orient="index", columns=["value"])
 
         return df
 

--- a/cognite/client/data_classes/_base.py
+++ b/cognite/client/data_classes/_base.py
@@ -165,7 +165,7 @@ class CogniteResource(_WithClientMixin):
                 else:
                     raise AssertionError(f"Could not expand attribute '{key}'")
 
-        df = pd.DataFrame(list(dumped.items()), columns=["Name", "Value"])
+        df = pd.Series(dumped).to_frame(name="value")
 
         return df
 

--- a/cognite/client/data_classes/_base.py
+++ b/cognite/client/data_classes/_base.py
@@ -165,9 +165,7 @@ class CogniteResource(_WithClientMixin):
                 else:
                     raise AssertionError(f"Could not expand attribute '{key}'")
 
-        df = pd.Series(dumped).to_frame(name="value")
-
-        return df
+        return pd.Series(dumped).to_frame(name="value")
 
     def _repr_html_(self) -> str:
         return notebook_display_with_fallback(self)

--- a/cognite/client/data_classes/_base.py
+++ b/cognite/client/data_classes/_base.py
@@ -165,8 +165,7 @@ class CogniteResource(_WithClientMixin):
                 else:
                     raise AssertionError(f"Could not expand attribute '{key}'")
 
-        data = [{"value": value} for name, value in dumped.items()]
-        df = pd.DataFrame(data, index=dumped.keys())
+        df = pd.DataFrame(list(dumped.values()), index=dumped.keys(), columns=["value"])
 
         return df
 

--- a/cognite/client/data_classes/_base.py
+++ b/cognite/client/data_classes/_base.py
@@ -164,9 +164,10 @@ class CogniteResource(_WithClientMixin):
                     dumped.update(dumped.pop(key))
                 else:
                     raise AssertionError(f"Could not expand attribute '{key}'")
-        df = pd.DataFrame(columns=["value"])
-        for name, value in dumped.items():
-            df.loc[name] = [value]
+
+        data = [{"value": value} for name, value in dumped.items()]
+        df = pd.DataFrame(data, index=dumped.keys())
+
         return df
 
     def _repr_html_(self) -> str:

--- a/cognite/client/data_classes/_base.py
+++ b/cognite/client/data_classes/_base.py
@@ -165,7 +165,7 @@ class CogniteResource(_WithClientMixin):
                 else:
                     raise AssertionError(f"Could not expand attribute '{key}'")
 
-        df = pd.DataFrame.from_dict(dumped, orient="index", columns=["value"])
+        df = pd.DataFrame(list(dumped.items()), columns=["Name", "Value"])
 
         return df
 

--- a/cognite/client/data_classes/_base.py
+++ b/cognite/client/data_classes/_base.py
@@ -165,7 +165,8 @@ class CogniteResource(_WithClientMixin):
                 else:
                     raise AssertionError(f"Could not expand attribute '{key}'")
 
-        df = pd.DataFrame(list(dumped.values()), index=dumped.keys(), columns=["value"])
+        data = [{"value": value} for name, value in dumped.items()]
+        df = pd.DataFrame(data, index=dumped.keys())
 
         return df
 

--- a/tests/tests_unit/test_base.py
+++ b/tests/tests_unit/test_base.py
@@ -370,6 +370,7 @@ class TestCogniteResourceList:
         with pytest.raises(CogniteMissingClientError):
             mr.use()
 
+    @pytest.mark.dsl
     def test_to_pandas_method(self):
         import pandas as pd
 

--- a/tests/tests_unit/test_base.py
+++ b/tests/tests_unit/test_base.py
@@ -370,6 +370,20 @@ class TestCogniteResourceList:
         with pytest.raises(CogniteMissingClientError):
             mr.use()
 
+    def test_to_pandas_method():
+        import pandas as pd
+
+        from cognite.client.data_classes import Asset
+
+        obj = Asset(id=1)
+
+        result_df = obj.to_pandas()
+
+        expected_df = pd.DataFrame({"value": [1]}, index=["id"])
+
+        # Assert that the resultant DataFrame is equal to the expected DataFrame
+        pd.testing.assert_frame_equal(result_df, expected_df)
+
 
 class TestCogniteFilter:
     def test_dump(self):

--- a/tests/tests_unit/test_base.py
+++ b/tests/tests_unit/test_base.py
@@ -374,17 +374,33 @@ class TestCogniteResourceList:
     def test_to_pandas_method(self):
         import pandas as pd
 
-        from cognite.client.data_classes import Asset, AssetList
+        from cognite.client.data_classes import Asset, Label
 
-        obj = AssetList([Asset(external_id=f"ext-{i}", name=f"name-{i}") for i in range(5)])
+        asset = Asset(
+            external_id="test-1",
+            name="test 1",
+            parent_external_id="parent-test-1",
+            description="A test asset",
+            data_set_id=123,
+            labels=[Label(external_id="ROTATING_EQUIPMENT", name="Rotating equipment")],
+        )
 
-        result_df = obj.to_pandas()
+        result_df = asset.to_pandas()
 
         data = {
-            "external_id": ["ext-0", "ext-1", "ext-2", "ext-3", "ext-4"],
-            "name": ["name-0", "name-1", "name-2", "name-3", "name-4"],
+            "value": [
+                "test-1",
+                "test 1",
+                "parent-test-1",
+                "A test asset",
+                123,
+                [{"externalId": "ROTATING_EQUIPMENT", "name": "Rotating equipment"}],
+            ]
         }
-        expected_df = pd.DataFrame(data)
+
+        index_labels = ["external_id", "name", "parent_external_id", "description", "data_set_id", "labels"]
+
+        expected_df = pd.DataFrame(data, index=index_labels)
 
         # Assert that the resultant DataFrame is equal to the expected DataFrame
         pd.testing.assert_frame_equal(result_df, expected_df)

--- a/tests/tests_unit/test_base.py
+++ b/tests/tests_unit/test_base.py
@@ -376,11 +376,15 @@ class TestCogniteResourceList:
 
         from cognite.client.data_classes import Asset, AssetList
 
-        obj = AssetList([Asset(id=i) for i in range(5)])
+        obj = AssetList([Asset(external_id=f"ext-{i}", name=f"name-{i}") for i in range(5)])
 
         result_df = obj.to_pandas()
 
-        expected_df = pd.DataFrame({"value": [1]}, index=["id"])
+        data = {
+            "external_id": ["ext-0", "ext-1", "ext-2", "ext-3", "ext-4"],
+            "name": ["name-0", "name-1", "name-2", "name-3", "name-4"],
+        }
+        expected_df = pd.DataFrame(data)
 
         # Assert that the resultant DataFrame is equal to the expected DataFrame
         pd.testing.assert_frame_equal(result_df, expected_df)

--- a/tests/tests_unit/test_base.py
+++ b/tests/tests_unit/test_base.py
@@ -376,7 +376,7 @@ class TestCogniteResourceList:
 
         from cognite.client.data_classes import Asset
 
-        obj = Asset(id=1)
+        obj = [Asset(id=i) for i in range(5)]
 
         result_df = obj.to_pandas()
 

--- a/tests/tests_unit/test_base.py
+++ b/tests/tests_unit/test_base.py
@@ -370,7 +370,7 @@ class TestCogniteResourceList:
         with pytest.raises(CogniteMissingClientError):
             mr.use()
 
-    def test_to_pandas_method():
+    def test_to_pandas_method(self):
         import pandas as pd
 
         from cognite.client.data_classes import Asset

--- a/tests/tests_unit/test_base.py
+++ b/tests/tests_unit/test_base.py
@@ -374,9 +374,9 @@ class TestCogniteResourceList:
     def test_to_pandas_method(self):
         import pandas as pd
 
-        from cognite.client.data_classes import Asset
+        from cognite.client.data_classes import Asset, AssetList
 
-        obj = [Asset(id=i) for i in range(5)]
+        obj = AssetList([Asset(id=i) for i in range(5)])
 
         result_df = obj.to_pandas()
 


### PR DESCRIPTION
## Description
Optimize DataFrame creation by initializing with a list of dictionaries

- Replace row-by-row addition using .loc with a more efficient bulk addition.
- The new approach improves speed and reduces memory usage int the to_pandas() method, especially for large DataFrames.

## Checklist:
- [x] Tests added/updated.
- [ ] Documentation updated. Documentation is generated from docstrings - these must be updated according to your change.
  If a new method has been added it should be referenced in [cognite.rst](https://github.com/cognitedata/cognite-sdk-python/blob/master/docs/source/cognite.rst) in order to generate docs based on its docstring.
- [ ] Changelog updated in [CHANGELOG.md](https://github.com/cognitedata/cognite-sdk-python/blob/master/CHANGELOG.md).
- [ ] Version bumped. If triggering a new release is desired, bump the version number in [_version.py](https://github.com/cognitedata/cognite-sdk-python/blob/master/cognite/client/_version.py) and [pyproject.toml](https://github.com/cognitedata/cognite-sdk-python/blob/master/pyproject.toml) per [semantic versioning](https://semver.org/).
