### PR TITLE
[v7] Do not return `DEFAULT_LIMIT_READ` when `limit=0`, but raise

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,7 @@ with no easy way to add a prefix. Also, it no longer expands metadata by default
   explicitly by the user.
 
 ### Fixed
+- Passing `limit=0` no longer returns `DEFAULT_LIMIT_READ` (25) resources, but raises a `ValueError`.
 - `Asset.dump()` was not dumping attributes `geo_location` and `aggregates` to `json` serializable data structures.
 - In data modeling, `NodeOrEdgeData.load` method was not loading the `source` attribute to `ContainerId` or `ViewId`. This is now fixed.
 - In data modeling, the attribute `property` used in `Node` and `Edge` was not `yaml` serializable.

--- a/MIGRATION_GUIDE.md
+++ b/MIGRATION_GUIDE.md
@@ -25,7 +25,7 @@ Changes are grouped as follows:
   `aggregate_metadata_values(keys=["country"], filter=my_filter)` to
   `aggregate_unique_values(["metadata", "country"], filter=my_filter)`.
 - Deprecated method `update_feature_types` on GeospatialAPI, use `patch_feature_types` instead.
-- The `SequenceColumns` no longer set the `external_id` to `column{no}` if it is missing. It now must be set 
+- The `SequenceColumns` no longer set the `external_id` to `column{no}` if it is missing. It now must be set
   explicitly by the user.
 
 ### Function Signature
@@ -43,7 +43,7 @@ Changes are grouped as follows:
 - `client.data_modeling.instances.aggregate` the parameters `instance_type` and `group_by` has swapped order.
 - The return type of `client.data_modeling.instances.aggregate` has changed from `InstanceAggregationResultList` to
   a more specific value `AggregatedNumberedValue | list[AggregatedNumberedValue] | InstanceAggregationResultList` depending on the `aggregates` and `group_by` parameters.
-- The `client.sequences.data.retrieve` method has changed signature: 
+- The `client.sequences.data.retrieve` method has changed signature:
   The parameter `columns_external_id` is renamed `columns`. This is to better match the API and have a consistent overload implementation.
 - The `client.sequences.data.retrieve_latest` is renamed `client.sequences.data.retrieve_last_row`.
 
@@ -52,6 +52,7 @@ Changes are grouped as follows:
 - `CogniteAssetHierarchyError` is no longer possible to catch as an `AssertionError`.
 - Several methods in the data modelling APIs have had parameter names now correctly reflect whether they accept
   a single or multiple items (i.e. id -> ids).
+- Passing `limit=0` no longer returns `DEFAULT_LIMIT_READ` (25) resources, but raises a `ValueError`.
 - Loading `ObjectDetection` attributes `.attributes`, `.bounding_box`, `.polygon` and
   `.polyline` now returns types `dict[str, Attribute]`, `BoundingBox`, `Polygon` and `Polyline` instead of `dicts`.
 - Loading `TextRegion` attribute `.text_region` now return `BoundingBox` instead of `dict`.

--- a/cognite/client/_api_client.py
+++ b/cognite/client/_api_client.py
@@ -59,7 +59,7 @@ from cognite.client.utils._identifier import (
     SingletonIdentifierSequence,
 )
 from cognite.client.utils._text import convert_all_keys_to_camel_case, shorten, to_camel_case, to_snake_case
-from cognite.client.utils._validation import assert_type
+from cognite.client.utils._validation import assert_type, verify_limit
 
 if TYPE_CHECKING:
     from cognite.client import CogniteClient
@@ -399,6 +399,7 @@ class APIClient:
         advanced_filter: dict | Filter | None = None,
         api_subversion: str | None = None,
     ) -> Iterator[T_CogniteResourceList] | Iterator[T_CogniteResource]:
+        verify_limit(limit)
         if is_unlimited(limit):
             limit = None
         resource_path = resource_path or self._RESOURCE_PATH
@@ -536,6 +537,7 @@ class APIClient:
         advanced_filter: dict | Filter | None = None,
         api_subversion: str | None = None,
     ) -> T_CogniteResourceList:
+        verify_limit(limit)
         if partitions:
             if not is_unlimited(limit):
                 raise ValueError("When using partitions, limit should be `None`, `-1` or `inf`.")
@@ -710,6 +712,7 @@ class APIClient:
         limit: int | None = None,
         api_subversion: str | None = None,
     ) -> int | UniqueResultList:
+        verify_limit(limit)
         if aggregate not in ["count", "cardinalityValues", "cardinalityProperties", "uniqueValues", "uniqueProperties"]:
             raise ValueError(
                 f"Invalid aggregate '{aggregate}'. Valid aggregates are 'count', 'cardinalityValues', "
@@ -1102,6 +1105,7 @@ class APIClient:
         headers: dict[str, Any] | None = None,
         api_subversion: str | None = None,
     ) -> T_CogniteResourceList:
+        verify_limit(limit)
         assert_type(filter, "filter", [dict, CogniteFilter], allow_none=True)
         if isinstance(filter, CogniteFilter):
             filter = filter.dump(camel_case=True)

--- a/cognite/client/utils/_validation.py
+++ b/cognite/client/utils/_validation.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING, Any, Callable, Literal, Mapping, Sequence, Tup
 from typing_extensions import TypeAlias
 
 from cognite.client.data_classes._base import T_CogniteSort
+from cognite.client.utils._auxiliary import is_unlimited
 from cognite.client.utils._identifier import Identifier, IdentifierSequence
 
 if TYPE_CHECKING:
@@ -74,3 +75,17 @@ def prepare_filter_sort(
             sort = [sort]
         return [sort_type.load(item).dump(camel_case=True) for item in sort]
     return None
+
+
+def verify_limit(limit: Any) -> None:
+    if is_unlimited(limit):
+        return
+
+    if isinstance(limit, int):
+        if limit <= 0:
+            raise ValueError("limit must be strictly positive")
+    else:
+        raise TypeError(
+            "A finite 'limit' must be given as a strictly positive integer. "
+            "To indicate 'no limit' use one of: [None, -1, math.inf]."
+        )

--- a/tests/tests_unit/test_api_client.py
+++ b/tests/tests_unit/test_api_client.py
@@ -1301,3 +1301,11 @@ def test_worker_in_backoff_loop_gets_new_token(rsps):
     assert call_count > 0
     assert rsps.calls[0].request.headers["Authorization"] == "Bearer outdated-token"
     assert rsps.calls[1].request.headers["Authorization"] == "Bearer valid-token"
+
+
+@pytest.mark.parametrize("limit, expected_error", ((-2, ValueError), (0, ValueError), ("10", TypeError)))
+def test_list_and_search__bad_limit_value_raises(limit, expected_error, cognite_client):
+    with pytest.raises(expected_error):
+        cognite_client.assets.list(limit=limit)
+    with pytest.raises(expected_error):
+        cognite_client.assets.search(limit=limit)


### PR DESCRIPTION
## Description
Please describe the change you have made.

## Checklist:
- [ ] Tests added/updated.
- [ ] Documentation updated. Documentation is generated from docstrings - these must be updated according to your change.
  If a new method has been added it should be referenced in [cognite.rst](https://github.com/cognitedata/cognite-sdk-python/blob/master/docs/source/cognite.rst) in order to generate docs based on its docstring.
- [ ] Changelog updated in [CHANGELOG.md](https://github.com/cognitedata/cognite-sdk-python/blob/master/CHANGELOG.md).
- [ ] Version bumped. If triggering a new release is desired, bump the version number in [_version.py](https://github.com/cognitedata/cognite-sdk-python/blob/master/cognite/client/_version.py) and [pyproject.toml](https://github.com/cognitedata/cognite-sdk-python/blob/master/pyproject.toml) per [semantic versioning](https://semver.org/).
