### PR TITLE
Optional fields containers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,11 @@ Changes are grouped as follows
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
+## [6.34.2] - 2023-10-23
+### Fixed
+- Loading a `ContainerApply` from source failed if `nullable`, `autoIncrement`, or `cursorable` were not set 
+  in the `ContainerProperty` and `BTreeIndex` classes even though they are optional. This is now fixed. 
+ 
 ## [6.34.1] - 2023-10-23
 ### Added
 - Support for setting `data_set_id` and `metadata` in `ThreeDModelsAPI.create`.

--- a/cognite/client/_version.py
+++ b/cognite/client/_version.py
@@ -1,4 +1,4 @@
 from __future__ import annotations
 
-__version__ = "6.34.1"
+__version__ = "6.34.2"
 __api_subversion__ = "V20220125"

--- a/cognite/client/data_classes/data_modeling/containers.py
+++ b/cognite/client/data_classes/data_modeling/containers.py
@@ -5,6 +5,8 @@ from abc import ABC, abstractmethod
 from dataclasses import asdict, dataclass
 from typing import Any, Literal
 
+from typing_extensions import Self
+
 from cognite.client.data_classes._base import (
     CogniteFilter,
     CogniteResourceList,
@@ -56,7 +58,7 @@ class ContainerCore(DataModelingResource):
         self.indexes = indexes
 
     @classmethod
-    def load(cls, resource: dict | str) -> ContainerCore:
+    def load(cls, resource: dict | str) -> Self:
         data = json.loads(resource) if isinstance(resource, str) else resource
         if "constraints" in data:
             data["constraints"] = {k: Constraint.load(v) for k, v in data["constraints"].items()} or None
@@ -225,8 +227,9 @@ class ContainerProperty:
             type_ = PropertyType.load(data["type"])
         return cls(
             type=type_,
-            nullable=data.get("nullable", True),
-            auto_increment=data.get("autoIncrement", False),
+            # If nothing is specified, we will pass through null values
+            nullable=data.get("nullable"),  # type: ignore[arg-type]
+            auto_increment=data.get("autoIncrement"),  # type: ignore[arg-type]
             name=data.get("name"),
             default_value=data.get("defaultValue"),
             description=data.get("description"),
@@ -316,7 +319,7 @@ class BTreeIndex(Index):
 
     @classmethod
     def load(cls, data: dict[str, Any]) -> BTreeIndex:
-        return cls(properties=data["properties"], cursorable=data.get("cursorable", False))
+        return cls(properties=data["properties"], cursorable=data.get("cursorable"))  # type: ignore[arg-type]
 
     def dump(self, camel_case: bool = False) -> dict[str, str | dict]:
         as_dict = asdict(self)

--- a/cognite/client/data_classes/data_modeling/containers.py
+++ b/cognite/client/data_classes/data_modeling/containers.py
@@ -236,9 +236,12 @@ class ContainerProperty:
         )
 
     def dump(self, camel_case: bool = False) -> dict[str, str | dict]:
-        output = asdict(self)
-        if "type" in output and isinstance(output["type"], dict):
+        output: dict[str, str | dict] = {}
+        if self.type:
             output["type"] = self.type.dump(camel_case)
+        for key in ["nullable", "auto_increment", "name", "default_value", "description"]:
+            if (value := getattr(self, key)) is not None:
+                output[key] = value
         return convert_all_keys_to_camel_case_recursive(output) if camel_case else output
 
 
@@ -321,10 +324,12 @@ class BTreeIndex(Index):
     def load(cls, data: dict[str, Any]) -> BTreeIndex:
         return cls(properties=data["properties"], cursorable=data.get("cursorable"))  # type: ignore[arg-type]
 
-    def dump(self, camel_case: bool = False) -> dict[str, str | dict]:
-        as_dict = asdict(self)
-        as_dict["indexType" if camel_case else "index_type"] = "btree"
-        return convert_all_keys_to_camel_case_recursive(as_dict) if camel_case else as_dict
+    def dump(self, camel_case: bool = False) -> dict[str, Any]:
+        dumped: dict[str, Any] = {"properties": self.properties}
+        if self.cursorable is not None:
+            dumped["cursorable"] = self.cursorable
+        dumped["indexType" if camel_case else "index_type"] = "btree"
+        return convert_all_keys_to_camel_case_recursive(dumped) if camel_case else dumped
 
 
 @dataclass(frozen=True)
@@ -335,7 +340,7 @@ class InvertedIndex(Index):
     def load(cls, data: dict[str, Any]) -> InvertedIndex:
         return cls(properties=data["properties"])
 
-    def dump(self, camel_case: bool = False) -> dict[str, str | dict]:
-        as_dict = asdict(self)
-        as_dict["indexType" if camel_case else "index_type"] = "inverted"
-        return convert_all_keys_to_camel_case_recursive(as_dict) if camel_case else as_dict
+    def dump(self, camel_case: bool = False) -> dict[str, Any]:
+        dumped: dict[str, Any] = {"properties": self.properties}
+        dumped["indexType" if camel_case else "index_type"] = "inverted"
+        return convert_all_keys_to_camel_case_recursive(dumped) if camel_case else dumped

--- a/cognite/client/data_classes/data_modeling/containers.py
+++ b/cognite/client/data_classes/data_modeling/containers.py
@@ -225,8 +225,8 @@ class ContainerProperty:
             type_ = PropertyType.load(data["type"])
         return cls(
             type=type_,
-            nullable=data["nullable"],
-            auto_increment=data["autoIncrement"],
+            nullable=data.get("nullable", True),
+            auto_increment=data.get("autoIncrement", False),
             name=data.get("name"),
             default_value=data.get("defaultValue"),
             description=data.get("description"),
@@ -316,7 +316,7 @@ class BTreeIndex(Index):
 
     @classmethod
     def load(cls, data: dict[str, Any]) -> BTreeIndex:
-        return cls(properties=data["properties"], cursorable=data["cursorable"])
+        return cls(properties=data["properties"], cursorable=data.get("cursorable", False))
 
     def dump(self, camel_case: bool = False) -> dict[str, str | dict]:
         as_dict = asdict(self)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "cognite-sdk"
 
-version = "6.34.1"
+version = "6.34.2"
 description = "Cognite Python SDK"
 readme = "README.md"
 documentation = "https://cognite-sdk-python.readthedocs-hosted.com"

--- a/tests/tests_integration/test_api/test_data_modeling/test_containers.py
+++ b/tests/tests_integration/test_api/test_data_modeling/test_containers.py
@@ -203,3 +203,21 @@ class TestContainersAPI:
 
         # Assert
         assert container == container_loaded
+
+    def test_load_and_create_only_required_fields(self, cognite_client: CogniteClient) -> None:
+        external_id = "test_load_and_create_only_required_fields"
+        data = {
+            "externalId": external_id,
+            "space": "publicdata",
+            "properties": {"name": {"type": "text"}},
+            "indexes": {"nameIdx": {"properties": ["name"], "indexType": "btree"}},
+        }
+
+        container = ContainerApply.load(data)
+
+        try:
+            created = cognite_client.data_modeling.containers.apply(container)
+
+            assert created.external_id == external_id
+        finally:
+            cognite_client.data_modeling.containers.delete(container.as_id())

--- a/tests/tests_integration/test_api/test_data_modeling/test_containers.py
+++ b/tests/tests_integration/test_api/test_data_modeling/test_containers.py
@@ -204,12 +204,14 @@ class TestContainersAPI:
         # Assert
         assert container == container_loaded
 
-    def test_load_and_create_only_required_fields(self, cognite_client: CogniteClient) -> None:
+    def test_load_and_create_only_required_fields(
+        self, cognite_client: CogniteClient, integration_test_space: Space
+    ) -> None:
         external_id = "test_load_and_create_only_required_fields"
         data = {
             "externalId": external_id,
-            "space": "publicdata",
-            "properties": {"name": {"type": "text"}},
+            "space": integration_test_space.space,
+            "properties": {"name": {"type": {"type": "text"}}},
             "indexes": {"nameIdx": {"properties": ["name"], "indexType": "btree"}},
         }
 

--- a/tests/tests_unit/test_data_classes/test_data_models/test_containers.py
+++ b/tests/tests_unit/test_data_classes/test_data_models/test_containers.py
@@ -8,9 +8,10 @@ class TestContainerProperty:
         "data",
         [
             {"type": {"type": "direct"}},
-            {"type": "int32"},
-            {"type": "text"},
-            {"type": "file"},
+            # List is not required, but gets set and thus will be dumped
+            {"type": {"type": "int32", "list": False}},
+            {"type": {"type": "text", "list": False, "collation": "ucs_basic"}},
+            {"type": {"type": "file", "list": False}},
         ],
     )
     def test_load_dump__only_required(self, data: dict) -> None:

--- a/tests/tests_unit/test_data_classes/test_data_models/test_containers.py
+++ b/tests/tests_unit/test_data_classes/test_data_models/test_containers.py
@@ -1,6 +1,21 @@
 import pytest
 
-from cognite.client.data_classes.data_modeling.containers import Constraint, Index
+from cognite.client.data_classes.data_modeling.containers import Constraint, ContainerProperty, Index
+
+
+class TestContainerProperty:
+    @pytest.mark.parametrize(
+        "data",
+        [
+            {"type": {"type": "direct"}},
+            {"type": "int32"},
+            {"type": "text"},
+            {"type": "file"},
+        ],
+    )
+    def test_load_dump__only_required(self, data: dict) -> None:
+        actual = ContainerProperty.load(data).dump(camel_case=True)
+        assert data == actual
 
 
 class TestConstraint:
@@ -41,6 +56,13 @@ class TestIndex:
     def test_load_dump__no_fail_on_unseen_key(self, data: dict) -> None:
         actual = Index.load(data).dump(camel_case=True)
         data.pop("this-key-is-new-sooo-new")
+        assert data == actual
+
+    @pytest.mark.parametrize(
+        "data", [{"properties": ["name"], "indexType": "btree"}, {"properties": ["name"], "indexType": "inverted"}]
+    )
+    def test_load_dump__only_required(self, data: dict) -> None:
+        actual = Index.load(data).dump(camel_case=True)
         assert data == actual
 
 

--- a/tests/tests_unit/test_data_classes/test_data_models/test_views.py
+++ b/tests/tests_unit/test_data_classes/test_data_models/test_views.py
@@ -30,7 +30,6 @@ class TestViewPropertyDefinition:
             "name": "fullName",
             "nullable": False,
             "type": {
-                "container": None,
                 "type": "direct",
                 "source": {"external_id": "myExternalId", "space": "mySpace", "version": "myVersion"},
             },


### PR DESCRIPTION
## Description
~Setting defaults value as these two nested attributes are used in the write classes.~ Extended dump methods to ignore `None`

## Checklist:
- [x] Tests added/updated.
- [ ] Documentation updated. Documentation is generated from docstrings - these must be updated according to your change.
  If a new method has been added it should be referenced in [cognite.rst](https://github.com/cognitedata/cognite-sdk-python/blob/master/docs/source/cognite.rst) in order to generate docs based on its docstring.
- [x] Changelog updated in [CHANGELOG.md](https://github.com/cognitedata/cognite-sdk-python/blob/master/CHANGELOG.md).
- [x] Version bumped. If triggering a new release is desired, bump the version number in [_version.py](https://github.com/cognitedata/cognite-sdk-python/blob/master/cognite/client/_version.py) and [pyproject.toml](https://github.com/cognitedata/cognite-sdk-python/blob/master/pyproject.toml) per [semantic versioning](https://semver.org/).
