### PR TITLE
add `client_credentials` param to workflow execution trigger method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,11 @@ Changes are grouped as follows
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
+## [7.2.0] - 2023-11-16
+### Added
+- The `trigger` method of the Workflow Execution API, now accepts a `client_credentials` to allow specifying specific
+  credentials to run with. Previously, the current credentials set on the CogniteClient object doing the call would be used.
+
 ## [7.1.0] - 2023-11-16
 ### Added
 - The list method for asset mappings in the 3D API now supports `intersects_bounding_box`, allowing users to only

--- a/cognite/client/_api/workflows.py
+++ b/cognite/client/_api/workflows.py
@@ -187,8 +187,9 @@ class WorkflowExecutionAPI(BetaWorkflowAPIClient):
 
             Trigger a workflow execution using a specific set of client credentials (i.e. not your current credentials):
 
+                >>> import os
                 >>> from cognite.client.data_classes import ClientCredentials
-                >>> credentials = ClientCredentials("my-client-id", os.environ["MY_CLIENT_SECRET"]),
+                >>> credentials = ClientCredentials("my-client-id", os.environ["MY_CLIENT_SECRET"])
                 >>> res = c.workflows.executions.trigger("foo", "1", client_credentials=credentials)
         """
         self._warning.warn()

--- a/cognite/client/_version.py
+++ b/cognite/client/_version.py
@@ -1,4 +1,4 @@
 from __future__ import annotations
 
-__version__ = "7.1.0"
+__version__ = "7.2.0"
 __api_subversion__ = "V20220125"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "cognite-sdk"
 
-version = "7.1.0"
+version = "7.2.0"
 description = "Cognite Python SDK"
 readme = "README.md"
 documentation = "https://cognite-sdk-python.readthedocs-hosted.com"

--- a/tests/tests_unit/test_docstring_examples.py
+++ b/tests/tests_unit/test_docstring_examples.py
@@ -40,7 +40,7 @@ def run_docstring_tests(module):
 
 
 @patch("cognite.client.CogniteClient", CogniteClientMock)
-@patch("os.environ", defaultdict(lambda: "value"))
+@patch("os.environ", defaultdict(lambda: "value"))  # ensure env.var. lookups does not fail in doctests
 class TestDocstringExamples:
     def test_time_series(self):
         run_docstring_tests(time_series)

--- a/tests/tests_unit/test_docstring_examples.py
+++ b/tests/tests_unit/test_docstring_examples.py
@@ -1,4 +1,5 @@
 import doctest
+from collections import defaultdict
 from unittest import TextTestRunner
 from unittest.mock import patch
 
@@ -39,6 +40,7 @@ def run_docstring_tests(module):
 
 
 @patch("cognite.client.CogniteClient", CogniteClientMock)
+@patch("os.environ", defaultdict(lambda: "value"))
 class TestDocstringExamples:
     def test_time_series(self):
         run_docstring_tests(time_series)


### PR DESCRIPTION
## Description
### [7.1.0] - 2023-11-16
#### Added
- The `trigger` method of the Workflow Execution API, now accepts a `client_credentials` to allow specifying specific
  credentials to run with. Previously, the current credentials set on the CogniteClient object doing the call would be used.

## Checklist:
- [ ] Tests added/updated.
- [x] Documentation updated. Documentation is generated from docstrings - these must be updated according to your change.
  If a new method has been added it should be referenced in [cognite.rst](https://github.com/cognitedata/cognite-sdk-python/blob/master/docs/source/cognite.rst) in order to generate docs based on its docstring.
- [x] Changelog updated in [CHANGELOG.md](https://github.com/cognitedata/cognite-sdk-python/blob/master/CHANGELOG.md).
- [x] Version bumped. If triggering a new release is desired, bump the version number in [_version.py](https://github.com/cognitedata/cognite-sdk-python/blob/master/cognite/client/_version.py) and [pyproject.toml](https://github.com/cognitedata/cognite-sdk-python/blob/master/pyproject.toml) per [semantic versioning](https://semver.org/).
