### PR TITLE
allow scopes to be a list of strings in `OidcCredentials` (used in transformations)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,15 +17,19 @@ Changes are grouped as follows
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
+## [6.32.2] - 2023-10-10
+### Added
+- The credentials class used in TransformationsAPI, `OidcCredentials`, now also accepts `scopes` as a list of strings
+  (used to be comma separated string only).
+
 ## [6.32.1] - 2023-10-10
 ### Added
-* Missing `unit_external_id` and `unit_quantity` fields on `TimeSeriesProperty`. 
-
+- Missing `unit_external_id` and `unit_quantity` fields on `TimeSeriesProperty`.
 
 ## [6.32.0] - 2023-10-10
 ### Fixed
-- Ref to openapi doc in Vision extract docstring 
-- Parameters to Vision models can be given as Python dict (updated doc accordingly). 
+- Ref to openapi doc in Vision extract docstring
+- Parameters to Vision models can be given as Python dict (updated doc accordingly).
 - Don't throw exception when trying to save empty list of vision extract predictions as annotations. This is to avoid having to wrap this method in try-except for every invocation of the method.
 
 ### Added

--- a/cognite/client/_version.py
+++ b/cognite/client/_version.py
@@ -1,4 +1,4 @@
 from __future__ import annotations
 
-__version__ = "6.32.1"
+__version__ = "6.32.2"
 __api_subversion__ = "V20220125"

--- a/cognite/client/data_classes/transformations/common.py
+++ b/cognite/client/data_classes/transformations/common.py
@@ -276,28 +276,48 @@ class Instances(TransformationDestination):
 
 
 class OidcCredentials:
+    """
+    Class that represents OpenID Connect (OIDC) credentials used to authenticate towards Cognite Data Fusion (CDF).
+
+    Note:
+        Is currently only used to specify inputs to TransformationsAPI like source_oidc_credentials and
+        destination_oidc_credentials.
+
+    Args:
+        client_id (str): Your application's client id.
+        client_secret (str): Your application's client secret
+        scopes (str | list[str]): A list of scopes or a comma-separated string (for backwards compatibility).
+        token_uri (str): OAuth token url
+        audience (str | None): Audience (optional)
+        cdf_project_name (str | None): Name of CDF project (optional)
+    """
+
     def __init__(
         self,
         client_id: str,
         client_secret: str,
-        scopes: str,
+        scopes: str | list[str],
         token_uri: str,
         audience: str | None = None,
         cdf_project_name: str | None = None,
     ) -> None:
         self.client_id = client_id
         self.client_secret = client_secret
-        self.scopes = scopes
         self.token_uri = token_uri
         self.audience = audience
         self.cdf_project_name = cdf_project_name
+
+        # For backwards compatibility, we accept scopes as a comma-separated string.
+        if isinstance(scopes, str):
+            scopes = scopes.split(",")
+        self.scopes = scopes
 
     def as_credential_provider(self) -> OAuthClientCredentials:
         return OAuthClientCredentials(
             token_url=self.token_uri,
             client_id=self.client_id,
             client_secret=self.client_secret,
-            scopes=self.scopes.split(","),
+            scopes=self.scopes,
             audience=self.audience,
         )
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "cognite-sdk"
 
-version = "6.32.1"
+version = "6.32.2"
 description = "Cognite Python SDK"
 readme = "README.md"
 documentation = "https://cognite-sdk-python.readthedocs-hosted.com"

--- a/tests/tests_unit/test_transformations/test_common.py
+++ b/tests/tests_unit/test_transformations/test_common.py
@@ -1,0 +1,32 @@
+import pytest
+
+from cognite.client.credentials import OAuthClientCredentials
+from cognite.client.data_classes.iam import ClientCredentials
+from cognite.client.data_classes.transformations.common import OidcCredentials
+
+
+@pytest.fixture
+def oidc_credentials():
+    return OidcCredentials(client_id="id", client_secret="secret", scopes=["impersonation"], token_uri="url")
+
+
+@pytest.mark.parametrize("scopes", ("comma,separated,scopes", ["comma", "separated", "scopes"]))
+def test_oidc_credentials(scopes):
+    oidc_credentials = OidcCredentials(client_id="id", client_secret="secret", scopes=scopes, token_uri="url")
+    assert oidc_credentials.scopes == ["comma", "separated", "scopes"]
+
+
+def test_oidc_credentials_as_credential_provider(oidc_credentials):
+    client_creds = oidc_credentials.as_credential_provider()
+
+    assert isinstance(client_creds, OAuthClientCredentials)
+    assert client_creds.token_url == oidc_credentials.token_uri
+    assert client_creds.scopes == oidc_credentials.scopes
+    assert client_creds.token_custom_args["audience"] is oidc_credentials.audience is None
+
+
+def test_oidc_credentials_as_client_credentials(oidc_credentials):
+    client_creds = oidc_credentials.as_client_credentials()
+
+    assert isinstance(client_creds, ClientCredentials)
+    assert client_creds == ClientCredentials("id", "secret")


### PR DESCRIPTION
## Description
https://cognitedata.slack.com/archives/CG10VQPFX/p1696416761539379

## Checklist:
- [x] Tests added/updated.
- [x] Documentation updated. Documentation is generated from docstrings - these must be updated according to your change.
  If a new method has been added it should be referenced in [cognite.rst](https://github.com/cognitedata/cognite-sdk-python/blob/master/docs/source/cognite.rst) in order to generate docs based on its docstring.
- [x] Changelog updated in [CHANGELOG.md](https://github.com/cognitedata/cognite-sdk-python/blob/master/CHANGELOG.md).
- [x] Version bumped. If triggering a new release is desired, bump the version number in [_version.py](https://github.com/cognitedata/cognite-sdk-python/blob/master/cognite/client/_version.py) and [pyproject.toml](https://github.com/cognitedata/cognite-sdk-python/blob/master/pyproject.toml) per [semantic versioning](https://semver.org/).
