### PR TITLE
[v7] feature: Compare capabilities and add validation

### DIFF
--- a/cognite/client/_api/iam.py
+++ b/cognite/client/_api/iam.py
@@ -178,7 +178,7 @@ class TokenAPI(APIClient):
                 >>> c = CogniteClient()
                 >>> res = c.iam.token.inspect()
         """
-        return TokenInspection.load(self._get("/api/v1/token/inspect").json())
+        return TokenInspection.load(self._get("/api/v1/token/inspect").json(), self._cognite_client)
 
 
 class SessionsAPI(APIClient):

--- a/cognite/client/data_classes/capabilities.py
+++ b/cognite/client/data_classes/capabilities.py
@@ -7,6 +7,7 @@ from abc import ABC
 from dataclasses import asdict, dataclass, field
 from itertools import groupby, product
 from operator import itemgetter
+from types import MappingProxyType
 from typing import TYPE_CHECKING, Any, ClassVar, Sequence, cast
 
 from typing_extensions import Self
@@ -31,6 +32,22 @@ class Capability(ABC):
     _capability_name: ClassVar[str]
     actions: Sequence[Action]
     scope: Scope
+
+    def __post_init__(self) -> None:
+        if (capability_cls := type(self)) is UnknownAcl:
+            return
+        acl = capability_cls.__name__
+        if bad_actions := [a for a in self.actions if a not in capability_cls.Action]:
+            raise ValueError(
+                f"{acl} got an unknown action: {bad_actions}, expected one of: {list(capability_cls.Action)}. "
+                f"Example usage: AssetsAcl(actions=[AssetsAcl.Action.Read], scope=AssetsAcl.Scope.All())"
+            )
+        allowed_scopes = _VALID_SCOPES_BY_CAPABILITY[capability_cls]
+        if allowed_scopes and type(self.scope) not in allowed_scopes:
+            raise ValueError(
+                f"{acl} got an unknown scope: {self.scope}, expected one of: {[s.__name__ for s in allowed_scopes]}. "
+                f"Example usage: AssetsAcl(actions=[AssetsAcl.Action.Read], scope=AssetsAcl.Scope.All())"
+            )
 
     class Action(enum.Enum):
         ...
@@ -1150,3 +1167,8 @@ for acl in _CAPABILITY_CLASS_BY_NAME.values():
     if acl.Action.__members__:
         _cls = type(next(iter(acl.Action.__members__.values())))
         _cls.__name__ = f"{acl.__name__} {_cls.__name__}"
+
+# Add lookup that knows which acls support which scopes:
+_VALID_SCOPES_BY_CAPABILITY: MappingProxyType[type[Capability], frozenset[type[Capability.Scope]]] = MappingProxyType(
+    {acl: frozenset(filter(inspect.isclass, vars(acl.Scope).values())) for acl in _CAPABILITY_CLASS_BY_NAME.values()}
+)

--- a/cognite/client/data_classes/capabilities.py
+++ b/cognite/client/data_classes/capabilities.py
@@ -13,7 +13,7 @@ from typing import TYPE_CHECKING, Any, ClassVar, Sequence, cast
 from typing_extensions import Self
 
 from cognite.client.data_classes._base import CogniteResource, CogniteResourceList
-from cognite.client.utils._auxiliary import combine_sets, load_yaml_or_json, rename_and_exclude_keys
+from cognite.client.utils._auxiliary import load_yaml_or_json, rename_and_exclude_keys
 from cognite.client.utils._text import (
     convert_all_keys_to_camel_case,
     convert_all_keys_to_snake_case,
@@ -235,7 +235,7 @@ class ProjectCapabilitiesList(CogniteResourceList[ProjectCapability]):
 
     def as_tuples(self, project: str | None = None) -> set[tuple]:
         project = self._infer_project(project)
-        return combine_sets(
+        return set().union(
             *(
                 proj_cap.capability.as_tuples()
                 for proj_cap in self
@@ -281,7 +281,7 @@ class ProjectCapabilitiesList(CogniteResourceList[ProjectCapability]):
         """
         project = self._infer_project(project)
         has_capabilities = self.as_tuples(project)
-        to_check = combine_sets(*(c.as_tuples() for c in capabilities))
+        to_check = set().union(*(c.as_tuples() for c in capabilities))
         missing = to_check - has_capabilities
 
         if ignore_allscope_meaning:

--- a/cognite/client/data_classes/capabilities.py
+++ b/cognite/client/data_classes/capabilities.py
@@ -82,7 +82,7 @@ class Capability(ABC):
             scope = scope_cls()
         elif len(scope_params) == 1:
             scope = scope_cls(scope_params)  # type: ignore [call-arg]
-        elif len(scope_params) == 2 and scope_name == TableScope._scope_name:
+        elif len(scope_params) == 2 and scope_cls is TableScope:
             db, tbl = scope_params
             scope = scope_cls({db: [tbl]})  # type: ignore [call-arg]
         else:

--- a/cognite/client/data_classes/capabilities.py
+++ b/cognite/client/data_classes/capabilities.py
@@ -511,7 +511,7 @@ class AssetsAcl(Capability):
 class DataSetsAcl(Capability):
     _capability_name = "datasetsAcl"
     actions: Sequence[Action]
-    scope: AllScope | DataSetScope
+    scope: AllScope | IDScope
 
     class Action(Capability.Action):
         Read = "READ"
@@ -520,7 +520,7 @@ class DataSetsAcl(Capability):
 
     class Scope:
         All = AllScope
-        DataSet = DataSetScope
+        ID = IDScope
 
 
 @dataclass

--- a/cognite/client/data_classes/capabilities.py
+++ b/cognite/client/data_classes/capabilities.py
@@ -989,6 +989,19 @@ class WorkflowOrchestrationAcl(Capability):
         All = AllScope
 
 
+@dataclass
+class UserProfilesAcl(Capability):
+    _capability_name = "userProfilesAcl"
+    actions: Sequence[Action]
+    scope: AllScope = field(default_factory=AllScope)
+
+    class Action(Capability.Action):
+        Read = "READ"
+
+    class Scope:
+        All = AllScope
+
+
 _CAPABILITY_CLASS_BY_NAME: dict[str, type[Capability]] = {
     c._capability_name: c for c in Capability.__subclasses__() if not issubclass(c, UnknownAcl)
 }

--- a/cognite/client/data_classes/capabilities.py
+++ b/cognite/client/data_classes/capabilities.py
@@ -164,11 +164,10 @@ class ProjectCapability(CogniteResource):
 
     @classmethod
     def _load(cls, resource: dict, cognite_client: CogniteClient | None = None) -> Self:
-        capability = next(key for key in resource if key != "projectScope")
-
+        project_scope_dct = {ProjectScope.name: resource.pop(ProjectScope.name)}
         return cls(
-            capability=Capability.load({capability: resource[capability]}),
-            project_scope=ProjectScope.load({ProjectScope.name: resource[ProjectScope.name]}),
+            capability=Capability.load(resource),
+            project_scope=ProjectScope.load(project_scope_dct),
         )
 
     def dump(self, camel_case: bool = True) -> dict[str, Any]:

--- a/cognite/client/data_classes/capabilities.py
+++ b/cognite/client/data_classes/capabilities.py
@@ -267,6 +267,7 @@ class ProjectCapabilitiesList(CogniteResourceList[ProjectCapability]):
             and write events scoped to a specific dataset with id=123:
 
                 >>> from cognite.client import CogniteClient
+                >>> from cognite.client.data_classes.capabilities import AssetsAcl, EventsAcl
                 >>> client = CogniteClient()
                 >>> capabilities = client.iam.token.inspect().capabilities
                 >>> capabilities.compare([

--- a/cognite/client/data_classes/capabilities.py
+++ b/cognite/client/data_classes/capabilities.py
@@ -302,6 +302,9 @@ class IDScope(Capability.Scope):
     _scope_name = "idScope"
     ids: list[int]
 
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "ids", [int(i) for i in self.ids])
+
     def as_tuples(self) -> set[tuple]:
         return {(self._scope_name, i) for i in self.ids}
 
@@ -314,6 +317,9 @@ class ExtractionPipelineScope(Capability.Scope):
     _scope_name = "extractionPipelineScope"
     ids: list[int]
 
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "ids", [int(i) for i in self.ids])
+
     def as_tuples(self) -> set[tuple]:
         return {(self._scope_name, i) for i in self.ids}
 
@@ -325,6 +331,9 @@ class ExtractionPipelineScope(Capability.Scope):
 class DataSetScope(Capability.Scope):
     _scope_name = "datasetScope"
     ids: list[int]
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "ids", [int(i) for i in self.ids])
 
     def as_tuples(self) -> set[tuple]:
         return {(self._scope_name, i) for i in self.ids}
@@ -370,6 +379,9 @@ class TableScope(Capability.Scope):
 class AssetRootIDScope(Capability.Scope):
     _scope_name = "assetRootIdScope"
     root_ids: list[int]
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "root_ids", [int(i) for i in self.root_ids])
 
     def as_tuples(self) -> set[tuple]:
         return {(self._scope_name, i) for i in self.root_ids}

--- a/cognite/client/data_classes/iam.py
+++ b/cognite/client/data_classes/iam.py
@@ -159,11 +159,11 @@ class TokenInspection(CogniteResponse):
         self.capabilities = capabilities
 
     @classmethod
-    def load(cls, api_response: dict[str, Any]) -> TokenInspection:
+    def load(cls, api_response: dict[str, Any], cognite_client: CogniteClient | None = None) -> TokenInspection:
         return cls(
             subject=api_response["subject"],
             projects=[ProjectSpec.load(p) for p in api_response["projects"]],
-            capabilities=ProjectCapabilitiesList.load(api_response["capabilities"]),
+            capabilities=ProjectCapabilitiesList.load(api_response["capabilities"], cognite_client),
         )
 
     def dump(self, camel_case: bool = True) -> dict[str, Any]:

--- a/cognite/client/utils/_auxiliary.py
+++ b/cognite/client/utils/_auxiliary.py
@@ -243,3 +243,7 @@ def load_resource(dct: dict[str, Any], cls: type[T_CogniteResource], key: str) -
 
 def unpack_items_in_payload(payload: dict[str, dict[str, Any]]) -> list:
     return payload["json"]["items"]
+
+
+def combine_sets(*sets: set[T] | frozenset[T]) -> set[T]:
+    return set().union(*sets)

--- a/cognite/client/utils/_auxiliary.py
+++ b/cognite/client/utils/_auxiliary.py
@@ -243,7 +243,3 @@ def load_resource(dct: dict[str, Any], cls: type[T_CogniteResource], key: str) -
 
 def unpack_items_in_payload(payload: dict[str, dict[str, Any]]) -> list:
     return payload["json"]["items"]
-
-
-def combine_sets(*sets: set[T] | frozenset[T]) -> set[T]:
-    return set().union(*sets)

--- a/tests/tests_unit/test_data_classes/test_capabilities.py
+++ b/tests/tests_unit/test_data_classes/test_capabilities.py
@@ -237,7 +237,7 @@ def proj_capabs_list(project_name):
                 project_scope=ProjectCapability.Scope.All(),
             ),
             ProjectCapability(
-                capability=EventsAcl([EventsAcl.Action.Write], scope=EventsAcl.Scope.DataSet([1, 2])),
+                capability=EventsAcl([EventsAcl.Action.Write], scope=EventsAcl.Scope.DataSet(["1", 2])),
                 project_scope=ProjectCapability.Scope.Projects([project_name]),
             ),
             ProjectCapability(
@@ -262,7 +262,7 @@ class TestProjectCapabilitiesList:
         "capability",
         [
             EventsAcl([EventsAcl.Action.Read], scope=EventsAcl.Scope.All()),
-            EventsAcl([EventsAcl.Action.Write], scope=EventsAcl.Scope.DataSet([1, 2])),
+            EventsAcl([EventsAcl.Action.Write], scope=EventsAcl.Scope.DataSet([1, "2"])),
             RawAcl([RawAcl.Action.Read], scope=RawAcl.Scope.Table({"my_db": ["my_table"]})),
         ],
     )
@@ -275,6 +275,7 @@ class TestProjectCapabilitiesList:
         "capability",
         [
             EventsAcl([EventsAcl.Action.Write], scope=EventsAcl.Scope.All()),
+            EventsAcl([EventsAcl.Action.Write], scope=EventsAcl.Scope.DataSet(["3"])),
             EventsAcl([EventsAcl.Action.Write], scope=EventsAcl.Scope.DataSet([3])),
             RawAcl([RawAcl.Action.Read], scope=RawAcl.Scope.Table({"my_db": ["unknown_table"]})),
             RawAcl([RawAcl.Action.Read], scope=RawAcl.Scope.Table({"unknown_db": ["my_table"]})),

--- a/tests/tests_unit/test_data_classes/test_capabilities.py
+++ b/tests/tests_unit/test_data_classes/test_capabilities.py
@@ -216,128 +216,75 @@ class TestCapabilities:
 
 
 @pytest.fixture
-def proj_cap_allprojects():
+def proj_cap_allprojects_dct():
     return {
         "labelsAcl": {"actions": ["READ"], "scope": {"all": {}}},
         "projectScope": {"allProjects": {}},
     }
 
 
+@pytest.fixture
+def project_name():
+    return "my-project"
+
+
+@pytest.fixture
+def proj_capabs_list(project_name):
+    return ProjectCapabilitiesList(
+        [
+            ProjectCapability(
+                capability=EventsAcl([EventsAcl.Action.Read], scope=EventsAcl.Scope.All()),
+                project_scope=ProjectCapability.Scope.All(),
+            ),
+            ProjectCapability(
+                capability=EventsAcl([EventsAcl.Action.Write], scope=EventsAcl.Scope.DataSet([1, 2])),
+                project_scope=ProjectCapability.Scope.Projects([project_name]),
+            ),
+            ProjectCapability(
+                capability=RawAcl(
+                    [RawAcl.Action.Read], scope=RawAcl.Scope.Table({"my_db": ["my_table", "my_other_table"]})
+                ),
+                project_scope=ProjectCapability.Scope.Projects([project_name]),
+            ),
+        ]
+    )
+
+
 class TestProjectCapabilitiesList:
-    def test_project_scope_is_all_projects(self, proj_cap_allprojects):
-        loaded = ProjectCapability.load(proj_cap_allprojects.copy())
+    def test_project_scope_is_all_projects(self, proj_cap_allprojects_dct):
+        loaded = ProjectCapability.load(proj_cap_allprojects_dct.copy())
         assert type(loaded.project_scope) is AllProjectsScope
 
-        loaded = ProjectCapabilitiesList.load([proj_cap_allprojects])
+        loaded = ProjectCapabilitiesList.load([proj_cap_allprojects_dct])
         assert type(loaded[0].project_scope) is AllProjectsScope
 
     @pytest.mark.parametrize(
-        "capabilities, capability, expected",
+        "capability",
         [
-            (
-                ProjectCapabilitiesList(
-                    [
-                        ProjectCapability(
-                            capability=EventsAcl(
-                                [EventsAcl.Action.Read, EventsAcl.Action.Write], scope=EventsAcl.Scope.All()
-                            ),
-                            project_scope=ProjectCapability.Scope.All(),
-                        )
-                    ]
-                ),
-                EventsAcl([EventsAcl.Action.Read], scope=EventsAcl.Scope.DataSet([1])),
-                True,
-            ),
-            (
-                ProjectCapabilitiesList(
-                    [
-                        ProjectCapability(
-                            capability=EventsAcl([EventsAcl.Action.Read], scope=EventsAcl.Scope.All()),
-                            project_scope=ProjectCapability.Scope.All(),
-                        )
-                    ]
-                ),
-                EventsAcl([EventsAcl.Action.Write], scope=EventsAcl.Scope.All()),
-                False,
-            ),
-            (
-                ProjectCapabilitiesList(
-                    [
-                        ProjectCapability(
-                            capability=EventsAcl([EventsAcl.Action.Read], scope=EventsAcl.Scope.DataSet([1, 2])),
-                            project_scope=ProjectCapability.Scope.All(),
-                        )
-                    ]
-                ),
-                EventsAcl([EventsAcl.Action.Read], scope=EventsAcl.Scope.DataSet([1])),
-                True,
-            ),
-            (
-                ProjectCapabilitiesList(
-                    [
-                        ProjectCapability(
-                            capability=EventsAcl([EventsAcl.Action.Read], scope=EventsAcl.Scope.DataSet([1, 2])),
-                            project_scope=ProjectCapability.Scope.All(),
-                        )
-                    ]
-                ),
-                EventsAcl([EventsAcl.Action.Read], scope=EventsAcl.Scope.DataSet([3])),
-                False,
-            ),
-            (
-                ProjectCapabilitiesList(
-                    [
-                        ProjectCapability(
-                            capability=RawAcl(
-                                [RawAcl.Action.Read],
-                                scope=RawAcl.Scope.Table({"my_db": ["my_table", "my_other_table"]}),
-                            ),
-                            project_scope=ProjectCapability.Scope.All(),
-                        )
-                    ]
-                ),
-                RawAcl([RawAcl.Action.Read], scope=RawAcl.Scope.Table({"my_db": ["my_table"]})),
-                True,
-            ),
-            (
-                ProjectCapabilitiesList(
-                    [
-                        ProjectCapability(
-                            capability=RawAcl(
-                                [RawAcl.Action.Read],
-                                scope=RawAcl.Scope.Table({"my_db": ["my_table", "my_other_table"]}),
-                            ),
-                            project_scope=ProjectCapability.Scope.All(),
-                        )
-                    ]
-                ),
-                RawAcl(
-                    [RawAcl.Action.Read],
-                    scope=RawAcl.Scope.Table({"my_db": ["unknown_table"]}),
-                ),
-                False,
-            ),
-            (
-                ProjectCapabilitiesList(
-                    [
-                        ProjectCapability(
-                            capability=RawAcl(
-                                [RawAcl.Action.Read],
-                                scope=RawAcl.Scope.Table({"my_db": ["my_table", "my_other_table"]}),
-                            ),
-                            project_scope=ProjectCapability.Scope.All(),
-                        )
-                    ]
-                ),
-                RawAcl(
-                    [RawAcl.Action.Read],
-                    scope=RawAcl.Scope.Table({"unknown_db": ["my_table"]}),
-                ),
-                False,
-            ),
+            EventsAcl([EventsAcl.Action.Read], scope=EventsAcl.Scope.All()),
+            EventsAcl([EventsAcl.Action.Write], scope=EventsAcl.Scope.DataSet([1, 2])),
+            RawAcl([RawAcl.Action.Read], scope=RawAcl.Scope.Table({"my_db": ["my_table"]})),
         ],
     )
     def test_has_capability(
-        self, capabilities: ProjectCapabilitiesList, capability: Capability, expected: bool
+        self, proj_capabs_list: ProjectCapabilitiesList, project_name: str, capability: Capability
     ) -> None:
-        assert capabilities.includes_capability(capability) is expected
+        assert not proj_capabs_list.compare([capability], project=project_name)
+
+    @pytest.mark.parametrize(
+        "capability",
+        [
+            EventsAcl([EventsAcl.Action.Write], scope=EventsAcl.Scope.All()),
+            EventsAcl([EventsAcl.Action.Write], scope=EventsAcl.Scope.DataSet([3])),
+            RawAcl([RawAcl.Action.Read], scope=RawAcl.Scope.Table({"my_db": ["unknown_table"]})),
+            RawAcl([RawAcl.Action.Read], scope=RawAcl.Scope.Table({"unknown_db": ["my_table"]})),
+        ],
+    )
+    def test_is_missing_capability(
+        self, proj_capabs_list: ProjectCapabilitiesList, project_name: str, capability: Capability
+    ) -> None:
+        missing_acls = proj_capabs_list.compare([capability], project=project_name)
+        assert missing_acls == [capability]
+
+        missing_acls = proj_capabs_list.compare([capability], project="do-es-nt-ex-is-ts")
+        assert missing_acls == [capability]


### PR DESCRIPTION
## Description
Adds the feature of easily comparing capabilities across groups.

Also

- add validation to all Acls on instantiation
- pass client ref to `ProjectCapabilitiesList`
- add missing acl: `UserProfilesAcl`
- fix `TableScope`, remove `DatabaseTableScope`
- Simplify `ProjectCapability`

## Checklist:
- [x] Tests added/updated.
- [x] Documentation updated. Documentation is generated from docstrings - these must be updated according to your change.
  If a new method has been added it should be referenced in [cognite.rst](https://github.com/cognitedata/cognite-sdk-python/blob/master/docs/source/cognite.rst) in order to generate docs based on its docstring.