### PR TITLE
Improve `Function.list_schedules()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ Changes are grouped as follows
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
+## [6.33.1] - 2023-10-14
+### Fixed
+- `Function.list_schedules()` would return schedules unrelated to the function if the function did not have an external id.
+
 ## [6.33.0] - 2023-10-13
 ### Added
 - Support for providing `DirectRelationReference` and `NodeId` as direct relation values when

--- a/cognite/client/_version.py
+++ b/cognite/client/_version.py
@@ -1,4 +1,4 @@
 from __future__ import annotations
 
-__version__ = "6.33.0"
+__version__ = "6.33.1"
 __api_subversion__ = "V20220125"

--- a/cognite/client/data_classes/functions.py
+++ b/cognite/client/data_classes/functions.py
@@ -134,15 +134,7 @@ class Function(CogniteResource):
         Returns:
             FunctionSchedulesList: List of function schedules
         """
-        schedules_by_external_id = self._cognite_client.functions.schedules.list(
-            function_external_id=self.external_id, limit=limit
-        )
-        schedules_by_id = self._cognite_client.functions.schedules.list(function_id=self.id, limit=limit)
-
-        if is_unlimited(limit):
-            limit = self._cognite_client.functions.schedules._LIST_LIMIT_CEILING
-
-        return (schedules_by_external_id + schedules_by_id)[:limit]
+        return self._cognite_client.functions.schedules.list(function_id=self.id, limit=limit)
 
     def retrieve_call(self, id: int) -> FunctionCall | None:
         """`Retrieve call by id. <https://docs.cognite.com/api/v1/#operation/getFunctionCall>`_

--- a/cognite/client/data_classes/functions.py
+++ b/cognite/client/data_classes/functions.py
@@ -13,7 +13,6 @@ from cognite.client.data_classes._base import (
     IdTransformerMixin,
 )
 from cognite.client.data_classes.shared import TimestampRange
-from cognite.client.utils._auxiliary import is_unlimited
 from cognite.client.utils._time import ms_to_datetime
 
 if TYPE_CHECKING:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "cognite-sdk"
 
-version = "6.33.0"
+version = "6.33.1"
 description = "Cognite Python SDK"
 readme = "README.md"
 documentation = "https://cognite-sdk-python.readthedocs-hosted.com"

--- a/tests/tests_integration/test_api/test_data_modeling/test_spaces.py
+++ b/tests/tests_integration/test_api/test_data_modeling/test_spaces.py
@@ -90,14 +90,12 @@ class TestSpacesAPI:
         with pytest.raises(CogniteAPIError) as error:
             cognite_client.data_modeling.spaces.apply(SpaceApply(space="myInvalidSpace", name="wayTooLong" * 255))
 
-        # Assert
         assert error.value.code == 400
-        assert "name size must be between 0 and 255" in error.value.message
+        assert error.value.message == "Name must be at most 255 characters long."
 
     def test_apply_failed_and_successful_task(
         self, cognite_client: CogniteClient, integration_test_space: Space, monkeypatch: Any
     ) -> None:
-        # Arrange
         valid_space = SpaceApply(
             space="myNewValidSpace",
         )
@@ -105,18 +103,15 @@ class TestSpacesAPI:
         monkeypatch.setattr(cognite_client.data_modeling.spaces, "_CREATE_LIMIT", 1)
 
         try:
-            # Act
             with pytest.raises(CogniteAPIError) as error:
                 cognite_client.data_modeling.spaces.apply([valid_space, invalid_space])
 
-            # Assert
-            assert "name size must be between 0 and 255" in error.value.message
+            assert error.value.message == "Name must be at most 255 characters long."
             assert error.value.code == 400
             assert len(error.value.successful) == 1
             assert len(error.value.failed) == 1
 
         finally:
-            # Cleanup
             cognite_client.data_modeling.spaces.delete(valid_space.as_id())
 
     def test_dump_json_serialize_load(self, cdf_spaces: SpaceList) -> None:

--- a/tests/tests_integration/test_api/test_functions.py
+++ b/tests/tests_integration/test_api/test_functions.py
@@ -18,9 +18,9 @@ class TestFunctionsAPI:
         assert len(res) == 0
 
     def test_function_list_schedules_unlimited(self, cognite_client: CogniteClient):
-        expected_unique_schedules = 100
-
-        fn = cognite_client.functions.retrieve(external_id="integration_test-dummy")
+        expected_unique_schedules = 5
+        # This is an integration test dummy function that purposefully doesn't have an external id.
+        fn = cognite_client.functions.retrieve(id=2495645514618888)
         schedules = fn.list_schedules(limit=-1)
 
         assert len(schedules) == expected_unique_schedules

--- a/tests/tests_integration/test_api/test_functions.py
+++ b/tests/tests_integration/test_api/test_functions.py
@@ -16,3 +16,15 @@ class TestFunctionsAPI:
     def test_retrieve_unknown_ignore_unknowns(self, cognite_client: CogniteClient):
         res = cognite_client.functions.retrieve_multiple(external_ids=["this does not exist"], ignore_unknown_ids=True)
         assert len(res) == 0
+
+    def test_function_get_schedules(self, cognite_client: CogniteClient):
+        fn = cognite_client.functions.retrieve(external_id="integration_test-dummy")
+
+        schedules = fn.list_schedules(limit=15)
+        assert len({s.cron_expression for s in schedules}) == len({s.id for s in schedules}) == 15
+
+    def test_function_get_schedules_unlimited(self, cognite_client: CogniteClient):
+        fn = cognite_client.functions.retrieve(external_id="integration_test-dummy")
+
+        schedules = fn.list_schedules(limit=-1)
+        assert len({s.cron_expression for s in schedules}) == len({s.id for s in schedules}) == 100

--- a/tests/tests_integration/test_api/test_functions.py
+++ b/tests/tests_integration/test_api/test_functions.py
@@ -17,14 +17,12 @@ class TestFunctionsAPI:
         res = cognite_client.functions.retrieve_multiple(external_ids=["this does not exist"], ignore_unknown_ids=True)
         assert len(res) == 0
 
-    def test_function_get_schedules(self, cognite_client: CogniteClient):
+    def test_function_list_schedules_unlimited(self, cognite_client: CogniteClient):
+        expected_unique_schedules = 100
+
         fn = cognite_client.functions.retrieve(external_id="integration_test-dummy")
-
-        schedules = fn.list_schedules(limit=15)
-        assert len({s.cron_expression for s in schedules}) == len({s.id for s in schedules}) == 15
-
-    def test_function_get_schedules_unlimited(self, cognite_client: CogniteClient):
-        fn = cognite_client.functions.retrieve(external_id="integration_test-dummy")
-
         schedules = fn.list_schedules(limit=-1)
-        assert len({s.cron_expression for s in schedules}) == len({s.id for s in schedules}) == 100
+
+        assert len(schedules) == expected_unique_schedules
+        assert len({s.id for s in schedules}) == expected_unique_schedules
+        assert len({s.cron_expression for s in schedules}) == expected_unique_schedules

--- a/tests/tests_unit/test_data_classes/test_functions.py
+++ b/tests/tests_unit/test_data_classes/test_functions.py
@@ -1,12 +1,12 @@
 import datetime
 import re
 from typing import List, Tuple
-from unittest.mock import MagicMock, call
+from unittest.mock import MagicMock
 
 import pytest
 
 from cognite.client import CogniteClient
-from cognite.client.data_classes import Function, FunctionCallLog, FunctionCallLogEntry, FunctionSchedule
+from cognite.client.data_classes import Function, FunctionCallLog, FunctionCallLogEntry
 from cognite.client.utils._time import datetime_to_ms
 from tests.utils import jsgz_load
 

--- a/tests/tests_unit/test_data_classes/test_functions.py
+++ b/tests/tests_unit/test_data_classes/test_functions.py
@@ -41,27 +41,6 @@ def function(mock_client):
 
 
 @pytest.fixture
-def function_schedules(mock_client):
-    schedule_1 = FunctionSchedule(
-        name="my-schedule-1",
-        function_id=123,
-        description="my schedule 1",
-        created_time=12345,
-        cron_expression="* * * * *",
-        cognite_client=mock_client,
-    )
-    schedule_2 = FunctionSchedule(
-        name="my-schedule-2",
-        function_external_id="my-function",
-        description="my schedule 2",
-        created_time=12345,
-        cron_expression="* * * * *",
-        cognite_client=mock_client,
-    )
-    return [schedule_1, schedule_2]
-
-
-@pytest.fixture
 def mock_function_call_resp(rsps, cognite_client):
     response_body = {
         "items": [
@@ -89,24 +68,6 @@ class TestFunction:
     def test_update_on_deleted_function(self, empty_function):
         empty_function._cognite_client.functions.retrieve.return_value = None
         empty_function.update()
-
-    @pytest.mark.parametrize("limit", [2, None, -1, float("inf")])
-    def test_list_schedules(self, function, function_schedules, limit):
-        function._cognite_client.functions.schedules._LIST_LIMIT_CEILING = 10
-        function._cognite_client.functions.schedules.list.side_effect = [
-            [function_schedules[0]],
-            [function_schedules[1]],
-        ]
-
-        schedules = function.list_schedules(limit=limit)
-
-        calls = [
-            call(function_external_id=function.external_id, limit=limit),
-            call(function_id=function.id, limit=limit),
-        ]
-
-        assert 2 == len(schedules)
-        function._cognite_client.functions.schedules.list.assert_has_calls(calls)
 
 
 class TestFunctionCall:


### PR DESCRIPTION
## Description
Looking at the ticket: https://cognitedata.atlassian.net/jira/software/projects/DOGE/boards/871?selectedIssue=DOGE-62

I agree that the implementation looks unusual but I can't reproduce a duplication issue.

## Checklist:
- [x] Tests added/updated.
- [ ] Documentation updated. Documentation is generated from docstrings - these must be updated according to your change.
  If a new method has been added it should be referenced in [cognite.rst](https://github.com/cognitedata/cognite-sdk-python/blob/master/docs/source/cognite.rst) in order to generate docs based on its docstring.
- [x] Changelog updated in [CHANGELOG.md](https://github.com/cognitedata/cognite-sdk-python/blob/master/CHANGELOG.md).
- [x] Version bumped. If triggering a new release is desired, bump the version number in [_version.py](https://github.com/cognitedata/cognite-sdk-python/blob/master/cognite/client/_version.py) and [pyproject.toml](https://github.com/cognitedata/cognite-sdk-python/blob/master/pyproject.toml) per [semantic versioning](https://semver.org/).
