### PR TITLE
DOCS 1062 - Update example to add externalId to timeseries

### DIFF
--- a/cognite/client/_api/time_series.py
+++ b/cognite/client/_api/time_series.py
@@ -499,7 +499,7 @@ class TimeSeriesAPI(APIClient):
                 >>> from cognite.client import CogniteClient
                 >>> from cognite.client.data_classes import TimeSeries
                 >>> c = CogniteClient()
-                >>> ts = c.time_series.create(TimeSeries(name="my ts"))
+                >>> ts = c.time_series.create(TimeSeries(name=tsname, data_set_id=dataset, external_id=tsname))
         """
         api_subversion = self._get_subapiversion_item(time_series)
 

--- a/cognite/client/_api/time_series.py
+++ b/cognite/client/_api/time_series.py
@@ -499,7 +499,7 @@ class TimeSeriesAPI(APIClient):
                 >>> from cognite.client import CogniteClient
                 >>> from cognite.client.data_classes import TimeSeries
                 >>> c = CogniteClient()
-                >>> ts = c.time_series.create(TimeSeries(name="my_ts", data_set_id=123, external_id="3"))
+                >>> ts = c.time_series.create(TimeSeries(name="my_ts", data_set_id=123, external_id="foo"))
         """
         api_subversion = self._get_subapiversion_item(time_series)
 

--- a/cognite/client/_api/time_series.py
+++ b/cognite/client/_api/time_series.py
@@ -499,7 +499,7 @@ class TimeSeriesAPI(APIClient):
                 >>> from cognite.client import CogniteClient
                 >>> from cognite.client.data_classes import TimeSeries
                 >>> c = CogniteClient()
-                >>> ts = c.time_series.create(TimeSeries(name=tsname, data_set_id=dataset, external_id=tsname))
+                >>> ts = c.time_series.create(TimeSeries(name="my_tsname", data_set_id="my_tsdataset", external_id="my_timeseriesid"))
         """
         api_subversion = self._get_subapiversion_item(time_series)
 

--- a/cognite/client/_api/time_series.py
+++ b/cognite/client/_api/time_series.py
@@ -499,7 +499,7 @@ class TimeSeriesAPI(APIClient):
                 >>> from cognite.client import CogniteClient
                 >>> from cognite.client.data_classes import TimeSeries
                 >>> c = CogniteClient()
-                >>> ts = c.time_series.create(TimeSeries(name="my_tsname", data_set_id="my_tsdataset", external_id="my_timeseriesid"))
+                >>> ts = c.time_series.create(TimeSeries(name="my_ts", data_set_id=123, external_id="3"))
         """
         api_subversion = self._get_subapiversion_item(time_series)
 


### PR DESCRIPTION
## Description
Added a line of code to update the time series example with externalId

JIRA Issue: https://cognitedata.atlassian.net/browse/DOCS-1062?atlOrigin=eyJpIjoiNmUwODVlMWRlN2NiNDM5MWFhNjZkNmExZTFmNjRjMTgiLCJwIjoiaiJ9 
## Checklist:
- [ ] Tests added/updated.
- [ ] Documentation updated. Documentation is generated from docstrings - these must be updated according to your change.
  If a new method has been added it should be referenced in [cognite.rst](https://github.com/cognitedata/cognite-sdk-python/blob/master/docs/source/cognite.rst) in order to generate docs based on its docstring.
- [ ] Changelog updated in [CHANGELOG.md](https://github.com/cognitedata/cognite-sdk-python/blob/master/CHANGELOG.md).
- [ ] Version bumped. If triggering a new release is desired, bump the version number in [_version.py](https://github.com/cognitedata/cognite-sdk-python/blob/master/cognite/client/_version.py) and [pyproject.toml](https://github.com/cognitedata/cognite-sdk-python/blob/master/pyproject.toml) per [semantic versioning](https://semver.org/).
