### PR TITLE
Revise retry logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,13 @@ Changes are grouped as follows
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
+## [6.39.6] - 2023-11-13
+## Fixed
+- HTTP status code retry strategy for RAW and labels. `/rows/insert` and `/rows/delete` will now 
+be retried for all status codes in `config.status_forcelist` (default 429, 502, 503, 504), while 
+`/dbs/{db}` and `/tables/{table}` will now only be retried for 429s and connection errors as those 
+endpoints are not idempotent. Also `labels/list` will now also be retried.
+
 ## [6.39.5] - 2023-11-12
 ## Fixed
 - The `.apply()` methods of `MappedProperty` was missing property `source`.

--- a/cognite/client/_api_client.py
+++ b/cognite/client/_api_client.py
@@ -75,12 +75,11 @@ class APIClient:
     _RETRYABLE_POST_ENDPOINT_REGEX_PATTERNS: ClassVar[frozenset[str]] = frozenset(
         rf"^{path}(\?.*)?$"
         for path in (
-            "/(assets|events|files|timeseries|sequences|datasets|relationships)/(list|byids|search|aggregate)",
+            "/(assets|events|files|timeseries|sequences|datasets|relationships|labels)/(list|byids|search|aggregate)",
             "/files/downloadlink",
-            "/timeseries/data",
-            "/timeseries/data/(list|latest|delete)",
-            "/sequences/data",
-            "/sequences/data/(list|delete)",
+            "/timeseries/data(/(list|latest|delete))?",
+            "/timeseries/synthetic/query",
+            "/sequences/data(/(list|delete))?",
             "/raw/dbs/[^/]+/tables/[^/]+/rows/.*",
             "/context/entitymatching/(byids|list|jobs)",
             "/sessions/revoke",

--- a/cognite/client/_api_client.py
+++ b/cognite/client/_api_client.py
@@ -81,7 +81,7 @@ class APIClient:
             "/timeseries/data/(list|latest|delete)",
             "/sequences/data",
             "/sequences/data/(list|delete)",
-            "/raw/dbs/[^/]+/tables/[^/]+",
+            "/raw/dbs/[^/]+/tables/[^/]+/rows/.*",
             "/context/entitymatching/(byids|list|jobs)",
             "/sessions/revoke",
             "/models/.*",

--- a/cognite/client/_version.py
+++ b/cognite/client/_version.py
@@ -1,4 +1,4 @@
 from __future__ import annotations
 
-__version__ = "6.39.5"
+__version__ = "6.39.6"
 __api_subversion__ = "V20220125"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "cognite-sdk"
 
-version = "6.39.5"
+version = "6.39.6"
 description = "Cognite Python SDK"
 readme = "README.md"
 documentation = "https://cognite-sdk-python.readthedocs-hosted.com"

--- a/tests/tests_unit/test_api_client.py
+++ b/tests/tests_unit/test_api_client.py
@@ -1199,7 +1199,6 @@ class TestHelpers:
             ("POST", "https://greenfield.cognitedata.com/api/playground/projects/blabla/relationships/list", True),
             ("PUT", "https://localhost:8000.com/api/v1/projects/blabla/assets", True),
             ("PATCH", "https://localhost:8000.com/api/v1/projects/blabla/patchy", True),
-            ("POST", "https://api.cognitedata.com/api/v1/projects/bla/raw/dbs/mydb/tables/mytable", True),
             ("POST", "https://api.cognitedata.com/api/v1/projects/bla/assets/list", True),
             ("POST", "https://api.cognitedata.com/api/v1/projects/bla/events/byids", True),
             ("POST", "https://api.cognitedata.com/api/v1/projects/bla/files/search", True),
@@ -1212,6 +1211,16 @@ class TestHelpers:
             ("POST", "https://api.cognitedata.com/api/v1/projects/bla/models/containers", True),
             ("POST", "https://api.cognitedata.com/api/v1/projects/bla/models/views", True),
             ("POST", "https://api.cognitedata.com/api/v1/projects/bla/models/datamodels", True),
+            (
+                "POST",
+                "https://api.cognitedata.com/api/v1/projects/bla/raw/dbs/somedb/tables/sometable/rows/insert",
+                True,
+            ),
+            (
+                "POST",
+                "https://api.cognitedata.com/api/v1/projects/bla/raw/dbs/somedb/tables/sometable/rows/delete",
+                True,
+            ),
         ],
     )
     def test_is_retryable(self, api_client_with_token, method, path, expected):


### PR DESCRIPTION
## Description
- Retry http codes in config.status_config_forcelist for idempotent RAW rows endpoints.
- Refactor and clarify tests for http status retry logic
- Bump version and update changelog

## Checklist:
- [x] Tests added/updated.
- [x] Documentation updated. Documentation is generated from docstrings - these must be updated according to your change.
  If a new method has been added it should be referenced in [cognite.rst](https://github.com/cognitedata/cognite-sdk-python/blob/master/docs/source/cognite.rst) in order to generate docs based on its docstring.
- [x] Changelog updated in [CHANGELOG.md](https://github.com/cognitedata/cognite-sdk-python/blob/master/CHANGELOG.md).
- [x] Version bumped. If triggering a new release is desired, bump the version number in [_version.py](https://github.com/cognitedata/cognite-sdk-python/blob/master/cognite/client/_version.py) and [pyproject.toml](https://github.com/cognitedata/cognite-sdk-python/blob/master/pyproject.toml) per [semantic versioning](https://semver.org/).
