### PR TITLE
Add information about python version in CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,7 +9,7 @@ git clone https://github.com/cognitedata/cognite-sdk-python.git
 cd cognite-sdk-python
 ```
 
-We use [poetry](https://pypi.org/project/poetry/) for dependency- and virtual environment management.
+We use [poetry](https://pypi.org/project/poetry/) for dependency- and virtual environment management. Make sure you use python 3.8.
 
 Install dependencies and initialize a shell within the virtual environment, with these commands:
 


### PR DESCRIPTION
Failed installing using `poetry install -E all` on my mac, as the default version of python is 3.12 on my machine.