### PR TITLE
Bugfix: onFailure missing in workflows response raising keyError

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ Changes are grouped as follows
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
+## [6.38.1] - 2023-10-31
+### Fixed
+- `onFailure` property in Workflows was expected as mandatory and was raising KeyError if it was not returnd by the API. The sdk now assumes the field to be optional loads it as None instead of raising an error.
+
 ## [6.38.0] - 2023-10-30
 ### Added
 - Support `onFailure` property in Workflows, allowing marking Tasks as optional in a Workflow.
@@ -37,9 +41,9 @@ Changes are grouped as follows
 
 ## [6.34.2] - 2023-10-23
 ### Fixed
-- Loading a `ContainerApply` from source failed with `KeyError` if `nullable`, `autoIncrement`, or `cursorable` were not set 
-  in the `ContainerProperty` and `BTreeIndex` classes even though they are optional. This is now fixed. 
- 
+- Loading a `ContainerApply` from source failed with `KeyError` if `nullable`, `autoIncrement`, or `cursorable` were not set
+  in the `ContainerProperty` and `BTreeIndex` classes even though they are optional. This is now fixed.
+
 ## [6.34.1] - 2023-10-23
 ### Added
 - Support for setting `data_set_id` and `metadata` in `ThreeDModelsAPI.create`.

--- a/cognite/client/_version.py
+++ b/cognite/client/_version.py
@@ -1,4 +1,4 @@
 from __future__ import annotations
 
-__version__ = "6.38.0"
+__version__ = "6.38.1"
 __api_subversion__ = "V20220125"

--- a/cognite/client/data_classes/workflows.py
+++ b/cognite/client/data_classes/workflows.py
@@ -382,7 +382,7 @@ class WorkflowTask(CogniteResource):
             # Allow default to come from the API.
             retries=resource.get("retries"),  # type: ignore[arg-type]
             timeout=resource.get("timeout"),  # type: ignore[arg-type]
-            on_failure=resource["onFailure"],
+            on_failure=resource.get("onFailure"),  # type: ignore[arg-type]
             depends_on=[dep["externalId"] for dep in resource.get("dependsOn", [])] or None,
         )
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "cognite-sdk"
 
-version = "6.38.0"
+version = "6.38.1"
 description = "Cognite Python SDK"
 readme = "README.md"
 documentation = "https://cognite-sdk-python.readthedocs-hosted.com"


### PR DESCRIPTION
## Description
`onFailure` property in Workflows was expected as mandatory and was raising KeyError if it was not returnd by the API. The sdk now assumes the field to be optional loads it as None instead of raising an error.

## Checklist:
- [ ] Tests added/updated.
- [ ] Documentation updated. Documentation is generated from docstrings - these must be updated according to your change.
  If a new method has been added it should be referenced in [cognite.rst](https://github.com/cognitedata/cognite-sdk-python/blob/master/docs/source/cognite.rst) in order to generate docs based on its docstring.
- [x] Changelog updated in [CHANGELOG.md](https://github.com/cognitedata/cognite-sdk-python/blob/master/CHANGELOG.md).
- [x] Version bumped. If triggering a new release is desired, bump the version number in [_version.py](https://github.com/cognitedata/cognite-sdk-python/blob/master/cognite/client/_version.py) and [pyproject.toml](https://github.com/cognitedata/cognite-sdk-python/blob/master/pyproject.toml) per [semantic versioning](https://semver.org/).
