### PR TITLE
Added missing properties in ViewProperty.as_apply methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,11 @@ Changes are grouped as follows
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
+## [6.39.5] - 2023-11-12
+## Fixed
+- The `.apply()` methods on `SingleHopConnectionDefinition` and `MappedProperty` were missing properties `connection_type` and `source`.
+  This is now fixed.
+
 ## [6.39.4] - 2023-11-09
 ## Fixed
 - Fetching datapoints from dense time series using a `targetUnit` or a target `targetUnitSystem` could result

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ Changes are grouped as follows
 
 ## [6.39.5] - 2023-11-12
 ## Fixed
-- The `.apply()` methods on `SingleHopConnectionDefinition` and `MappedProperty` were missing properties `connection_type` and `source`.
+- The `.apply()` methods of `MappedProperty` was missing property `source`.
   This is now fixed.
 
 ## [6.39.4] - 2023-11-09

--- a/cognite/client/_version.py
+++ b/cognite/client/_version.py
@@ -1,4 +1,4 @@
 from __future__ import annotations
 
-__version__ = "6.39.4"
+__version__ = "6.39.5"
 __api_subversion__ = "V20220125"

--- a/cognite/client/data_classes/data_modeling/views.py
+++ b/cognite/client/data_classes/data_modeling/views.py
@@ -370,6 +370,7 @@ class MappedProperty(ViewProperty):
             container_property_identifier=self.container_property_identifier,
             name=self.name,
             description=self.description,
+            source=self.source,
         )
 
 
@@ -428,6 +429,7 @@ class SingleHopConnectionDefinition(ConnectionDefinition):
             description=self.description,
             edge_source=self.edge_source,
             direction=self.direction,
+            connection_type=self.connection_type,
         )
 
 

--- a/cognite/client/data_classes/data_modeling/views.py
+++ b/cognite/client/data_classes/data_modeling/views.py
@@ -429,7 +429,6 @@ class SingleHopConnectionDefinition(ConnectionDefinition):
             description=self.description,
             edge_source=self.edge_source,
             direction=self.direction,
-            connection_type=self.connection_type,
         )
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "cognite-sdk"
 
-version = "6.39.4"
+version = "6.39.5"
 description = "Cognite Python SDK"
 readme = "README.md"
 documentation = "https://cognite-sdk-python.readthedocs-hosted.com"


### PR DESCRIPTION
## Description
- The `.apply()` methods on `SingleHopConnectionDefinition` and `MappedProperty` were missing properties `connection_type` and `source`.
  This is now fixed.

## Checklist:
- [ ] Tests added/updated.
- [ ] Documentation updated. Documentation is generated from docstrings - these must be updated according to your change.
  If a new method has been added it should be referenced in [cognite.rst](https://github.com/cognitedata/cognite-sdk-python/blob/master/docs/source/cognite.rst) in order to generate docs based on its docstring.
- [x] Changelog updated in [CHANGELOG.md](https://github.com/cognitedata/cognite-sdk-python/blob/master/CHANGELOG.md).
- [x] Version bumped. If triggering a new release is desired, bump the version number in [_version.py](https://github.com/cognitedata/cognite-sdk-python/blob/master/cognite/client/_version.py) and [pyproject.toml](https://github.com/cognitedata/cognite-sdk-python/blob/master/pyproject.toml) per [semantic versioning](https://semver.org/).
