### PR TITLE
Support `unit` property. Don't break on future additions (but warn)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,13 @@ Changes are grouped as follows
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
+## [6.34.0] - 2023-10-20
+### Fixed
+- `PropertyType`s no longer fail on instantiation, but warn on missing SDK support for the new property(-ies).
+
+### Added
+- `PropertyType`s `Float32`, `Float64`, `Int32`, `Int64` now support `unit`.
+
 ## [6.33.3] - 2023-10-18
 ### Added
 - `functions.create()` now accepts a `data_set_id` parameter. Note: This is not for the Cognite function, but for the zipfile containing

--- a/cognite/client/_api/data_modeling/instances.py
+++ b/cognite/client/_api/data_modeling/instances.py
@@ -89,7 +89,7 @@ _DATA_MODELING_SUPPORTED_FILTERS: frozenset[type[Filter]] = frozenset(
     }
 )
 
-_LOGGER = logging.getLogger(__name__)
+logger = logging.getLogger(__name__)
 
 
 class _NodeOrEdgeList(CogniteResourceList):
@@ -470,7 +470,7 @@ class InstancesAPI(APIClient):
                 setattr(_poll_delay, "has_been_invoked", True)
             else:
                 delay = seconds
-            _LOGGER.debug(f"Waiting {delay} seconds before polling sync endpoint again...")
+            logger.debug(f"Waiting {delay} seconds before polling sync endpoint again...")
             time.sleep(delay)
 
         def _do_subscribe() -> None:
@@ -486,7 +486,7 @@ class InstancesAPI(APIClient):
                 try:
                     callback(result)
                 except Exception:
-                    _LOGGER.exception("Unhandled exception in sync subscriber callback. Backing off and retrying...")
+                    logger.exception("Unhandled exception in sync subscriber callback. Backing off and retrying...")
                     time.sleep(next(error_backoff))
                     continue
 

--- a/cognite/client/_api_client.py
+++ b/cognite/client/_api_client.py
@@ -65,7 +65,7 @@ if TYPE_CHECKING:
     from cognite.client import CogniteClient
     from cognite.client.config import ClientConfig
 
-log = logging.getLogger(__name__)
+logger = logging.getLogger(__name__)
 
 T = TypeVar("T")
 
@@ -1214,10 +1214,10 @@ class APIClient:
 
         if res.history:
             for res_hist in res.history:
-                log.debug(
+                logger.debug(
                     f"REDIRECT AFTER HTTP Error {res_hist.status_code} {res_hist.request.method} {res_hist.request.url}: {res_hist.content.decode()}"
                 )
-        log.debug(f"HTTP Error {code} {res.request.method} {res.request.url}: {msg}", extra=error_details)
+        logger.debug(f"HTTP Error {code} {res.request.method} {res.request.url}: {msg}", extra=error_details)
         raise CogniteAPIError(msg, code, x_request_id, missing=missing, duplicated=duplicated, extra=extra)
 
     def _log_request(self, res: Response, **kwargs: Any) -> None:
@@ -1242,7 +1242,7 @@ class APIClient:
             # If this fails, it means we are running in a browser (pyodide) with patched requests package:
             http_protocol = "XMLHTTP"
 
-        log.debug(f"{http_protocol} {method} {url} {status_code}", extra=extra)
+        logger.debug(f"{http_protocol} {method} {url} {status_code}", extra=extra)
 
     @staticmethod
     def _get_response_content_safe(res: Response) -> str:

--- a/cognite/client/_version.py
+++ b/cognite/client/_version.py
@@ -1,4 +1,4 @@
 from __future__ import annotations
 
-__version__ = "6.33.3"
+__version__ = "6.34.0"
 __api_subversion__ = "V20220125"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "cognite-sdk"
 
-version = "6.33.3"
+version = "6.34.0"
 description = "Cognite Python SDK"
 readme = "README.md"
 documentation = "https://cognite-sdk-python.readthedocs-hosted.com"

--- a/tests/tests_unit/test_data_classes/test_data_models/test_data_types.py
+++ b/tests/tests_unit/test_data_classes/test_data_models/test_data_types.py
@@ -19,12 +19,19 @@ class TestPropertyType:
         "data",
         [
             {"type": "text", "collation": "ucs_basic", "list": False},
-            {"type": "int32", "list": True},
+            {"type": "int32", "list": True, "unit": "temperature:deg_c"},
             {"type": "timeseries", "list": False},
         ],
     )
     def test_load_dump(self, data: dict) -> None:
         actual = PropertyType.load(data).dump(camel_case=True)
+
+        assert data == actual
+
+    def test_load_ignore_unknown_properties(self) -> None:
+        data = {"type": "float64", "list": True, "unit": "known", "super_unit": "unknown"}
+        actual = PropertyType.load(data).dump(camel_case=True)
+        data.pop("super_unit")
 
         assert data == actual
 


### PR DESCRIPTION
## Description
- Standardise name for logger as `logger`

## Checklist:
- [ ] Tests added/updated.
- [ ] Documentation updated. Documentation is generated from docstrings - these must be updated according to your change.
  If a new method has been added it should be referenced in [cognite.rst](https://github.com/cognitedata/cognite-sdk-python/blob/master/docs/source/cognite.rst) in order to generate docs based on its docstring.
- [ ] Changelog updated in [CHANGELOG.md](https://github.com/cognitedata/cognite-sdk-python/blob/master/CHANGELOG.md).
- [ ] Version bumped. If triggering a new release is desired, bump the version number in [_version.py](https://github.com/cognitedata/cognite-sdk-python/blob/master/cognite/client/_version.py) and [pyproject.toml](https://github.com/cognitedata/cognite-sdk-python/blob/master/pyproject.toml) per [semantic versioning](https://semver.org/).
