### PR TITLE
[v7] Sequences transition ease

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,8 +62,9 @@ with no easy way to add a prefix. Also, it no longer expands metadata by default
   on the `aggregates` and `group_by` parameters. Previously, it always returned `InstanceAggregationResultList`.
 - The `Group` attribute `capabilities` is now a `Capabilities` object, instead of a `dict`.
 - Support for `YAML` in all `CogniteResource.load()` and `CogniteResourceList.load()` methods.
-- The `client.sequences.data.retrieve` method has changed signature:
-  The parameter `columns_external_id` is renamed `columns`, the parameters `id` and `external_id` have
+- The `client.sequences.data` methods `.retrieve`, `.retrieve_last_row`, `.insert`  method has changed signature:
+  The parameter `column_external_ids` is renamed `columns`. The old parameter `column_external_ids` is still there, but is
+  deprecated. In addition, int the `.retrieve` method, the parameters `id` and `external_id` have
   been moved to the beginning of the signature. This is to better match the API and have a consistent overload
   implementation.
 - The class `SequenceData` has been replaced by `SequenceRows`. The old `SequenceData` class is still available for

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,7 +62,7 @@ with no easy way to add a prefix. Also, it no longer expands metadata by default
   on the `aggregates` and `group_by` parameters. Previously, it always returned `InstanceAggregationResultList`.
 - The `Group` attribute `capabilities` is now a `Capabilities` object, instead of a `dict`.
 - Support for `YAML` in all `CogniteResource.load()` and `CogniteResourceList.load()` methods.
-- The `client.sequences.data` methods `.retrieve`, `.retrieve_last_row`, `.insert`  method has changed signature:
+- The `client.sequences.data` methods `.retrieve`, `.retrieve_last_row` (previously `retrieve_latest`), `.insert`  method has changed signature:
   The parameter `column_external_ids` is renamed `columns`. The old parameter `column_external_ids` is still there, but is
   deprecated. In addition, int the `.retrieve` method, the parameters `id` and `external_id` have
   been moved to the beginning of the signature. This is to better match the API and have a consistent overload

--- a/MIGRATION_GUIDE.md
+++ b/MIGRATION_GUIDE.md
@@ -52,7 +52,7 @@ Changes are grouped as follows:
 - `client.data_modeling.instances.aggregate` the parameters `instance_type` and `group_by` has swapped order.
 - The return type of `client.data_modeling.instances.aggregate` has changed from `InstanceAggregationResultList` to
   a more specific value `AggregatedNumberedValue | list[AggregatedNumberedValue] | InstanceAggregationResultList` depending on the `aggregates` and `group_by` parameters.
-- The `client.sequences.data` methods `.retrieve`, `.retrieve_last_row`, `.insert`  method has changed signature:
+- The `client.sequences.data` methods `.retrieve` and `.insert`  method has changed signature:
   The parameter `column_external_ids` is renamed `columns`. The old parameter `column_external_ids` is still there, but is
   deprecated. In addition, int the `.retrieve` method, the parameters `id` and `external_id` have
   been moved to the beginning of the signature. This is to better match the API and have a consistent overload

--- a/MIGRATION_GUIDE.md
+++ b/MIGRATION_GUIDE.md
@@ -52,8 +52,11 @@ Changes are grouped as follows:
 - `client.data_modeling.instances.aggregate` the parameters `instance_type` and `group_by` has swapped order.
 - The return type of `client.data_modeling.instances.aggregate` has changed from `InstanceAggregationResultList` to
   a more specific value `AggregatedNumberedValue | list[AggregatedNumberedValue] | InstanceAggregationResultList` depending on the `aggregates` and `group_by` parameters.
-- The `client.sequences.data.retrieve` method has changed signature:
-  The parameter `columns_external_id` is renamed `columns`. This is to better match the API and have a consistent overload implementation.
+- The `client.sequences.data` methods `.retrieve`, `.retrieve_last_row`, `.insert`  method has changed signature:
+  The parameter `column_external_ids` is renamed `columns`. The old parameter `column_external_ids` is still there, but is
+  deprecated. In addition, int the `.retrieve` method, the parameters `id` and `external_id` have
+  been moved to the beginning of the signature. This is to better match the API and have a consistent overload
+  implementation.
 - The `client.sequences.data.retrieve_latest` is renamed `client.sequences.data.retrieve_last_row`.
 
 ### Changed
@@ -95,7 +98,7 @@ Changes are grouped as follows:
   backwards compatibility, but will be removed in the next major version. However, all API methods now return
   `SequenceRows` instead of `SequenceData`.
 - The attribute `columns` in `Sequence` has been changed from `SequenceType[dict]` to `SequnceColumnList`.
--The class `SequenceRows` in `client.data_classes.transformations.common` has been renamed to `SequenceRowsDestination`.
+- The class `SequenceRows` in `client.data_classes.transformations.common` has been renamed to `SequenceRowsDestination`.
 - Classes `Geometry`, `AssetAggregate`, `AggregateResultItem`, `EndTimeFilter`, `Label`, `LabelFilter`, `ExtractionPipelineContact`,
   `TimestampRange`, `AggregateResult`, `GeometryFilter`, `GeoLocation`, `RevisionCameraProperties`, `BoundingBox3D` are no longer
   `dict` but classes with attributes matchhng the API.

--- a/cognite/client/_api/sequences.py
+++ b/cognite/client/_api/sequences.py
@@ -26,6 +26,7 @@ from cognite.client.data_classes.sequences import (
     SortableSequenceProperty,
 )
 from cognite.client.data_classes.shared import TimestampRange
+from cognite.client.utils._auxiliary import handle_renamed_argument
 from cognite.client.utils._concurrency import execute_tasks
 from cognite.client.utils._identifier import Identifier, IdentifierSequence
 from cognite.client.utils._validation import (
@@ -903,13 +904,10 @@ class SequencesDataAPI(APIClient):
                 >>> data = c.sequences.data.retrieve(id=2,start=0,end=10)
                 >>> c.sequences.data.insert(rows=data, id=1,column_external_ids=None)
         """
-        if column_external_ids is not None:
-            warnings.warn(
-                "The column_external_ids argument is deprecated. Use the columns argument instead.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
-        columns = columns or column_external_ids
+
+        columns = handle_renamed_argument(
+            columns, "columns", "column_external_ids", "insert", {"column_external_ids": column_external_ids}, False
+        )
         if isinstance(rows, SequenceRows):
             columns = rows.column_external_ids
             rows = [{"rowNumber": k, "values": v} for k, v in rows.items()]
@@ -1100,14 +1098,9 @@ class SequencesDataAPI(APIClient):
                 >>> col = res.get_column(external_id='columnExtId') # ... get the array of values for a specific column,
                 >>> df = res.to_pandas() # ... or convert the result to a dataframe
         """
-        if column_external_ids is not None:
-            warnings.warn(
-                "The column_external_ids argument is deprecated. Use the columns argument instead.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
-
-        columns = columns or column_external_ids
+        columns = handle_renamed_argument(
+            columns, "columns", "column_external_ids", "insert", {"column_external_ids": column_external_ids}, False
+        )
 
         ident_sequence = IdentifierSequence.load(id, external_id)
         identifiers = ident_sequence.as_dicts()
@@ -1162,13 +1155,9 @@ class SequencesDataAPI(APIClient):
                 >>> c = CogniteClient()
                 >>> res = c.sequences.data.retrieve_last_row(id=1, before=1000)
         """
-        if column_external_ids is not None:
-            warnings.warn(
-                "The column_external_ids argument is deprecated. Use the columns argument instead.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
-        columns = columns or column_external_ids
+        columns = handle_renamed_argument(
+            columns, "columns", "column_external_ids", "insert", {"column_external_ids": column_external_ids}, False
+        )
         identifier = Identifier.of_either(id, external_id).as_dict()
         res = self._do_request(
             "POST", self._DATA_PATH + "/latest", json={**identifier, "before": before, "columns": columns}

--- a/cognite/client/_api/sequences.py
+++ b/cognite/client/_api/sequences.py
@@ -881,28 +881,28 @@ class SequencesDataAPI(APIClient):
                 >>> seq = c.sequences.create(Sequence(columns=[SequenceColumn(value_type="String", external_id="col_a"),
                 ...     SequenceColumn(value_type="Double", external_id ="col_b")]))
                 >>> data = [(1, ['pi',3.14]), (2, ['e',2.72]) ]
-                >>> c.sequences.data.insert(column_external_ids=["col_a","col_b"], rows=data, id=1)
+                >>> c.sequences.data.insert(columns=["col_a","col_b"], rows=data, id=1)
 
             They can also be provided as a list of API-style objects with a rowNumber and values field::
 
                 >>> from cognite.client import CogniteClient
                 >>> c = CogniteClient()
                 >>> data = [{"rowNumber": 123, "values": ['str',3]}, {"rowNumber": 456, "values": ["bar",42]} ]
-                >>> c.sequences.data.insert(data, id=1, column_external_ids=["col_a","col_b"]) # implicit columns are retrieved from metadata
+                >>> c.sequences.data.insert(data, id=1, columns=["col_a","col_b"]) # implicit columns are retrieved from metadata
 
             Or they can be a given as a dictionary with row number as the key, and the value is the data to be inserted at that row::
 
                 >>> from cognite.client import CogniteClient
                 >>> c = CogniteClient()
                 >>> data = {123 : ['str',3], 456 : ['bar',42] }
-                >>> c.sequences.data.insert(column_external_ids=['stringColumn','intColumn'], rows=data, id=1)
+                >>> c.sequences.data.insert(columns=['stringColumn','intColumn'], rows=data, id=1)
 
-            Finally, they can be a SequenceData object retrieved from another request. In this case column_external_ids from this object are used as well.
+            Finally, they can be a SequenceData object retrieved from another request. In this case columns from this object are used as well.
 
                 >>> from cognite.client import CogniteClient
                 >>> c = CogniteClient()
                 >>> data = c.sequences.data.retrieve(id=2,start=0,end=10)
-                >>> c.sequences.data.insert(rows=data, id=1,column_external_ids=None)
+                >>> c.sequences.data.insert(rows=data, id=1,columns=None)
         """
 
         columns = handle_renamed_argument(

--- a/cognite/client/_api/sequences.py
+++ b/cognite/client/_api/sequences.py
@@ -859,18 +859,18 @@ class SequencesDataAPI(APIClient):
         | typing.Sequence[tuple[int, typing.Sequence[int | float | str]]]
         | typing.Sequence[dict[str, Any]],
         columns: SequenceNotStr[str] | None = None,
-        column_external_ids: SequenceNotStr[str] | None = None,
         id: int | None = None,
         external_id: str | None = None,
+        **kwargs: Any,
     ) -> None:
         """`Insert rows into a sequence <https://developer.cognite.com/api#tag/Sequences/operation/postSequenceData>`_
 
         Args:
             rows (SequenceRows | dict[int, typing.Sequence[int | float | str]] | typing.Sequence[tuple[int, typing.Sequence[int | float | str]]] | typing.Sequence[dict[str, Any]]):  The rows you wish to insert. Can either be a list of tuples, a list of {"rowNumber":... ,"values": ...} objects, a dictionary of rowNumber: data, or a SequenceData object. See examples below.
             columns (SequenceNotStr[str] | None): List of external id for the columns of the sequence.
-            column_external_ids (SequenceNotStr[str] | None): DEPRECATED: List of external id for the columns of the sequence.
             id (int | None): Id of sequence to insert rows into.
             external_id (str | None): External id of sequence to insert rows into.
+            **kwargs (Any): To support deprecated argument 'column_external_ids', will be removed in the next major version. Use 'columns' instead.
 
         Examples:
             Your rows of data can be a list of tuples where the first element is the rownumber and the second element is the data to be inserted::
@@ -904,10 +904,7 @@ class SequencesDataAPI(APIClient):
                 >>> data = c.sequences.data.retrieve(id=2,start=0,end=10)
                 >>> c.sequences.data.insert(rows=data, id=1,columns=None)
         """
-
-        columns = handle_renamed_argument(
-            columns, "columns", "column_external_ids", "insert", {"column_external_ids": column_external_ids}, False
-        )
+        columns = handle_renamed_argument(columns, "columns", "column_external_ids", "insert", kwargs, False)
         if isinstance(rows, SequenceRows):
             columns = rows.column_external_ids
             rows = [{"rowNumber": k, "values": v} for k, v in rows.items()]
@@ -964,7 +961,7 @@ class SequencesDataAPI(APIClient):
         dataframe = dataframe.replace({math.nan: None})  # TODO: Optimization required (memory usage)
         data = [(v[0], list(v[1:])) for v in dataframe.itertuples()]
         columns = [str(s) for s in dataframe.columns]
-        self.insert(rows=data, columns=columns, id=id, external_id=external_id, column_external_ids=None)
+        self.insert(rows=data, columns=columns, id=id, external_id=external_id)
 
     def _insert_data(self, task: dict[str, Any]) -> None:
         self._post(url_path=self._DATA_PATH, json={"items": [task]})
@@ -1020,7 +1017,6 @@ class SequencesDataAPI(APIClient):
         start: int = 0,
         end: int | None = None,
         columns: SequenceNotStr[str] | None = None,
-        column_external_ids: SequenceNotStr[str] | None = None,
         limit: int | None = None,
     ) -> SequenceRows:
         ...
@@ -1033,7 +1029,6 @@ class SequencesDataAPI(APIClient):
         start: int = 0,
         end: int | None = None,
         columns: SequenceNotStr[str] | None = None,
-        column_external_ids: SequenceNotStr[str] | None = None,
         limit: int | None = None,
     ) -> SequenceRowsList:
         ...
@@ -1046,7 +1041,6 @@ class SequencesDataAPI(APIClient):
         start: int = 0,
         end: int | None = None,
         columns: SequenceNotStr[str] | None = None,
-        column_external_ids: SequenceNotStr[str] | None = None,
         limit: int | None = None,
     ) -> SequenceRows:
         ...
@@ -1059,7 +1053,6 @@ class SequencesDataAPI(APIClient):
         start: int = 0,
         end: int | None = None,
         columns: SequenceNotStr[str] | None = None,
-        column_external_ids: SequenceNotStr[str] | None = None,
         limit: int | None = None,
     ) -> SequenceRowsList:
         ...
@@ -1071,8 +1064,8 @@ class SequencesDataAPI(APIClient):
         start: int = 0,
         end: int | None = None,
         columns: SequenceNotStr[str] | None = None,
-        column_external_ids: SequenceNotStr[str] | None = None,
         limit: int | None = None,
+        **kwargs: Any,
     ) -> SequenceRows | SequenceRowsList:
         """`Retrieve data from a sequence <https://developer.cognite.com/api#tag/Sequences/operation/getSequenceData>`_
 
@@ -1082,8 +1075,8 @@ class SequencesDataAPI(APIClient):
             start (int): Row number to start from (inclusive).
             end (int | None): Upper limit on the row number (exclusive). Set to None or -1 to get all rows until end of sequence.
             columns (SequenceNotStr[str] | None): List of external id for the columns of the sequence. If 'None' is passed, all columns will be retrieved.
-            column_external_ids (SequenceNotStr[str] | None): DEPRECATED: List of external id for the columns of the sequence. If 'None' is passed, all columns will be retrieved.
             limit (int | None): Maximum number of rows to return per sequence. Pass None to fetch all (possibly limited by 'end').
+            **kwargs (Any): To support deprecated argument 'column_external_ids', will be removed in the next major version. Use 'columns' instead.
 
         Returns:
             SequenceRows | SequenceRowsList: SequenceRows if a single identifier was given, else SequenceDataList
@@ -1098,9 +1091,7 @@ class SequencesDataAPI(APIClient):
                 >>> col = res.get_column(external_id='columnExtId') # ... get the array of values for a specific column,
                 >>> df = res.to_pandas() # ... or convert the result to a dataframe
         """
-        columns = handle_renamed_argument(
-            columns, "columns", "column_external_ids", "insert", {"column_external_ids": column_external_ids}, False
-        )
+        columns = handle_renamed_argument(columns, "columns", "column_external_ids", "insert", kwargs, False)
 
         ident_sequence = IdentifierSequence.load(id, external_id)
         identifiers = ident_sequence.as_dicts()
@@ -1132,8 +1123,8 @@ class SequencesDataAPI(APIClient):
         id: int | None = None,
         external_id: str | None = None,
         columns: SequenceNotStr[str] | None = None,
-        column_external_ids: SequenceNotStr[str] | None = None,
         before: int | None = None,
+        **kwargs: Any,
     ) -> SequenceRows:
         """`Retrieves the last row (i.e the row with the highest row number) in a sequence. <https://developer.cognite.com/api#tag/Sequences/operation/getLatestSequenceRow>`_
 
@@ -1141,8 +1132,8 @@ class SequencesDataAPI(APIClient):
             id (int | None): Id or list of ids.
             external_id (str | None): External id or list of external ids.
             columns (SequenceNotStr[str] | None): List of external id for the columns of the sequence. If 'None' is passed, all columns will be retrieved.
-            column_external_ids (SequenceNotStr[str] | None): (optional, typing.Sequence[str]): DEPRECATED external ids of columns to include. Omitting will return all columns.
             before (int | None): (optional, int): Get latest datapoint before this row number.
+            **kwargs (Any): To support deprecated argument 'column_external_ids', will be removed in the next major version. Use 'columns' instead.
 
         Returns:
             SequenceRows: A Datapoints object containing the requested data, or a list of such objects.
@@ -1155,9 +1146,7 @@ class SequencesDataAPI(APIClient):
                 >>> c = CogniteClient()
                 >>> res = c.sequences.data.retrieve_last_row(id=1, before=1000)
         """
-        columns = handle_renamed_argument(
-            columns, "columns", "column_external_ids", "insert", {"column_external_ids": column_external_ids}, False
-        )
+        columns = handle_renamed_argument(columns, "columns", "column_external_ids", "insert", kwargs, False)
         identifier = Identifier.of_either(id, external_id).as_dict()
         res = self._do_request(
             "POST", self._DATA_PATH + "/latest", json={**identifier, "before": before, "columns": columns}

--- a/cognite/client/_api/sequences.py
+++ b/cognite/client/_api/sequences.py
@@ -1102,7 +1102,9 @@ class SequencesDataAPI(APIClient):
         """
         if column_external_ids is not None:
             warnings.warn(
-                "The column_external_ids argument is deprecated. Use the columns argument instead.", stacklevel=2
+                "The column_external_ids argument is deprecated. Use the columns argument instead.",
+                DeprecationWarning,
+                stacklevel=2,
             )
 
         columns = columns or column_external_ids
@@ -1162,12 +1164,14 @@ class SequencesDataAPI(APIClient):
         """
         if column_external_ids is not None:
             warnings.warn(
-                "The column_external_ids argument is deprecated. Use the columns argument instead.", stacklevel=2
+                "The column_external_ids argument is deprecated. Use the columns argument instead.",
+                DeprecationWarning,
+                stacklevel=2,
             )
         columns = columns or column_external_ids
         identifier = Identifier.of_either(id, external_id).as_dict()
         res = self._do_request(
-            "POST", self._DATA_PATH + "/latest", json={**identifier, "before": before, "columns": column_external_ids}
+            "POST", self._DATA_PATH + "/latest", json={**identifier, "before": before, "columns": columns}
         ).json()
         return SequenceRows.load(res)
 

--- a/cognite/client/_api/sequences.py
+++ b/cognite/client/_api/sequences.py
@@ -858,8 +858,8 @@ class SequencesDataAPI(APIClient):
         | dict[int, typing.Sequence[int | float | str]]
         | typing.Sequence[tuple[int, typing.Sequence[int | float | str]]]
         | typing.Sequence[dict[str, Any]],
-        columns: SequenceNotStr[str] | None,
-        column_external_ids: SequenceNotStr[str] | None,
+        columns: SequenceNotStr[str] | None = None,
+        column_external_ids: SequenceNotStr[str] | None = None,
         id: int | None = None,
         external_id: str | None = None,
     ) -> None:

--- a/cognite/client/data_classes/_base.py
+++ b/cognite/client/data_classes/_base.py
@@ -140,8 +140,8 @@ class CogniteObject:
         """
         return basic_instance_dump(self, camel_case=camel_case)
 
-    @classmethod
     @final
+    @classmethod
     def load(cls, resource: dict | str, cognite_client: CogniteClient | None = None) -> Self:
         """Load a resource from a YAML/JSON string or dict."""
         if isinstance(resource, dict):

--- a/cognite/client/data_classes/sequences.py
+++ b/cognite/client/data_classes/sequences.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import json
 import typing
 import warnings
-from collections.abc import Collection
 from typing import TYPE_CHECKING, Any, Iterator, List, Literal, NoReturn, Union, cast, get_args, overload
 
 from typing_extensions import Self, TypeAlias
@@ -586,12 +585,11 @@ class SequenceData(SequenceRows):
         self,
         id: int | None = None,
         external_id: str | None = None,
-        rows: typing.Sequence[dict] | None = None,
+        rows: typing.Sequence[dict] | typing.Sequence[SequenceRow] | None = None,
         row_numbers: typing.Sequence[int] | None = None,
         values: typing.Sequence[typing.Sequence[int | str | float]] | None = None,
-        columns: typing.Sequence[dict[str, Any]] | None = None,
+        columns: typing.Sequence[dict[str, Any]] | SequenceColumnList | None = None,
     ):
-        warnings.warn("SequenceData is deprecated, use SequenceRows instead", DeprecationWarning)
         # Conversion for backwards compatibility
         rows_parsed: list[SequenceRow]
         if rows and isinstance(rows, list) and rows and isinstance(rows[0], dict):
@@ -603,6 +601,7 @@ class SequenceData(SequenceRows):
                 raise ValueError(
                     f"row_numbers and values must have same length, got {len(row_numbers)} and {len(values)}"
                 )
+            warnings.warn("row_numbers and values are deprecated, use rows instead", DeprecationWarning, stacklevel=2)
             rows_parsed = [SequenceRow(row_number, value) for row_number, value in zip(row_numbers, values)]
         else:
             raise ValueError("Either rows or both row_numbers and values must be specified")
@@ -683,10 +682,7 @@ class SequenceRowsList(CogniteResourceList[SequenceRows]):
         raise ValueError(f"Invalid key value '{key}', should be one of ['id', 'external_id']")
 
 
-class SequencesDataList(SequenceRowsList):
-    def __init__(self, resources: Collection[Any], cognite_client: CogniteClient | None = None) -> None:
-        super().__init__(resources, cognite_client)
-        warnings.warn("SequencesDataList is deprecated, use SequenceRowsList instead", DeprecationWarning)
+SequenceDataList = SequenceRowsList
 
 
 class SequenceProperty(EnumProperty):

--- a/cognite/client/data_classes/sequences.py
+++ b/cognite/client/data_classes/sequences.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 import typing
 import warnings
+from collections.abc import Collection
 from typing import TYPE_CHECKING, Any, Iterator, List, Literal, NoReturn, Union, cast, get_args, overload
 
 from typing_extensions import Self, TypeAlias
@@ -695,6 +696,12 @@ class SequenceRowsList(CogniteResourceList[SequenceRows]):
             return {seq.id: seq.to_pandas(column_names) for seq in self}
 
         raise ValueError(f"Invalid key value '{key}', should be one of ['id', 'external_id']")
+
+
+class SequencesDataList(SequenceRowsList):
+    def __init__(self, resources: Collection[Any], cognite_client: CogniteClient | None = None) -> None:
+        super().__init__(resources, cognite_client)
+        warnings.warn("SequencesDataList is deprecated, use SequenceRowsList instead", DeprecationWarning)
 
 
 class SequenceProperty(EnumProperty):

--- a/cognite/client/data_classes/sequences.py
+++ b/cognite/client/data_classes/sequences.py
@@ -74,21 +74,6 @@ class SequenceColumn(CogniteResource):
         resource = convert_all_keys_to_camel_case(resource)
         return super()._load(resource, cognite_client)
 
-    def as_write(self) -> Self:
-        """
-        Returns the write version of the Sequence Column
-
-        Returns:
-            Self: Write version of the Sequence Column
-        """
-        return type(self)(
-            external_id=self.external_id,
-            name=self.name,
-            description=self.description,
-            value_type=self.value_type,
-            metadata=self.metadata.copy() if self.metadata is not None else None,
-        )
-
 
 class SequenceColumnList(CogniteResourceList[SequenceColumn], ExternalIDTransformerMixin):
     _RESOURCE = SequenceColumn


### PR DESCRIPTION
## Description
This is made from the experience with migrating to v7 in PowerOps which use Sequences a lot, to make the transition as easy as possible. 

## Checklist:
- [ ] Tests added/updated.
- [ ] Documentation updated. Documentation is generated from docstrings - these must be updated according to your change.
  If a new method has been added it should be referenced in [cognite.rst](https://github.com/cognitedata/cognite-sdk-python/blob/master/docs/source/cognite.rst) in order to generate docs based on its docstring.
- [ ] Changelog updated in [CHANGELOG.md](https://github.com/cognitedata/cognite-sdk-python/blob/master/CHANGELOG.md).
- [ ] Version bumped. If triggering a new release is desired, bump the version number in [_version.py](https://github.com/cognitedata/cognite-sdk-python/blob/master/cognite/client/_version.py) and [pyproject.toml](https://github.com/cognitedata/cognite-sdk-python/blob/master/pyproject.toml) per [semantic versioning](https://semver.org/).
