### PR TITLE
Fix filter dumps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,11 @@ Changes are grouped as follows
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
-## [6.32.3] - 2023-10-06
+## [6.32.4] - 2023-10-12
+### Fixed
+- Filters using e.g. metadata keys no longer dumps the key in camel case.
+
+## [6.32.3] - 2023-10-12
 ### Added
 - Ability to toggle the SDK debug logging on/off by setting `config.debug` property on a CogniteClient to True (enable) or False (disable).
 
@@ -30,7 +34,7 @@ Changes are grouped as follows
 ### Added
 - Missing `unit_external_id` and `unit_quantity` fields on `TimeSeriesProperty`.
 
-## [6.32.0] - 2023-10-10
+## [6.32.0] - 2023-10-09
 ### Fixed
 - Ref to openapi doc in Vision extract docstring
 - Parameters to Vision models can be given as Python dict (updated doc accordingly).

--- a/cognite/client/_api/datapoints_subscriptions.py
+++ b/cognite/client/_api/datapoints_subscriptions.py
@@ -3,9 +3,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Iterator, Sequence
 
 from cognite.client._api_client import APIClient
-from cognite.client._constants import (
-    DEFAULT_LIMIT_READ,
-)
+from cognite.client._constants import DEFAULT_LIMIT_READ
 from cognite.client.data_classes.datapoints_subscriptions import (
     DatapointSubscription,
     DatapointSubscriptionBatch,

--- a/cognite/client/_version.py
+++ b/cognite/client/_version.py
@@ -1,4 +1,4 @@
 from __future__ import annotations
 
-__version__ = "6.32.3"
+__version__ = "6.32.4"
 __api_subversion__ = "V20220125"

--- a/cognite/client/data_classes/_base.py
+++ b/cognite/client/data_classes/_base.py
@@ -512,6 +512,11 @@ class CogniteFilter:
 T_CogniteFilter = TypeVar("T_CogniteFilter", bound=CogniteFilter)
 
 
+class NoCaseConversionPropertyList(list):
+    def as_reference(self) -> list[str]:
+        return list(self)
+
+
 class EnumProperty(Enum):
     @staticmethod
     def _generate_next_value_(name: str, *_: Any) -> str:

--- a/cognite/client/data_classes/assets.py
+++ b/cognite/client/data_classes/assets.py
@@ -39,6 +39,7 @@ from cognite.client.data_classes._base import (
     CogniteUpdate,
     EnumProperty,
     IdTransformerMixin,
+    NoCaseConversionPropertyList,
     PropertySpec,
 )
 from cognite.client.data_classes.labels import Label, LabelDefinition, LabelFilter
@@ -889,7 +890,7 @@ class AssetProperty(EnumProperty):
 
     @staticmethod
     def metadata_key(key: str) -> list[str]:
-        return ["metadata", key]
+        return NoCaseConversionPropertyList(["metadata", key])
 
 
 AssetPropertyLike: TypeAlias = Union[AssetProperty, str, List[str]]
@@ -907,7 +908,7 @@ class SortableAssetProperty(EnumProperty):
 
     @staticmethod
     def metadata_key(key: str) -> list[str]:
-        return ["metadata", key]
+        return NoCaseConversionPropertyList(["metadata", key])
 
 
 SortableAssetPropertyLike: TypeAlias = Union[SortableAssetProperty, str, List[str]]

--- a/cognite/client/data_classes/datapoints_subscriptions.py
+++ b/cognite/client/data_classes/datapoints_subscriptions.py
@@ -13,6 +13,7 @@ from cognite.client.data_classes._base import (
     CogniteResourceList,
     CogniteUpdate,
     EnumProperty,
+    NoCaseConversionPropertyList,
     PropertySpec,
     T_CogniteResource,
 )
@@ -361,7 +362,7 @@ class DatapointSubscriptionList(CogniteResourceList[DatapointSubscription]):
 
 
 def _metadata(key: str) -> list[str]:
-    return ["metadata", key]
+    return NoCaseConversionPropertyList(["metadata", key])
 
 
 class DatapointSubscriptionFilterProperties(EnumProperty):

--- a/cognite/client/data_classes/documents.py
+++ b/cognite/client/data_classes/documents.py
@@ -12,6 +12,7 @@ from cognite.client.data_classes._base import (
     CogniteSort,
     EnumProperty,
     IdTransformerMixin,
+    NoCaseConversionPropertyList,
 )
 from cognite.client.data_classes.aggregations import UniqueResult
 from cognite.client.data_classes.labels import Label, LabelDefinition
@@ -283,7 +284,7 @@ class SourceFileProperty(EnumProperty):
 
     @staticmethod
     def metadata_key(key: str) -> list[str]:
-        return ["sourceFile", "metadata", key]
+        return NoCaseConversionPropertyList(["sourceFile", "metadata", key])
 
     def as_reference(self) -> list[str]:
         return ["sourceFile", self.value]

--- a/cognite/client/data_classes/events.py
+++ b/cognite/client/data_classes/events.py
@@ -17,6 +17,7 @@ from cognite.client.data_classes._base import (
     CogniteUpdate,
     EnumProperty,
     IdTransformerMixin,
+    NoCaseConversionPropertyList,
     PropertySpec,
 )
 from cognite.client.data_classes.shared import TimestampRange
@@ -271,7 +272,7 @@ class EventProperty(EnumProperty):
 
     @staticmethod
     def metadata_key(key: str) -> list[str]:
-        return ["metadata", key]
+        return NoCaseConversionPropertyList(["metadata", key])
 
 
 EventPropertyLike: TypeAlias = Union[EventProperty, str, List[str]]
@@ -292,7 +293,7 @@ class SortableEventProperty(EnumProperty):
 
     @staticmethod
     def metadata_key(key: str) -> list[str]:
-        return ["metadata", key]
+        return NoCaseConversionPropertyList(["metadata", key])
 
 
 SortableEventPropertyLike: TypeAlias = Union[SortableEventProperty, str, List[str]]

--- a/cognite/client/data_classes/filters.py
+++ b/cognite/client/data_classes/filters.py
@@ -6,9 +6,9 @@ from typing import TYPE_CHECKING, Any, List, Mapping, Sequence, Tuple, Union, ca
 
 from typing_extensions import TypeAlias
 
-from cognite.client.data_classes._base import EnumProperty, Geometry
+from cognite.client.data_classes._base import EnumProperty, Geometry, NoCaseConversionPropertyList
 from cognite.client.data_classes.labels import Label
-from cognite.client.utils._text import to_camel_case
+from cognite.client.utils._text import iterable_to_case, to_camel_case
 
 if TYPE_CHECKING:
     from cognite.client.data_classes.data_modeling.ids import ContainerId, ViewId
@@ -35,35 +35,32 @@ FilterValueList = Union[Sequence[RawValue], PropertyReferenceValue, ParameterVal
 
 def _dump_filter_value(filter_value: FilterValueList | FilterValue) -> Any:
     if isinstance(filter_value, PropertyReferenceValue):
-        return {
-            "property": filter_value.property.as_reference()
-            if isinstance(filter_value.property, EnumProperty)
-            else filter_value.property
-        }
+        if isinstance(filter_value.property, EnumProperty):
+            return {"property": filter_value.property.as_reference()}
+        return {"property": filter_value.property}
+
     if isinstance(filter_value, ParameterValue):
         return {"parameter": filter_value.parameter}
-    else:
-        return filter_value
+    return filter_value
 
 
 def _load_filter_value(value: Any) -> FilterValue | FilterValueList:
     if isinstance(value, Mapping) and len(value.keys()) == 1:
-        (value_key,) = value
+        ((value_key, to_load),) = value.items()
         if value_key == "property":
-            return PropertyReferenceValue(value[value_key])
+            return PropertyReferenceValue(to_load)
         if value_key == "parameter":
-            return ParameterValue(value[value_key])
+            return ParameterValue(to_load)
     return value
 
 
 def _dump_property(property_: PropertyReference, camel_case: bool) -> list[str] | tuple[str, ...]:
-    if isinstance(property_, EnumProperty):
+    if isinstance(property_, (EnumProperty, NoCaseConversionPropertyList)):
         return property_.as_reference()
     elif isinstance(property_, str):
         return [to_camel_case(property_) if camel_case else property_]
     elif isinstance(property_, (list, tuple)):
-        output = [to_camel_case(p) if camel_case else p for p in property_]
-        return tuple(output) if isinstance(property_, tuple) else output
+        return type(property_)(iterable_to_case(property_, camel_case))
     else:
         raise ValueError(f"Invalid property format {property_}")
 

--- a/cognite/client/data_classes/sequences.py
+++ b/cognite/client/data_classes/sequences.py
@@ -20,6 +20,7 @@ from cognite.client.data_classes._base import (
     CogniteUpdate,
     EnumProperty,
     IdTransformerMixin,
+    NoCaseConversionPropertyList,
     PropertySpec,
 )
 from cognite.client.data_classes.shared import TimestampRange
@@ -493,7 +494,7 @@ class SequenceProperty(EnumProperty):
 
     @staticmethod
     def metadata_key(key: str) -> list[str]:
-        return ["metadata", key]
+        return NoCaseConversionPropertyList(["metadata", key])
 
 
 class SortableSequenceProperty(EnumProperty):
@@ -507,7 +508,7 @@ class SortableSequenceProperty(EnumProperty):
 
     @staticmethod
     def metadata_key(key: str) -> list[str]:
-        return ["metadata", key]
+        return NoCaseConversionPropertyList(["metadata", key])
 
 
 SortableSequencePropertyLike: TypeAlias = Union[SortableSequenceProperty, str, List[str]]

--- a/cognite/client/data_classes/time_series.py
+++ b/cognite/client/data_classes/time_series.py
@@ -18,6 +18,7 @@ from cognite.client.data_classes._base import (
     CogniteUpdate,
     EnumProperty,
     IdTransformerMixin,
+    NoCaseConversionPropertyList,
     PropertySpec,
 )
 from cognite.client.data_classes.shared import TimestampRange
@@ -340,7 +341,7 @@ class TimeSeriesProperty(EnumProperty):
 
     @staticmethod
     def metadata_key(key: str) -> list[str]:
-        return ["metadata", key]
+        return NoCaseConversionPropertyList(["metadata", key])
 
 
 class SortableTimeSeriesProperty(EnumProperty):
@@ -354,7 +355,7 @@ class SortableTimeSeriesProperty(EnumProperty):
 
     @staticmethod
     def metadata_key(key: str) -> list[str]:
-        return ["metadata", key]
+        return NoCaseConversionPropertyList(["metadata", key])
 
 
 SortableTimeSeriesPropertyLike: TypeAlias = Union[SortableTimeSeriesProperty, str, List[str]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "cognite-sdk"
 
-version = "6.32.3"
+version = "6.32.4"
 description = "Cognite Python SDK"
 readme = "README.md"
 documentation = "https://cognite-sdk-python.readthedocs-hosted.com"

--- a/tests/tests_unit/test_data_classes/test_data_models/test_filters.py
+++ b/tests/tests_unit/test_data_classes/test_data_models/test_filters.py
@@ -4,7 +4,9 @@ import pytest
 from _pytest.mark import ParameterSet
 
 import cognite.client.data_classes.filters as f
+from cognite.client.data_classes._base import EnumProperty
 from cognite.client.data_classes.filters import Filter
+from tests.utils import all_subclasses
 
 
 def load_and_dump_equals_data() -> Iterator[ParameterSet]:
@@ -97,9 +99,7 @@ def load_and_dump_equals_data() -> Iterator[ParameterSet]:
 @pytest.mark.parametrize("raw_data", list(load_and_dump_equals_data()))
 def test_load_and_dump_equals(raw_data: dict) -> None:
     parsed = Filter.load(raw_data)
-
     dumped = parsed.dump()
-
     assert dumped == raw_data
 
 
@@ -163,3 +163,14 @@ def test_dump_filter(user_filter: Filter, expected: dict) -> None:
 def test_unknown_filter_type() -> None:
     with pytest.raises(ValueError, match="Unknown filter type: unknown"):
         Filter.load({"unknown": {}})
+
+
+@pytest.mark.parametrize("property_cls", filter(lambda cls: hasattr(cls, "metadata_key"), all_subclasses(EnumProperty)))
+def test_user_given_metadata_keys_are_not_camel_cased(property_cls: type) -> None:
+    # Bug prior to 6.32.4 would dump user given keys in camelCase
+    flt = f.Equals(property_cls.metadata_key("key_foo_Bar_baz"), "value_foo Bar_baz")  # type: ignore [attr-defined]
+    dumped = flt.dump(camel_case=True)["equals"]
+
+    # property may contain more (static) values, so we just verify the end:
+    assert dumped["property"][-2:] == ["metadata", "key_foo_Bar_baz"]
+    assert dumped["value"] == "value_foo Bar_baz"

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -23,7 +23,7 @@ def all_subclasses(base: type) -> list[type]:
     """
     return sorted(
         filter(
-            lambda sub: str(sub).startswith("<class 'cognite.client"),
+            lambda sub: sub.__module__.startswith("cognite.client"),
             set(base.__subclasses__()).union(s for c in base.__subclasses__() for s in all_subclasses(c)),
         ),
         key=str,


### PR DESCRIPTION
## Description
User given string would end up getting camelCased:
```
>>> f.Equals(EventProperty.metadata_key("some_key"), "some_value").dump(camel_case=True)
{'equals': {'property': ['metadata', 'someKey'], 'value': 'some_value'}}
                                     ^^^^^^^^^
```
https://cognitedata.slack.com/archives/CG10VQPFX/p1694426855201089

## Checklist:
- [x] Tests added/updated.
- [ ] Documentation updated. Documentation is generated from docstrings - these must be updated according to your change.
  If a new method has been added it should be referenced in [cognite.rst](https://github.com/cognitedata/cognite-sdk-python/blob/master/docs/source/cognite.rst) in order to generate docs based on its docstring.
- [x] Changelog updated in [CHANGELOG.md](https://github.com/cognitedata/cognite-sdk-python/blob/master/CHANGELOG.md).
- [x] Version bumped. If triggering a new release is desired, bump the version number in [_version.py](https://github.com/cognitedata/cognite-sdk-python/blob/master/cognite/client/_version.py) and [pyproject.toml](https://github.com/cognitedata/cognite-sdk-python/blob/master/pyproject.toml) per [semantic versioning](https://semver.org/).
