### PR TITLE
chore: fix renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,8 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:base"
+    "local>cognitedata/renovate-config-public",
+    ":automergeMinor"
   ],
   "packageRules": [
     {
@@ -12,5 +13,9 @@
   ],
   "vulnerabilityAlerts": {
     "enabled": true
-  }
+  },
+  "labels": [
+    "dependencies",
+    "auto-merge"
+  ]
 }


### PR DESCRIPTION
## Description

Fixes for renovate config. Extend the Cognite [public renovate config](https://github.com/cognitedata/renovate-config-public). Add `auto-merge` label. Similar change as https://github.com/cognitedata/indsl/pull/35 

## Checklist:
- [ ] Tests added/updated.
- [ ] Documentation updated. Documentation is generated from docstrings - these must be updated according to your change.
  If a new method has been added it should be referenced in [cognite.rst](https://github.com/cognitedata/cognite-sdk-python/blob/master/docs/source/cognite.rst) in order to generate docs based on its docstring.
- [ ] Changelog updated in [CHANGELOG.md](https://github.com/cognitedata/cognite-sdk-python/blob/master/CHANGELOG.md).
- [ ] Version bumped. If triggering a new release is desired, bump the version number in [_version.py](https://github.com/cognitedata/cognite-sdk-python/blob/master/cognite/client/_version.py) and [pyproject.toml](https://github.com/cognitedata/cognite-sdk-python/blob/master/pyproject.toml) per [semantic versioning](https://semver.org/).
