### PR TITLE
[v7] Add timestamp conversion to `CogniteResourceList.to_pandas`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,8 +24,9 @@ in sequence produces an equal object to the original, for example,
 methods are `json` and `yaml` serializable.
 
 ### Added
-- `CogniteResource.to_pandas` now converts known timestamps to `datetime` by default. Can be turned off with
-  the new parameter `convert_timestamps`.
+- `CogniteResource.to_pandas` and `CogniteResourceList.to_pandas` now converts known timestamps to `datetime` by
+  default. Can be turned off with the new parameter `convert_timestamps`. Note: To comply with older pandas v1, the
+  dtype will always be `datetime64[ns]`, although in v2 this could have been `datetime64[ms]`.
 
 ### Deprecated
 - The Templates API (migrate to Data Modeling).
@@ -34,6 +35,9 @@ methods are `json` and `yaml` serializable.
 - `CogniteResource.to_pandas` now more closely resembles `CogniteResourceList.to_pandas` with parameters
 `expand_metadata` and `metadata_prefix`, instead of accepting a sequence of column names (`expand`) to expand,
 with no easy way to add a prefix. Also, it no longer expands metadata by default.
+- Additionally, `Asset.to_pandas`, now accepts the parameters `expand_aggregates` and `aggregates_prefix`. Since
+  the possible `aggregates` keys are known, `camel_case` will also apply to these (if expanded) as opposed to
+  the metadata keys.
 - The `CogniteResource._load` has been made public, i.e., it is now `CogniteResource.load`.
 - The `CogniteResourceList._load` has been made public, i.e., it is now `CogniteResourceList.load`.
 - All `.delete` and `.retrieve_multiple` methods now accepts an empty sequence, and will return an empty `CogniteResourceList`.

--- a/MIGRATION_GUIDE.md
+++ b/MIGRATION_GUIDE.md
@@ -10,8 +10,9 @@ Changes are grouped as follows:
 
 ## From v6 to v7
 ### Functionality
-- `CogniteResource.to_pandas` now converts known timestamps to `datetime` by default. Can be turned off with
-  the new parameter `convert_timestamps`.
+- `CogniteResource.to_pandas` and `CogniteResourceList.to_pandas` now converts known timestamps to `datetime` by
+  default. Can be turned off with the new parameter `convert_timestamps`. Note: To comply with older pandas v1, the
+  dtype will always be `datetime64[ns]`, although in v2 this could have been `datetime64[ms]`.
 
 ### Deprecated
 - The Templates API is deprecated, and will be removed in a future version. Please migrate to Data Modeling.
@@ -29,6 +30,8 @@ Changes are grouped as follows:
 - `CogniteResource.to_pandas` now more closely resembles `CogniteResourceList.to_pandas` with parameters
   `expand_metadata` and `metadata_prefix`, instead of accepting a sequence of column names (`expand`) to expand,
   with no easy way to add a prefix. Also, it no longer expands metadata by default.
+- Additionally, `Asset.to_pandas`, have `expand_aggregates` and `aggregates_prefix`. Since the possible `aggregates`
+  keys are known, `camel_case` will also apply to these if expanded as opposed to metadata keys.
 - Removed parameters `property` and `aggregates` for method `aggregate_unique_values` on GeospatialAPI, use the
   `output` parameter instead.
 - Removed parameter `fields` for method `aggregate_unique_values` on EventsAPI, use the other aggregate-prefixed

--- a/cognite/client/_api/datapoints.py
+++ b/cognite/client/_api/datapoints.py
@@ -1427,7 +1427,7 @@ class DatapointsAPI(APIClient):
                 >>> df = pd.DataFrame({ts_xid: noise}, index=idx)
                 >>> client.time_series.data.insert_dataframe(df)
         """
-        np, pd = cast(Any, local_import("numpy", "pandas"))
+        np, pd = local_import("numpy", "pandas")
         if not isinstance(df.index, pd.DatetimeIndex):
             raise ValueError(f"DataFrame index must be `pd.DatetimeIndex`, got: {type(df.index)}")
         if df.columns.has_duplicates:

--- a/cognite/client/_api/functions.py
+++ b/cognite/client/_api/functions.py
@@ -688,7 +688,7 @@ def _validate_and_parse_requirements(requirements: list[str]) -> list[str]:
     Returns:
         list[str]: The parsed requirements
     """
-    constructors = cast(Any, local_import("pip._internal.req.constructors"))
+    constructors = local_import("pip._internal.req.constructors")
     install_req_from_line = constructors.install_req_from_line
     parsed_reqs: list[str] = []
     for req in requirements:

--- a/cognite/client/_api/raw.py
+++ b/cognite/client/_api/raw.py
@@ -539,7 +539,7 @@ class RawRowsAPI(APIClient):
                 >>> c = CogniteClient()
                 >>> df = c.raw.rows.retrieve_dataframe("db1", "t1", limit=5)
         """
-        pd = cast(Any, local_import("pandas"))
+        pd = local_import("pandas")
         rows = self.list(db_name, table_name, min_last_updated_time, max_last_updated_time, columns, limit)
         idx = [r.key for r in rows]
         cols = [r.columns for r in rows]

--- a/cognite/client/_api/synthetic_time_series.py
+++ b/cognite/client/_api/synthetic_time_series.py
@@ -136,7 +136,7 @@ class SyntheticDatapointsAPI(APIClient):
 
     @staticmethod
     def _sympy_to_sts(expression: str | sympy.Expr) -> str:
-        sympy_module = cast(Any, local_import("sympy"))
+        sympy_module = local_import("sympy")
 
         infix_ops = {sympy_module.Add: "+", sympy_module.Mul: "*"}
         functions = {

--- a/cognite/client/data_classes/_base.py
+++ b/cognite/client/data_classes/_base.py
@@ -30,7 +30,11 @@ from cognite.client.exceptions import CogniteMissingClientError
 from cognite.client.utils._auxiliary import fast_dict_load, json_dump_default
 from cognite.client.utils._identifier import IdentifierSequence
 from cognite.client.utils._importing import local_import
-from cognite.client.utils._pandas_helpers import convert_nullable_int_cols, notebook_display_with_fallback
+from cognite.client.utils._pandas_helpers import (
+    convert_nullable_int_cols,
+    convert_timestamp_columns_to_datetime,
+    notebook_display_with_fallback,
+)
 from cognite.client.utils._text import convert_all_keys_to_camel_case, to_camel_case
 from cognite.client.utils._time import TIME_ATTRIBUTES, convert_and_isoformat_time_attrs
 
@@ -287,6 +291,7 @@ class CogniteResourceList(UserList, Generic[T_CogniteResource], _WithClientMixin
         camel_case: bool = False,
         expand_metadata: bool = False,
         metadata_prefix: str = "metadata.",
+        convert_timestamps: bool = True,
     ) -> pandas.DataFrame:
         """Convert the instance into a pandas DataFrame. Note that if the metadata column is expanded and there are
         keys in the metadata that already exist in the DataFrame, then an error will be raised by pd.join.
@@ -295,13 +300,17 @@ class CogniteResourceList(UserList, Generic[T_CogniteResource], _WithClientMixin
             camel_case (bool): Convert column names to camel case (e.g. `externalId` instead of `external_id`)
             expand_metadata (bool): Expand the metadata column into separate columns.
             metadata_prefix (str): Prefix to use for metadata columns.
+            convert_timestamps (bool): Convert known columns storing CDF timestamps (milliseconds since epoch) to datetime. Does not affect custom data like metadata.
 
         Returns:
             pandas.DataFrame: The Cognite resource as a dataframe.
         """
         pd = local_import("pandas")
         df = pd.DataFrame(self.dump(camel_case=camel_case))
-        df = convert_nullable_int_cols(df, camel_case)
+        df = convert_nullable_int_cols(df)
+
+        if convert_timestamps:
+            df = convert_timestamp_columns_to_datetime(df)
 
         if expand_metadata and "metadata" in df.columns:
             # Equivalent to pd.json_normalize(df["metadata"]) but is a faster implementation.

--- a/cognite/client/data_classes/_base.py
+++ b/cognite/client/data_classes/_base.py
@@ -159,7 +159,7 @@ class CogniteResource(_WithClientMixin):
         Returns:
             pandas.DataFrame: The dataframe.
         """
-        pd = cast(Any, local_import("pandas"))
+        pd = local_import("pandas")
         dumped = self.dump(camel_case=camel_case)
 
         for element in ignore or []:
@@ -299,7 +299,7 @@ class CogniteResourceList(UserList, Generic[T_CogniteResource], _WithClientMixin
         Returns:
             pandas.DataFrame: The Cognite resource as a dataframe.
         """
-        pd = cast(Any, local_import("pandas"))
+        pd = local_import("pandas")
         df = pd.DataFrame(self.dump(camel_case=camel_case))
         df = convert_nullable_int_cols(df, camel_case)
 

--- a/cognite/client/data_classes/annotation_types/primitives.py
+++ b/cognite/client/data_classes/annotation_types/primitives.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import json
 from abc import ABC
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, Literal, cast
+from typing import TYPE_CHECKING, Any, Literal
 
 from typing_extensions import Self
 
@@ -50,7 +50,7 @@ class VisionResource(CogniteResource, ABC):
         Returns:
             pandas.DataFrame: The dataframe.
         """
-        pd = cast(Any, local_import("pandas"))
+        pd = local_import("pandas")
         return pd.Series(self.dump(camel_case), name="value").to_frame()
 
 

--- a/cognite/client/data_classes/assets.py
+++ b/cognite/client/data_classes/assets.py
@@ -293,7 +293,7 @@ class Asset(CogniteResource):
         if not (expand_aggregates and "aggregates" in df.index):
             return df
 
-        pd = cast(Any, local_import("pandas"))
+        pd = local_import("pandas")
         col = df.squeeze()
         aggregates = convert_dict_to_case(col.pop("aggregates"), camel_case)
         return pd.concat((col, pd.Series(aggregates).add_prefix(aggregates_prefix))).to_frame()

--- a/cognite/client/data_classes/data_modeling/query.py
+++ b/cognite/client/data_classes/data_modeling/query.py
@@ -4,7 +4,7 @@ import json
 from abc import ABC, abstractmethod
 from collections import UserDict
 from dataclasses import dataclass, field
-from typing import Any, Literal, Mapping, cast
+from typing import Any, Literal, Mapping
 
 from cognite.client.data_classes.data_modeling.ids import ViewId
 from cognite.client.data_classes.data_modeling.instances import (
@@ -113,7 +113,7 @@ class Query:
 
     @classmethod
     def load_yaml(cls, data: str) -> Query:
-        yaml = cast(Any, local_import("yaml"))
+        yaml = local_import("yaml")
         return cls.load(yaml.safe_load(data))
 
     @classmethod

--- a/cognite/client/data_classes/datapoints.py
+++ b/cognite/client/data_classes/datapoints.py
@@ -16,7 +16,6 @@ from typing import (
     Iterator,
     Literal,
     Sequence,
-    cast,
     overload,
 )
 
@@ -148,7 +147,7 @@ class Datapoint(CogniteResource):
         Returns:
             pandas.DataFrame: pandas.DataFrame
         """
-        pd = cast(Any, local_import("pandas"))
+        pd = local_import("pandas")
 
         dumped = self.dump(camel_case=camel_case)
         timestamp = dumped.pop("timestamp")
@@ -376,7 +375,7 @@ class DatapointsArray(CogniteResource):
         Returns:
             pandas.DataFrame: The datapoints as a pandas DataFrame.
         """
-        pd = cast(Any, local_import("pandas"))
+        pd = local_import("pandas")
         if column_names == "id":
             if self.id is None:
                 raise ValueError("Unable to use `id` as column name(s), not set on object")
@@ -560,7 +559,7 @@ class Datapoints(CogniteResource):
         Returns:
             pandas.DataFrame: The dataframe.
         """
-        pd = cast(Any, local_import("pandas"))
+        pd = local_import("pandas")
         if column_names in ["external_id", "externalId"]:  # Camel case for backwards compat
             identifier = self.external_id if self.external_id is not None else self.id
         elif column_names == "id":
@@ -780,7 +779,7 @@ class DatapointsArrayList(CogniteResourceList[DatapointsArray]):
         Returns:
             pandas.DataFrame: The datapoints as a pandas DataFrame.
         """
-        pd = cast(Any, local_import("pandas"))
+        pd = local_import("pandas")
         dfs = [dps.to_pandas(column_names, include_aggregate_name, include_granularity_name) for dps in self]
         if not dfs:
             return pd.DataFrame(index=pd.to_datetime([]))
@@ -862,7 +861,7 @@ class DatapointsList(CogniteResourceList[Datapoints]):
         Returns:
             pandas.DataFrame: The datapoints list as a pandas DataFrame.
         """
-        pd = cast(Any, local_import("pandas"))
+        pd = local_import("pandas")
         dfs = [dps.to_pandas(column_names, include_aggregate_name, include_granularity_name) for dps in self]
         if not dfs:
             return pd.DataFrame(index=pd.to_datetime([]))

--- a/cognite/client/data_classes/geospatial.py
+++ b/cognite/client/data_classes/geospatial.py
@@ -185,9 +185,9 @@ class FeatureList(CogniteResourceList[Feature]):
                 >>> gdf.head()
         """
         df = self.to_pandas(camel_case)
-        wkt = cast(Any, local_import("shapely.wkt"))
+        wkt = local_import("shapely.wkt")
         df[geometry] = df[geometry].apply(lambda g: wkt.loads(g["wkt"]))
-        geopandas = cast(Any, local_import("geopandas"))
+        geopandas = local_import("geopandas")
         return geopandas.GeoDataFrame(df, geometry=geometry)
 
     @staticmethod

--- a/cognite/client/data_classes/raw.py
+++ b/cognite/client/data_classes/raw.py
@@ -40,7 +40,7 @@ class Row(CogniteResource):
         Returns:
             pandas.DataFrame: The pandas DataFrame representing this instance.
         """
-        pd = cast(Any, local_import("pandas"))
+        pd = local_import("pandas")
         return pd.DataFrame([self.columns], [self.key])
 
 
@@ -53,7 +53,7 @@ class RowList(CogniteResourceList[Row]):
         Returns:
             pandas.DataFrame: The pandas DataFrame representing this instance.
         """
-        pd = cast(Any, local_import("pandas"))
+        pd = local_import("pandas")
         return pd.DataFrame.from_dict(OrderedDict((d.key, d.columns) for d in self.data), orient="index")
 
 

--- a/cognite/client/utils/_pandas_helpers.py
+++ b/cognite/client/utils/_pandas_helpers.py
@@ -65,16 +65,8 @@ def convert_nullable_int_cols(df: pd.DataFrame) -> pd.DataFrame:
 
 
 def convert_timestamp_columns_to_datetime(df: pd.DataFrame) -> pd.DataFrame:
-    pd = local_import("pandas")
     to_convert = df.columns.intersection(TIME_ATTRIBUTES)
-    df[to_convert] = df[to_convert].apply(
-        pd.to_datetime,
-        axis="index",  # means 'apply function to each column', yeah, idk
-        # Kwargs to pd.to_datetime:
-        unit="ms",
-        origin="unix",
-        errors="raise",
-    )
+    df[to_convert] = (1_000_000 * df[to_convert]).astype("datetime64[ns]")
     return df
 
 

--- a/cognite/client/utils/_pandas_helpers.py
+++ b/cognite/client/utils/_pandas_helpers.py
@@ -5,7 +5,7 @@ import warnings
 from inspect import signature
 from itertools import chain
 from numbers import Integral
-from typing import TYPE_CHECKING, Any, Sequence, cast
+from typing import TYPE_CHECKING, Any, Sequence
 
 from cognite.client.exceptions import CogniteImportError
 from cognite.client.utils._importing import local_import
@@ -65,7 +65,7 @@ def convert_nullable_int_cols(df: pd.DataFrame, camel_case: bool) -> pd.DataFram
 
 
 def concat_dataframes_with_nullable_int_cols(dfs: Sequence[pd.DataFrame]) -> pd.DataFrame:
-    pd = cast(Any, local_import("pandas"))
+    pd = local_import("pandas")
     int_cols = [
         i for i, dtype in enumerate(chain.from_iterable(df.dtypes for df in dfs)) if issubclass(dtype.type, Integral)
     ]

--- a/cognite/client/utils/_time.py
+++ b/cognite/client/utils/_time.py
@@ -8,7 +8,7 @@ import time
 from abc import ABC, abstractmethod
 from contextlib import suppress
 from datetime import datetime, timedelta, timezone
-from typing import TYPE_CHECKING, Any, cast, overload
+from typing import TYPE_CHECKING, overload
 
 from cognite.client.utils._importing import local_import
 from cognite.client.utils._text import to_camel_case
@@ -509,7 +509,7 @@ def _to_fixed_utc_intervals_variable_unit_length(
 def _to_fixed_utc_intervals_fixed_unit_length(
     start: datetime, end: datetime, multiplier: int, unit: str
 ) -> list[dict[str, datetime | str]]:
-    pd = cast(Any, local_import("pandas"))
+    pd = local_import("pandas")
     utc = get_utc_zoneinfo()
 
     freq = multiplier * GRANULARITY_IN_HOURS[unit]
@@ -548,7 +548,7 @@ def pandas_date_range_tz(start: datetime, end: datetime, freq: str, inclusive: s
 
     Assumes that start and end have the same timezone.
     """
-    pd = cast(Any, local_import("pandas"))
+    pd = local_import("pandas")
     # There is a bug in date_range which makes it fail to handle ambiguous timestamps when you use time zone aware
     # datetimes. This is a workaround by passing the time zone as an argument to the function.
     # In addition, pandas struggle with ZoneInfo objects, so we convert them to string so that pandas can use its own
@@ -606,7 +606,7 @@ def validate_timezone(start: datetime, end: datetime) -> ZoneInfo:
     if isinstance(start_tz, ZoneInfo):
         return start_tz
 
-    pd = cast(Any, local_import("pandas"))
+    pd = local_import("pandas")
     if isinstance(start, pd.Timestamp):
         return ZoneInfo(str(start_tz))
 

--- a/tests/tests_unit/test_base.py
+++ b/tests/tests_unit/test_base.py
@@ -29,11 +29,20 @@ from tests.utils import FakeCogniteResourceGenerator, all_concrete_subclasses, a
 
 
 class MyResource(CogniteResource):
-    def __init__(self, var_a=None, var_b=None, id=None, external_id=None, cognite_client=None):
+    def __init__(
+        self,
+        var_a=None,
+        var_b=None,
+        id=None,
+        external_id=None,
+        last_updated_time=None,
+        cognite_client=None,
+    ):
         self.var_a = var_a
         self.var_b = var_b
         self.id = id
         self.external_id = external_id
+        self.last_updated_time = last_updated_time
         self._cognite_client = cognite_client
 
     def use(self):
@@ -278,8 +287,14 @@ class TestCogniteResourceList:
     def test_to_pandas(self):
         import pandas as pd
 
-        resource_list = MyResourceList([MyResource(1), MyResource(2, 3)])
-        expected_df = pd.DataFrame({"varA": [1, 2], "varB": [None, 3]})
+        resource_list = MyResourceList([MyResource(1, last_updated_time=60), MyResource(2, 3)])
+        expected_df = pd.DataFrame(
+            {
+                "varA": [1, 2],
+                "lastUpdatedTime": [pd.Timestamp(60, unit="ms"), pd.NaT],
+                "varB": [None, 3],
+            },
+        )
         pd.testing.assert_frame_equal(resource_list.to_pandas(camel_case=True), expected_df)
 
     @pytest.mark.dsl


### PR DESCRIPTION
## Description
- Add default conversion of CDF (milliseconds-integer) timestamps to `datetime` for all known columns.
- Add test for to_pandas on values + dtypes. Reason: _this PR did not cause a single test to fail_... which is bad.

Tested with lowest supported pandas version (1.4.0) and newest.

## Checklist:
- [x] Tests added/updated.
- [x] Documentation updated. Documentation is generated from docstrings - these must be updated according to your change.
  If a new method has been added it should be referenced in [cognite.rst](https://github.com/cognitedata/cognite-sdk-python/blob/master/docs/source/cognite.rst) in order to generate docs based on its docstring.