### PR TITLE
[v7] Allow empty ID sequences in retrieve_multiple and delete

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ methods is `json` and `yaml` serializable.
 ### Changed
 * The `CogniteResource._load` has been made public, i.e., it is now `CogniteResource.load`.
 * The `CogniteResourceList._load` has been made public, i.e., it is now `CogniteResourceList.load`.
+* All `.delete` and `.retrieve_multiple` methods now accepts an empty sequence, and will return an empty `CogniteResourceList`.
 
 ### Added
 

--- a/cognite/client/utils/_identifier.py
+++ b/cognite/client/utils/_identifier.py
@@ -143,8 +143,6 @@ T_Identifier = TypeVar("T_Identifier", bound=IdentifierCore)
 
 class IdentifierSequenceCore(Generic[T_Identifier], ABC):
     def __init__(self, identifiers: list[T_Identifier], is_singleton: bool) -> None:
-        if not identifiers:
-            raise ValueError("No identifiers specified")
         self._identifiers = identifiers
         self.__is_singleton = is_singleton
 

--- a/tests/tests_integration/test_api_client.py
+++ b/tests/tests_integration/test_api_client.py
@@ -427,6 +427,6 @@ class TestAPIClientRetrieveMultiple:
 
 class TestAPIClientDelete:
     def test_delete_empty(self, cognite_client: CogniteClient) -> None:
-        res = cognite_client.events.delete(external_ids=[])
+        res = cognite_client.events.delete(external_id=[])
 
         assert res is None

--- a/tests/tests_integration/test_api_client.py
+++ b/tests/tests_integration/test_api_client.py
@@ -415,3 +415,18 @@ class TestAPIClientAdvancedAggregate:
             for key in event.metadata
             if key.startswith("shop")
         )
+
+
+class TestAPIClientRetrieveMultiple:
+    def test_retrieve_multiple_empty(self, cognite_client: CogniteClient) -> None:
+        res = cognite_client.events.retrieve_multiple(external_ids=[])
+
+        assert isinstance(res, EventList)
+        assert len(res) == 0
+
+
+class TestAPIClientDelete:
+    def test_delete_empty(self, cognite_client: CogniteClient) -> None:
+        res = cognite_client.events.delete(external_ids=[])
+
+        assert res is None

--- a/tests/tests_unit/test_api_client.py
+++ b/tests/tests_unit/test_api_client.py
@@ -342,13 +342,15 @@ class TestStandardRetrieveMultiple:
         assert 400 == e.value.code
 
     def test_ids_all_None(self, api_client_with_token):
-        with pytest.raises(ValueError, match="No identifiers specified"):
-            api_client_with_token._retrieve_multiple(
-                list_cls=SomeResourceList,
-                resource_cls=SomeResource,
-                resource_path=URL_PATH,
-                identifiers=IdentifierSequence.of(),
-            )
+        result = api_client_with_token._retrieve_multiple(
+            list_cls=SomeResourceList,
+            resource_cls=SomeResource,
+            resource_path=URL_PATH,
+            identifiers=IdentifierSequence.of(),
+        )
+
+        assert isinstance(result, SomeResourceList)
+        assert len(result) == 0
 
     def test_single_id_not_found(self, api_client_with_token, rsps):
         rsps.add(

--- a/tests/tests_unit/test_utils/test_identifier.py
+++ b/tests/tests_unit/test_utils/test_identifier.py
@@ -54,13 +54,10 @@ class TestIdentifierSequence:
         else:
             assert identifiers.as_primitives() == expected
 
-    @pytest.mark.parametrize(
-        "ids, external_ids, exception, match",
-        [(None, None, ValueError, "No identifiers specified")],
-    )
-    def test_process_ids_fail(self, ids, external_ids, exception, match) -> None:
-        with pytest.raises(exception, match=match):
-            IdentifierSequence.load(ids, external_ids)
+    def test_process_ids_empty(self) -> None:
+        sequence = IdentifierSequence.load(None, None)
+
+        assert len(sequence) == 0
 
     @pytest.mark.parametrize(
         "id, external_id, expected",


### PR DESCRIPTION
## Description
Please describe the change you have made.

## Checklist:
- [x] Tests added/updated.
- [x] Documentation updated. Documentation is generated from docstrings - these must be updated according to your change.
  If a new method has been added it should be referenced in [cognite.rst](https://github.com/cognitedata/cognite-sdk-python/blob/master/docs/source/cognite.rst) in order to generate docs based on its docstring.
- [x] Changelog updated in [CHANGELOG.md](https://github.com/cognitedata/cognite-sdk-python/blob/master/CHANGELOG.md).
- [x] Version bumped. If triggering a new release is desired, bump the version number in [_version.py](https://github.com/cognitedata/cognite-sdk-python/blob/master/cognite/client/_version.py) and [pyproject.toml](https://github.com/cognitedata/cognite-sdk-python/blob/master/pyproject.toml) per [semantic versioning](https://semver.org/).
