### PR TITLE
fix `Capability.load` for responses with multiple top-level keys

### DIFF
--- a/cognite/client/_api/data_modeling/instances.py
+++ b/cognite/client/_api/data_modeling/instances.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import json
 import logging
 import random
 import time
@@ -62,6 +61,7 @@ from cognite.client.data_classes.data_modeling.query import (
 )
 from cognite.client.data_classes.data_modeling.views import View
 from cognite.client.data_classes.filters import Filter, _validate_filter
+from cognite.client.utils._auxiliary import load_yaml_or_json
 from cognite.client.utils._concurrency import ConcurrencySettings
 from cognite.client.utils._identifier import DataModelingIdentifierSequence
 from cognite.client.utils._retry import Backoff
@@ -112,7 +112,7 @@ class _NodeOrEdgeList(CogniteResourceList):
 class _NodeOrEdgeResourceAdapter:
     @staticmethod
     def _load(data: str | dict, cognite_client: CogniteClient | None = None) -> Node | Edge:
-        data = json.loads(data) if isinstance(data, str) else data
+        data = load_yaml_or_json(data) if isinstance(data, str) else data
         if data["instanceType"] == "node":
             return Node._load(data)
         return Edge._load(data)
@@ -125,7 +125,7 @@ class _NodeOrEdgeApplyResultList(CogniteResourceList):
     def _load(
         cls, resource_list: Iterable[dict[str, Any]] | str, cognite_client: CogniteClient | None = None
     ) -> _NodeOrEdgeApplyResultList:
-        resource_list = json.loads(resource_list) if isinstance(resource_list, str) else resource_list
+        resource_list = load_yaml_or_json(resource_list) if isinstance(resource_list, str) else resource_list
         resources: list[NodeApplyResult | EdgeApplyResult] = [
             NodeApplyResult._load(data) if data["instanceType"] == "node" else EdgeApplyResult._load(data)
             for data in resource_list
@@ -139,7 +139,7 @@ class _NodeOrEdgeApplyResultList(CogniteResourceList):
 class _NodeOrEdgeApplyResultAdapter:
     @staticmethod
     def load(data: str | dict, cognite_client: CogniteClient | None = None) -> NodeApplyResult | EdgeApplyResult:
-        data = json.loads(data) if isinstance(data, str) else data
+        data = load_yaml_or_json(data) if isinstance(data, str) else data
         if data["instanceType"] == "node":
             return NodeApplyResult._load(data)
         return EdgeApplyResult._load(data)

--- a/cognite/client/data_classes/_base.py
+++ b/cognite/client/data_classes/_base.py
@@ -144,11 +144,11 @@ class CogniteObject:
     @final
     def load(cls, resource: dict | str, cognite_client: CogniteClient | None = None) -> Self:
         """Load a resource from a YAML/JSON string or dict."""
-        if isinstance(resource, str):
-            resource = load_yaml_or_json(resource)
-
         if isinstance(resource, dict):
             return cls._load(resource, cognite_client=cognite_client)
+
+        if isinstance(resource, str):
+            resource = load_yaml_or_json(resource)
 
         raise TypeError(f"Resource must be json or yaml str, or dict, not {type(resource)}")
 

--- a/cognite/client/data_classes/capabilities.py
+++ b/cognite/client/data_classes/capabilities.py
@@ -23,6 +23,8 @@ logger = logging.getLogger(__name__)
 @dataclass
 class Capability(ABC):
     _capability_name: ClassVar[str]
+    actions: Sequence[Action]
+    scope: Scope
 
     class Action(enum.Enum):
         ...
@@ -57,30 +59,37 @@ class Capability(ABC):
                 data = convert_all_keys_to_camel_case(data)
             return {self._scope_name: data}
 
-    actions: Sequence[Action]
-    scope: Scope
-
     @classmethod
     def load(cls, resource: dict | str) -> Self:
         resource = resource if isinstance(resource, dict) else load_yaml_or_json(resource)
-        ((name, data),) = resource.items()
-        if capability_cls := _CAPABILITY_CLASS_BY_NAME.get(name):
+        known_acls = set(resource).intersection(_CAPABILITY_CLASS_BY_NAME)
+        if len(known_acls) == 1:
+            (name,) = known_acls
+            capability_cls = _CAPABILITY_CLASS_BY_NAME[name]
+            # TODO: We ignore extra keys that might be present like 'projectUrlNames' - are these needed?
             return cast(
                 Self,
                 capability_cls(
-                    actions=[capability_cls.Action(action) for action in data["actions"]],
-                    scope=Capability.Scope.load(data["scope"]),
+                    actions=[capability_cls.Action(action) for action in resource[name]["actions"]],
+                    scope=Capability.Scope.load(resource[name]["scope"]),
                 ),
             )
-
-        return cast(
-            Self,
-            UnknownAcl(
-                capability_name=name,
-                actions=[UnknownAcl.Action.UNKNOWN for _ in data["actions"]],
-                scope=Capability.Scope.load(data["scope"]),
-                raw_data=resource,
-            ),
+        elif not known_acls and len(resource) == 1:
+            # We infer this as an unknown acl not yet added to the SDK:
+            ((name, data),) = resource.items()
+            return cast(
+                Self,
+                UnknownAcl(
+                    capability_name=name,
+                    actions=[UnknownAcl.Action.Unknown for _ in data["actions"]],
+                    scope=Capability.Scope.load(data["scope"]),
+                    raw_data=resource,
+                ),
+            )
+        # We got more than one acl (highly unlikely) or we got an unknown acl + extra keys in the response:
+        raise ValueError(
+            "Unable to parse capability from API-response, please create an issue on Github: "
+            "https://github.com/cognitedata/cognite-sdk-python"
         )
 
     def dump(self, camel_case: bool = False) -> dict[str, Any]:
@@ -179,7 +188,7 @@ class UnknownAcl(Capability):
     """
 
     class Action(Capability.Action):
-        UNKNOWN = "UNKNOWN"
+        Unknown = "UNKNOWN"
 
     capability_name: str
     raw_data: dict[str, Any]

--- a/cognite/client/data_classes/capabilities.py
+++ b/cognite/client/data_classes/capabilities.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import enum
 import inspect
-import json
 import logging
 from abc import ABC
 from dataclasses import asdict, dataclass, field
@@ -10,7 +9,7 @@ from typing import Any, ClassVar, Sequence, cast
 
 from typing_extensions import Self
 
-from cognite.client.utils._auxiliary import rename_and_exclude_keys
+from cognite.client.utils._auxiliary import load_yaml_or_json, rename_and_exclude_keys
 from cognite.client.utils._text import (
     convert_all_keys_to_camel_case,
     convert_all_keys_to_snake_case,
@@ -34,7 +33,7 @@ class Capability(ABC):
 
         @classmethod
         def load(cls, resource: dict | str) -> Self:
-            resource = resource if isinstance(resource, dict) else json.loads(resource)
+            resource = resource if isinstance(resource, dict) else load_yaml_or_json(resource)
             ((name, data),) = resource.items()
             data = convert_all_keys_to_snake_case(data)
             if scope_cls := _SCOPE_CLASS_BY_NAME.get(name):
@@ -63,7 +62,7 @@ class Capability(ABC):
 
     @classmethod
     def load(cls, resource: dict | str) -> Self:
-        resource = resource if isinstance(resource, dict) else json.loads(resource)
+        resource = resource if isinstance(resource, dict) else load_yaml_or_json(resource)
         ((name, data),) = resource.items()
         if capability_cls := _CAPABILITY_CLASS_BY_NAME.get(name):
             return cast(

--- a/cognite/client/data_classes/data_sets.py
+++ b/cognite/client/data_classes/data_sets.py
@@ -83,7 +83,7 @@ class DataSetFilter(CogniteFilter):
         self.external_id_prefix = external_id_prefix
         self.write_protected = write_protected
 
-    def dump(self, camel_case: bool = True) -> dict[str, Any]:
+    def dump(self, camel_case: bool = False) -> dict[str, Any]:
         dumped = super().dump(camel_case=camel_case)
         if self.created_time and isinstance(self.created_time, TimestampRange):
             dumped["createdTime"] = self.created_time.dump(camel_case=camel_case)

--- a/cognite/client/data_classes/transformations/__init__.py
+++ b/cognite/client/data_classes/transformations/__init__.py
@@ -417,7 +417,7 @@ class TransformationUpdate(CogniteUpdate):
     def tags(self) -> _ListTransformationUpdate:
         return TransformationUpdate._ListTransformationUpdate(self, "tags")
 
-    def dump(self, camel_case: bool = True) -> dict[str, Any]:
+    def dump(self, camel_case: bool = False) -> dict[str, Any]:
         obj = super().dump()
 
         for update in obj.get("update", {}).values():
@@ -472,7 +472,7 @@ class ContainsAny(TagsFilter):
     def __init__(self, tags: list[str] | None = None) -> None:
         self.tags = tags
 
-    def dump(self, camel_case: bool = True) -> dict[str, Any]:
+    def dump(self, camel_case: bool = False) -> dict[str, Any]:
         contains_any_key = "containsAny" if camel_case else "contains_any"
         return {contains_any_key: self.tags}
 
@@ -520,7 +520,7 @@ class TransformationFilter(CogniteFilter):
         self.data_set_ids = data_set_ids
         self.tags = tags
 
-    def dump(self, camel_case: bool = True) -> dict[str, Any]:
+    def dump(self, camel_case: bool = False) -> dict[str, Any]:
         obj = super().dump(camel_case=camel_case)
         if (value := obj.pop("includePublic" if camel_case else "include_public", None)) is not None:
             obj["isPublic" if camel_case else "is_public"] = value

--- a/tests/tests_unit/test_data_classes/test_capabilities.py
+++ b/tests/tests_unit/test_data_classes/test_capabilities.py
@@ -4,7 +4,29 @@ from typing import Any
 
 import pytest
 
-from cognite.client.data_classes import capabilities
+from cognite.client.data_classes.capabilities import (
+    AllScope,
+    Capability,
+    ProjectsAcl,
+    UnknownAcl,
+    UnknownScope,
+)
+
+
+@pytest.fixture
+def cap_with_extra_key():
+    return {
+        "extra-key": {"urlNames": ["my-sandbox"]},
+        "projectsAcl": {"actions": ["UPDATE", "LIST", "READ"], "scope": {"all": {}}},
+    }
+
+
+@pytest.fixture
+def unknown_cap_with_extra_key():
+    return {
+        "extra-key": {"urlNames": ["my-sandbox"]},
+        "veryUnknownAcl": {"actions": ["DELETE"], "scope": {"all": {}}},
+    }
 
 
 class TestCapabilities:
@@ -29,14 +51,30 @@ class TestCapabilities:
         ],
     )
     def test_load_dump(self, raw: dict[str, Any]) -> None:
-        capability = capabilities.Capability.load(raw)
+        capability = Capability.load(raw)
         assert capability.dump(camel_case=True) == raw
+
+    def test_load_dump__extra_top_level_keys(self, cap_with_extra_key) -> None:
+        capability = Capability.load(cap_with_extra_key)
+        assert isinstance(capability, ProjectsAcl)
+        assert isinstance(capability.scope, AllScope)
+        assert all(isinstance(action, ProjectsAcl.Action) for action in capability.actions)
+
+        assert capability.dump(camel_case=True) != cap_with_extra_key
+        cap_with_extra_key.pop("extra-key")
+        assert capability.dump(camel_case=True) == cap_with_extra_key
+
+    def test_load_dump_unknown__extra_top_level_keys(self, unknown_cap_with_extra_key) -> None:
+        with pytest.raises(ValueError, match="^Unable to parse capability from API-response"):
+            Capability.load(unknown_cap_with_extra_key)
 
     @pytest.mark.parametrize(
         "raw", [{"dataproductAcl": {"actions": ["UTILIZE"], "scope": {"components": {"ids": [1, 2, 3]}}}}]
     )
     def test_load_dump_unknown(self, raw: dict[str, Any]) -> None:
-        capability = capabilities.Capability.load(raw)
-        assert isinstance(capability, capabilities.UnknownAcl)
+        capability = Capability.load(raw)
+        assert isinstance(capability, UnknownAcl)
+        assert isinstance(capability.scope, UnknownScope)
+        assert all(action is UnknownAcl.Action.Unknown for action in capability.actions)
         assert capability.raw_data == raw
         assert capability.dump(camel_case=True) == raw


### PR DESCRIPTION
## Description

1. fix Capability.load for responses with mulitple top-level keys
2. change a few json.loads to load_yaml_or_json
3. performance: loading from dict is the most common pattern
4. unify all dump methods to camel_case=False

## Checklist:
- [x] Tests added/updated.
