### PR TITLE
fix Transformation.dump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ Changes are grouped as follows
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
+## [6.30.2] - 2023-10-09
+### Fixed
+- Serialization of `Transformation` or `TransformationList` no longer fails in `json.dumps` due to unhandled composite objects.
+
 ## [6.30.1] - 2023-10-06
 ### Added
 - Support for metadata on Workflow executions. Set custom metadata when triggering a workflow (`workflows.executions.trigger()`). The metadata is included in results from `workflows.executions.list()` and `workflows.executions.retrieve_detailed()`.

--- a/cognite/client/_version.py
+++ b/cognite/client/_version.py
@@ -1,4 +1,4 @@
 from __future__ import annotations
 
-__version__ = "6.30.1"
+__version__ = "6.30.2"
 __api_subversion__ = "V20220125"

--- a/cognite/client/data_classes/transformations/__init__.py
+++ b/cognite/client/data_classes/transformations/__init__.py
@@ -328,16 +328,7 @@ class Transformation(CogniteResource):
         ret = super().dump(camel_case=camel_case)
 
         for name, prop in ret.items():
-            if isinstance(
-                prop,
-                (
-                    OidcCredentials,
-                    NonceCredentials,
-                    TransformationDestination,
-                    SessionDetails,
-                    TransformationSchedule,
-                ),
-            ):
+            if hasattr(prop, "dump"):
                 ret[name] = prop.dump(camel_case=camel_case)
         return ret
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "cognite-sdk"
 
-version = "6.30.1"
+version = "6.30.2"
 description = "Cognite Python SDK"
 readme = "README.md"
 documentation = "https://cognite-sdk-python.readthedocs-hosted.com"


### PR DESCRIPTION
## Description
https://cognitedata.slack.com/archives/CG10VQPFX/p1696410001082259

```
>>> print(client.transformations.list())
TypeError: Object <unlocked _thread.lock object at 0x0000024AD1963900> of type <class '_thread.lock'> can't be serialized by the JSON encoder
```


## Checklist:
- [ ] Tests added/updated.
- [ ] Documentation updated. Documentation is generated from docstrings - these must be updated according to your change.
  If a new method has been added it should be referenced in [cognite.rst](https://github.com/cognitedata/cognite-sdk-python/blob/master/docs/source/cognite.rst) in order to generate docs based on its docstring.
- [x] Changelog updated in [CHANGELOG.md](https://github.com/cognitedata/cognite-sdk-python/blob/master/CHANGELOG.md).
- [x] Version bumped. If triggering a new release is desired, bump the version number in [_version.py](https://github.com/cognitedata/cognite-sdk-python/blob/master/cognite/client/_version.py) and [pyproject.toml](https://github.com/cognitedata/cognite-sdk-python/blob/master/pyproject.toml) per [semantic versioning](https://semver.org/).
