### PR TITLE
Add data set scoping to time series subscription capability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,11 @@ Changes are grouped as follows
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
+## [7.3.0] - 2023-11-20
+### Added
+- Added Scope `DataSet` for `TimeSeriesSubscriptionsAcl`.
+- Added `data_set_id` to `DatapointSubscription`.
+
 ## [7.2.1] - 2023-11-17
 ### Fixed
 - The new compare methods for capabilities in major version 7, `IAMAPI.verify_capabilities` and `IAMAPI.compare_capabilities`

--- a/cognite/client/_version.py
+++ b/cognite/client/_version.py
@@ -1,4 +1,4 @@
 from __future__ import annotations
 
-__version__ = "7.2.1"
+__version__ = "7.3.0"
 __api_subversion__ = "V20220125"

--- a/cognite/client/data_classes/capabilities.py
+++ b/cognite/client/data_classes/capabilities.py
@@ -819,6 +819,7 @@ class TimeSeriesSubscriptionsAcl(Capability):
 
     class Scope:
         All = AllScope
+        DataSet = DataSetScope
 
 
 @dataclass

--- a/cognite/client/data_classes/datapoints_subscriptions.py
+++ b/cognite/client/data_classes/datapoints_subscriptions.py
@@ -157,7 +157,7 @@ class DataPointSubscriptionCreate(DatapointSubscriptionCore):
             filter=filter,
             name=resource.get("name"),
             description=resource.get("description"),
-            data_set_id=resource.get("data_set_id"),
+            data_set_id=resource.get("dataSetId"),
         )
 
 

--- a/cognite/client/data_classes/datapoints_subscriptions.py
+++ b/cognite/client/data_classes/datapoints_subscriptions.py
@@ -52,6 +52,7 @@ class DatapointSubscriptionCore(CogniteResource):
         filter: Filter | None = None,
         name: str | None = None,
         description: str | None = None,
+        data_set_id: int | None = None,
         **_: Any,
     ) -> None:
         self.external_id = external_id
@@ -59,6 +60,7 @@ class DatapointSubscriptionCore(CogniteResource):
         self.filter = filter
         self.name = name
         self.description = description
+        self.data_set_id = data_set_id
 
     @classmethod
     def _load(
@@ -90,6 +92,7 @@ class DatapointSubscription(DatapointSubscriptionCore):
         filter (Filter | None): If present, the subscription is defined by this filter.
         name (str | None): No description.
         description (str | None): A summary explanation for the subscription.
+        data_set_id (int | None): The id of the dataset this subscription belongs to.
         **_ (Any): No description.
     """
 
@@ -103,9 +106,10 @@ class DatapointSubscription(DatapointSubscriptionCore):
         filter: Filter | None = None,
         name: str | None = None,
         description: str | None = None,
+        data_set_id: int | None = None,
         **_: Any,
     ) -> None:
-        super().__init__(external_id, partition_count, filter, name, description)
+        super().__init__(external_id, partition_count, filter, name, description, data_set_id)
         self.time_series_count = time_series_count
         self.created_time = created_time
         self.last_updated_time = last_updated_time
@@ -124,6 +128,7 @@ class DataPointSubscriptionCreate(DatapointSubscriptionCore):
         filter (Filter | None): A filter DSL (Domain Specific Language) to define advanced filter queries. Not compatible with time_series_ids.
         name (str | None): No description.
         description (str | None): A summary explanation for the subscription.
+        data_set_id (int | None): The id of the dataset this subscription belongs to.
     """
 
     def __init__(
@@ -134,11 +139,12 @@ class DataPointSubscriptionCreate(DatapointSubscriptionCore):
         filter: Filter | None = None,
         name: str | None = None,
         description: str | None = None,
+        data_set_id: int | None = None,
     ) -> None:
         if not exactly_one_is_not_none(time_series_ids, filter):
             raise ValueError("Exactly one of time_series_ids and filter must be given")
         _validate_filter(filter, _DATAPOINT_SUBSCRIPTION_SUPPORTED_FILTERS, "DataPointSubscriptions")
-        super().__init__(external_id, partition_count, filter, name, description)
+        super().__init__(external_id, partition_count, filter, name, description, data_set_id)
         self.time_series_ids = time_series_ids
 
     @classmethod
@@ -185,6 +191,10 @@ class DataPointSubscriptionUpdate(CogniteUpdate):
     @property
     def name(self) -> _PrimitiveDataPointSubscriptionUpdate:
         return DataPointSubscriptionUpdate._PrimitiveDataPointSubscriptionUpdate(self, "name")
+
+    @property
+    def data_set_id(self) -> _PrimitiveDataPointSubscriptionUpdate:
+        return DataPointSubscriptionUpdate._PrimitiveDataPointSubscriptionUpdate(self, "dataSetId")
 
     @property
     def time_series_ids(self) -> _ListDataPointSubscriptionUpdate:

--- a/cognite/client/data_classes/datapoints_subscriptions.py
+++ b/cognite/client/data_classes/datapoints_subscriptions.py
@@ -210,6 +210,7 @@ class DataPointSubscriptionUpdate(CogniteUpdate):
             PropertySpec("name"),
             PropertySpec("time_series_ids", is_container=True),
             PropertySpec("filter", is_nullable=False),
+            PropertySpec("data_set_id"),
         ]
 
 

--- a/cognite/client/data_classes/datapoints_subscriptions.py
+++ b/cognite/client/data_classes/datapoints_subscriptions.py
@@ -157,6 +157,7 @@ class DataPointSubscriptionCreate(DatapointSubscriptionCore):
             filter=filter,
             name=resource.get("name"),
             description=resource.get("description"),
+            data_set_id=resource.get("data_set_id"),
         )
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "cognite-sdk"
 
-version = "7.2.1"
+version = "7.3.0"
 description = "Cognite Python SDK"
 readme = "README.md"
 documentation = "https://cognite-sdk-python.readthedocs-hosted.com"

--- a/tests/tests_integration/test_api/test_datapoint_subscriptions.py
+++ b/tests/tests_integration/test_api/test_datapoint_subscriptions.py
@@ -100,6 +100,9 @@ class TestDatapointSubscriptions:
             assert created.last_updated_time
             assert created.time_series_count == len(new_subscription.time_series_ids)
             assert retrieved_subscription.external_id == new_subscription.external_id == created.external_id
+            assert retrieved_subscription.name == new_subscription.name == created.name
+            assert retrieved_subscription.description == new_subscription.description == created.description
+            assert retrieved_subscription.data_set_id == new_subscription.data_set_id == created.data_set_id
 
             time_series_in_subscription = cognite_client.time_series.subscriptions.list_member_time_series(
                 new_subscription.external_id, limit=10

--- a/tests/tests_integration/test_api/test_datapoint_subscriptions.py
+++ b/tests/tests_integration/test_api/test_datapoint_subscriptions.py
@@ -83,12 +83,14 @@ class TestDatapointSubscriptions:
     def test_create_retrieve_delete_subscription(
         self, cognite_client: CogniteClient, time_series_external_ids: list[str]
     ):
+        data_set = cognite_client.data_sets.list(limit=1)[0]
         # Arrange
         new_subscription = DataPointSubscriptionCreate(
             external_id=f"PYSDKDataPointSubscriptionCreateRetrieveDeleteTest-{random_string(10)}",
             name="PYSDKDataPointSubscriptionCreateRetrieveDeleteTest",
             time_series_ids=time_series_external_ids,
             partition_count=1,
+            data_set_id=data_set.id,
         )
         with create_subscription_with_cleanup(cognite_client, new_subscription) as created:
             retrieved_subscription = cognite_client.time_series.subscriptions.retrieve(new_subscription.external_id)
@@ -122,11 +124,13 @@ class TestDatapointSubscriptions:
             time_series_ids=time_series_external_ids,
             partition_count=1,
         )
+        data_set = cognite_client.data_sets.list(limit=1)[0]
         with create_subscription_with_cleanup(cognite_client, new_subscription):
             update = (
                 DataPointSubscriptionUpdate(new_subscription.external_id)
                 .name.set("New Name")
                 .time_series_ids.remove([time_series_external_ids[0]])
+                .data_set_id.set(data_set.id)
             )
 
             # Act
@@ -135,6 +139,7 @@ class TestDatapointSubscriptions:
             # Assert
             assert updated.name == "New Name"
             assert updated.time_series_count == len(time_series_external_ids) - 1
+            assert updated.data_set_id == data_set.id
 
     def test_update_filter_defined_subscription(self, cognite_client: CogniteClient):
         # Arrange


### PR DESCRIPTION
## Description
Add data set scoping to subscriptions.

## Checklist:
- [x] Tests added/updated.
- [x] Documentation updated. Documentation is generated from docstrings - these must be updated according to your change.
  If a new method has been added it should be referenced in [cognite.rst](https://github.com/cognitedata/cognite-sdk-python/blob/master/docs/source/cognite.rst) in order to generate docs based on its docstring.
- [x] Changelog updated in [CHANGELOG.md](https://github.com/cognitedata/cognite-sdk-python/blob/master/CHANGELOG.md).
- [x] Version bumped. If triggering a new release is desired, bump the version number in [_version.py](https://github.com/cognitedata/cognite-sdk-python/blob/master/cognite/client/_version.py) and [pyproject.toml](https://github.com/cognitedata/cognite-sdk-python/blob/master/pyproject.toml) per [semantic versioning](https://semver.org/).
