### PR TITLE
Add support for `through` in node result expressions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,12 @@ Changes are grouped as follows
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
+## [6.35.0] - 2023-10-25
+### Added
+- Support for `through` on node result set expressions.
+### Fixed
+- `unit` on properties in data modeling. This was typed as a string, but it is in fact a direct relation.
+
 ## [6.34.2] - 2023-10-23
 ### Fixed
 - Loading a `ContainerApply` from source failed with `KeyError` if `nullable`, `autoIncrement`, or `cursorable` were not set 

--- a/cognite/client/_version.py
+++ b/cognite/client/_version.py
@@ -1,4 +1,4 @@
 from __future__ import annotations
 
-__version__ = "6.34.2"
+__version__ = "6.35.0"
 __api_subversion__ = "V20220125"

--- a/cognite/client/data_classes/data_modeling/query.py
+++ b/cognite/client/data_classes/data_modeling/query.py
@@ -162,6 +162,12 @@ class ResultSetExpression(ABC):
                 "from_": query_node.get("from"),
                 "filter": Filter.load(query_node["filter"]) if "filter" in query_node else None,
             }
+            if (through := query_node.get("through")) is not None:
+                node["through"] = [
+                    through["view"]["space"],
+                    through["view"]["externalId"] + "/" + through["view"]["version"],
+                    through["identifier"],
+                ]
             return NodeResultSetExpression(sort=sort, limit=query.get("limit"), **node)
         elif "edges" in query:
             query_edge = query["edges"]
@@ -191,8 +197,10 @@ class NodeResultSetExpression(ResultSetExpression):
         filter: Filter | None = None,
         sort: list[InstanceSort] | None = None,
         limit: int | None = None,
+        through: list[str] | tuple[str, str, str] | None = None,
     ):
         super().__init__(from_=from_, filter=filter, limit=limit, sort=sort)
+        self.through = through
 
     def dump(self, camel_case: bool = False) -> dict[str, Any]:
         output: dict[str, Any] = {"nodes": {}}
@@ -201,6 +209,18 @@ class NodeResultSetExpression(ResultSetExpression):
             nodes["from"] = self.from_
         if self.filter:
             nodes["filter"] = self.filter.dump()
+        if self.through:
+            if len(self.through) != 3:
+                raise ValueError(f"`through` must be on the form (space, view/version, property), was {self.through}")
+            nodes["through"] = {
+                "view": {
+                    "type": "view",
+                    "space": self.through[0],
+                    "externalId": self.through[1].split("/")[0],
+                    "version": self.through[1].split("/")[1],
+                },
+                "identifier": self.through[2],
+            }
 
         if self.sort:
             output["sort"] = [s.dump(camel_case=camel_case) for s in self.sort]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "cognite-sdk"
 
-version = "6.34.2"
+version = "6.35.0"
 description = "Cognite Python SDK"
 readme = "README.md"
 documentation = "https://cognite-sdk-python.readthedocs-hosted.com"

--- a/tests/tests_unit/test_data_classes/test_data_models/test_data_types.py
+++ b/tests/tests_unit/test_data_classes/test_data_models/test_data_types.py
@@ -1,8 +1,10 @@
 import pytest
 
+from cognite.client.data_classes.data_modeling import NodeId
 from cognite.client.data_classes.data_modeling.data_types import (
     DirectRelation,
     DirectRelationReference,
+    Float32,
     PropertyType,
 )
 
@@ -41,3 +43,11 @@ class TestDirectRelation:
         data = {"type": "direct", "container": {"space": "mySpace", "externalId": "myId", "type": "container"}}
 
         assert data == DirectRelation.load(data).dump(camel_case=True)
+
+
+class TestUnitSupport:
+    def test_load_dump_property_with_unit(self) -> None:
+        data = {"type": "float32", "list": False, "unit": {"space": "cdf_units", "externalId": "temperature:celsius"}}
+        property = Float32.load(data)
+        assert isinstance(property.unit, NodeId)
+        assert data == property.dump(camel_case=True)

--- a/tests/tests_unit/test_data_classes/test_data_models/test_queries.py
+++ b/tests/tests_unit/test_data_classes/test_data_models/test_queries.py
@@ -11,18 +11,22 @@ from cognite.client.data_classes.data_modeling import query as q
 def result_set_expression_load_and_dump_equals_data() -> Iterator[ParameterSet]:
     raw = {
         "nodes": {
-            "filter": {"equals": {"property": ["node", "externalId"], "value": {"parameter": "airplaneExternalId"}}}
+            "filter": {"equals": {"property": ["node", "externalId"], "value": {"parameter": "airplaneExternalId"}}},
+            "from": "bla",
+            "through": {
+                "view": {"type": "view", "space": "some", "externalId": "extid", "version": "v1"},
+                "identifier": "bla",
+            },
         },
         "limit": 1,
     }
     loaded_node = q.NodeResultSetExpression(
-        filter=f.Equals(property=["node", "externalId"], value={"parameter": "airplaneExternalId"}), limit=1
+        filter=f.Equals(property=["node", "externalId"], value={"parameter": "airplaneExternalId"}),
+        limit=1,
+        from_="bla",
+        through=["some", "extid/v1", "bla"],
     )
-    yield pytest.param(
-        raw,
-        loaded_node,
-        id="Documentation Example",
-    )
+    yield pytest.param(raw, loaded_node, id="Documentation Example")
 
     raw = {
         "nodes": {
@@ -33,11 +37,7 @@ def result_set_expression_load_and_dump_equals_data() -> Iterator[ParameterSet]:
         filter=f.Range(lt=2000, property=["IntegrationTestsImmutable", "Movie/2", "releaseYear"])
     )
 
-    yield pytest.param(
-        raw,
-        loaded_node,
-        id="Filter Node on Range",
-    )
+    yield pytest.param(raw, loaded_node, id="Filter Node on Range")
 
     raw = {
         "edges": {
@@ -50,11 +50,7 @@ def result_set_expression_load_and_dump_equals_data() -> Iterator[ParameterSet]:
     loaded_edge = q.EdgeResultSetExpression(
         filter=f.Equals(property=["edge", "type"], value={"space": "MovieSpace", "externalId": "Movie.actors"})
     )
-    yield pytest.param(
-        raw,
-        loaded_edge,
-        id="Filter Edge on Type",
-    )
+    yield pytest.param(raw, loaded_edge, id="Filter Edge on Type")
 
 
 class TestResultSetExpressions:


### PR DESCRIPTION
- Support 'through' on node result expressions
- Bump version and update changelog

## Description
Please describe the change you have made.

## Checklist:
- [ ] Tests added/updated.
- [ ] Documentation updated. Documentation is generated from docstrings - these must be updated according to your change.
  If a new method has been added it should be referenced in [cognite.rst](https://github.com/cognitedata/cognite-sdk-python/blob/master/docs/source/cognite.rst) in order to generate docs based on its docstring.
- [ ] Changelog updated in [CHANGELOG.md](https://github.com/cognitedata/cognite-sdk-python/blob/master/CHANGELOG.md).
- [ ] Version bumped. If triggering a new release is desired, bump the version number in [_version.py](https://github.com/cognitedata/cognite-sdk-python/blob/master/cognite/client/_version.py) and [pyproject.toml](https://github.com/cognitedata/cognite-sdk-python/blob/master/pyproject.toml) per [semantic versioning](https://semver.org/).
