### PR TITLE
fix fixtures with unwanted side effects

### DIFF
--- a/tests/tests_unit/conftest.py
+++ b/tests/tests_unit/conftest.py
@@ -4,7 +4,7 @@ from cognite.client import ClientConfig, CogniteClient
 from cognite.client.credentials import Token
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture(scope="class")
 def cognite_client():
     cnf = ClientConfig(client_name="any", project="dummy", credentials=Token("bla"))
     yield CogniteClient(cnf)

--- a/tests/tests_unit/test_api/test_files.py
+++ b/tests/tests_unit/test_api/test_files.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import json
 import os
 import re
@@ -699,7 +701,7 @@ class TestFilesAPI:
         cognite_client,
         data_set_id: int,
         api_error: CogniteAPIError,
-        expected_error: type(CogniteAPIError),
+        expected_error: type[CogniteAPIError],
         expected_error_message: str,
     ):
         def raise_api_error(*args, **kwargs):

--- a/tests/tests_unit/test_api_client.py
+++ b/tests/tests_unit/test_api_client.py
@@ -34,7 +34,7 @@ URL_PATH = "/someurl"
 RESPONSE = {"any": "ok"}
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture(scope="class")
 def api_client_with_token_factory(cognite_client):
     return APIClient(
         ClientConfig(
@@ -50,7 +50,7 @@ def api_client_with_token_factory(cognite_client):
     )
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture(scope="class")
 def api_client_with_token(cognite_client):
     return APIClient(
         ClientConfig(


### PR DESCRIPTION
## Description
Running:
`pytests tests/tests_unit/test_api/test_files.py`
fails as the mock is mutated in a way that breaks tests following `test_upload_bytes_post_error`.

This PR reduces the scope from `module` to `class` on certain (stateful) mocks, so as to not re-use them in too many tests.

## Checklist:
- [x] Tests added/updated.
- [ ] Documentation updated. Documentation is generated from docstrings - these must be updated according to your change.
  If a new method has been added it should be referenced in [cognite.rst](https://github.com/cognitedata/cognite-sdk-python/blob/master/docs/source/cognite.rst) in order to generate docs based on its docstring.
- [ ] Changelog updated in [CHANGELOG.md](https://github.com/cognitedata/cognite-sdk-python/blob/master/CHANGELOG.md).
- [ ] Version bumped. If triggering a new release is desired, bump the version number in [_version.py](https://github.com/cognitedata/cognite-sdk-python/blob/master/cognite/client/_version.py) and [pyproject.toml](https://github.com/cognitedata/cognite-sdk-python/blob/master/pyproject.toml) per [semantic versioning](https://semver.org/).
