### PR TITLE
[v7] Fix exceptions not being raised together as `CogniteMultiException`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ methods are `json` and `yaml` serializable.
 - `CogniteResource.to_pandas` and `CogniteResourceList.to_pandas` now converts known timestamps to `datetime` by
   default. Can be turned off with the new parameter `convert_timestamps`. Note: To comply with older pandas v1, the
   dtype will always be `datetime64[ns]`, although in v2 this could have been `datetime64[ms]`.
+- `CogniteImportError` can now be caught as `ImportError`.
 
 ### Deprecated
 - The Templates API (migrate to Data Modeling).
@@ -42,6 +43,10 @@ with no easy way to add a prefix. Also, it no longer expands metadata by default
 - Additionally, `Asset.to_pandas`, now accepts the parameters `expand_aggregates` and `aggregates_prefix`. Since
   the possible `aggregates` keys are known, `camel_case` will also apply to these (if expanded) as opposed to
   the metadata keys.
+- More narrow exception types like `CogniteNotFoundError` and `CogniteDuplicatedError` are now raised instead of
+  `CogniteAPIError` for the following methods: `DatapointsAPI.retrieve_latest`, `RawRowsAPI.list`,
+  `RelationshipsAPI.list`, `SequencesDataAPI.retrieve`, `SyntheticDatapointsAPI.query`. Additionally, all calls
+  using `partitions` to API methods like `list` (or the generator version) now do the same.
 - The `CogniteResource._load` has been made public, i.e., it is now `CogniteResource.load`.
 - The `CogniteResourceList._load` has been made public, i.e., it is now `CogniteResourceList.load`.
 - All `.delete` and `.retrieve_multiple` methods now accepts an empty sequence, and will return an empty `CogniteResourceList`.

--- a/MIGRATION_GUIDE.md
+++ b/MIGRATION_GUIDE.md
@@ -57,6 +57,10 @@ Changes are grouped as follows:
 ### Changed
 - All `assert`s meant for the SDK user, now raise appropriate errors instead (`ValueError`, `RuntimeError`...).
 - `CogniteAssetHierarchyError` is no longer possible to catch as an `AssertionError`.
+- More narrow exception types like `CogniteNotFoundError` and `CogniteDuplicatedError` are now raised instead of
+  `CogniteAPIError` for the following methods: `DatapointsAPI.retrieve_latest`, `RawRowsAPI.list`,
+  `RelationshipsAPI.list`, `SequencesDataAPI.retrieve`, `SyntheticDatapointsAPI.query`. Additionally, all calls
+  using `partitions` to API methods like `list` (or the generator version) now do the same.
 - Several methods in the data modelling APIs have had parameter names now correctly reflect whether they accept
   a single or multiple items (i.e. id -> ids).
 - Passing `limit=0` no longer returns `DEFAULT_LIMIT_READ` (25) resources, but raises a `ValueError`.
@@ -93,6 +97,9 @@ Changes are grouped as follows:
 - Classes `Geometry`, `AssetAggregate`, `AggregateResultItem`, `EndTimeFilter`, `Label`, `LabelFilter`, `ExtractionPipelineContact`,
   `TimestampRange`, `AggregateResult`, `GeometryFilter`, `GeoLocation`, `RevisionCameraProperties`, `BoundingBox3D` are no longer 
   `dict` but classes with attributes matchhng the API.
+
+### Optional
+- `CogniteImportError` can now be caught as `ImportError`.
 
 ## From v5 to v6
 ### Removed

--- a/cognite/client/_api/datapoints.py
+++ b/cognite/client/_api/datapoints.py
@@ -53,6 +53,7 @@ from cognite.client.utils._auxiliary import (
     find_duplicates,
     split_into_chunks,
     split_into_n_parts,
+    unpack_items_in_payload,
 )
 from cognite.client.utils._concurrency import execute_tasks, get_executor
 from cognite.client.utils._experimental import FeaturePreviewWarning
@@ -1643,7 +1644,7 @@ class RetrieveLatestDpsFetcher:
         ]
         tasks_summary = execute_tasks(self.dps_client._post, tasks, max_workers=self.dps_client._config.max_workers)
         tasks_summary.raise_compound_exception_if_failed_tasks(
-            task_unwrap_fn=lambda task: task["json"]["items"],
+            task_unwrap_fn=unpack_items_in_payload,
             task_list_element_unwrap_fn=IdentifierSequenceCore.extract_identifiers,
         )
         return tasks_summary.joined_results(lambda res: res.json()["items"])

--- a/cognite/client/_api/datapoints.py
+++ b/cognite/client/_api/datapoints.py
@@ -1529,9 +1529,10 @@ class DatapointsPoster:
     def _bin_datapoints(self, dps_object_list: list[dict[str, Any]]) -> list[list[dict[str, Any]]]:
         for dps_object in dps_object_list:
             for i in range(0, len(dps_object["datapoints"]), self.limit):
-                dps_object_chunk = {k: dps_object[k] for k in ["id", "externalId"] if k in dps_object}
+                dps_object_chunk: dict[str, Any] = IdentifierSequenceCore.extract_identifiers(dps_object)
                 dps_object_chunk["datapoints"] = dps_object["datapoints"][i : i + self.limit]
-                for bin in self.bins:
+                # Try to fit into any existing bin for dense packing:
+                for bin in self.bins:  # Note: O(N^2), first bins will be tried again and again...
                     if bin.will_fit(len(dps_object_chunk["datapoints"])):
                         bin.add(dps_object_chunk)
                         break

--- a/cognite/client/_api/datapoints.py
+++ b/cognite/client/_api/datapoints.py
@@ -1642,6 +1642,6 @@ class RetrieveLatestDpsFetcher:
             for chunk in split_into_chunks(self._all_identifiers, self.dps_client._RETRIEVE_LATEST_LIMIT)
         ]
         tasks_summary = execute_tasks(self.dps_client._post, tasks, max_workers=self.dps_client._config.max_workers)
-        tasks_summary.raise_first_encountered_exception()
+        tasks_summary.raise_compound_exception_if_failed_tasks()
 
         return tasks_summary.joined_results(lambda res: res.json()["items"])

--- a/cognite/client/_api/raw.py
+++ b/cognite/client/_api/raw.py
@@ -617,6 +617,6 @@ class RawRowsAPI(APIClient):
             for cursor in cursors
         ]
         summary = execute_tasks(self._list, tasks, max_workers=self._config.max_workers)
-        summary.raise_first_encountered_exception()
+        summary.raise_compound_exception_if_failed_tasks()
 
         return RowList(summary.joined_results())

--- a/cognite/client/_api/raw.py
+++ b/cognite/client/_api/raw.py
@@ -9,6 +9,7 @@ from cognite.client.utils._auxiliary import (
     interpolate_and_url_encode,
     is_unlimited,
     split_into_chunks,
+    unpack_items_in_payload,
 )
 from cognite.client.utils._concurrency import execute_tasks
 from cognite.client.utils._identifier import Identifier
@@ -117,7 +118,7 @@ class RawDatabasesAPI(APIClient):
         ]
         summary = execute_tasks(self._post, tasks, max_workers=self._config.max_workers)
         summary.raise_compound_exception_if_failed_tasks(
-            task_unwrap_fn=lambda task: task["json"]["items"], task_list_element_unwrap_fn=lambda el: el["name"]
+            task_unwrap_fn=unpack_items_in_payload, task_list_element_unwrap_fn=lambda el: el["name"]
         )
 
     def list(self, limit: int | None = DEFAULT_LIMIT_READ) -> DatabaseList:
@@ -250,7 +251,7 @@ class RawTablesAPI(APIClient):
         ]
         summary = execute_tasks(self._post, tasks, max_workers=self._config.max_workers)
         summary.raise_compound_exception_if_failed_tasks(
-            task_unwrap_fn=lambda task: task["json"]["items"], task_list_element_unwrap_fn=lambda el: el["name"]
+            task_unwrap_fn=unpack_items_in_payload, task_list_element_unwrap_fn=lambda el: el["name"]
         )
 
     def _set_db_name_on_tables(self, tb: Table | TableList, db_name: str) -> Table | TableList:
@@ -391,7 +392,7 @@ class RawRowsAPI(APIClient):
         ]
         summary = execute_tasks(self._post, tasks, max_workers=self._config.max_workers)
         summary.raise_compound_exception_if_failed_tasks(
-            task_unwrap_fn=lambda task: task["json"]["items"], task_list_element_unwrap_fn=lambda row: row.get("key")
+            task_unwrap_fn=unpack_items_in_payload, task_list_element_unwrap_fn=lambda row: row.get("key")
         )
 
     def insert_dataframe(self, db_name: str, table_name: str, dataframe: Any, ensure_parent: bool = False) -> None:
@@ -469,7 +470,7 @@ class RawRowsAPI(APIClient):
         ]
         summary = execute_tasks(self._post, tasks, max_workers=self._config.max_workers)
         summary.raise_compound_exception_if_failed_tasks(
-            task_unwrap_fn=lambda task: task["json"]["items"], task_list_element_unwrap_fn=lambda el: el["key"]
+            task_unwrap_fn=unpack_items_in_payload, task_list_element_unwrap_fn=lambda el: el["key"]
         )
 
     def retrieve(self, db_name: str, table_name: str, key: str) -> Row | None:

--- a/cognite/client/_api/relationships.py
+++ b/cognite/client/_api/relationships.py
@@ -311,7 +311,7 @@ class RelationshipsAPI(APIClient):
                 tasks,
                 max_workers=self._config.max_workers,
             )
-            tasks_summary.raise_first_encountered_exception()
+            tasks_summary.raise_compound_exception_if_failed_tasks()
 
             return RelationshipList(tasks_summary.joined_results())
         return self._list(

--- a/cognite/client/_api/sequences.py
+++ b/cognite/client/_api/sequences.py
@@ -27,7 +27,7 @@ from cognite.client.data_classes.sequences import (
 )
 from cognite.client.data_classes.shared import TimestampRange
 from cognite.client.utils._concurrency import execute_tasks
-from cognite.client.utils._identifier import Identifier, IdentifierSequence, IdentifierSequenceCore
+from cognite.client.utils._identifier import Identifier, IdentifierSequence
 from cognite.client.utils._validation import (
     assert_type,
     prepare_filter_sort,
@@ -1102,7 +1102,7 @@ class SequencesDataAPI(APIClient):
 
         tasks_summary = execute_tasks(_fetch_sequence, list(zip(identifiers)), max_workers=self._config.max_workers)
         tasks_summary.raise_compound_exception_if_failed_tasks(
-            task_list_element_unwrap_fn=IdentifierSequenceCore.extract_identifiers
+            task_list_element_unwrap_fn=ident_sequence.extract_identifiers
         )
         results = tasks_summary.joined_results()
         if ident_sequence.is_singleton():

--- a/cognite/client/_api/sequences.py
+++ b/cognite/client/_api/sequences.py
@@ -27,7 +27,7 @@ from cognite.client.data_classes.sequences import (
 )
 from cognite.client.data_classes.shared import TimestampRange
 from cognite.client.utils._concurrency import execute_tasks
-from cognite.client.utils._identifier import Identifier, IdentifierSequence
+from cognite.client.utils._identifier import Identifier, IdentifierSequence, IdentifierSequenceCore
 from cognite.client.utils._validation import (
     assert_type,
     prepare_filter_sort,
@@ -1101,7 +1101,9 @@ class SequencesDataAPI(APIClient):
             return SequenceRows.load(sequence_rows)
 
         tasks_summary = execute_tasks(_fetch_sequence, list(zip(identifiers)), max_workers=self._config.max_workers)
-        tasks_summary.raise_compound_exception_if_failed_tasks()
+        tasks_summary.raise_compound_exception_if_failed_tasks(
+            task_list_element_unwrap_fn=IdentifierSequenceCore.extract_identifiers
+        )
         results = tasks_summary.joined_results()
         if ident_sequence.is_singleton():
             return results[0]

--- a/cognite/client/_api/sequences.py
+++ b/cognite/client/_api/sequences.py
@@ -1085,8 +1085,8 @@ class SequencesDataAPI(APIClient):
                 >>> col = res.get_column(external_id='columnExtId') # ... get the array of values for a specific column,
                 >>> df = res.to_pandas() # ... or convert the result to a dataframe
         """
-        is_single = (isinstance(external_id, str) and id is None) or (isinstance(id, int) and external_id is None)
-        identifiers = IdentifierSequence.load(id, external_id).as_dicts()
+        ident_sequence = IdentifierSequence.load(id, external_id)
+        identifiers = ident_sequence.as_dicts()
 
         def _fetch_sequence(post_obj: dict[str, Any]) -> SequenceRows:
             post_obj.update(self._wrap_columns(column_external_ids=columns))
@@ -1101,9 +1101,9 @@ class SequencesDataAPI(APIClient):
             return SequenceRows.load(sequence_rows)
 
         tasks_summary = execute_tasks(_fetch_sequence, list(zip(identifiers)), max_workers=self._config.max_workers)
-        tasks_summary.raise_first_encountered_exception()
+        tasks_summary.raise_compound_exception_if_failed_tasks()
         results = tasks_summary.joined_results()
-        if is_single:
+        if ident_sequence.is_singleton():
             return results[0]
         else:
             return SequenceRowsList(results)

--- a/cognite/client/_api/synthetic_time_series.py
+++ b/cognite/client/_api/synthetic_time_series.py
@@ -85,7 +85,7 @@ class SyntheticDatapointsAPI(APIClient):
             tasks.append((query, query_datapoints, limit))
 
         datapoints_summary = execute_tasks(self._fetch_datapoints, tasks, max_workers=self._config.max_workers)
-        datapoints_summary.raise_first_encountered_exception()
+        datapoints_summary.raise_compound_exception_if_failed_tasks()
 
         return (
             DatapointsList(datapoints_summary.results, cognite_client=self._cognite_client)

--- a/cognite/client/_api/three_d.py
+++ b/cognite/client/_api/three_d.py
@@ -16,7 +16,7 @@ from cognite.client.data_classes import (
     ThreeDNode,
     ThreeDNodeList,
 )
-from cognite.client.utils._auxiliary import interpolate_and_url_encode, split_into_chunks
+from cognite.client.utils._auxiliary import interpolate_and_url_encode, split_into_chunks, unpack_items_in_payload
 from cognite.client.utils._concurrency import execute_tasks
 from cognite.client.utils._identifier import IdentifierSequence, InternalId
 from cognite.client.utils._validation import assert_type
@@ -648,7 +648,7 @@ class ThreeDAssetMappingAPI(APIClient):
         tasks = [{"url_path": path + "/delete", "json": {"items": chunk}} for chunk in chunks]
         summary = execute_tasks(self._post, tasks, self._config.max_workers)
         summary.raise_compound_exception_if_failed_tasks(
-            task_unwrap_fn=lambda task: task["json"]["items"],
+            task_unwrap_fn=unpack_items_in_payload,
             task_list_element_unwrap_fn=lambda el: ThreeDAssetMapping.load(el),
             str_format_element_fn=lambda el: (el.asset_id, el.node_id),
         )

--- a/cognite/client/_api_client.py
+++ b/cognite/client/_api_client.py
@@ -49,6 +49,7 @@ from cognite.client.utils._auxiliary import (
     is_unlimited,
     json_dump_default,
     split_into_chunks,
+    unpack_items_in_payload,
 )
 from cognite.client.utils._concurrency import TaskExecutor, collect_exc_info_and_raise, execute_tasks
 from cognite.client.utils._identifier import (
@@ -900,7 +901,7 @@ class APIClient:
         ]
         summary = execute_tasks(self._post, tasks, max_workers=self._config.max_workers, executor=executor)
         summary.raise_compound_exception_if_failed_tasks(
-            task_unwrap_fn=lambda task: task["json"]["items"],
+            task_unwrap_fn=unpack_items_in_payload,
             task_list_element_unwrap_fn=identifiers.unwrap_identifier,
         )
         if returns_items:
@@ -981,7 +982,7 @@ class APIClient:
             functools.partial(self._post, api_subversion=api_subversion), tasks, max_workers=self._config.max_workers
         )
         tasks_summary.raise_compound_exception_if_failed_tasks(
-            task_unwrap_fn=lambda task: task["json"]["items"],
+            task_unwrap_fn=unpack_items_in_payload,
             task_list_element_unwrap_fn=lambda el: IdentifierSequenceCore.unwrap_identifier(el),
         )
         updated_items = tasks_summary.joined_results(lambda res: res.json()["items"])

--- a/cognite/client/_api_client.py
+++ b/cognite/client/_api_client.py
@@ -512,7 +512,7 @@ class APIClient:
             tasks_summary = execute_tasks(
                 get_partition, [(partition,) for partition in next_cursors], max_workers=partitions
             )
-            tasks_summary.raise_first_encountered_exception()
+            tasks_summary.raise_compound_exception_if_failed_tasks()
 
             for item in tasks_summary.joined_results():
                 yield resource_cls._load(item, cognite_client=self._cognite_client)
@@ -625,7 +625,7 @@ class APIClient:
 
         tasks = [(f"{i + 1}/{partitions}",) for i in range(partitions)]
         tasks_summary = execute_tasks(get_partition, tasks, max_workers=partitions)
-        tasks_summary.raise_first_encountered_exception()
+        tasks_summary.raise_compound_exception_if_failed_tasks()
 
         return list_cls._load(tasks_summary.joined_results(), cognite_client=self._cognite_client)
 

--- a/cognite/client/exceptions.py
+++ b/cognite/client/exceptions.py
@@ -236,7 +236,7 @@ class CogniteDuplicatedError(CogniteMultiException):
         return msg
 
 
-class CogniteImportError(CogniteException):
+class CogniteImportError(CogniteException, ImportError):
     """Cognite Import Error
 
     Raised if the user attempts to use functionality which requires an uninstalled package.

--- a/cognite/client/utils/_auxiliary.py
+++ b/cognite/client/utils/_auxiliary.py
@@ -239,3 +239,7 @@ def load_resource(dct: dict[str, Any], cls: type[T_CogniteResource], key: str) -
     if (res := dct.get(key)) is not None:
         return cls._load(res)
     return None
+
+
+def unpack_items_in_payload(payload: dict[str, dict[str, Any]]) -> list:
+    return payload["json"]["items"]

--- a/cognite/client/utils/_concurrency.py
+++ b/cognite/client/utils/_concurrency.py
@@ -65,11 +65,6 @@ class TasksSummary:
             self.exceptions, successful=successful, failed=failed, unknown=unknown, unwrap_fn=str_format_element_fn
         )
 
-    def raise_first_encountered_exception(self) -> None:
-        # TODO: Change to 'raise_compound_exception_if_failed_tasks' in next major version?
-        if self.exceptions:
-            raise self.exceptions[0]
-
 
 def collect_exc_info_and_raise(
     exceptions: list[Exception],

--- a/cognite/client/utils/_identifier.py
+++ b/cognite/client/utils/_identifier.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import numbers
 from abc import ABC
 from typing import (
+    Any,
     Generic,
     Literal,
     NoReturn,
@@ -191,6 +192,11 @@ class IdentifierSequenceCore(Generic[T_Identifier], ABC):
             return identifier["space"]
         raise ValueError(f"{identifier} does not contain 'id' or 'externalId' or 'space'")
 
+    @staticmethod
+    def extract_identifiers(dct: dict[str, Any]) -> dict[str, str | int]:
+        """An API payload might look like {"id": 1, "before": "2w-ago", ...}. This function extracts the identifiers"""
+        return {k: dct[k] for k in ("id", "externalId") if k in dct}
+
 
 T_IdentifierSequenceCore = TypeVar("T_IdentifierSequenceCore", bound=IdentifierSequenceCore)
 
@@ -304,4 +310,4 @@ class WorkflowVersionIdentifierSequence(IdentifierSequenceCore[WorkflowVersionId
             return identifier
         if "workflowExternalId" in identifier and "version" in identifier:
             return identifier["workflowExternalId"], identifier["version"]
-        raise ValueError(f"{identifier} does not contain both 'workflowExternalId' and 'version''")
+        raise ValueError(f"{identifier} does not contain both 'workflowExternalId' and 'version'")


### PR DESCRIPTION
## Description
Fixes one of the oldest issues: #578 

With this change, `client.time_series.data.retrieve_latest(id=123)`, assuming this id doesn't randomly exist, now raises `CogniteNotFoundError` instead of `CogniteAPIError`.


