### PR TITLE
explicitly import all functions

### DIFF
--- a/cognite/client/_api/data_modeling/instances.py
+++ b/cognite/client/_api/data_modeling/instances.py
@@ -697,7 +697,7 @@ class InstancesAPI(APIClient):
 
                 >>> from cognite.client import CogniteClient
                 >>> from cognite.client.data_classes.data_modeling import ViewId
-                >>> import cognite.client.data_classes.filters as filters
+                >>> from cognite.client.data_classes import filters
                 >>> c = CogniteClient()
                 >>> born_after_1970 = filters.Range(["mySpace", "PersonView/v1", "birthYear"], gt=1970)
                 >>> res = c.data_modeling.instances.search(ViewId("mySpace", "PersonView", "v1"),

--- a/cognite/client/_api/extractionpipelines.py
+++ b/cognite/client/_api/extractionpipelines.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any, Literal, Sequence, overload
 
-from cognite.client import utils
 from cognite.client._api_client import APIClient
 from cognite.client._constants import DEFAULT_LIMIT_READ
 from cognite.client.data_classes import (
@@ -17,6 +16,7 @@ from cognite.client.data_classes import (
     TimestampRange,
 )
 from cognite.client.data_classes.extractionpipelines import StringFilter
+from cognite.client.utils._auxiliary import assert_type
 from cognite.client.utils._identifier import IdentifierSequence
 
 if TYPE_CHECKING:
@@ -151,7 +151,7 @@ class ExtractionPipelinesAPI(APIClient):
                 >>> extpipes = [ExtractionPipeline(name="extPipe1",...), ExtractionPipeline(name="extPipe2",...)]
                 >>> res = c.extraction_pipelines.create(extpipes)
         """
-        utils._auxiliary.assert_type(extraction_pipeline, "extraction_pipeline", [ExtractionPipeline, Sequence])
+        assert_type(extraction_pipeline, "extraction_pipeline", [ExtractionPipeline, Sequence])
         return self._create_multiple(
             list_cls=ExtractionPipelineList, resource_cls=ExtractionPipeline, items=extraction_pipeline
         )
@@ -303,7 +303,7 @@ class ExtractionPipelineRunsAPI(APIClient):
                 >>> res = c.extraction_pipelines.runs.create(
                 ...     ExtractionPipelineRun(status="success", extpipe_external_id="extId"))
         """
-        utils._auxiliary.assert_type(run, "run", [ExtractionPipelineRun, Sequence])
+        assert_type(run, "run", [ExtractionPipelineRun, Sequence])
         return self._create_multiple(list_cls=ExtractionPipelineRunList, resource_cls=ExtractionPipelineRun, items=run)
 
 

--- a/cognite/client/_api/functions.py
+++ b/cognite/client/_api/functions.py
@@ -15,7 +15,6 @@ from tempfile import TemporaryDirectory
 from typing import TYPE_CHECKING, Any, Callable, Sequence, cast
 from zipfile import ZipFile
 
-from cognite.client import utils
 from cognite.client._api_client import APIClient
 from cognite.client._constants import DEFAULT_LIMIT_READ
 from cognite.client.data_classes import (
@@ -33,7 +32,7 @@ from cognite.client.data_classes import (
     TimestampRange,
 )
 from cognite.client.data_classes.functions import FunctionCallsFilter, FunctionsStatus
-from cognite.client.utils._auxiliary import is_unlimited
+from cognite.client.utils._auxiliary import assert_type, is_unlimited, local_import
 from cognite.client.utils._identifier import Identifier, IdentifierSequence
 from cognite.client.utils._session import create_session_and_return_nonce
 
@@ -187,8 +186,8 @@ class FunctionsAPI(APIClient):
         elif function_handle:
             _validate_function_handle(function_handle)
             file_id = self._zip_and_upload_handle(function_handle, name, external_id)
-        utils._auxiliary.assert_type(cpu, "cpu", [Number], allow_none=True)
-        utils._auxiliary.assert_type(memory, "memory", [Number], allow_none=True)
+        assert_type(cpu, "cpu", [Number], allow_none=True)
+        assert_type(memory, "memory", [Number], allow_none=True)
 
         sleep_time = 1.0  # seconds
         for i in range(MAX_RETRIES):
@@ -350,8 +349,8 @@ class FunctionsAPI(APIClient):
                 >>> c = CogniteClient()
                 >>> res = c.functions.retrieve_multiple(external_ids=["func1", "func2"])
         """
-        utils._auxiliary.assert_type(ids, "id", [Sequence], allow_none=True)
-        utils._auxiliary.assert_type(external_ids, "external_id", [Sequence], allow_none=True)
+        assert_type(ids, "id", [Sequence], allow_none=True)
+        assert_type(external_ids, "external_id", [Sequence], allow_none=True)
         return self._retrieve_multiple(
             identifiers=IdentifierSequence.load(ids=ids, external_ids=external_ids),
             resource_cls=Function,
@@ -665,7 +664,7 @@ def _validate_and_parse_requirements(requirements: list[str]) -> list[str]:
     Returns:
         list[str]: The parsed requirements
     """
-    constructors = cast(Any, utils._auxiliary.local_import("pip._internal.req.constructors"))
+    constructors = cast(Any, local_import("pip._internal.req.constructors"))
     install_req_from_line = constructors.install_req_from_line
     parsed_reqs: list[str] = []
     for req in requirements:

--- a/cognite/client/_api/relationships.py
+++ b/cognite/client/_api/relationships.py
@@ -3,12 +3,12 @@ from __future__ import annotations
 import copy
 from typing import TYPE_CHECKING, Any, Iterator, Literal, Sequence, cast, overload
 
-from cognite.client import utils
 from cognite.client._api_client import APIClient
 from cognite.client._constants import DEFAULT_LIMIT_READ
 from cognite.client.data_classes import Relationship, RelationshipFilter, RelationshipList, RelationshipUpdate
 from cognite.client.data_classes.labels import LabelFilter
-from cognite.client.utils._auxiliary import is_unlimited
+from cognite.client.utils._auxiliary import assert_type, is_unlimited
+from cognite.client.utils._concurrency import execute_tasks
 from cognite.client.utils._identifier import IdentifierSequence
 from cognite.client.utils._validation import process_data_set_ids
 
@@ -298,7 +298,7 @@ class RelationshipsAPI(APIClient):
                         task_filter["sourceExternalIds"] = source_external_id_list[si : si + self._LIST_SUBQUERY_LIMIT]
                     tasks.append((task_filter,))
 
-            tasks_summary = utils._concurrency.execute_tasks(
+            tasks_summary = execute_tasks(
                 lambda filter: self._list(
                     list_cls=RelationshipList,
                     resource_cls=Relationship,
@@ -363,7 +363,7 @@ class RelationshipsAPI(APIClient):
                 ... )
                 >>> res = c.relationships.create([flowrel1,flowrel2])
         """
-        utils._auxiliary.assert_type(relationship, "relationship", [Relationship, Sequence])
+        assert_type(relationship, "relationship", [Relationship, Sequence])
         if isinstance(relationship, Sequence):
             relationship = [r._validate_resource_types() for r in relationship]
         else:

--- a/cognite/client/_api/synthetic_time_series.py
+++ b/cognite/client/_api/synthetic_time_series.py
@@ -5,9 +5,10 @@ from datetime import datetime
 from typing import TYPE_CHECKING, Any, Sequence, cast
 
 import cognite.client.utils._time
-from cognite.client import utils
 from cognite.client._api_client import APIClient
 from cognite.client.data_classes import Datapoints, DatapointsList, TimeSeries
+from cognite.client.utils._auxiliary import local_import
+from cognite.client.utils._concurrency import execute_tasks
 
 if TYPE_CHECKING:
     import sympy
@@ -87,9 +88,7 @@ class SyntheticDatapointsAPI(APIClient):
 
             tasks.append((query, query_datapoints, limit))
 
-        datapoints_summary = utils._concurrency.execute_tasks(
-            self._fetch_datapoints, tasks, max_workers=self._config.max_workers
-        )
+        datapoints_summary = execute_tasks(self._fetch_datapoints, tasks, max_workers=self._config.max_workers)
         datapoints_summary.raise_first_encountered_exception()
 
         return (
@@ -141,7 +140,7 @@ class SyntheticDatapointsAPI(APIClient):
 
     @staticmethod
     def _sympy_to_sts(expression: str | sympy.Expr) -> str:
-        sympy_module = cast(Any, utils._auxiliary.local_import("sympy"))
+        sympy_module = cast(Any, local_import("sympy"))
 
         infix_ops = {sympy_module.Add: "+", sympy_module.Mul: "*"}
         functions = {

--- a/cognite/client/_api/synthetic_time_series.py
+++ b/cognite/client/_api/synthetic_time_series.py
@@ -4,11 +4,11 @@ import re
 from datetime import datetime
 from typing import TYPE_CHECKING, Any, Sequence, cast
 
-import cognite.client.utils._time
 from cognite.client._api_client import APIClient
 from cognite.client.data_classes import Datapoints, DatapointsList, TimeSeries
 from cognite.client.utils._auxiliary import local_import
 from cognite.client.utils._concurrency import execute_tasks
+from cognite.client.utils._time import timestamp_to_ms
 
 if TYPE_CHECKING:
     import sympy
@@ -77,11 +77,7 @@ class SyntheticDatapointsAPI(APIClient):
 
         for exp in expressions_to_iterate:
             expression, short_expression = self._build_expression(exp, variables, aggregate, granularity)
-            query = {
-                "expression": expression,
-                "start": cognite.client.utils._time.timestamp_to_ms(start),
-                "end": cognite.client.utils._time.timestamp_to_ms(end),
-            }
+            query = {"expression": expression, "start": timestamp_to_ms(start), "end": timestamp_to_ms(end)}
             values: list[float] = []  # mypy
             query_datapoints = Datapoints(value=values, error=[])
             query_datapoints.external_id = short_expression

--- a/cognite/client/_api/templates.py
+++ b/cognite/client/_api/templates.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any, List, Sequence, cast
 
-from cognite.client import utils
 from cognite.client._api_client import APIClient
 from cognite.client._constants import DEFAULT_LIMIT_READ
 from cognite.client.data_classes.templates import (
@@ -19,6 +18,7 @@ from cognite.client.data_classes.templates import (
     ViewResolveItem,
     ViewResolveList,
 )
+from cognite.client.utils._auxiliary import interpolate_and_url_encode
 from cognite.client.utils._identifier import IdentifierSequence
 
 if TYPE_CHECKING:
@@ -72,7 +72,7 @@ class TemplatesAPI(APIClient):
                 >>> result = c.templates.graphql_query("template-group-ext-id", 1, query)
         """
         path = "/templategroups/{}/versions/{}/graphql"
-        path = utils._auxiliary.interpolate_and_url_encode(path, external_id, version)
+        path = interpolate_and_url_encode(path, external_id, version)
         response = self._post(path, {"query": query})
         return GraphQlResponse._load(response.json())
 
@@ -255,7 +255,7 @@ class TemplateGroupVersionsAPI(APIClient):
                 >>> template_group_version = TemplateGroupVersion(schema)
                 >>> c.templates.versions.upsert(template_group.external_id, template_group_version)
         """
-        resource_path = utils._auxiliary.interpolate_and_url_encode(self._RESOURCE_PATH, external_id) + "/upsert"
+        resource_path = interpolate_and_url_encode(self._RESOURCE_PATH, external_id) + "/upsert"
         version_res = self._post(resource_path, version.dump(camel_case=True)).json()
         return TemplateGroupVersion._load(version_res)
 
@@ -285,7 +285,7 @@ class TemplateGroupVersionsAPI(APIClient):
                 >>> c = CogniteClient()
                 >>> template_group_list = c.templates.versions.list("template-group-ext-id", limit=5)
         """
-        resource_path = utils._auxiliary.interpolate_and_url_encode(self._RESOURCE_PATH, external_id)
+        resource_path = interpolate_and_url_encode(self._RESOURCE_PATH, external_id)
         filter = {}
         if min_version is not None:
             filter["minVersion"] = min_version
@@ -314,7 +314,7 @@ class TemplateGroupVersionsAPI(APIClient):
                 >>> c = CogniteClient()
                 >>> c.templates.versions.delete("sdk-test-group", 1)
         """
-        resource_path = utils._auxiliary.interpolate_and_url_encode(self._RESOURCE_PATH, external_id)
+        resource_path = interpolate_and_url_encode(self._RESOURCE_PATH, external_id)
         self._post(resource_path + "/delete", {"version": version})
 
 
@@ -358,7 +358,7 @@ class TemplateInstancesAPI(APIClient):
                 >>>                               )
                 >>> c.templates.instances.create("sdk-test-group", 1, [template_instance_1, template_instance_2])
         """
-        resource_path = utils._auxiliary.interpolate_and_url_encode(self._RESOURCE_PATH, external_id, version)
+        resource_path = interpolate_and_url_encode(self._RESOURCE_PATH, external_id, version)
         return self._create_multiple(
             list_cls=TemplateInstanceList, resource_cls=TemplateInstance, resource_path=resource_path, items=instances
         )
@@ -403,9 +403,7 @@ class TemplateInstancesAPI(APIClient):
         """
         if isinstance(instances, TemplateInstance):
             instances = [instances]
-        resource_path = (
-            utils._auxiliary.interpolate_and_url_encode(self._RESOURCE_PATH, external_id, version) + "/upsert"
-        )
+        resource_path = interpolate_and_url_encode(self._RESOURCE_PATH, external_id, version) + "/upsert"
         updated = self._post(
             resource_path, {"items": [instance.dump(camel_case=True) for instance in instances]}
         ).json()["items"]
@@ -435,7 +433,7 @@ class TemplateInstancesAPI(APIClient):
                 >>> my_update = TemplateInstanceUpdate(external_id="test").field_resolvers.add({ "name": ConstantResolver("Norway") })
                 >>> res = c.templates.instances.update("sdk-test-group", 1, my_update)
         """
-        resource_path = utils._auxiliary.interpolate_and_url_encode(self._RESOURCE_PATH, external_id, version)
+        resource_path = interpolate_and_url_encode(self._RESOURCE_PATH, external_id, version)
         return self._update_multiple(
             list_cls=TemplateInstanceList,
             resource_cls=TemplateInstance,
@@ -465,7 +463,7 @@ class TemplateInstancesAPI(APIClient):
                 >>> c = CogniteClient()
                 >>> res = c.templates.instances.retrieve_multiple(external_id="sdk-test-group", version=1, external_ids=["abc", "def"])
         """
-        resource_path = utils._auxiliary.interpolate_and_url_encode(self._RESOURCE_PATH, external_id, version)
+        resource_path = interpolate_and_url_encode(self._RESOURCE_PATH, external_id, version)
         identifiers = IdentifierSequence.load(ids=None, external_ids=external_ids)
         return self._retrieve_multiple(
             list_cls=TemplateInstanceList,
@@ -503,7 +501,7 @@ class TemplateInstancesAPI(APIClient):
                 >>> c = CogniteClient()
                 >>> template_instances_list = c.templates.instances.list("template-group-ext-id", 1, limit=5)
         """
-        resource_path = utils._auxiliary.interpolate_and_url_encode(self._RESOURCE_PATH, external_id, version)
+        resource_path = interpolate_and_url_encode(self._RESOURCE_PATH, external_id, version)
         filter: dict[str, Any] = {}
         if data_set_ids is not None:
             filter["dataSetIds"] = data_set_ids
@@ -536,7 +534,7 @@ class TemplateInstancesAPI(APIClient):
                 >>> c = CogniteClient()
                 >>> c.templates.instances.delete("sdk-test-group", 1, external_ids=["a", "b"])
         """
-        resource_path = utils._auxiliary.interpolate_and_url_encode(self._RESOURCE_PATH, external_id, version)
+        resource_path = interpolate_and_url_encode(self._RESOURCE_PATH, external_id, version)
         self._delete_multiple(
             resource_path=resource_path,
             identifiers=IdentifierSequence.load(external_ids=external_ids),
@@ -581,7 +579,7 @@ class TemplateViewsAPI(APIClient):
                 >>>        )
                 >>> c.templates.views.create("sdk-test-group", 1, [view])
         """
-        resource_path = utils._auxiliary.interpolate_and_url_encode(self._RESOURCE_PATH, external_id, version)
+        resource_path = interpolate_and_url_encode(self._RESOURCE_PATH, external_id, version)
         return self._create_multiple(list_cls=ViewList, resource_cls=View, resource_path=resource_path, items=views)
 
     def upsert(self, external_id: str, version: int, views: View | Sequence[View]) -> View | ViewList:
@@ -619,9 +617,7 @@ class TemplateViewsAPI(APIClient):
         """
         if isinstance(views, View):
             views = [views]
-        resource_path = (
-            utils._auxiliary.interpolate_and_url_encode(self._RESOURCE_PATH, external_id, version) + "/upsert"
-        )
+        resource_path = interpolate_and_url_encode(self._RESOURCE_PATH, external_id, version) + "/upsert"
         updated = self._post(resource_path, {"items": [view.dump(camel_case=True) for view in views]}).json()["items"]
         res = ViewList._load(updated, cognite_client=self._cognite_client)
         if len(res) == 1:
@@ -656,7 +652,7 @@ class TemplateViewsAPI(APIClient):
                 >>> c = CogniteClient()
                 >>> c.templates.views.resolve("template-group-ext-id", 1, "view", { "startTime": 10 }, limit=5)
         """
-        url_path = utils._auxiliary.interpolate_and_url_encode(self._RESOURCE_PATH, external_id, version) + "/resolve"
+        url_path = interpolate_and_url_encode(self._RESOURCE_PATH, external_id, version) + "/resolve"
         return self._list(
             list_cls=ViewResolveList,
             resource_cls=ViewResolveItem,
@@ -685,7 +681,7 @@ class TemplateViewsAPI(APIClient):
                 >>> c = CogniteClient()
                 >>> c.templates.views.list("template-group-ext-id", 1, limit=5)
         """
-        resource_path = utils._auxiliary.interpolate_and_url_encode(self._RESOURCE_PATH, external_id, version)
+        resource_path = interpolate_and_url_encode(self._RESOURCE_PATH, external_id, version)
         return self._list(list_cls=ViewList, resource_cls=View, resource_path=resource_path, method="POST", limit=limit)
 
     def delete(
@@ -710,7 +706,7 @@ class TemplateViewsAPI(APIClient):
                 >>> c = CogniteClient()
                 >>> c.templates.views.delete("sdk-test-group", 1, external_id=["a", "b"])
         """
-        resource_path = utils._auxiliary.interpolate_and_url_encode(self._RESOURCE_PATH, external_id, version)
+        resource_path = interpolate_and_url_encode(self._RESOURCE_PATH, external_id, version)
         self._delete_multiple(
             resource_path=resource_path,
             identifiers=IdentifierSequence.load(external_ids=view_external_id),

--- a/cognite/client/_api/transformations/jobs.py
+++ b/cognite/client/_api/transformations/jobs.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 from typing import Sequence
 
-from cognite.client import utils
 from cognite.client._api_client import APIClient
 from cognite.client._constants import DEFAULT_LIMIT_READ
 from cognite.client.data_classes import (
@@ -12,6 +11,7 @@ from cognite.client.data_classes import (
     TransformationJobMetric,
     TransformationJobMetricList,
 )
+from cognite.client.utils._auxiliary import interpolate_and_url_encode
 from cognite.client.utils._identifier import IdentifierSequence
 
 
@@ -96,7 +96,7 @@ class TransformationJobsAPI(APIClient):
                 >>> c = CogniteClient()
                 >>> res = c.transformations.jobs.list_metrics(id=1)
         """
-        url_path = utils._auxiliary.interpolate_and_url_encode(self._RESOURCE_PATH + "/{}/metrics", str(id))
+        url_path = interpolate_and_url_encode(self._RESOURCE_PATH + "/{}/metrics", str(id))
 
         return self._list(
             list_cls=TransformationJobMetricList,

--- a/cognite/client/_api/transformations/notifications.py
+++ b/cognite/client/_api/transformations/notifications.py
@@ -2,11 +2,11 @@ from __future__ import annotations
 
 from typing import Sequence
 
-from cognite.client import utils
 from cognite.client._api_client import APIClient
 from cognite.client._constants import DEFAULT_LIMIT_READ
 from cognite.client.data_classes import TransformationNotification, TransformationNotificationList
 from cognite.client.data_classes.transformations.notifications import TransformationNotificationFilter
+from cognite.client.utils._auxiliary import assert_type
 from cognite.client.utils._identifier import IdentifierSequence
 
 
@@ -34,7 +34,7 @@ class TransformationNotificationsAPI(APIClient):
                 >>> notifications = [TransformationNotification(transformation_id = 1, destination="my@email.com"), TransformationNotification(transformation_external_id="transformation2", destination="other@email.com"))]
                 >>> res = c.transformations.notifications.create(notifications)
         """
-        utils._auxiliary.assert_type(notification, "notification", [TransformationNotification, Sequence])
+        assert_type(notification, "notification", [TransformationNotification, Sequence])
         return self._create_multiple(
             list_cls=TransformationNotificationList, resource_cls=TransformationNotification, items=notification
         )

--- a/cognite/client/_api/transformations/schedules.py
+++ b/cognite/client/_api/transformations/schedules.py
@@ -2,11 +2,11 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Sequence
 
-from cognite.client import utils
 from cognite.client._api_client import APIClient
 from cognite.client._constants import DEFAULT_LIMIT_READ
 from cognite.client.data_classes import TransformationSchedule, TransformationScheduleList, TransformationScheduleUpdate
 from cognite.client.data_classes.transformations import TransformationFilter
+from cognite.client.utils._auxiliary import assert_type
 from cognite.client.utils._identifier import IdentifierSequence
 
 if TYPE_CHECKING:
@@ -44,7 +44,7 @@ class TransformationSchedulesAPI(APIClient):
                 >>> schedules = [TransformationSchedule(id = 1, interval = "0 * * * *"), TransformationSchedule(external_id="transformation2", interval = "5 * * * *"))]
                 >>> res = c.transformations.schedules.create(schedules)
         """
-        utils._auxiliary.assert_type(schedule, "schedule", [TransformationSchedule, list])
+        assert_type(schedule, "schedule", [TransformationSchedule, list])
         return self._create_multiple(
             list_cls=TransformationScheduleList, resource_cls=TransformationSchedule, items=schedule
         )

--- a/cognite/client/_api/transformations/schema.py
+++ b/cognite/client/_api/transformations/schema.py
@@ -1,12 +1,12 @@
 from __future__ import annotations
 
-from cognite.client import utils
 from cognite.client._api_client import APIClient
 from cognite.client.data_classes import (
     TransformationDestination,
     TransformationSchemaColumn,
     TransformationSchemaColumnList,
 )
+from cognite.client.utils._auxiliary import interpolate_and_url_encode
 
 
 class TransformationSchemaAPI(APIClient):
@@ -34,7 +34,7 @@ class TransformationSchemaAPI(APIClient):
                 >>> columns = c.transformations.schema.retrieve(destination = TransformationDestination.assets())
         """
 
-        url_path = utils._auxiliary.interpolate_and_url_encode(self._RESOURCE_PATH + "/{}", str(destination.type))
+        url_path = interpolate_and_url_encode(self._RESOURCE_PATH + "/{}", str(destination.type))
         filter = destination.dump(True)
         filter.pop("type")
         other_params = {"conflictMode": conflict_mode} if conflict_mode else None

--- a/cognite/client/_api_client.py
+++ b/cognite/client/_api_client.py
@@ -28,7 +28,6 @@ import requests.utils
 from requests import Response
 from requests.structures import CaseInsensitiveDict
 
-from cognite.client import utils
 from cognite.client._http_client import HTTPClient, HTTPClientConfig, get_global_requests_session
 from cognite.client.config import global_config
 from cognite.client.data_classes._base import (
@@ -49,6 +48,7 @@ from cognite.client.utils._auxiliary import (
     get_user_agent,
     interpolate_and_url_encode,
     is_unlimited,
+    json_dump_default,
     split_into_chunks,
 )
 from cognite.client.utils._concurrency import TaskExecutor, collect_exc_info_and_raise, execute_tasks
@@ -183,7 +183,7 @@ class APIClient:
 
         if json_payload:
             try:
-                data = _json.dumps(json_payload, default=utils._auxiliary.json_dump_default, allow_nan=False)
+                data = _json.dumps(json_payload, default=json_dump_default, allow_nan=False)
             except ValueError as e:
                 # A lot of work to give a more human friendly error message when nans and infs are present:
                 msg = "Out of range float values are not JSON compliant"

--- a/cognite/client/_api_client.py
+++ b/cognite/client/_api_client.py
@@ -43,8 +43,15 @@ from cognite.client.data_classes._base import (
 from cognite.client.data_classes.aggregations import AggregationFilter, UniqueResultList
 from cognite.client.data_classes.filters import Filter
 from cognite.client.exceptions import CogniteAPIError, CogniteNotFoundError
-from cognite.client.utils._auxiliary import is_unlimited, split_into_chunks
-from cognite.client.utils._concurrency import TaskExecutor
+from cognite.client.utils._auxiliary import (
+    assert_type,
+    get_current_sdk_version,
+    get_user_agent,
+    interpolate_and_url_encode,
+    is_unlimited,
+    split_into_chunks,
+)
+from cognite.client.utils._concurrency import TaskExecutor, collect_exc_info_and_raise, execute_tasks
 from cognite.client.utils._identifier import (
     Identifier,
     IdentifierCore,
@@ -218,13 +225,13 @@ class APIClient:
         self._refresh_auth_header(headers)
         headers["content-type"] = "application/json"
         headers["accept"] = accept
-        headers["x-cdp-sdk"] = f"CognitePythonSDK:{utils._auxiliary.get_current_sdk_version()}"
+        headers["x-cdp-sdk"] = f"CognitePythonSDK:{get_current_sdk_version()}"
         headers["x-cdp-app"] = self._config.client_name
         headers["cdf-version"] = api_subversion or self._api_subversion
         if "User-Agent" in headers:
-            headers["User-Agent"] += " " + utils._auxiliary.get_user_agent()
+            headers["User-Agent"] += " " + get_user_agent()
         else:
-            headers["User-Agent"] = utils._auxiliary.get_user_agent()
+            headers["User-Agent"] = get_user_agent()
         headers.update(additional_headers)
         return headers
 
@@ -284,9 +291,7 @@ class APIClient:
         resource_path = resource_path or self._RESOURCE_PATH
         try:
             res = self._get(
-                url_path=utils._auxiliary.interpolate_and_url_encode(
-                    resource_path + "/{}", str(identifier.as_primitive())
-                ),
+                url_path=interpolate_and_url_encode(resource_path + "/{}", str(identifier.as_primitive())),
                 params=params,
                 headers=headers,
             )
@@ -354,13 +359,11 @@ class APIClient:
             }
             for id_chunk in identifiers.chunked(self._RETRIEVE_LIMIT)
         ]
-        tasks_summary = utils._concurrency.execute_tasks(
-            self._post, tasks, max_workers=self._config.max_workers, executor=executor
-        )
+        tasks_summary = execute_tasks(self._post, tasks, max_workers=self._config.max_workers, executor=executor)
 
         if tasks_summary.exceptions:
             try:
-                utils._concurrency.collect_exc_info_and_raise(tasks_summary.exceptions)
+                collect_exc_info_and_raise(tasks_summary.exceptions)
             except CogniteNotFoundError:
                 if identifiers.is_singleton():
                     return None
@@ -504,7 +507,7 @@ class APIClient:
             return res.json()["items"]
 
         while len(next_cursors) > 0:
-            tasks_summary = utils._concurrency.execute_tasks(
+            tasks_summary = execute_tasks(
                 get_partition, [(partition,) for partition in next_cursors], max_workers=partitions
             )
             tasks_summary.raise_first_encountered_exception()
@@ -618,7 +621,7 @@ class APIClient:
             return retrieved_items
 
         tasks = [(f"{i + 1}/{partitions}",) for i in range(partitions)]
-        tasks_summary = utils._concurrency.execute_tasks(get_partition, tasks, max_workers=partitions)
+        tasks_summary = execute_tasks(get_partition, tasks, max_workers=partitions)
         tasks_summary.raise_first_encountered_exception()
 
         return list_cls._load(tasks_summary.joined_results(), cognite_client=self._cognite_client)
@@ -633,8 +636,8 @@ class APIClient:
         keys: Sequence[str] | None = None,
         headers: dict | None = None,
     ) -> list[T]:
-        utils._auxiliary.assert_type(filter, "filter", [dict, CogniteFilter], allow_none=True)
-        utils._auxiliary.assert_type(fields, "fields", [list], allow_none=True)
+        assert_type(filter, "filter", [dict, CogniteFilter], allow_none=True)
+        assert_type(fields, "fields", [list], allow_none=True)
         if isinstance(filter, CogniteFilter):
             dumped_filter = filter.dump(camel_case=True)
         elif isinstance(filter, dict):
@@ -746,7 +749,7 @@ class APIClient:
             body["search"] = {"query": query}
 
         if filter is not None:
-            utils._auxiliary.assert_type(filter, "filter", [dict, CogniteFilter], allow_none=False)
+            assert_type(filter, "filter", [dict, CogniteFilter], allow_none=False)
             if isinstance(filter, CogniteFilter):
                 dumped_filter = filter.dump(camel_case=True)
             elif isinstance(filter, dict):
@@ -832,9 +835,7 @@ class APIClient:
             (resource_path, task_items, params, headers)
             for task_items in self._prepare_item_chunks(items, limit, extra_body_fields)
         ]
-        summary = utils._concurrency.execute_tasks(
-            self._post, tasks, max_workers=self._config.max_workers, executor=executor
-        )
+        summary = execute_tasks(self._post, tasks, max_workers=self._config.max_workers, executor=executor)
 
         def unwrap_element(el: T) -> CogniteResource | T:
             if isinstance(el, dict):
@@ -885,9 +886,7 @@ class APIClient:
             }
             for chunk in identifiers.chunked(self._DELETE_LIMIT)
         ]
-        summary = utils._concurrency.execute_tasks(
-            self._post, tasks, max_workers=self._config.max_workers, executor=executor
-        )
+        summary = execute_tasks(self._post, tasks, max_workers=self._config.max_workers, executor=executor)
         summary.raise_compound_exception_if_failed_tasks(
             task_unwrap_fn=lambda task: task["json"]["items"],
             task_list_element_unwrap_fn=identifiers.unwrap_identifier,
@@ -963,7 +962,7 @@ class APIClient:
             for chunk in patch_object_chunks
         ]
 
-        tasks_summary = utils._concurrency.execute_tasks(self._post, tasks, max_workers=self._config.max_workers)
+        tasks_summary = execute_tasks(self._post, tasks, max_workers=self._config.max_workers)
         tasks_summary.raise_compound_exception_if_failed_tasks(
             task_unwrap_fn=lambda task: task["json"]["items"],
             task_list_element_unwrap_fn=lambda el: IdentifierSequenceCore.unwrap_identifier(el),
@@ -1080,7 +1079,7 @@ class APIClient:
         params: dict[str, Any] | None = None,
         headers: dict[str, Any] | None = None,
     ) -> T_CogniteResourceList:
-        utils._auxiliary.assert_type(filter, "filter", [dict, CogniteFilter], allow_none=True)
+        assert_type(filter, "filter", [dict, CogniteFilter], allow_none=True)
         if isinstance(filter, CogniteFilter):
             filter = filter.dump(camel_case=True)
         elif isinstance(filter, dict):

--- a/cognite/client/_cognite_client.py
+++ b/cognite/client/_cognite_client.py
@@ -4,7 +4,6 @@ from typing import Any
 
 from requests import Response
 
-from cognite.client import utils
 from cognite.client._api.annotations import AnnotationsAPI
 from cognite.client._api.assets import AssetsAPI
 from cognite.client._api.data_modeling import DataModelingAPI
@@ -32,6 +31,7 @@ from cognite.client._api.workflows import WorkflowAPI
 from cognite.client._api_client import APIClient
 from cognite.client.config import ClientConfig, global_config
 from cognite.client.credentials import CredentialProvider, OAuthClientCredentials, OAuthInteractive
+from cognite.client.utils._auxiliary import get_current_sdk_version
 
 
 class CogniteClient:
@@ -111,7 +111,7 @@ class CogniteClient:
         Returns:
             str: The current SDK version
         """
-        return utils._auxiliary.get_current_sdk_version()
+        return get_current_sdk_version()
 
     @property
     def config(self) -> ClientConfig:

--- a/cognite/client/data_classes/_base.py
+++ b/cognite/client/data_classes/_base.py
@@ -26,9 +26,8 @@ from typing import (
 
 from typing_extensions import TypeAlias
 
-from cognite.client import utils
 from cognite.client.exceptions import CogniteMissingClientError
-from cognite.client.utils._auxiliary import fast_dict_load, local_import
+from cognite.client.utils._auxiliary import fast_dict_load, json_dump_default, local_import
 from cognite.client.utils._identifier import IdentifierSequence
 from cognite.client.utils._pandas_helpers import convert_nullable_int_cols, notebook_display_with_fallback
 from cognite.client.utils._text import convert_all_keys_to_camel_case, to_camel_case
@@ -51,7 +50,7 @@ def basic_instance_dump(obj: Any, camel_case: bool) -> dict[str, Any]:
 class CogniteResponse:
     def __str__(self) -> str:
         item = convert_time_attributes_to_datetime(self.dump())
-        return json.dumps(item, default=utils._auxiliary.json_dump_default, indent=4)
+        return json.dumps(item, default=json_dump_default, indent=4)
 
     def __repr__(self) -> str:
         return str(self)
@@ -116,7 +115,7 @@ class CogniteResource(_WithClientMixin):
 
     def __str__(self) -> str:
         item = convert_time_attributes_to_datetime(self.dump())
-        return json.dumps(item, default=utils._auxiliary.json_dump_default, indent=4)
+        return json.dumps(item, default=json_dump_default, indent=4)
 
     def dump(self, camel_case: bool = False) -> dict[str, Any]:
         """Dump the instance into a json serializable Python data type.
@@ -237,7 +236,7 @@ class CogniteResourceList(UserList, Generic[T_CogniteResource], _WithClientMixin
 
     def __str__(self) -> str:
         item = convert_time_attributes_to_datetime(self.dump())
-        return json.dumps(item, default=utils._auxiliary.json_dump_default, indent=4)
+        return json.dumps(item, default=json_dump_default, indent=4)
 
     # TODO: We inherit a lot from UserList that we don't actually support...
     def extend(self, other: Collection[Any]) -> None:  # type: ignore [override]
@@ -341,7 +340,7 @@ class CogniteUpdate:
         return type(self) is type(other) and self.dump() == other.dump()
 
     def __str__(self) -> str:
-        return json.dumps(self.dump(), default=utils._auxiliary.json_dump_default, indent=4)
+        return json.dumps(self.dump(), default=json_dump_default, indent=4)
 
     def __repr__(self) -> str:
         return str(self)
@@ -491,7 +490,7 @@ class CogniteFilter:
 
     def __str__(self) -> str:
         item = convert_time_attributes_to_datetime(self.dump())
-        return json.dumps(item, default=utils._auxiliary.json_dump_default, indent=4)
+        return json.dumps(item, default=json_dump_default, indent=4)
 
     def __repr__(self) -> str:
         return str(self)
@@ -618,7 +617,7 @@ class CogniteSort:
         self.nulls = nulls
 
     def __str__(self) -> str:
-        return json.dumps(self.dump(), default=utils._auxiliary.json_dump_default, indent=4)
+        return json.dumps(self.dump(), default=json_dump_default, indent=4)
 
     def __repr__(self) -> str:
         return str(self)

--- a/cognite/client/data_classes/_base.py
+++ b/cognite/client/data_classes/_base.py
@@ -28,7 +28,7 @@ from typing_extensions import TypeAlias
 
 from cognite.client import utils
 from cognite.client.exceptions import CogniteMissingClientError
-from cognite.client.utils._auxiliary import fast_dict_load
+from cognite.client.utils._auxiliary import fast_dict_load, local_import
 from cognite.client.utils._identifier import IdentifierSequence
 from cognite.client.utils._pandas_helpers import convert_nullable_int_cols, notebook_display_with_fallback
 from cognite.client.utils._text import convert_all_keys_to_camel_case, to_camel_case
@@ -153,7 +153,7 @@ class CogniteResource(_WithClientMixin):
             pandas.DataFrame: The dataframe.
         """
         ignore = [] if ignore is None else ignore
-        pd = cast(Any, utils._auxiliary.local_import("pandas"))
+        pd = cast(Any, local_import("pandas"))
         dumped = self.dump(camel_case=camel_case)
 
         for element in ignore:
@@ -292,7 +292,7 @@ class CogniteResourceList(UserList, Generic[T_CogniteResource], _WithClientMixin
         Returns:
             pandas.DataFrame: The Cognite resource as a dataframe.
         """
-        pd = cast(Any, utils._auxiliary.local_import("pandas"))
+        pd = cast(Any, local_import("pandas"))
         df = pd.DataFrame(self.dump(camel_case=camel_case))
         df = convert_nullable_int_cols(df, camel_case)
 

--- a/cognite/client/data_classes/annotation_types/primitives.py
+++ b/cognite/client/data_classes/annotation_types/primitives.py
@@ -3,8 +3,8 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Dict, cast
 
-from cognite.client import utils
 from cognite.client.data_classes._base import CogniteResource
+from cognite.client.utils._auxiliary import local_import
 from cognite.client.utils._text import convert_dict_to_case
 
 if TYPE_CHECKING:
@@ -42,7 +42,7 @@ class VisionResource(CogniteResource):
         Returns:
             pandas.DataFrame: The dataframe.
         """
-        pd = cast(Any, utils._auxiliary.local_import("pandas"))
+        pd = cast(Any, local_import("pandas"))
         return pd.Series(self.dump(camel_case), name="value").to_frame()
 
 

--- a/cognite/client/data_classes/datapoints.py
+++ b/cognite/client/data_classes/datapoints.py
@@ -20,7 +20,6 @@ from typing import (
     overload,
 )
 
-from cognite.client import utils
 from cognite.client.data_classes._base import CogniteResource, CogniteResourceList
 from cognite.client.utils._auxiliary import find_duplicates, local_import
 from cognite.client.utils._identifier import Identifier
@@ -34,6 +33,7 @@ from cognite.client.utils._text import (
     to_camel_case,
     to_snake_case,
 )
+from cognite.client.utils._time import convert_time_attributes_to_datetime
 
 Aggregate = Literal[
     "average",
@@ -455,7 +455,7 @@ class Datapoints(CogniteResource):
 
     def __str__(self) -> str:
         item = self.dump()
-        item["datapoints"] = utils._time.convert_time_attributes_to_datetime(item["datapoints"])
+        item["datapoints"] = convert_time_attributes_to_datetime(item["datapoints"])
         return json.dumps(item, indent=4)
 
     def __len__(self) -> int:
@@ -809,7 +809,7 @@ class DatapointsList(CogniteResourceList[Datapoints]):
     def __str__(self) -> str:
         item = self.dump()
         for i in item:
-            i["datapoints"] = utils._time.convert_time_attributes_to_datetime(i["datapoints"])
+            i["datapoints"] = convert_time_attributes_to_datetime(i["datapoints"])
         return json.dumps(item, default=lambda x: x.__dict__, indent=4)
 
     def to_pandas(  # type: ignore [override]

--- a/cognite/client/data_classes/geospatial.py
+++ b/cognite/client/data_classes/geospatial.py
@@ -5,8 +5,8 @@ import json
 from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING, Any, List, cast
 
-from cognite.client import utils
 from cognite.client.data_classes._base import CogniteResource, CogniteResourceList
+from cognite.client.utils._auxiliary import local_import
 from cognite.client.utils._text import to_camel_case, to_snake_case
 
 if TYPE_CHECKING:
@@ -205,9 +205,9 @@ class FeatureList(CogniteResourceList[Feature]):
                 >>> gdf.head()
         """
         df = self.to_pandas(camel_case)
-        wkt = cast(Any, utils._auxiliary.local_import("shapely.wkt"))
+        wkt = cast(Any, local_import("shapely.wkt"))
         df[geometry] = df[geometry].apply(lambda g: wkt.loads(g["wkt"]))
-        geopandas = cast(Any, utils._auxiliary.local_import("geopandas"))
+        geopandas = cast(Any, local_import("geopandas"))
         return geopandas.GeoDataFrame(df, geometry=geometry)
 
     @staticmethod

--- a/cognite/client/data_classes/raw.py
+++ b/cognite/client/data_classes/raw.py
@@ -3,8 +3,8 @@ from __future__ import annotations
 from collections import OrderedDict
 from typing import TYPE_CHECKING, Any, cast, overload
 
-from cognite.client import utils
 from cognite.client.data_classes._base import CogniteResource, CogniteResourceList
+from cognite.client.utils._auxiliary import local_import
 
 if TYPE_CHECKING:
     import pandas
@@ -40,7 +40,7 @@ class Row(CogniteResource):
         Returns:
             pandas.DataFrame: The pandas DataFrame representing this instance.
         """
-        pd = cast(Any, utils._auxiliary.local_import("pandas"))
+        pd = cast(Any, local_import("pandas"))
         return pd.DataFrame([self.columns], [self.key])
 
 
@@ -53,7 +53,7 @@ class RowList(CogniteResourceList[Row]):
         Returns:
             pandas.DataFrame: The pandas DataFrame representing this instance.
         """
-        pd = cast(Any, utils._auxiliary.local_import("pandas"))
+        pd = cast(Any, local_import("pandas"))
         return pd.DataFrame.from_dict(OrderedDict((d.key, d.columns) for d in self.data), orient="index")
 
 

--- a/cognite/client/data_classes/sequences.py
+++ b/cognite/client/data_classes/sequences.py
@@ -7,7 +7,6 @@ from typing import Sequence as SequenceType
 
 from typing_extensions import TypeAlias
 
-from cognite.client import utils
 from cognite.client.data_classes._base import (
     CogniteFilter,
     CogniteLabelUpdate,
@@ -24,6 +23,7 @@ from cognite.client.data_classes._base import (
     PropertySpec,
 )
 from cognite.client.data_classes.shared import TimestampRange
+from cognite.client.utils._auxiliary import local_import
 from cognite.client.utils._identifier import Identifier
 from cognite.client.utils._text import convert_all_keys_to_camel_case
 
@@ -416,7 +416,7 @@ class SequenceData(CogniteResource):
         Returns:
             pandas.DataFrame: The dataframe.
         """
-        pd = utils._auxiliary.local_import("pandas")
+        pd = local_import("pandas")
 
         options = ["externalId", "id", "columnExternalId", "id|columnExternalId", "externalId|columnExternalId"]
         if column_names not in options:
@@ -474,7 +474,7 @@ class SequenceDataList(CogniteResourceList[SequenceData]):
         Returns:
             pandas.DataFrame: The sequence data list as a pandas DataFrame.
         """
-        pd = utils._auxiliary.local_import("pandas")
+        pd = local_import("pandas")
         return pd.concat([seq_data.to_pandas(column_names=column_names) for seq_data in self.data], axis=1)
 
 

--- a/cognite/client/utils/_auxiliary.py
+++ b/cognite/client/utils/_auxiliary.py
@@ -20,7 +20,6 @@ from typing import (
 )
 from urllib.parse import quote
 
-import cognite.client
 from cognite.client.exceptions import CogniteImportError
 from cognite.client.utils._text import (
     convert_all_keys_to_camel_case,
@@ -168,7 +167,9 @@ def import_legacy_protobuf() -> bool:
 
 
 def get_current_sdk_version() -> str:
-    return cognite.client.__version__
+    from cognite.client import __version__
+
+    return __version__
 
 
 @functools.lru_cache(maxsize=1)

--- a/cognite/client/utils/_pyodide_helpers.py
+++ b/cognite/client/utils/_pyodide_helpers.py
@@ -4,7 +4,7 @@ import os
 import warnings
 from typing import TYPE_CHECKING, Any, Callable, MutableMapping
 
-import cognite.client as cc
+import cognite.client as cc  # Do not import individual entities
 from cognite.client._http_client import _RetryTracker
 from cognite.client.config import ClientConfig
 from cognite.client.credentials import CredentialProvider

--- a/tests/tests_integration/test_api/test_geospatial.py
+++ b/tests/tests_integration/test_api/test_geospatial.py
@@ -7,7 +7,6 @@ from pathlib import Path
 
 import pytest
 
-from cognite.client import utils
 from cognite.client.data_classes import Asset
 from cognite.client.data_classes.geospatial import (
     CoordinateReferenceSystem,
@@ -23,6 +22,7 @@ from cognite.client.data_classes.geospatial import (
     PropertyAndSearchSpec,
 )
 from cognite.client.exceptions import CogniteAPIError
+from cognite.client.utils._auxiliary import local_import
 from tests.utils import set_request_limit
 
 FIXED_SRID = 121111 + random.randint(0, 1_000)
@@ -503,11 +503,11 @@ class TestGeospatialAPI:
             "lastUpdatedTime",
             "assetIds",
         ]
-        geopandas = utils._auxiliary.local_import("geopandas")
-        assert type(gdf.dtypes["position"]) == geopandas.array.GeometryDtype
+        geopandas = local_import("geopandas")
+        assert type(gdf.dtypes["position"]) is geopandas.array.GeometryDtype
 
     def test_from_geopandas_basic(self, cognite_client, test_feature_type):
-        pd = utils._auxiliary.local_import("pandas")
+        pd = local_import("pandas")
         df = pd.DataFrame(
             {
                 "externalId": [f"F{i}_{uuid.uuid4().hex[:10]}" for i in range(4)],
@@ -522,8 +522,8 @@ class TestGeospatialAPI:
                 "pressure": [2121.0, 2121.0, 2121.0, 2121.0],
             }
         )
-        utils._auxiliary.local_import("shapely.wkt")
-        geopandas = utils._auxiliary.local_import("geopandas")
+        local_import("shapely.wkt")
+        geopandas = local_import("geopandas")
         df["position"] = geopandas.GeoSeries.from_wkt(df["position"])
         gdf = geopandas.GeoDataFrame(df, geometry="position")
         fl = FeatureList.from_geopandas(test_feature_type, gdf)
@@ -531,7 +531,7 @@ class TestGeospatialAPI:
         assert len(res) == 4
 
     def test_from_geopandas_flexible(self, cognite_client, test_feature_type):
-        pd = utils._auxiliary.local_import("pandas")
+        pd = local_import("pandas")
         df = pd.DataFrame(
             {
                 "some_unique_id": [f"F{i}_{uuid.uuid4().hex[:10]}" for i in range(4)],
@@ -546,8 +546,8 @@ class TestGeospatialAPI:
                 "some_pressure": [2121.0, 2121.0, 2121.0, 2121.0],
             }
         )
-        utils._auxiliary.local_import("shapely.wkt")
-        geopandas = utils._auxiliary.local_import("geopandas")
+        local_import("shapely.wkt")
+        geopandas = local_import("geopandas")
         df["some_position"] = geopandas.GeoSeries.from_wkt(df["some_position"])
         gdf = geopandas.GeoDataFrame(df, geometry="some_position")
         fl = FeatureList.from_geopandas(

--- a/tests/tests_unit/test_api/test_geospatial.py
+++ b/tests/tests_unit/test_api/test_geospatial.py
@@ -3,8 +3,8 @@ import uuid
 
 import pytest
 
-from cognite.client import utils
 from cognite.client.data_classes.geospatial import Feature, FeatureList, FeatureType
+from cognite.client.utils._auxiliary import local_import
 
 
 @pytest.fixture()
@@ -76,14 +76,14 @@ class TestGeospatialAPI:
     def test_to_geopandas(self, test_feature_type, test_features):
         gdf = test_features.to_geopandas(geometry="position", camel_case=True)
         assert set(gdf) == {"externalId", "dataSetId", "position", "volume", "temperature", "pressure", "assetIds"}
-        geopandas = utils._auxiliary.local_import("geopandas")
-        assert type(gdf.dtypes["position"]) == geopandas.array.GeometryDtype
+        geopandas = local_import("geopandas")
+        assert type(gdf.dtypes["position"]) is geopandas.array.GeometryDtype
 
     @pytest.mark.dsl
     def test_from_geopandas(self, test_feature_type, test_features):
         gdf = test_features.to_geopandas(geometry="position", camel_case=True)
         fl = FeatureList.from_geopandas(test_feature_type, gdf)
-        assert type(fl) == FeatureList
+        assert type(fl) is FeatureList
         assert len(fl) == 4
         for idx, f in enumerate(fl):
             for attr_name in test_feature_type.properties:
@@ -99,9 +99,9 @@ class TestGeospatialAPI:
 
     @pytest.mark.dsl
     def test_from_geopandas_missing_column(self, test_feature_type):
-        pd = utils._auxiliary.local_import("pandas")
+        pd = local_import("pandas")
         df = pd.DataFrame([{"externalId": "12", "volume": 12.0}])
-        geopandas = utils._auxiliary.local_import("geopandas")
+        geopandas = local_import("geopandas")
         gdf = geopandas.GeoDataFrame(df)
         with pytest.raises(ValueError) as error:
             FeatureList.from_geopandas(test_feature_type, gdf)
@@ -109,7 +109,7 @@ class TestGeospatialAPI:
 
     @pytest.mark.dsl
     def test_from_geopandas_nan_values(self, test_feature_type):
-        pd = utils._auxiliary.local_import("pandas")
+        pd = local_import("pandas")
         df = pd.DataFrame(
             [
                 {"externalId": "12", "temperature": 11.0, "pressure": 10.0, "volume": 12.0, "weight": 10.0},
@@ -124,7 +124,7 @@ class TestGeospatialAPI:
                 },
             ]
         )
-        geopandas = utils._auxiliary.local_import("geopandas")
+        geopandas = local_import("geopandas")
         gdf = geopandas.GeoDataFrame(df)
         features = FeatureList.from_geopandas(test_feature_type, gdf)
         assert features[0].weight == 10.0


### PR DESCRIPTION
## Description
Replaced utils-import with explicit import statements.


```python
# this:
utils._auxiliary.assert_type(filter, "filter", [dict, CogniteFilter], allow_none=True)

# became this (+ extra import):
assert_type(filter, "filter", [dict, CogniteFilter], allow_none=True)
```
## Checklist:
- [ ] Tests added/updated.
- [ ] Documentation updated. Documentation is generated from docstrings - these must be updated according to your change.
  If a new method has been added it should be referenced in [cognite.rst](https://github.com/cognitedata/cognite-sdk-python/blob/master/docs/source/cognite.rst) in order to generate docs based on its docstring.
- [ ] Changelog updated in [CHANGELOG.md](https://github.com/cognitedata/cognite-sdk-python/blob/master/CHANGELOG.md).
- [ ] Version bumped. If triggering a new release is desired, bump the version number in [_version.py](https://github.com/cognitedata/cognite-sdk-python/blob/master/cognite/client/_version.py) and [pyproject.toml](https://github.com/cognitedata/cognite-sdk-python/blob/master/pyproject.toml) per [semantic versioning](https://semver.org/).
