### PR TITLE
[v7] Fix asserts meant for the SDK user

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -4,8 +4,5 @@ source=cognite
 [report]
 exclude_lines =
     pragma: no cover
-    raise AssertionError
     raise NotImplementedError
     if TYPE_CHECKING:
-omit =
-    cognite/client/_auxiliary/*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@ Changes are grouped as follows
 - `Security` in case of vulnerabilities.
 
 ## [7.0.0] - 2023-10-24
+### Changed
+- All `assert`s meant for the SDK user, now raise appropriate errors instead (`ValueError`, `RuntimeError`...).
+- `CogniteAssetHierarchyError` is no longer possible to catch as an `AssertionError`.
 
 ## [6.35.0] - 2023-10-25
 ### Added

--- a/MIGRATION_GUIDE.md
+++ b/MIGRATION_GUIDE.md
@@ -8,6 +8,13 @@ Changes are grouped as follows:
 - `Changed` for changes that do not fall into any other category
 - `Optional` for new, optional methods/features that you should be aware of - *and could take advantage of*
 
+## From v6 to v7
+
+### Changed
+
+- All `assert`s meant for the SDK user, now raise appropriate errors instead (`ValueError`, `RuntimeError`...).
+- `CogniteAssetHierarchyError` is no longer possible to catch as an `AssertionError`.
+
 ## From v5 to v6
 
 ### Removed

--- a/cognite/client/_api/files.py
+++ b/cognite/client/_api/files.py
@@ -822,7 +822,8 @@ class FilesAPI(APIClient):
         """
         if isinstance(path, str):
             path = Path(path)
-        assert path.parent.is_dir(), f"{path.parent} is not a directory"
+        if not path.parent.is_dir():
+            raise NotADirectoryError(f"{path.parent} is not a directory")
         identifier = Identifier.of_either(id, external_id).as_dict()
         download_link = self._get_download_link(identifier)
         self._download_file_to_path(download_link, path)

--- a/cognite/client/_api/functions.py
+++ b/cognite/client/_api/functions.py
@@ -67,7 +67,7 @@ def _get_function_identifier(function_id: int | None, function_external_id: str 
     identifier = IdentifierSequence.load(function_id, function_external_id, id_name="function")
     if identifier.is_singleton():
         return identifier[0]
-    raise AssertionError("Exactly one of function_id and function_external_id must be specified")
+    raise ValueError("Exactly one of function_id and function_external_id must be specified")
 
 
 class FunctionsAPI(APIClient):
@@ -964,9 +964,9 @@ class FunctionSchedulesAPI(APIClient):
             try:
                 IdentifierSequence.load(ids=function_id, external_ids=function_external_id).assert_singleton()
             except ValueError:
-                raise AssertionError(
+                raise ValueError(
                     "Both 'function_id' and 'function_external_id' were supplied, pass exactly one or neither."
-                )
+                ) from None
 
         if is_unlimited(limit):
             limit = self._LIST_LIMIT_CEILING

--- a/cognite/client/data_classes/_base.py
+++ b/cognite/client/data_classes/_base.py
@@ -393,17 +393,14 @@ class CogniteUpdate:
         update_obj["modify"] = value
         self._update_object[name] = update_obj
 
-    def dump(self, camel_case: bool = True) -> dict[str, Any]:
+    def dump(self, camel_case: Literal[True] = True) -> dict[str, Any]:
         """Dump the instance into a json serializable Python data type.
 
         Args:
-            camel_case (bool): No description.
+            camel_case (Literal[True]): No description.
         Returns:
             dict[str, Any]: A dictionary representation of the instance.
         """
-        if camel_case is False:
-            # TODO maybe (when unifying classes)
-            raise ValueError("snake_case is currently unsupported")
         dumped: dict[str, Any] = {"update": self._update_object}
         if self._id is not None:
             dumped["id"] = self._id

--- a/cognite/client/data_classes/_base.py
+++ b/cognite/client/data_classes/_base.py
@@ -163,7 +163,7 @@ class CogniteResource(_WithClientMixin):
                 if isinstance(dumped[key], dict):
                     dumped.update(dumped.pop(key))
                 else:
-                    raise AssertionError(f"Could not expand attribute '{key}'")
+                    raise ValueError(f"Could not expand attribute '{key}'")
 
         return pd.Series(dumped).to_frame(name="value")
 

--- a/cognite/client/data_classes/_base.py
+++ b/cognite/client/data_classes/_base.py
@@ -350,9 +350,8 @@ class CogniteUpdate:
 
     def _set(self, name: str, value: Any) -> None:
         update_obj = self._update_object.get(name, {})
-        assert (
-            "remove" not in update_obj and "add" not in update_obj
-        ), "Can not call set after adding or removing fields from an update object."
+        if "remove" in update_obj or "add" in update_obj:
+            raise RuntimeError("Can not call set after adding or removing fields from an update object.")
         self._update_object[name] = {"set": value}
 
     def _set_null(self, name: str) -> None:
@@ -360,28 +359,37 @@ class CogniteUpdate:
 
     def _add(self, name: str, value: Any) -> None:
         update_obj = self._update_object.get(name, {})
-        assert "set" not in update_obj, "Can not call remove or add fields after calling set on an update object."
-        assert (
-            "add" not in update_obj
-        ), "Can not call add twice on the same object, please combine your objects and pass them to add in one call."
+        if "set" in update_obj:
+            raise RuntimeError("Can not call remove or add fields after calling set on an update object.")
+        if "add" in update_obj:
+            raise RuntimeError(
+                "Can not call add twice on the same object, please combine your objects "
+                "and pass them to add in one call."
+            )
         update_obj["add"] = value
         self._update_object[name] = update_obj
 
     def _remove(self, name: str, value: Any) -> None:
         update_obj = self._update_object.get(name, {})
-        assert "set" not in update_obj, "Can not call remove or add fields after calling set on an update object."
-        assert (
-            "remove" not in update_obj
-        ), "Can not call remove twice on the same object, please combine your items and pass them to remove in one call."
+        if "set" in update_obj:
+            raise RuntimeError("Can not call remove or add fields after calling set on an update object.")
+        if "remove" in update_obj:
+            raise RuntimeError(
+                "Can not call remove twice on the same object, please combine your items "
+                "and pass them to remove in one call."
+            )
         update_obj["remove"] = value
         self._update_object[name] = update_obj
 
     def _modify(self, name: str, value: Any) -> None:
         update_obj = self._update_object.get(name, {})
-        assert "set" not in update_obj, "Can not call remove or add fields after calling set on an update object."
-        assert (
-            "modify" not in update_obj
-        ), "Can not call modify twice on the same object, please combine your items and pass them to modify in one call."
+        if "set" in update_obj:
+            raise RuntimeError("Can not call remove or add fields after calling set on an update object.")
+        if "modify" in update_obj:
+            raise RuntimeError(
+                "Can not call modify twice on the same object, please combine your items "
+                "and pass them to modify in one call."
+            )
         update_obj["modify"] = value
         self._update_object[name] = update_obj
 
@@ -393,7 +401,9 @@ class CogniteUpdate:
         Returns:
             dict[str, Any]: A dictionary representation of the instance.
         """
-        assert camel_case is True, "snake_case is currently unsupported"  # TODO maybe (when unifying classes)
+        if camel_case is False:
+            # TODO maybe (when unifying classes)
+            raise ValueError("snake_case is currently unsupported")
         dumped: dict[str, Any] = {"update": self._update_object}
         if self._id is not None:
             dumped["id"] = self._id

--- a/cognite/client/exceptions.py
+++ b/cognite/client/exceptions.py
@@ -277,13 +277,10 @@ class CogniteAuthError(CogniteException):
     ...
 
 
-class CogniteAssetHierarchyError(CogniteException, AssertionError):
+class CogniteAssetHierarchyError(CogniteException):
     """Cognite Asset Hierarchy validation Error.
 
     Raised if the given assets form an invalid hierarchy (by CDF standards).
-
-    Note:
-        For historical reasons, we make the error catchable as an AssertionError.
 
     Args:
         message (str): The error message to output.

--- a/cognite/client/utils/_version_checker.py
+++ b/cognite/client/utils/_version_checker.py
@@ -49,8 +49,10 @@ def _is_newer_pre_release(
     pr_cycle_a: str | None, pr_v_a: int | None, pr_cycle_b: str | None, pr_v_b: int | None
 ) -> bool:
     cycles = ["a", "b", "rc", None]
-    assert pr_cycle_a in cycles, f"pr_cycle_a must be one of '{pr_cycle_a}', not '{cycles}'."
-    assert pr_cycle_b in cycles, f"pr_cycle_a must be one of '{pr_cycle_b}', not '{cycles}'."
+    if pr_cycle_a not in cycles:
+        raise RuntimeError(f"pr_cycle_a must be one of '{pr_cycle_a}', not '{cycles}'.")
+    if pr_cycle_b not in cycles:
+        raise RuntimeError(f"pr_cycle_a must be one of '{pr_cycle_b}', not '{cycles}'.")
     is_newer = False
     if cycles.index(pr_cycle_a) > cycles.index(pr_cycle_b):
         is_newer = True

--- a/tests/tests_unit/test_api/test_datapoints.py
+++ b/tests/tests_unit/test_api/test_datapoints.py
@@ -224,7 +224,7 @@ class TestInsertDatapoints:
     @pytest.mark.parametrize("ts_key, value_key", [("timestamp", "values"), ("timstamp", "value")])
     def test_invalid_datapoints_keys(self, cognite_client, ts_key, value_key):
         dps = [{ts_key: i * 1e11, value_key: i} for i in range(1, 11)]
-        with pytest.raises(AssertionError, match="is missing the"):
+        with pytest.raises(KeyError, match="A datapoint is missing one or both keys"):
             cognite_client.time_series.data.insert(dps, id=1)
 
     def test_insert_datapoints_over_limit(self, cognite_client, mock_post_datapoints, monkeypatch):
@@ -242,7 +242,7 @@ class TestInsertDatapoints:
         } in request_bodies
 
     def test_insert_datapoints_no_data(self, cognite_client):
-        with pytest.raises(AssertionError, match="No datapoints provided"):
+        with pytest.raises(ValueError, match="No datapoints provided"):
             cognite_client.time_series.data.insert(id=1, datapoints=[])
 
     def test_insert_datapoints_in_multiple_time_series(self, cognite_client, mock_post_datapoints):
@@ -323,7 +323,7 @@ class TestDeleteDatapoints:
             cognite_client.time_series.data.delete_range("1d-ago", "now", id, external_id)
 
     def test_delete_range_start_after_end(self, cognite_client):
-        with pytest.raises(AssertionError, match="must be"):
+        with pytest.raises(ValueError, match="must be"):
             cognite_client.time_series.data.delete_range(1, 0, 1)
 
     def test_delete_ranges(self, cognite_client, mock_delete_datapoints):

--- a/tests/tests_unit/test_api/test_functions.py
+++ b/tests/tests_unit/test_api/test_functions.py
@@ -904,7 +904,7 @@ class TestFunctionSchedulesAPI:
         assert len(res) == 1
 
     def test_list_schedules_with_function_id_and_function_external_id_raises(self, cognite_client):
-        with pytest.raises(AssertionError) as excinfo:
+        with pytest.raises(ValueError) as excinfo:
             cognite_client.functions.schedules.list(function_id=123, function_external_id="my-func")
         assert (
             "Both 'function_id' and 'function_external_id' were supplied, pass exactly one or neither."
@@ -947,7 +947,7 @@ class TestFunctionSchedulesAPI:
         assert expected == res.dump(camel_case=True)
 
     def test_create_schedules_with_function_id_and_function_external_id_raises(self, cognite_client):
-        with pytest.raises(AssertionError) as excinfo:
+        with pytest.raises(ValueError) as excinfo:
             cognite_client.functions.schedules.create(
                 name="my-schedule",
                 function_id=123,
@@ -1026,7 +1026,7 @@ class TestFunctionCallsAPI:
         assert mock_function_calls_filter_response.calls[1].response.json()["items"] == res.dump(camel_case=True)
 
     def test_list_calls_with_function_id_and_function_external_id_raises(self, cognite_client):
-        with pytest.raises(AssertionError) as excinfo:
+        with pytest.raises(ValueError) as excinfo:
             cognite_client.functions.calls.list(function_id=123, function_external_id="my-function")
         assert "Exactly one of function_id and function_external_id must be specified" == excinfo.value.args[0]
 
@@ -1042,7 +1042,7 @@ class TestFunctionCallsAPI:
         assert mock_function_calls_retrieve_response.calls[1].response.json()["items"][0] == res.dump(camel_case=True)
 
     def test_retrieve_call_with_function_id_and_function_external_id_raises(self, cognite_client):
-        with pytest.raises(AssertionError) as excinfo:
+        with pytest.raises(ValueError) as excinfo:
             cognite_client.functions.calls.retrieve(
                 call_id=CALL_ID, function_id=FUNCTION_ID, function_external_id=f"func-no-{FUNCTION_ID}"
             )
@@ -1062,7 +1062,7 @@ class TestFunctionCallsAPI:
     def test_function_call_logs_by_function_id_and_function_external_id_raises(
         self, mock_function_call_logs_response, cognite_client
     ):
-        with pytest.raises(AssertionError) as excinfo:
+        with pytest.raises(ValueError) as excinfo:
             cognite_client.functions.calls.get_logs(
                 call_id=CALL_ID, function_id=FUNCTION_ID, function_external_id=f"func-no-{FUNCTION_ID}"
             )
@@ -1105,7 +1105,7 @@ class TestFunctionCallsAPI:
         assert mock_function_call_response_response.calls[0].response.json()["response"] == res
 
     def test_function_call_response_by_function_id_and_function_external_id_raises(self, cognite_client):
-        with pytest.raises(AssertionError) as excinfo:
+        with pytest.raises(ValueError) as excinfo:
             cognite_client.functions.calls.get_response(
                 call_id=CALL_ID, function_id=FUNCTION_ID, function_external_id=f"func-no-{FUNCTION_ID}"
             )

--- a/tests/tests_unit/test_api_client.py
+++ b/tests/tests_unit/test_api_client.py
@@ -576,7 +576,7 @@ class TestStandardList:
             elif len(resource_chunk) == 500:
                 total_resources += 500
             else:
-                raise AssertionError("resource chunk length was not 1000 or 500")
+                raise ValueError("resource chunk length was not 1000 or 500")
         assert 11500 == total_resources
 
     @pytest.mark.usefixtures("mock_get_for_autopaging_2589")

--- a/tests/tests_unit/test_base.py
+++ b/tests/tests_unit/test_base.py
@@ -470,23 +470,23 @@ class TestCogniteUpdate:
 
     def test_add_or_remove_after_set_raises_error(self):
         update = MyUpdate(1).object.set({"key": "value"})
-        with pytest.raises(AssertionError):
+        with pytest.raises(RuntimeError):
             update.object.add({"key2": "value2"})
-        with pytest.raises(AssertionError):
+        with pytest.raises(RuntimeError):
             update.object.remove(["key2"])
 
     def test_set_after_add_or_removeraises_error(self):
         update = MyUpdate(1).object.add({"key": "value"})
-        with pytest.raises(AssertionError):
+        with pytest.raises(RuntimeError):
             update.object.set({"key2": "value2"})
 
     def test_add_object_and_remove(self):
         update = MyUpdate(1).object.add({"key": "value"})
         update.object.remove(["key2"])
         assert {"id": 1, "update": {"object": {"add": {"key": "value"}, "remove": ["key2"]}}} == update.dump()
-        with pytest.raises(AssertionError):
+        with pytest.raises(RuntimeError):
             update.object.add({"key": "overwrite"})
-        with pytest.raises(AssertionError):
+        with pytest.raises(RuntimeError):
             update.object.remove(["key2", "key4"])
 
     def test_remove_object(self):

--- a/tests/tests_unit/test_data_classes/test_assets.py
+++ b/tests/tests_unit/test_data_classes/test_assets.py
@@ -226,36 +226,31 @@ def cycles_issue_output():
 
 class TestAssetHierarchy:
     @pytest.mark.parametrize(
-        "exc_type, asset",
+        "asset",
         (
             # Invalid name:
-            (AssertionError, Asset(name="", external_id="foo")),
-            (CogniteAssetHierarchyError, Asset(name="", external_id="foo")),
-            (AssertionError, Asset(name=None, external_id="foo")),
-            (CogniteAssetHierarchyError, Asset(name=None, external_id="foo")),
+            Asset(name="", external_id="foo"),
+            Asset(name=None, external_id="foo"),
             # Invalid external_id (empty str allowed):
-            (AssertionError, Asset(name="a", external_id=None)),
-            (CogniteAssetHierarchyError, Asset(name="a", external_id=None)),
+            Asset(name="a", external_id=None),
             # Id given:
-            (AssertionError, Asset(name="a", external_id="", id=123)),
-            (CogniteAssetHierarchyError, Asset(name="a", external_id="", id=123)),
+            Asset(name="a", external_id="", id=123),
         ),
     )
-    def test_validate_asset_hierarchy___invalid_assets(self, exc_type, asset):
+    def test_validate_asset_hierarchy___invalid_assets(self, asset):
         hierarchy = AssetHierarchy([asset]).validate(on_error="ignore")
         assert len(hierarchy.invalid) == 1
-        with pytest.raises(exc_type, match=r"Issue\(s\): 1 invalid$"):
+        with pytest.raises(CogniteAssetHierarchyError, match=r"Issue\(s\): 1 invalid$"):
             hierarchy.is_valid(on_error="raise")
 
-    @pytest.mark.parametrize("exc_type", (AssertionError, CogniteAssetHierarchyError))
-    def test_validate_asset_hierarchy__orphans_given_ignore_false(self, exc_type):
+    def test_validate_asset_hierarchy__orphans_given_ignore_false(self):
         assets = [
             Asset(name="a", parent_external_id="1", external_id="2"),
             Asset(name="a", parent_external_id="2", external_id="3"),
         ]
         hierarchy = AssetHierarchy(assets, ignore_orphans=False).validate(on_error="ignore")
         assert len(hierarchy.orphans) == 1
-        with pytest.raises(exc_type, match=r"Issue\(s\): 1 orphans$"):
+        with pytest.raises(CogniteAssetHierarchyError, match=r"Issue\(s\): 1 orphans$"):
             hierarchy.is_valid(on_error="raise")
 
     @pytest.mark.parametrize("n", [1, 2, 3, 10])
@@ -283,28 +278,25 @@ class TestAssetHierarchy:
         assert len(hierarchy.orphans) == 1  # note: still marked as orphans, but no issues are raised:
         assert hierarchy.is_valid(on_error="raise") is True
 
-    @pytest.mark.parametrize("exc_type", (AssertionError, CogniteAssetHierarchyError))
-    def test_validate_asset_hierarchy_asset_has_parent_id_and_parent_ref_id(self, exc_type):
+    def test_validate_asset_hierarchy_asset_has_parent_id_and_parent_ref_id(self):
         assets = [
             Asset(name="a", external_id="1"),
             Asset(name="a", parent_external_id="1", parent_id=1, external_id="2"),
         ]
         hierarchy = AssetHierarchy(assets).validate(on_error="ignore")
         assert len(hierarchy.unsure_parents) == 1
-        with pytest.raises(exc_type, match=r"Issue\(s\): 1 unsure_parents$"):
+        with pytest.raises(CogniteAssetHierarchyError, match=r"Issue\(s\): 1 unsure_parents$"):
             hierarchy.is_valid(on_error="raise")
 
-    @pytest.mark.parametrize("exc_type", (AssertionError, CogniteAssetHierarchyError))
-    def test_validate_asset_hierarchy_duplicate_ref_ids(self, exc_type):
+    def test_validate_asset_hierarchy_duplicate_ref_ids(self):
         assets = [Asset(name="a", external_id="1"), Asset(name="a", parent_external_id="1", external_id="1")]
         hierarchy = AssetHierarchy(assets).validate(on_error="ignore")
         assert list(hierarchy.duplicates) == ["1"]
         assert sum(len(assets) for assets in hierarchy.duplicates.values()) == 2
-        with pytest.raises(exc_type, match=r"Issue\(s\): 2 duplicates$"):
+        with pytest.raises(CogniteAssetHierarchyError, match=r"Issue\(s\): 2 duplicates$"):
             hierarchy.is_valid(on_error="raise")
 
-    @pytest.mark.parametrize("exc_type", (AssertionError, CogniteAssetHierarchyError))
-    def test_validate_asset_hierarchy_circular_dependency(self, exc_type):
+    def test_validate_asset_hierarchy_circular_dependency(self):
         assets = [
             Asset(name="a", external_id="1", parent_external_id="3"),
             Asset(name="a", external_id="2", parent_external_id="1"),
@@ -312,16 +304,15 @@ class TestAssetHierarchy:
         ]
         hierarchy = AssetHierarchy(assets).validate(on_error="ignore")
         assert len(hierarchy.cycles) == 1
-        with pytest.raises(exc_type, match=r"Issue\(s\): 1 cycles$"):
+        with pytest.raises(CogniteAssetHierarchyError, match=r"Issue\(s\): 1 cycles$"):
             hierarchy.is_valid(on_error="raise")
 
-    @pytest.mark.parametrize("exc_type", (AssertionError, CogniteAssetHierarchyError))
-    def test_validate_asset_hierarchy_self_dependency(self, exc_type):
+    def test_validate_asset_hierarchy_self_dependency(self):
         # Shortest cycle possible is self->self:
         assets = [Asset(name="a", external_id="2", parent_external_id="2")]
         hierarchy = AssetHierarchy(assets).validate(on_error="ignore")
         assert len(hierarchy.cycles) == 1
-        with pytest.raises(exc_type, match=r"Issue\(s\): 1 cycles$"):
+        with pytest.raises(CogniteAssetHierarchyError, match=r"Issue\(s\): 1 cycles$"):
             hierarchy.is_valid(on_error="raise")
 
     def test_validate_asset_hierarchy__everything_is_wrong(self):


### PR DESCRIPTION
## Description
See changelog.

## Checklist:
- [ ] Tests added/updated.
- [ ] Documentation updated. Documentation is generated from docstrings - these must be updated according to your change.
  If a new method has been added it should be referenced in [cognite.rst](https://github.com/cognitedata/cognite-sdk-python/blob/master/docs/source/cognite.rst) in order to generate docs based on its docstring.
- [ ] Changelog updated in [CHANGELOG.md](https://github.com/cognitedata/cognite-sdk-python/blob/master/CHANGELOG.md).
- [ ] Version bumped. If triggering a new release is desired, bump the version number in [_version.py](https://github.com/cognitedata/cognite-sdk-python/blob/master/cognite/client/_version.py) and [pyproject.toml](https://github.com/cognitedata/cognite-sdk-python/blob/master/pyproject.toml) per [semantic versioning](https://semver.org/).
