### PR TITLE
Support more direct relation types when ingesting instance data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,11 @@ Changes are grouped as follows
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
+## [6.33.0] - 2023-10-13
+### Added
+- Support for providing `DirectRelationReference` and `NodeId` as direct relation values when
+ingesting node and edge data.
+
 ## [6.32.4] - 2023-10-12
 ### Fixed
 - Filters using e.g. metadata keys no longer dumps the key in camel case.

--- a/cognite/client/_version.py
+++ b/cognite/client/_version.py
@@ -1,4 +1,4 @@
 from __future__ import annotations
 
-__version__ = "6.32.4"
+__version__ = "6.33.0"
 __api_subversion__ = "V20220125"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "cognite-sdk"
 
-version = "6.32.4"
+version = "6.33.0"
 description = "Cognite Python SDK"
 readme = "README.md"
 documentation = "https://cognite-sdk-python.readthedocs-hosted.com"

--- a/tests/tests_unit/test_data_classes/test_data_models/test_instances.py
+++ b/tests/tests_unit/test_data_classes/test_data_models/test_instances.py
@@ -3,6 +3,7 @@ from cognite.client.data_classes.data_modeling import (
     DirectRelationReference,
     EdgeApply,
     NodeApply,
+    NodeId,
     NodeOrEdgeData,
 )
 
@@ -31,6 +32,26 @@ class TestEdgeApply:
             },
             "endNode": {"space": "mySpace", "externalId": "actor.external_id"},
         }
+
+
+class TestNodeOrEdgeData:
+    def test_direct_relation_serialization(self) -> None:
+        data = NodeOrEdgeData(
+            source=ContainerId("IntegrationTestsImmutable", "Case"),
+            properties=dict(
+                name="Integration test",
+                some_direct_relation=DirectRelationReference("space", "external_id"),
+                another_direct_relation_type=NodeId("space", "external_id"),
+            ),
+        )
+        assert {
+            "properties": {
+                "another_direct_relation_type": {"external_id": "external_id", "space": "space"},
+                "name": "Integration test",
+                "some_direct_relation": {"external_id": "external_id", "space": "space"},
+            },
+            "source": {"external_id": "Case", "space": "IntegrationTestsImmutable", "type": "container"},
+        } == data.dump()
 
 
 class TestNodeApply:


### PR DESCRIPTION
- Support DirectRelationReference and NodeId as direct relation values when ingesting
- Update changelog

## Description
Please describe the change you have made.

## Checklist:
- [ ] Tests added/updated.
- [ ] Documentation updated. Documentation is generated from docstrings - these must be updated according to your change.
  If a new method has been added it should be referenced in [cognite.rst](https://github.com/cognitedata/cognite-sdk-python/blob/master/docs/source/cognite.rst) in order to generate docs based on its docstring.
- [ ] Changelog updated in [CHANGELOG.md](https://github.com/cognitedata/cognite-sdk-python/blob/master/CHANGELOG.md).
- [ ] Version bumped. If triggering a new release is desired, bump the version number in [_version.py](https://github.com/cognitedata/cognite-sdk-python/blob/master/cognite/client/_version.py) and [pyproject.toml](https://github.com/cognitedata/cognite-sdk-python/blob/master/pyproject.toml) per [semantic versioning](https://semver.org/).
