### PR TITLE
Fix `rawAcl` database scope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@ Changes are grouped as follows
 ### Fixed
 - The new compare methods for capabilities in major version 7, `IAMAPI.verify_capabilities` and `IAMAPI.compare_capabilities`
   now works correctly for rawAcl with database scope ("all tables").
+### Removed
+- Capability scopes no longer have the `is_within` method, and capabilities no longer have `has_capability`. Use the more
+  general `IAMAPI.compare_capabilities` instead.
 
 ## [7.2.0] - 2023-11-16
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,11 @@ Changes are grouped as follows
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
+## [7.2.1] - 2023-11-17
+### Fixed
+- The new compare methods for capabilities in major version 7, `IAMAPI.verify_capabilities` and `IAMAPI.compare_capabilities`
+  now works correctly for rawAcl with database scope ("all tables").
+
 ## [7.2.0] - 2023-11-16
 ### Added
 - The `trigger` method of the Workflow Execution API, now accepts a `client_credentials` to allow specifying specific
@@ -169,9 +174,9 @@ with no easy way to add a prefix. Also, it no longer expands metadata by default
 ## [6.39.6] - 2023-11-13
 ## Fixed
 - HTTP status code retry strategy for RAW and labels. `/rows/insert` and `/rows/delete` will now
-be retried for all status codes in `config.status_forcelist` (default 429, 502, 503, 504), while
-`/dbs/{db}` and `/tables/{table}` will now only be retried for 429s and connection errors as those
-endpoints are not idempotent.
+  be retried for all status codes in `config.status_forcelist` (default 429, 502, 503, 504), while
+  `/dbs/{db}` and `/tables/{table}` will now only be retried for 429s and connection errors as those
+  endpoints are not idempotent.
 - Also, `labels/list` will now also be retried.
 
 ## [6.39.5] - 2023-11-12

--- a/cognite/client/_api/iam.py
+++ b/cognite/client/_api/iam.py
@@ -156,7 +156,7 @@ class IAMAPI(APIClient):
         for key, check_grp in to_check_lookup.items():
             group = has_capabilties_lookup.get(key, set())
             if any(AllScope._scope_name == grp[2] for grp in group):
-                continue  # If allScope exists for capability, we safely skip ahead:
+                continue  # If allScope exists for capability, we safely skip ahead
             elif RawAcl._capability_name == next(iter(check_grp))[0]:
                 raw_group.update(group)
                 raw_check_grp.update(check_grp)

--- a/cognite/client/_version.py
+++ b/cognite/client/_version.py
@@ -1,4 +1,4 @@
 from __future__ import annotations
 
-__version__ = "7.2.0"
+__version__ = "7.2.1"
 __api_subversion__ = "V20220125"

--- a/cognite/client/data_classes/capabilities.py
+++ b/cognite/client/data_classes/capabilities.py
@@ -98,9 +98,6 @@ class Capability(ABC):
             # Basic implementation for all simple Scopes (e.g. all or currentuser)
             return {(self._scope_name,)}
 
-        def is_within(self, other: Self) -> bool:
-            raise NotImplementedError
-
     @classmethod
     def from_tuple(cls, tpl: tuple) -> Self:
         acl_name, action, scope_name, *scope_params = tpl
@@ -115,7 +112,7 @@ class Capability(ABC):
             db, tbl = scope_params
             scope = scope_cls({db: [tbl] if tbl else []})  # type: ignore [call-arg]
         else:
-            raise ValueError(f"tuple not understood as capability ({tpl})")
+            raise ValueError(f"tuple not understood as capability: {tpl}")
 
         return cast(Self, capability_cls(actions=[capability_cls.Action(action)], scope=scope))
 
@@ -161,13 +158,6 @@ class Capability(ABC):
         }
         capability_name = self._capability_name
         return {to_camel_case(capability_name) if camel_case else to_snake_case(capability_name): data}
-
-    def has_capability(self, other: Capability) -> bool:
-        if not isinstance(self, type(other)):
-            return False
-        if not other.scope.is_within(self.scope):
-            return False
-        return not set(other.actions) - set(self.actions)
 
     def as_tuples(self) -> set[tuple]:
         return set(
@@ -262,16 +252,10 @@ class ProjectCapabilityList(CogniteResourceList[ProjectCapability]):
 class AllScope(Capability.Scope):
     _scope_name = "all"
 
-    def is_within(self, other: Self) -> bool:
-        return isinstance(other, AllScope)
-
 
 @dataclass(frozen=True)
 class CurrentUserScope(Capability.Scope):
     _scope_name = "currentuserscope"
-
-    def is_within(self, other: Self) -> bool:
-        return isinstance(other, (AllScope, CurrentUserScope))
 
 
 @dataclass(frozen=True)
@@ -284,9 +268,6 @@ class IDScope(Capability.Scope):
 
     def as_tuples(self) -> set[tuple]:
         return {(self._scope_name, i) for i in self.ids}
-
-    def is_within(self, other: Self) -> bool:
-        return isinstance(other, AllScope) or type(self) is type(other) and set(self.ids).issubset(other.ids)
 
 
 @dataclass(frozen=True)
@@ -302,9 +283,6 @@ class IDScopeLowerCase(Capability.Scope):
     def as_tuples(self) -> set[tuple]:
         return {(self._scope_name, i) for i in self.ids}
 
-    def is_within(self, other: Self) -> bool:
-        return isinstance(other, AllScope) or type(self) is type(other) and set(self.ids).issubset(other.ids)
-
 
 @dataclass(frozen=True)
 class ExtractionPipelineScope(Capability.Scope):
@@ -317,9 +295,6 @@ class ExtractionPipelineScope(Capability.Scope):
     def as_tuples(self) -> set[tuple]:
         return {(self._scope_name, i) for i in self.ids}
 
-    def is_within(self, other: Self) -> bool:
-        return isinstance(other, AllScope) or type(self) is type(other) and set(self.ids).issubset(other.ids)
-
 
 @dataclass(frozen=True)
 class DataSetScope(Capability.Scope):
@@ -331,9 +306,6 @@ class DataSetScope(Capability.Scope):
 
     def as_tuples(self) -> set[tuple]:
         return {(self._scope_name, i) for i in self.ids}
-
-    def is_within(self, other: Self) -> bool:
-        return isinstance(other, AllScope) or type(self) is type(other) and set(self.ids).issubset(other.ids)
 
 
 @dataclass(frozen=True)
@@ -361,19 +333,6 @@ class TableScope(Capability.Scope):
         # character, we represent this internally with the empty string:
         return {(self._scope_name, db, tbl) for db, tables in self.dbs_to_tables.items() for tbl in tables or [""]}
 
-    def is_within(self, other: Self) -> bool:
-        if isinstance(other, AllScope):
-            return True
-        if not isinstance(other, TableScope):
-            return False
-
-        for db_name, tables in self.dbs_to_tables.items():
-            if (other_tables := other.dbs_to_tables.get(db_name)) is None:
-                return False
-            if not set(tables).issubset(other_tables):
-                return False
-        return True
-
 
 @dataclass(frozen=True)
 class AssetRootIDScope(Capability.Scope):
@@ -386,9 +345,6 @@ class AssetRootIDScope(Capability.Scope):
     def as_tuples(self) -> set[tuple]:
         return {(self._scope_name, i) for i in self.root_ids}
 
-    def is_within(self, other: Self) -> bool:
-        return isinstance(other, AllScope) or type(self) is type(other) and set(self.root_ids).issubset(other.root_ids)
-
 
 @dataclass(frozen=True)
 class ExperimentsScope(Capability.Scope):
@@ -398,13 +354,6 @@ class ExperimentsScope(Capability.Scope):
     def as_tuples(self) -> set[tuple]:
         return {(self._scope_name, s) for s in self.experiments}
 
-    def is_within(self, other: Self) -> bool:
-        return (
-            isinstance(other, AllScope)
-            or type(self) is type(other)
-            and set(self.experiments).issubset(other.experiments)
-        )
-
 
 @dataclass(frozen=True)
 class SpaceIDScope(Capability.Scope):
@@ -413,11 +362,6 @@ class SpaceIDScope(Capability.Scope):
 
     def as_tuples(self) -> set[tuple]:
         return {(self._scope_name, s) for s in self.space_ids}
-
-    def is_within(self, other: Self) -> bool:
-        return (
-            isinstance(other, AllScope) or type(self) is type(other) and set(self.space_ids).issubset(other.space_ids)
-        )
 
 
 @dataclass(frozen=True)
@@ -435,9 +379,6 @@ class UnknownScope(Capability.Scope):
 
     def as_tuples(self) -> set[tuple]:
         raise NotImplementedError("Unknown scope cannot be converted to tuples (needed for comparisons)")
-
-    def is_within(self, other: Self) -> bool:
-        raise NotImplementedError("Unknown scope cannot be compared")
 
 
 _SCOPE_CLASS_BY_NAME: MappingProxyType[str, type[Capability.Scope]] = MappingProxyType(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "cognite-sdk"
 
-version = "7.2.0"
+version = "7.2.1"
 description = "Cognite Python SDK"
 readme = "README.md"
 documentation = "https://cognite-sdk-python.readthedocs-hosted.com"

--- a/tests/tests_unit/test_data_classes/test_capabilities.py
+++ b/tests/tests_unit/test_data_classes/test_capabilities.py
@@ -357,15 +357,15 @@ class TestIAMCompareCapabilities:
         assert not cognite_client.iam.compare_capabilities(has_all_scope, has_db_scope)
 
     @pytest.mark.parametrize(
-        "extra_existing, no_read_missing",
+        "extra_existing",
         [
-            ([], False),
-            ([RawAcl(actions=[RawAcl.Action.Read], scope=AllScope)], True),
-            ([RawAcl(actions=[RawAcl.Action.Read], scope=TableScope({"db1": []}))], True),
-            ([RawAcl(actions=[RawAcl.Action.Read], scope=TableScope({"db1": {"tables": []}}))], True),
+            [],
+            [RawAcl(actions=[RawAcl.Action.Read], scope=AllScope)],
+            [RawAcl(actions=[RawAcl.Action.Read], scope=TableScope({"db1": []}))],
+            [RawAcl(actions=[RawAcl.Action.Read], scope=TableScope({"db1": {"tables": []}}))],
         ],
     )
-    def test_raw_acl_database_scope(self, cognite_client, extra_existing, no_read_missing):
+    def test_raw_acl_database_scope(self, cognite_client, extra_existing):
         existing = [
             RawAcl([RawAcl.Action.Read], RawAcl.Scope.Table({"db1": ["t1"]})),
             RawAcl([RawAcl.Action.Read], RawAcl.Scope.Table({"db1": ["t1", "t2"]})),
@@ -377,12 +377,12 @@ class TestIAMCompareCapabilities:
             RawAcl([RawAcl.Action.Write], RawAcl.Scope.Table({"db1": ["t1"]})),
         ]
         missing = cognite_client.iam.compare_capabilities(existing, desired)
-        if no_read_missing:
-            assert missing == [RawAcl([RawAcl.Action.Write], RawAcl.Scope.Table(dbs_to_tables={"db1": ["t1"]}))]
+        if extra_existing:
+            assert missing == [RawAcl([RawAcl.Action.Write], RawAcl.Scope.Table({"db1": ["t1"]}))]
         else:
             assert missing == [
-                RawAcl([RawAcl.Action.Read], RawAcl.Scope.Table(dbs_to_tables={"db1": ["t3"]})),
-                RawAcl([RawAcl.Action.Write], RawAcl.Scope.Table(dbs_to_tables={"db1": ["t1"]})),
+                RawAcl([RawAcl.Action.Read], RawAcl.Scope.Table({"db1": ["t3"]})),
+                RawAcl([RawAcl.Action.Write], RawAcl.Scope.Table({"db1": ["t1"]})),
             ]
 
 

--- a/tests/tests_unit/test_data_classes/test_capabilities.py
+++ b/tests/tests_unit/test_data_classes/test_capabilities.py
@@ -380,10 +380,9 @@ class TestIAMCompareCapabilities:
         if extra_existing:
             assert missing == [RawAcl([RawAcl.Action.Write], RawAcl.Scope.Table({"db1": ["t1"]}))]
         else:
-            assert missing == [
-                RawAcl([RawAcl.Action.Read], RawAcl.Scope.Table({"db1": ["t3"]})),
-                RawAcl([RawAcl.Action.Write], RawAcl.Scope.Table({"db1": ["t1"]})),
-            ]
+            assert len(missing) == 2
+            assert RawAcl([RawAcl.Action.Read], RawAcl.Scope.Table({"db1": ["t3"]})) in missing
+            assert RawAcl([RawAcl.Action.Write], RawAcl.Scope.Table({"db1": ["t1"]})) in missing
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Description
### [7.2.1] - 2023-11-17
#### Fixed
- The new compare methods for capabilities in major version 7, `IAMAPI.verify_capabilities` and `IAMAPI.compare_capabilities` now works correctly for rawAcl with database scope ("all tables").

#### Removed
- Capability scopes no longer have the `is_within` method, and capabilities no longer have `has_capability`. Use the more general `IAMAPI.compare_capabilities` instead.

## Checklist:
- [x] Tests added/updated.
- [ ] Documentation updated. Documentation is generated from docstrings - these must be updated according to your change.
  If a new method has been added it should be referenced in [cognite.rst](https://github.com/cognitedata/cognite-sdk-python/blob/master/docs/source/cognite.rst) in order to generate docs based on its docstring.
- [x] Changelog updated in [CHANGELOG.md](https://github.com/cognitedata/cognite-sdk-python/blob/master/CHANGELOG.md).
- [x] Version bumped. If triggering a new release is desired, bump the version number in [_version.py](https://github.com/cognitedata/cognite-sdk-python/blob/master/cognite/client/_version.py) and [pyproject.toml](https://github.com/cognitedata/cognite-sdk-python/blob/master/pyproject.toml) per [semantic versioning](https://semver.org/).
