### PR TITLE
Alpha/Beta Definitions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ Changes are grouped as follows
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
+## [6.28.1] - 2023-09-30
+### Improved
+- Warning when using alpha/beta features.
+
 ## [6.28.0] - 2023-09-26
 ### Added
 - Support for the WorkflowOrchestrationAPI with the implementation `client.workflows`.

--- a/cognite/client/_api/datapoints_subscriptions.py
+++ b/cognite/client/_api/datapoints_subscriptions.py
@@ -28,10 +28,9 @@ class DatapointsSubscriptionAPI(APIClient):
     def __init__(self, config: ClientConfig, api_version: str | None, cognite_client: CogniteClient) -> None:
         super().__init__(config, api_version, cognite_client)
         self._api_subversion = "beta"
-
-    def _experimental_warning(self) -> None:
-        warning = FeaturePreviewWarning(api_version="beta", sdk_version="alpha", feature_name="DataPoint Subscriptions")
-        warning.warn()
+        self._warning = FeaturePreviewWarning(
+            api_maturity="beta", sdk_maturity="alpha", feature_name="DataPoint Subscriptions"
+        )
 
     def create(self, subscription: DataPointSubscriptionCreate) -> DatapointSubscription:
         """`Create a subscription <https://pr-2221.specs.preview.cogniteapp.com/20230101-beta.json.html#tag/Data-point-subscriptions/operation/postSubscriptions>`_
@@ -67,7 +66,7 @@ class DatapointsSubscriptionAPI(APIClient):
                 >>> sub = DataPointSubscriptionCreate("mySubscription", partition_count=1, filter=numeric_timeseries, name="My subscription for Numeric time series")
                 >>> created = c.time_series.subscriptions.create(sub)
         """
-        self._experimental_warning()
+        self._warning.warn()
 
         return self._create_multiple(
             subscription,
@@ -91,7 +90,7 @@ class DatapointsSubscriptionAPI(APIClient):
                 >>> c = CogniteClient()
                 >>> batch = c.time_series.subscriptions.delete("my_subscription")
         """
-        self._experimental_warning()
+        self._warning.warn()
 
         self._delete_multiple(
             identifiers=IdentifierSequence.load(external_ids=external_id),
@@ -117,7 +116,7 @@ class DatapointsSubscriptionAPI(APIClient):
                 >>> c = CogniteClient()
                 >>> batch = c.time_series.subscriptions.retrieve("my_subscription")
         """
-        self._experimental_warning()
+        self._warning.warn()
 
         result = self._retrieve_multiple(
             list_cls=DatapointSubscriptionList,
@@ -161,7 +160,7 @@ class DatapointsSubscriptionAPI(APIClient):
                 >>> update = DataPointSubscriptionUpdate("my_subscription").time_series_ids.add("MyNewTimeSeriesExternalId")
                 >>> updated = c.time_series.subscriptions.update(update)
         """
-        self._experimental_warning()
+        self._warning.warn()
 
         return self._update_multiple(
             items=update,
@@ -215,7 +214,7 @@ class DatapointsSubscriptionAPI(APIClient):
                 ...     print(f"Removed {len(batch.subscription_changes.removed)} timeseries")
                 ...     print(f"Changed data in {len(batch.updates)} timeseries")
         """
-        self._experimental_warning()
+        self._warning.warn()
 
         current_partitions = [DatapointSubscriptionPartition.create((partition, cursor))]
         while True:
@@ -255,7 +254,7 @@ class DatapointsSubscriptionAPI(APIClient):
                 >>> subscriptions = c.time_series.subscriptions.list(limit=5)
 
         """
-        self._experimental_warning()
+        self._warning.warn()
 
         return self._list(
             method="GET", limit=limit, list_cls=DatapointSubscriptionList, resource_cls=DatapointSubscription

--- a/cognite/client/_api/datapoints_subscriptions.py
+++ b/cognite/client/_api/datapoints_subscriptions.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from typing import TYPE_CHECKING, Iterator, Sequence
-from warnings import warn
 
 from cognite.client._api_client import APIClient
 from cognite.client._constants import (
@@ -16,6 +15,7 @@ from cognite.client.data_classes.datapoints_subscriptions import (
     DataPointSubscriptionUpdate,
     _DatapointSubscriptionBatchWithPartitions,
 )
+from cognite.client.utils._experimental import FeaturePreviewWarning
 from cognite.client.utils._identifier import IdentifierSequence
 
 if TYPE_CHECKING:
@@ -30,10 +30,8 @@ class DatapointsSubscriptionAPI(APIClient):
         self._api_subversion = "beta"
 
     def _experimental_warning(self) -> None:
-        warn(
-            "DataPoint Subscriptions are experimental and may be subject to breaking changes in future versions without notice.",
-            FutureWarning,
-        )
+        warning = FeaturePreviewWarning(api_version="beta", sdk_version="alpha", feature_name="DataPoint Subscriptions")
+        warning.warn()
 
     def create(self, subscription: DataPointSubscriptionCreate) -> DatapointSubscription:
         """`Create a subscription <https://pr-2221.specs.preview.cogniteapp.com/20230101-beta.json.html#tag/Data-point-subscriptions/operation/postSubscriptions>`_

--- a/cognite/client/_api/workflows.py
+++ b/cognite/client/_api/workflows.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 from abc import ABC
 from typing import TYPE_CHECKING, Any, Literal, MutableSequence, Sequence, Tuple, Union
-from warnings import warn
 
 from typing_extensions import TypeAlias
 
@@ -23,6 +22,7 @@ from cognite.client.data_classes.workflows import (
     WorkflowVersionUpsert,
 )
 from cognite.client.exceptions import CogniteAPIError
+from cognite.client.utils._experimental import FeaturePreviewWarning
 from cognite.client.utils._identifier import (
     IdentifierSequence,
     WorkflowVersionIdentifierSequence,
@@ -45,10 +45,8 @@ class BetaWorkflowAPIClient(APIClient, ABC):
 
     @staticmethod
     def _experimental_warning() -> None:
-        warn(
-            "Workflow Orchestration endpoints are experimental and may be subject to breaking changes in future versions without notice.",
-            FutureWarning,
-        )
+        warning = FeaturePreviewWarning(api_version="beta", sdk_version="alpha", feature_name="Workflow Orchestration")
+        warning.warn()
 
 
 WorkflowIdentifier: TypeAlias = Union[WorkflowVersionId, Tuple[str, str], str]

--- a/cognite/client/_api/workflows.py
+++ b/cognite/client/_api/workflows.py
@@ -42,11 +42,9 @@ class BetaWorkflowAPIClient(APIClient, ABC):
     ) -> None:
         super().__init__(config, api_version, cognite_client)
         self._api_subversion = "beta"
-
-    @staticmethod
-    def _experimental_warning() -> None:
-        warning = FeaturePreviewWarning(api_version="beta", sdk_version="alpha", feature_name="Workflow Orchestration")
-        warning.warn()
+        self._warning = FeaturePreviewWarning(
+            api_maturity="beta", sdk_maturity="alpha", feature_name="Workflow Orchestration"
+        )
 
 
 WorkflowIdentifier: TypeAlias = Union[WorkflowVersionId, Tuple[str, str], str]
@@ -94,7 +92,7 @@ class WorkflowTaskAPI(BetaWorkflowAPIClient):
                 >>> res = c.workflows.tasks.update(res.tasks[1].id, "completed")
 
         """
-        self._experimental_warning()
+        self._warning.warn()
 
         body: dict[str, Any] = {"status": status.upper()}
         if output is not None:
@@ -134,7 +132,7 @@ class WorkflowExecutionAPI(BetaWorkflowAPIClient):
                 >>> res = c.workflows.executions.retrieve_detailed(res[0].id)
 
         """
-        self._experimental_warning()
+        self._warning.warn()
         try:
             response = self._get(url_path=f"{self._RESOURCE_PATH}/{id}")
         except CogniteAPIError as e:
@@ -186,7 +184,7 @@ class WorkflowExecutionAPI(BetaWorkflowAPIClient):
                 >>> res = c.workflows.executions.trigger("my workflow", "1", input={"a": 1, "b": 2})
 
         """
-        self._experimental_warning()
+        self._warning.warn()
         nonce = create_session_and_return_nonce(self._cognite_client, api_name="Workflow API")
         body = {"authentication": {"nonce": nonce}}
         if input is not None:
@@ -233,7 +231,7 @@ class WorkflowExecutionAPI(BetaWorkflowAPIClient):
                 >>> res = c.workflows.executions.list(created_time_start=int((datetime.now() - timedelta(days=1)).timestamp() * 1000))
 
         """
-        self._experimental_warning()
+        self._warning.warn()
         filter_: dict[str, Any] = {}
         if workflow_version_ids is not None:
             filter_["workflowFilters"] = WorkflowIds._load(workflow_version_ids).dump(
@@ -299,7 +297,7 @@ class WorkflowVersionAPI(BetaWorkflowAPIClient):
                 ... )
                 >>> res = c.workflows.upsert(new_version)
         """
-        self._experimental_warning()
+        self._warning.warn()
         if mode != "replace":
             raise ValueError("Only replace mode is supported for upserting workflow versions.")
 
@@ -337,7 +335,7 @@ class WorkflowVersionAPI(BetaWorkflowAPIClient):
                 >>> c.workflows.versions.delete([WorkflowVersionId("my workflow", "1"), WorkflowVersionId("my workflow 2", "2")])
 
         """
-        self._experimental_warning()
+        self._warning.warn()
         identifiers = WorkflowIds._load(workflow_version_id).dump(camel_case=True)
         self._delete_multiple(
             identifiers=WorkflowVersionIdentifierSequence.load(identifiers),
@@ -363,7 +361,7 @@ class WorkflowVersionAPI(BetaWorkflowAPIClient):
                 >>> c = CogniteClient()
                 >>> res = c.workflows.versions.retrieve("my workflow", "1")
         """
-        self._experimental_warning()
+        self._warning.warn()
         try:
             response = self._get(
                 url_path=f"/workflows/{workflow_external_id}/versions/{version}",
@@ -411,7 +409,7 @@ class WorkflowVersionAPI(BetaWorkflowAPIClient):
                 >>> res = c.workflows.versions.list([("my_workflow", "1"), ("my_workflow_2", "2")])
 
         """
-        self._experimental_warning()
+        self._warning.warn()
         if workflow_version_ids is None:
             workflow_ids_dumped = []
         else:
@@ -462,7 +460,7 @@ class WorkflowAPI(BetaWorkflowAPIClient):
                 >>> c = CogniteClient()
                 >>> res = c.workflows.upsert(WorkflowUpsert(external_id="my workflow", description="my workflow description"))
         """
-        self._experimental_warning()
+        self._warning.warn()
         if mode != "replace":
             raise ValueError("Only replace mode is supported for upserting workflows.")
 
@@ -489,7 +487,7 @@ class WorkflowAPI(BetaWorkflowAPIClient):
                 >>> c = CogniteClient()
                 >>> res = c.workflows.retrieve("my workflow")
         """
-        self._experimental_warning()
+        self._warning.warn()
         try:
             response = self._get(url_path=self._RESOURCE_PATH + f"/{external_id}")
         except CogniteAPIError as e:
@@ -513,7 +511,7 @@ class WorkflowAPI(BetaWorkflowAPIClient):
                 >>> c = CogniteClient()
                 >>> c.workflows.delete("my workflow")
         """
-        self._experimental_warning()
+        self._warning.warn()
         self._delete_multiple(
             identifiers=IdentifierSequence.load(external_ids=external_id),
             params={"ignoreUnknownIds": ignore_unknown_ids},
@@ -536,7 +534,7 @@ class WorkflowAPI(BetaWorkflowAPIClient):
                 >>> c = CogniteClient()
                 >>> res = c.workflows.list()
         """
-        self._experimental_warning()
+        self._warning.warn()
 
         return self._list(
             method="GET",

--- a/cognite/client/_version.py
+++ b/cognite/client/_version.py
@@ -1,4 +1,4 @@
 from __future__ import annotations
 
-__version__ = "6.28.0"
+__version__ = "6.28.1"
 __api_subversion__ = "V20220125"

--- a/cognite/client/utils/_experimental.py
+++ b/cognite/client/utils/_experimental.py
@@ -27,3 +27,7 @@ class FeaturePreviewWarning(FutureWarning):
 
     def warn(self) -> None:
         warnings.warn(self, stacklevel=2)
+
+    def __reduce__(self) -> tuple:
+        # This is needed to make the cognite client picklable as warings are stored on APIClass objects.
+        return self.__class__, (self.api_version, self.sdk_version, self.feature_name)

--- a/cognite/client/utils/_experimental.py
+++ b/cognite/client/utils/_experimental.py
@@ -1,0 +1,25 @@
+import warnings
+from typing import Literal
+
+
+class FeaturePreviewWarning(FutureWarning):
+    def __init__(self, api_version: Literal["alpha", "beta"], sdk_version: Literal["alpha", "beta"], feature_name: str):
+        self.api_version = api_version
+        self.sdk_version = sdk_version
+        self.feature_name = feature_name
+
+    def __str__(self) -> str:
+        if self.api_version == "alpha" or self.sdk_version == "alpha":
+            return (
+                f"{self.feature_name} is in alpha and is subject to breaking changes without notice. API version={self.api_version}, SDK version={self.sdk_version}. "
+                "See https://cognite-sdk-python.readthedocs-hosted.com/en/latest/appendix.html for more information."
+            )
+        else:
+            return (
+                f"{self.feature_name} is in beta, breaking changes may occur but will be preceded by a DeprecationWarning. "
+                f"API version={self.api_version}, SDK version={self.sdk_version}. "
+                "See https://cognite-sdk-python.readthedocs-hosted.com/en/latest/appendix.html for more information."
+            )
+
+    def warn(self) -> None:
+        warnings.warn(self, stacklevel=2)

--- a/cognite/client/utils/_experimental.py
+++ b/cognite/client/utils/_experimental.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import warnings
 from typing import Literal
 

--- a/cognite/client/utils/_experimental.py
+++ b/cognite/client/utils/_experimental.py
@@ -5,15 +5,17 @@ from typing import Literal
 
 
 class FeaturePreviewWarning(FutureWarning):
-    def __init__(self, api_version: Literal["alpha", "beta"], sdk_version: Literal["alpha", "beta"], feature_name: str):
-        self.api_version = api_version
-        self.sdk_version = sdk_version
+    def __init__(
+        self, api_maturity: Literal["alpha", "beta"], sdk_maturity: Literal["alpha", "beta"], feature_name: str
+    ):
+        self.api_version = api_maturity
+        self.sdk_version = sdk_maturity
         self.feature_name = feature_name
 
     def __str__(self) -> str:
         if self.api_version == "alpha" or self.sdk_version == "alpha":
             return (
-                f"{self.feature_name} is in alpha and is subject to breaking changes without notice. API version={self.api_version}, SDK version={self.sdk_version}. "
+                f"{self.feature_name} is in alpha and is subject to breaking changes without notice. API maturity={self.api_version}, SDK maturity={self.sdk_version}. "
                 "See https://cognite-sdk-python.readthedocs-hosted.com/en/latest/appendix.html for more information."
             )
         else:

--- a/docs/source/appendix.rst
+++ b/docs/source/appendix.rst
@@ -29,7 +29,7 @@ New Cognite Data Fusion API features may get support in the Python SDK before th
 general availability (GA). These features are marked as alpha or beta in the documentation, and will also
 invoke a `FeaturePreviewWarning` when used.
 
-Furthermore, we distinguish between version of the API specification and the SDK implementation. Typically,
+Furthermore, we distinguish between maturity of the API specification and the SDK implementation. Typically,
 the API specification may be in beta, while the SDK implementation is in alpha.
 
 * `aplha` - The feature is not yet released for general availability. There may be breaking changes to the API

--- a/docs/source/appendix.rst
+++ b/docs/source/appendix.rst
@@ -20,3 +20,21 @@ notes apply:
     fields that are not specified will not be changed. If you set 'replace', all the fields that are not
     specified, i.e., set to None and support being set to null, will be nulled out. See the API
     documentation for the update endpoint for more information.
+
+.. _appendix-alpha-beta-features:
+
+Alpha and Beta Features
+^^^^^^^^^^^^^^^^^^^^^^^^
+New Cognite Data Fusion API features may get support in the Python SDK before they are released for
+general availability (GA). These features are marked as alpha or beta in the documentation, and will also
+invoke a `FeaturePreviewWarning` when used.
+
+Furthermore, we distinguish between version of the API specification and the SDK implementation. Typically,
+the API specification may be in beta, while the SDK implementation is in alpha.
+
+* `aplha` - The feature is not yet released for general availability. There may be breaking changes to the API
+  specification and/or the SDK implementation without further notice.
+* `beta` - The feature is not yet released for general availability. The feature is considered stable and 'settled'.
+  Learnings during the Beta period may result in a requirement to make breaking changes to API spec/SDK implementation.
+  In these situations, release processes must be coordinated to minimise Beta customer disruption (for example use of
+  `DeprecationWarning`).

--- a/docs/source/core_data_model.rst
+++ b/docs/source/core_data_model.rst
@@ -541,7 +541,11 @@ Data Point Subscriptions
 ---------------------------
 
 .. warning::
-    DataPoint Subscriptions are experimental and may be subject to breaking changes in future versions without notice.
+    DataPoint Subscription is a new feature:
+      * The API specification is in beta.
+      * The SDK implementation is in alpha.
+
+    Thus, breaking changes may occur without further notice, see :ref:`appendix-alpha-beta-features` for more information.
 
 
 Create data point subscriptions

--- a/docs/source/workflow_orchestration.rst
+++ b/docs/source/workflow_orchestration.rst
@@ -2,7 +2,11 @@ Workflow Orchestration
 ======================
 
 .. warning::
-    Workflow Orchestration is experimental and may be subject to breaking changes in future versions without notice.
+    Workflow Orchestration is a new feature:
+      * The API specification is in beta.
+      * The SDK implementation is in alpha.
+
+    Thus, breaking changes may occur without further notice, see :ref:`appendix-alpha-beta-features` for more information.
 
 
 Workflows

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "cognite-sdk"
 
-version = "6.28.0"
+version = "6.28.1"
 description = "Cognite Python SDK"
 readme = "README.md"
 documentation = "https://cognite-sdk-python.readthedocs-hosted.com"


### PR DESCRIPTION
## Description
The first call you do to a alpha/beta feature you will get the following printed in the terminal:
```
FeaturePreviewWarning: Workflow Orchestration is in alpha and is subject to breaking changes without notice. 
API version=beta, SDK version=alpha. 
See https://cognite-sdk-python.readthedocs-hosted.com/en/latest/appendix.html for more information.
```

In addition, updated docs appendix with definition of alpha and beta features.

## Checklist:
- [ ] Tests added/updated.
- [x] Documentation updated. Documentation is generated from docstrings - these must be updated according to your change.
  If a new method has been added it should be referenced in [cognite.rst](https://github.com/cognitedata/cognite-sdk-python/blob/master/docs/source/cognite.rst) in order to generate docs based on its docstring.
- [x] Changelog updated in [CHANGELOG.md](https://github.com/cognitedata/cognite-sdk-python/blob/master/CHANGELOG.md).
- [x] Version bumped. If triggering a new release is desired, bump the version number in [_version.py](https://github.com/cognitedata/cognite-sdk-python/blob/master/cognite/client/_version.py) and [pyproject.toml](https://github.com/cognitedata/cognite-sdk-python/blob/master/pyproject.toml) per [semantic versioning](https://semver.org/).
