### PR TITLE
fix transformations backup auth flow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,12 @@ Changes are grouped as follows
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
-## [6.39.0] - 2023-11-1
+## [6.39.1] - 2023-11-01
+## Fixed
+- When creating transformations using backup auth. flow (aka a session could not be created for any reason),
+  the scopes for the credentials would not be passed correctly (bug introduced in 6.25.1).
+
+## [6.39.0] - 2023-11-01
 ## Added
 - Support for `concurrencyPolicy` property in Workflows `TransformationsWorker`.
 

--- a/cognite/client/_version.py
+++ b/cognite/client/_version.py
@@ -1,4 +1,4 @@
 from __future__ import annotations
 
-__version__ = "6.39.0"
+__version__ = "6.39.1"
 __api_subversion__ = "V20220125"

--- a/cognite/client/data_classes/transformations/__init__.py
+++ b/cognite/client/data_classes/transformations/__init__.py
@@ -258,7 +258,6 @@ class Transformation(CogniteResource):
             config.credentials = oidc_credentials.as_credential_provider()
             other_client = CogniteClient(config)
             try:
-                raise CogniteAPIError("skipping to test if backup flow is working...", 400)
                 session = other_client.iam.sessions.create(credentials)
                 ret = sessions_cache[key] = NonceCredentials(session.id, session.nonce, project)
             except CogniteAPIError as err:

--- a/cognite/client/data_classes/transformations/__init__.py
+++ b/cognite/client/data_classes/transformations/__init__.py
@@ -258,6 +258,7 @@ class Transformation(CogniteResource):
             config.credentials = oidc_credentials.as_credential_provider()
             other_client = CogniteClient(config)
             try:
+                raise CogniteAPIError("skipping to test if backup flow is working...", 400)
                 session = other_client.iam.sessions.create(credentials)
                 ret = sessions_cache[key] = NonceCredentials(session.id, session.nonce, project)
             except CogniteAPIError as err:

--- a/cognite/client/data_classes/transformations/common.py
+++ b/cognite/client/data_classes/transformations/common.py
@@ -306,18 +306,22 @@ class OidcCredentials:
         self.token_uri = token_uri
         self.audience = audience
         self.cdf_project_name = cdf_project_name
+        self.scopes = self._verify_scopes(scopes)
 
-        # For backwards compatibility, we accept scopes as a comma-separated string.
+    @staticmethod
+    def _verify_scopes(scopes: str | list[str]) -> str:
         if isinstance(scopes, str):
-            scopes = scopes.split(",")
-        self.scopes = scopes
+            return scopes
+        elif isinstance(scopes, list):
+            return ",".join(scopes)
+        raise TypeError(f"scopes must be provided as a comma-separated string or list, not {type(scopes)}")
 
     def as_credential_provider(self) -> OAuthClientCredentials:
         return OAuthClientCredentials(
             token_url=self.token_uri,
             client_id=self.client_id,
             client_secret=self.client_secret,
-            scopes=self.scopes,
+            scopes=self.scopes.split(","),
             audience=self.audience,
         )
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "cognite-sdk"
 
-version = "6.39.0"
+version = "6.39.1"
 description = "Cognite Python SDK"
 readme = "README.md"
 documentation = "https://cognite-sdk-python.readthedocs-hosted.com"

--- a/tests/tests_unit/test_transformations/test_common.py
+++ b/tests/tests_unit/test_transformations/test_common.py
@@ -13,7 +13,7 @@ def oidc_credentials():
 @pytest.mark.parametrize("scopes", ("comma,separated,scopes", ["comma", "separated", "scopes"]))
 def test_oidc_credentials(scopes):
     oidc_credentials = OidcCredentials(client_id="id", client_secret="secret", scopes=scopes, token_uri="url")
-    assert oidc_credentials.scopes == ["comma", "separated", "scopes"]
+    assert oidc_credentials.scopes == "comma,separated,scopes"
 
 
 def test_oidc_credentials_as_credential_provider(oidc_credentials):
@@ -21,7 +21,7 @@ def test_oidc_credentials_as_credential_provider(oidc_credentials):
 
     assert isinstance(client_creds, OAuthClientCredentials)
     assert client_creds.token_url == oidc_credentials.token_uri
-    assert client_creds.scopes == oidc_credentials.scopes
+    assert client_creds.scopes == [oidc_credentials.scopes]
     assert client_creds.token_custom_args["audience"] is oidc_credentials.audience is None
 
 


### PR DESCRIPTION
## Description
When backup flow is used, scopes is not dumped as a comma-separated string.
