### PR TITLE
fix: copy-stransformation

### DIFF
--- a/cognite/client/data_classes/transformations/__init__.py
+++ b/cognite/client/data_classes/transformations/__init__.py
@@ -214,8 +214,8 @@ class Transformation(CogniteResource):
             self.last_updated_time,
             self.owner,
             self.owner_is_current_user,
-            self.has_source_oidc_credentials,
-            self.has_destination_oidc_credentials,
+            None,  # has source oidc credentials is a property
+            None,  # has destination oidc credentials is a property
             self.running_job,
             self.last_finished_job,
             self.blocked,


### PR DESCRIPTION
## Description
Currently, you get this warning when you try to create a new transformation
```
UserWarning: The arguments 'has_source_oidc_credentials' and 'has_destination_oidc_credentials' are deprecated and will be removed in a future version.These are now properties returning whether the transformation has source or destination oidc credentials set.
```
due to the call to `.copy()` in the `client.transformations.create`

## Checklist:
- [ ] Tests added/updated.
- [ ] Documentation updated. Documentation is generated from docstrings - these must be updated according to your change.
  If a new method has been added it should be referenced in [cognite.rst](https://github.com/cognitedata/cognite-sdk-python/blob/master/docs/source/cognite.rst) in order to generate docs based on its docstring.
- [ ] Changelog updated in [CHANGELOG.md](https://github.com/cognitedata/cognite-sdk-python/blob/master/CHANGELOG.md).
- [ ] Version bumped. If triggering a new release is desired, bump the version number in [_version.py](https://github.com/cognitedata/cognite-sdk-python/blob/master/cognite/client/_version.py) and [pyproject.toml](https://github.com/cognitedata/cognite-sdk-python/blob/master/pyproject.toml) per [semantic versioning](https://semver.org/).
