### PR TITLE
 Replace AssetAggregate with CountAggregate

### DIFF
--- a/cognite/client/_api/assets.py
+++ b/cognite/client/_api/assets.py
@@ -33,11 +33,11 @@ from cognite.client._api_client import APIClient
 from cognite.client._constants import DEFAULT_LIMIT_READ
 from cognite.client.data_classes import (
     Asset,
-    AssetAggregate,
     AssetFilter,
     AssetHierarchy,
     AssetList,
     AssetUpdate,
+    CountAggregate,
     GeoLocationFilter,
     LabelFilter,
     TimestampRange,
@@ -247,14 +247,14 @@ class AssetsAPI(APIClient):
             list_cls=AssetList, resource_cls=Asset, identifiers=identifiers, ignore_unknown_ids=ignore_unknown_ids
         )
 
-    def aggregate(self, filter: AssetFilter | dict | None = None) -> list[AssetAggregate]:
+    def aggregate(self, filter: AssetFilter | dict | None = None) -> list[CountAggregate]:
         """`Aggregate assets <https://developer.cognite.com/api#tag/Assets/operation/aggregateAssets>`_
 
         Args:
             filter (AssetFilter | dict | None): Filter on assets with strict matching.
 
         Returns:
-            list[AssetAggregate]: List of asset aggregates
+            list[CountAggregate]: List of asset aggregates
 
         Examples:
 
@@ -267,7 +267,7 @@ class AssetsAPI(APIClient):
         warnings.warn(
             f"This method is deprecated. Use {self.__class__.__name__}.aggregate_count instead.", DeprecationWarning
         )
-        return self._aggregate(filter=filter, cls=AssetAggregate)
+        return self._aggregate(filter=filter, cls=CountAggregate)
 
     def aggregate_count(
         self,

--- a/cognite/client/data_classes/__init__.py
+++ b/cognite/client/data_classes/__init__.py
@@ -11,7 +11,6 @@ from cognite.client.data_classes.annotations import (
 from cognite.client.data_classes.assets import (
     AggregateResultItem,
     Asset,
-    AssetAggregate,
     AssetFilter,
     AssetHierarchy,
     AssetList,
@@ -241,7 +240,6 @@ __all__ = [
     "AggregateResultItem",
     "Asset",
     "CountAggregate",
-    "AssetAggregate",
     "AssetFilter",
     "AssetHierarchy",
     "AssetList",

--- a/cognite/client/data_classes/assets.py
+++ b/cognite/client/data_classes/assets.py
@@ -59,18 +59,6 @@ if TYPE_CHECKING:
     from cognite.client.data_classes._base import T_CogniteResource, T_CogniteResourceList
 
 
-class AssetAggregate(CogniteObject):
-    """Aggregation group of assets
-
-    Args:
-        count (int | None): Size of the aggregation group
-        **_ (Any): No description.
-    """
-
-    def __init__(self, count: int | None = None, **_: Any) -> None:
-        self.count = count
-
-
 class AggregateResultItem(CogniteObject):
     """Aggregated metrics of the asset
 


### PR DESCRIPTION
## Description
We removed the `events` , `sequences`, `timeseries` aggregates. This one slipped passed me.

## Checklist:
- [ ] Tests added/updated.
- [ ] Documentation updated. Documentation is generated from docstrings - these must be updated according to your change.
  If a new method has been added it should be referenced in [cognite.rst](https://github.com/cognitedata/cognite-sdk-python/blob/master/docs/source/cognite.rst) in order to generate docs based on its docstring.
- [ ] Changelog updated in [CHANGELOG.md](https://github.com/cognitedata/cognite-sdk-python/blob/master/CHANGELOG.md).
- [ ] Version bumped. If triggering a new release is desired, bump the version number in [_version.py](https://github.com/cognitedata/cognite-sdk-python/blob/master/cognite/client/_version.py) and [pyproject.toml](https://github.com/cognitedata/cognite-sdk-python/blob/master/pyproject.toml) per [semantic versioning](https://semver.org/).
