### PR TITLE
Encoding bug for string uploaded files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ Changes are grouped as follows
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
+## [6.28.3] - 2023-10-03
+### Fixed
+- Uploading files, `client.files.upload_bytes`, as string with nordic characters loses some characters due to an encoding issue. This is now fixed.
+
 ## [6.28.2] - 2023-10-02
 ### Fixed
 - When cache lookup did not yield a token for `CredentialProvider`s like `OAuthDeviceCode` or `OAuthInteractive`, a

--- a/cognite/client/_api/files.py
+++ b/cognite/client/_api/files.py
@@ -545,6 +545,9 @@ class FilesAPI(APIClient):
                 >>> c = CogniteClient()
                 >>> res = c.files.upload_bytes(b"some content", name="my_file", asset_ids=[1,2,3])
         """
+        if isinstance(content, str):
+            content = content.encode("utf-8")
+
         file_metadata = FileMetadata(
             name=name,
             external_id=external_id,

--- a/cognite/client/_version.py
+++ b/cognite/client/_version.py
@@ -1,4 +1,4 @@
 from __future__ import annotations
 
-__version__ = "6.28.2"
+__version__ = "6.28.3"
 __api_subversion__ = "V20220125"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "cognite-sdk"
 
-version = "6.28.2"
+version = "6.28.3"
 description = "Cognite Python SDK"
 readme = "README.md"
 documentation = "https://cognite-sdk-python.readthedocs-hosted.com"

--- a/tests/tests_integration/test_api/test_files.py
+++ b/tests/tests_integration/test_api/test_files.py
@@ -3,6 +3,7 @@ import uuid
 
 import pytest
 
+from cognite.client import CogniteClient
 from cognite.client.data_classes import (
     FileMetadata,
     FileMetadataFilter,
@@ -202,3 +203,14 @@ class TestFilesAPI:
             time.sleep(0.2)
             res = cognite_client.files.list(geo_location=geo_location_filter)
         assert res[0].geo_location == new_file_with_geoLocation.geo_location
+
+    def test_upload_bytes_string_with_nordic_characters(self, cognite_client: CogniteClient) -> None:
+        content = "æøåååæææøøøøø"
+        external_id = "test_upload_bytes_string_with_nordic_characters"
+
+        _ = cognite_client.files.upload_bytes(
+            content=content, name="nordic.txt", external_id=external_id, overwrite=True
+        )
+
+        downloaded_content = cognite_client.files.download_bytes(external_id=external_id)
+        assert downloaded_content == content.encode("utf-8")


### PR DESCRIPTION
## Description
Ref: https://github.com/psf/requests/issues/5560


## Checklist:
- [x] Tests added/updated.
- [ ] Documentation updated. Documentation is generated from docstrings - these must be updated according to your change.
  If a new method has been added it should be referenced in [cognite.rst](https://github.com/cognitedata/cognite-sdk-python/blob/master/docs/source/cognite.rst) in order to generate docs based on its docstring.
- [x] Changelog updated in [CHANGELOG.md](https://github.com/cognitedata/cognite-sdk-python/blob/master/CHANGELOG.md).
- [ ] Version bumped. If triggering a new release is desired, bump the version number in [_version.py](https://github.com/cognitedata/cognite-sdk-python/blob/master/cognite/client/_version.py) and [pyproject.toml](https://github.com/cognitedata/cognite-sdk-python/blob/master/pyproject.toml) per [semantic versioning](https://semver.org/).
