### PR TITLE
Add callback to global_config to allow tracking of one's own SDK usage

### DIFF
--- a/cognite/client/_http_client.py
+++ b/cognite/client/_http_client.py
@@ -13,6 +13,7 @@ import urllib3
 
 from cognite.client.config import global_config
 from cognite.client.exceptions import CogniteConnectionError, CogniteConnectionRefused, CogniteReadTimeout
+from cognite.client.utils._api_usage import RequestDetails
 
 
 class BlockAll(cookiejar.CookiePolicy):
@@ -114,6 +115,10 @@ class HTTPClient:
         while True:
             try:
                 res = self._do_request(method=method, url=url, **kwargs)
+                if global_config.usage_tracking_callback:
+                    # We use the RequestDetails as an indirection to avoid the user mutating the request:
+                    global_config.usage_tracking_callback(RequestDetails.from_response(res))
+
                 last_status = res.status_code
                 retry_tracker.status += 1
                 if not retry_tracker.should_retry(status_code=last_status):

--- a/cognite/client/config.py
+++ b/cognite/client/config.py
@@ -3,9 +3,13 @@ from __future__ import annotations
 import getpass
 import pprint
 from contextlib import suppress
+from typing import TYPE_CHECKING, Callable
 
 from cognite.client._version import __api_subversion__
 from cognite.client.credentials import CredentialProvider
+
+if TYPE_CHECKING:
+    from cognite.client.utils._api_usage import RequestDetails
 
 
 class GlobalConfig:
@@ -39,6 +43,7 @@ class GlobalConfig:
         self.max_connection_pool_size: int = 50
         self.disable_ssl: bool = False
         self.proxies: dict[str, str] | None = {}
+        self.usage_tracking_callback: Callable[[RequestDetails], None] | None = None
 
 
 global_config = GlobalConfig()

--- a/cognite/client/utils/_api_usage.py
+++ b/cognite/client/utils/_api_usage.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import timedelta
+from typing import TYPE_CHECKING
+
+from typing_extensions import Self
+
+if TYPE_CHECKING:
+    from requests import Response
+
+
+@dataclass
+class RequestDetails:
+    """
+    SDK users wanting to track their own API usage (with the SDK) - for metrics or surveilance, may set
+    a callback on the global_config object that will then receive instances of this class, one per
+    actual request.
+
+    Note that due to concurrency, the sum of time_elapsed is (much) greater than the actual wall clock
+    waiting time.
+
+    Args:
+        url (str): The API endpoint that was called.
+        status_code (int): The status code of the API response.
+        content_length (int | None): The size of the response if available.
+        time_elapsed (timedelta): The amount of time elapsed between sending the request and the arrival of the response.
+
+    Example:
+
+        Store info on the last 1000 requests made:
+
+            >>> from cognite.client.config import global_config
+            >>> from collections import deque
+            >>> usage_info = deque(maxlen=1000)
+            >>> global_config.usage_tracking_callback = usage_info.append
+
+        Store the time elapsed per request, grouped per API endpoint, for all requests:
+
+            >>> from collections import defaultdict
+            >>> usage_info = defaultdict(list)
+            >>> def callback(details):
+            ...     usage_info[details.url].append(details.time_elapsed)
+            >>> global_config.usage_tracking_callback = callback
+
+    Tip:
+        Ensure the provided callback is fast to execute, or it might negatively impact the overall performance.
+
+    Warning:
+        Your provided callback function will be called from several different threads and thus any operation
+        executed must be thread-safe (or while holding a thread lock, not recommended). Best practise is to dump
+        the required details to a container like in the examples above, then inspect those separately in your code.
+    """
+
+    url: str
+    status_code: int
+    content_length: int | None
+    time_elapsed: timedelta
+
+    @classmethod
+    def from_response(cls, resp: Response) -> Self:
+        # If header not set, we don't report the size. We could do len(resp.content), but
+        # for streaming requests this would fetch everything into memory...
+        content_length = int(resp.headers.get("Content-length", 0)) or None
+        return cls(
+            url=resp.url,
+            status_code=resp.status_code,
+            content_length=content_length,
+            time_elapsed=resp.elapsed,
+        )


### PR DESCRIPTION
# DRAFT
Ref. edm-pipeline debug discussion: @spex66 @thorkildcognite 

## Checklist:
- [ ] Tests added/updated.
- [ ] Documentation updated. Documentation is generated from docstrings - these must be updated according to your change.
  If a new method has been added it should be referenced in [cognite.rst](https://github.com/cognitedata/cognite-sdk-python/blob/master/docs/source/cognite.rst) in order to generate docs based on its docstring.
- [ ] Changelog updated in [CHANGELOG.md](https://github.com/cognitedata/cognite-sdk-python/blob/master/CHANGELOG.md).
- [ ] Version bumped. If triggering a new release is desired, bump the version number in [_version.py](https://github.com/cognitedata/cognite-sdk-python/blob/master/cognite/client/_version.py) and [pyproject.toml](https://github.com/cognitedata/cognite-sdk-python/blob/master/pyproject.toml) per [semantic versioning](https://semver.org/).
