### PR TITLE
[CDF-19684] Add Transformation Worker concurrencyPolicy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ Changes are grouped as follows
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
-## [6.37.1] - 2023-10-27
+## [6.38.0] - 2023-10-27
 ## Added
 - Support for `concurrencyPolicy` property in Workflows `TransformationsWorker`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ Changes are grouped as follows
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
+## [6.37.1] - 2023-10-27
+## Added
+- Support for `concurrencyPolicy` property in Workflows `TransformationsWorker`.
+
 ## [6.37.0] - 2023-10-27
 ### Added
 - Support for `type` property in `NodeApply` and `Node`.

--- a/cognite/client/_version.py
+++ b/cognite/client/_version.py
@@ -1,4 +1,4 @@
 from __future__ import annotations
 
-__version__ = "6.37.0"
+__version__ = "6.37.1"
 __api_subversion__ = "V20220125"

--- a/cognite/client/_version.py
+++ b/cognite/client/_version.py
@@ -1,4 +1,4 @@
 from __future__ import annotations
 
-__version__ = "6.38.0"
+__version__ = "6.39.0"
 __api_subversion__ = "V20220125"

--- a/cognite/client/_version.py
+++ b/cognite/client/_version.py
@@ -1,4 +1,4 @@
 from __future__ import annotations
 
-__version__ = "6.37.1"
+__version__ = "6.38.0"
 __api_subversion__ = "V20220125"

--- a/cognite/client/data_classes/workflows.py
+++ b/cognite/client/data_classes/workflows.py
@@ -232,12 +232,10 @@ class TransformationTaskParameters(WorkflowTaskParameters):
         )
 
     def dump(self, camel_case: bool = False) -> dict[str, Any]:
-        transformation = {("externalId" if camel_case else "external_id"): self.external_id}
+        transformation = {"externalId" if camel_case else "external_id": self.external_id}
 
         if self.concurrency_policy is not None:
-            transformation[
-                ("concurrencyPolicy" if camel_case else "concurrency_policy")
-            ] = self.concurrency_policy.value
+            transformation["concurrencyPolicy" if camel_case else "concurrency_policy"] = self.concurrency_policy.value
 
         return {"transformation": transformation}
 

--- a/cognite/client/data_classes/workflows.py
+++ b/cognite/client/data_classes/workflows.py
@@ -5,7 +5,7 @@ from abc import ABC, abstractmethod
 from collections import UserList
 from collections.abc import Collection
 from dataclasses import dataclass
-from enum import StrEnum
+from enum import Enum
 from typing import TYPE_CHECKING, Any, ClassVar, Literal, Sequence, cast
 
 from typing_extensions import Self, TypeAlias
@@ -194,7 +194,7 @@ class FunctionTaskParameters(WorkflowTaskParameters):
         return output
 
 
-class TransformationConcurrencyPolicy(StrEnum):
+class TransformationConcurrencyPolicy(Enum):
     """
     Determines the behavior of the task if the Transformation is already running.
 

--- a/cognite/client/data_classes/workflows.py
+++ b/cognite/client/data_classes/workflows.py
@@ -235,7 +235,9 @@ class TransformationTaskParameters(WorkflowTaskParameters):
         transformation = {("externalId" if camel_case else "external_id"): self.external_id}
 
         if self.concurrency_policy is not None:
-            transformation[("concurrencyPolicy" if camel_case else "concurrency_policy")] = self.concurrency_policy
+            transformation[
+                ("concurrencyPolicy" if camel_case else "concurrency_policy")
+            ] = self.concurrency_policy.value
 
         return {"transformation": transformation}
 

--- a/cognite/client/data_classes/workflows.py
+++ b/cognite/client/data_classes/workflows.py
@@ -5,7 +5,6 @@ from abc import ABC, abstractmethod
 from collections import UserList
 from collections.abc import Collection
 from dataclasses import dataclass
-from enum import Enum
 from typing import TYPE_CHECKING, Any, ClassVar, Literal, Sequence, cast
 
 from typing_extensions import Self, TypeAlias
@@ -194,32 +193,23 @@ class FunctionTaskParameters(WorkflowTaskParameters):
         return output
 
 
-class TransformationConcurrencyPolicy(Enum):
-    """
-    Determines the behavior of the task if the Transformation is already running.
-
-    - FAIL: The task fails if another instance of the Transformation is currently running.
-    - WAIT_FOR_CURRENT: The task will pause and wait for the already running Transformation to complete. Once completed, the task is completed. This mode is useful for preventing redundant Transformation runs.
-    - RESTART_AFTER_CURRENT: The task waits for the ongoing Transformation to finish. After completion, the task restarts the Transformation. This mode ensures that the most recent data can be used by following tasks.
-    """
-
-    FAIL = "fail"
-    RESTART_AFTER_CURRENT = "restartAfterCurrent"
-    WAIT_FOR_CURRENT = "waitForCurrent"
-
-
 class TransformationTaskParameters(WorkflowTaskParameters):
     """
     The transformation parameters are used to specify the transformation to be called.
 
     Args:
         external_id (str): The external ID of the transformation to be called.
-        concurrency_policy (TransformationConcurrencyPolicy | None): The concurrency policy of the transformation.
+        concurrency_policy (Literal["fail", "restartAfterCurrent", "waitForCurrent"]): Determines the behavior of the task if the Transformation is already running.\n
+            * *fail*: The task fails if another instance of the Transformation is currently running.\n
+            * *waitForCurrent*: The task will pause and wait for the already running Transformation to complete. Once completed, the task is completed. This mode is useful for preventing redundant Transformation runs.\n
+            * *restartAfterCurrent*: The task waits for the ongoing Transformation to finish. After completion, the task restarts the Transformation. This mode ensures that the most recent data can be used by following tasks.
     """
 
     task_type = "transformation"
 
-    def __init__(self, external_id: str, concurrency_policy: TransformationConcurrencyPolicy | None = None) -> None:
+    def __init__(
+        self, external_id: str, concurrency_policy: Literal["fail", "restartAfterCurrent", "waitForCurrent"] = "fail"
+    ) -> None:
         self.external_id = external_id
         self.concurrency_policy = concurrency_policy
 
@@ -228,14 +218,14 @@ class TransformationTaskParameters(WorkflowTaskParameters):
         resource = json.loads(resource) if isinstance(resource, str) else resource
         return cls(
             resource["transformation"]["externalId"],
-            TransformationConcurrencyPolicy(resource["transformation"]["concurrencyPolicy"]),
+            resource["transformation"]["concurrencyPolicy"],
         )
 
     def dump(self, camel_case: bool = False) -> dict[str, Any]:
-        transformation = {"externalId" if camel_case else "external_id": self.external_id}
-
-        if self.concurrency_policy is not None:
-            transformation["concurrencyPolicy" if camel_case else "concurrency_policy"] = self.concurrency_policy.value
+        transformation = {
+            "externalId" if camel_case else "external_id": self.external_id,
+            "concurrencyPolicy" if camel_case else "concurrency_policy": self.concurrency_policy,
+        }
 
         return {"transformation": transformation}
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "cognite-sdk"
 
-version = "6.37.0"
+version = "6.37.1"
 description = "Cognite Python SDK"
 readme = "README.md"
 documentation = "https://cognite-sdk-python.readthedocs-hosted.com"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "cognite-sdk"
 
-version = "6.37.1"
+version = "6.38.0"
 description = "Cognite Python SDK"
 readme = "README.md"
 documentation = "https://cognite-sdk-python.readthedocs-hosted.com"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "cognite-sdk"
 
-version = "6.38.0"
+version = "6.39.0"
 description = "Cognite Python SDK"
 readme = "README.md"
 documentation = "https://cognite-sdk-python.readthedocs-hosted.com"


### PR DESCRIPTION
## Description
Adds concurrencyPolicy for Transformations:
```
    Determines the behavior of the task if the Transformation is already running.

    - FAIL: The task fails if another instance of the Transformation is currently running.
    - WAIT_FOR_CURRENT: The task will pause and wait for the already running Transformation to complete. Once completed, the task is completed. This mode is useful for preventing redundant Transformation runs.
    - RESTART_AFTER_CURRENT: The task waits for the ongoing Transformation to finish. After completion, the task restarts the Transformation. This mode ensures that the most recent data can be used by following tasks.
```

## Checklist:
- [x] Tests added/updated.
- [x] Documentation updated. Documentation is generated from docstrings - these must be updated according to your change.
  If a new method has been added it should be referenced in [cognite.rst](https://github.com/cognitedata/cognite-sdk-python/blob/master/docs/source/cognite.rst) in order to generate docs based on its docstring.
- [x] Changelog updated in [CHANGELOG.md](https://github.com/cognitedata/cognite-sdk-python/blob/master/CHANGELOG.md).
- [x] Version updated

