### PR TITLE
[v7] Deprecate dependent attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,8 @@ with no easy way to add a prefix. Also, it no longer expands metadata by default
   `dict` but classes with attributes matching the API.
 - Calling `client.iam.token.inspect()` now gives an object `TokenInspection` with attribute `cababilities` of type `ProjectCapabilitiesList`
   instead of `list[dict]`
+- In data class `Transformation` the attribute `schedule`, `running_job`, and `last_running_job` `external_id` and `id`
+  are set to the `Transformation` `id` and `external_id` if not set. If they are set to a different value, a `ValueError` is raised.
 
 ### Added
 - Added `load` implementation for `VisionResource`s: `ObjectDetection`, `TextRegion`, `AssetLink`, `BoundingBox`,
@@ -100,6 +102,7 @@ with no easy way to add a prefix. Also, it no longer expands metadata by default
 - DataClass `ViewDirectRelation`, `ContainerDirectRelation` replaced by `DirectRelation`.
 - DataClasses `MappedPropertyDefinition`, `MappedApplyPropertyDefinition` replaced by `MappedProperty`, `MappedPropertyApply`.
 - DataClasses `RequiresConstraintDefinition` and `UniquenessConstraintDefinition` replaced by `RequiresConstraint` and `UniquenessConstraint`.
+- In data class `Transformation` attributes `has_source_oidc_credentials` and `has_destination_oidc_credentials` are replaced by properties.
 
 ### Fixed
 - Passing `limit=0` no longer returns `DEFAULT_LIMIT_READ` (25) resources, but raises a `ValueError`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ methods are `json` and `yaml` serializable.
 - The `client.events.aggregate` use `client.events.aggregate_count` instead.
 - The `client.sequence.aggregate` use `client.sequence.aggregate_count` instead.
 - The `client.time_series.aggregate` use `client.time_series.aggregate_count` instead.
+- In `Transformations` attributes `has_source_oidc_credentials` and `has_destination_oidc_credentials`.
 
 ### Changed
 - `CogniteResource.to_pandas` now more closely resembles `CogniteResourceList.to_pandas` with parameters

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,7 +39,8 @@ methods are `json` and `yaml` serializable.
 - The `client.events.aggregate` use `client.events.aggregate_count` instead.
 - The `client.sequence.aggregate` use `client.sequence.aggregate_count` instead.
 - The `client.time_series.aggregate` use `client.time_series.aggregate_count` instead.
-- In `Transformations` attributes `has_source_oidc_credentials` and `has_destination_oidc_credentials`.
+- In `Transformations` attributes `has_source_oidc_credentials` and `has_destination_oidc_credentials` are deprecated,
+  and replaced by properties with the same names.
 
 ### Changed
 - `CogniteResource.to_pandas` now more closely resembles `CogniteResourceList.to_pandas` with parameters
@@ -78,8 +79,8 @@ with no easy way to add a prefix. Also, it no longer expands metadata by default
   `dict` but classes with attributes matching the API.
 - Calling `client.iam.token.inspect()` now gives an object `TokenInspection` with attribute `cababilities` of type `ProjectCapabilitiesList`
   instead of `list[dict]`
-- In data class `Transformation` the attribute `schedule`, `running_job`, and `last_running_job` `external_id` and `id`
-  are set to the `Transformation` `id` and `external_id` if not set. If they are set to a different value, a `ValueError` is raised.
+- In data class `Transformation` the attribute `schedule`, `running_job`, and `last_running_job`, `external_id` and `id`
+  are set to the `Transformation` `id` and `external_id` if not set. If they are set to a different value, a `ValueError` is raised
 
 ### Added
 - Added `load` implementation for `VisionResource`s: `ObjectDetection`, `TextRegion`, `AssetLink`, `BoundingBox`,

--- a/MIGRATION_GUIDE.md
+++ b/MIGRATION_GUIDE.md
@@ -102,8 +102,8 @@ Changes are grouped as follows:
   `dict` but classes with attributes matchhng the API.
 - Calling `client.iam.token.inspect()` now gives an object `TokenInspection` with attribute `cababilities` of type `ProjectCapabilitiesList`
   instead of `list[dict]`
-- In data class `Transformation` the attribute `schedule`, `running_job`, and `last_running_job` `external_id` and `id`
-  are set to the `Transformation` `id` and `external_id` if not set. If they are set to a different value, a `ValueError` is raised.
+- In data class `Transformation` the attribute `schedule`, `running_job`, and `last_running_job`, `external_id` and `id`
+  are set to the `Transformation` `id` and `external_id` if not set. If they are set to a different value, a `ValueError` is raised
 
 ### Optional
 - `CogniteImportError` can now be caught as `ImportError`.

--- a/MIGRATION_GUIDE.md
+++ b/MIGRATION_GUIDE.md
@@ -36,6 +36,7 @@ Changes are grouped as follows:
 - DataClass `ViewDirectRelation`, `ContainerDirectRelation` replaced by `DirectRelation`.
 - DataClasses `MappedPropertyDefinition`, `MappedApplyPropertyDefinition` replaced by `MappedProperty`, `MappedPropertyApply`.
 - DataClasses `RequiresConstraintDefinition` and `UniquenessConstraintDefinition` replaced by `RequiresConstraint` and `UniquenessConstraint`.
+- In data class `Transformation` attributes `has_source_oidc_credentials` and `has_destination_oidc_credentials` are replaced by properties.
 
 ### Function Signature
 - `CogniteResource.to_pandas` now more closely resembles `CogniteResourceList.to_pandas` with parameters
@@ -101,6 +102,8 @@ Changes are grouped as follows:
   `dict` but classes with attributes matchhng the API.
 - Calling `client.iam.token.inspect()` now gives an object `TokenInspection` with attribute `cababilities` of type `ProjectCapabilitiesList`
   instead of `list[dict]`
+- In data class `Transformation` the attribute `schedule`, `running_job`, and `last_running_job` `external_id` and `id`
+  are set to the `Transformation` `id` and `external_id` if not set. If they are set to a different value, a `ValueError` is raised.
 
 ### Optional
 - `CogniteImportError` can now be caught as `ImportError`.

--- a/cognite/client/data_classes/transformations/__init__.py
+++ b/cognite/client/data_classes/transformations/__init__.py
@@ -107,6 +107,7 @@ class Transformation(CogniteResource):
         source_session (SessionDetails | None): Details for the session used to read from the source project.
         destination_session (SessionDetails | None): Details for the session used to write to the destination project.
         tags (list[str] | None): No description.
+        **_ (Any): No description.
     """
 
     def __init__(
@@ -138,6 +139,7 @@ class Transformation(CogniteResource):
         source_session: SessionDetails | None = None,
         destination_session: SessionDetails | None = None,
         tags: list[str] | None = None,
+        **_: Any,
     ) -> None:
         self.id = id
         self.external_id = external_id
@@ -148,11 +150,14 @@ class Transformation(CogniteResource):
         self.is_public = is_public
         self.ignore_null_fields = ignore_null_fields
         self.source_oidc_credentials = source_oidc_credentials
-        self.has_source_oidc_credentials = has_source_oidc_credentials or source_oidc_credentials is not None
+        if has_source_oidc_credentials or has_destination_oidc_credentials:
+            warnings.warn(
+                "The arguments 'has_source_oidc_credentials' and 'has_destination_oidc_credentials' are "
+                "deprecated and will be removed in a future version."
+                "These are now properties returning whether the transformation has source or destination oidc credentials set.",
+                DeprecationWarning,
+            )
         self.destination_oidc_credentials = destination_oidc_credentials
-        self.has_destination_oidc_credentials = (
-            has_destination_oidc_credentials or destination_oidc_credentials is not None
-        )
         self.created_time = created_time
         self.last_updated_time = last_updated_time
         self.owner = owner
@@ -168,6 +173,14 @@ class Transformation(CogniteResource):
         self.destination_session = destination_session
         self.tags = tags
         self._cognite_client = cast("CogniteClient", cognite_client)
+
+    @property
+    def has_source_oidc_credentials(self) -> bool:
+        return self.source_oidc_credentials is not None
+
+    @property
+    def has_destination_oidc_credentials(self) -> bool:
+        return self.destination_oidc_credentials is not None
 
     def copy(self) -> Transformation:
         return Transformation(

--- a/cognite/client/data_classes/transformations/__init__.py
+++ b/cognite/client/data_classes/transformations/__init__.py
@@ -107,7 +107,7 @@ class Transformation(CogniteResource):
         source_session (SessionDetails | None): Details for the session used to read from the source project.
         destination_session (SessionDetails | None): Details for the session used to write to the destination project.
         tags (list[str] | None): No description.
-        **_ (Any): No description.
+        **kwargs (Any): No description.
     """
 
     def __init__(
@@ -139,7 +139,7 @@ class Transformation(CogniteResource):
         source_session: SessionDetails | None = None,
         destination_session: SessionDetails | None = None,
         tags: list[str] | None = None,
-        **_: Any,
+        **kwargs: Any,
     ) -> None:
         self.id = id
         self.external_id = external_id
@@ -155,7 +155,7 @@ class Transformation(CogniteResource):
                 "The arguments 'has_source_oidc_credentials' and 'has_destination_oidc_credentials' are "
                 "deprecated and will be removed in a future version."
                 "These are now properties returning whether the transformation has source or destination oidc credentials set.",
-                DeprecationWarning,
+                UserWarning,
             )
         self.destination_oidc_credentials = destination_oidc_credentials
         self.created_time = created_time

--- a/cognite/client/data_classes/transformations/__init__.py
+++ b/cognite/client/data_classes/transformations/__init__.py
@@ -174,6 +174,22 @@ class Transformation(CogniteResource):
         self.tags = tags
         self._cognite_client = cast("CogniteClient", cognite_client)
 
+        if self.schedule:
+            self.schedule.id = self.schedule.id or self.id
+            self.schedule.external_id = self.schedule.external_id or self.external_id
+        if self.running_job:
+            self.running_job.id = self.running_job.id or self.id
+        if self.last_finished_job:
+            self.last_finished_job.id = self.last_finished_job.id or self.id
+        if self.schedule and self.external_id != self.schedule.external_id:
+            raise ValueError("Transformation external_id must be the same as the schedule.external_id.")
+        if (
+            (self.schedule and self.id != self.schedule.id)
+            or (self.running_job and self.id != self.running_job.id)
+            or (self.last_finished_job and self.id != self.last_finished_job.id)
+        ):
+            raise ValueError("Transformation id must be the same as the schedule, running_job, last_running_job id.")
+
     @property
     def has_source_oidc_credentials(self) -> bool:
         return self.source_oidc_credentials is not None


### PR DESCRIPTION
## Description
These attributes should just be properties.

## Checklist:
- [ ] Tests added/updated.
- [ ] Documentation updated. Documentation is generated from docstrings - these must be updated according to your change.
  If a new method has been added it should be referenced in [cognite.rst](https://github.com/cognitedata/cognite-sdk-python/blob/master/docs/source/cognite.rst) in order to generate docs based on its docstring.
- [ ] Changelog updated in [CHANGELOG.md](https://github.com/cognitedata/cognite-sdk-python/blob/master/CHANGELOG.md).
- [ ] Version bumped. If triggering a new release is desired, bump the version number in [_version.py](https://github.com/cognitedata/cognite-sdk-python/blob/master/cognite/client/_version.py) and [pyproject.toml](https://github.com/cognitedata/cognite-sdk-python/blob/master/pyproject.toml) per [semantic versioning](https://semver.org/).
