### PR TITLE
Fix: url encode workflows external id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,9 +17,13 @@ Changes are grouped as follows
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
+## [7.3.2] - 2023-11-21
+### Fixed
+- `workflows.retrieve` and `workflows.versions.retrieve` returned None if the provided workflow external id contained special characters. This is now fixed.
+
 ## [7.3.1] - 2023-11-21
 ### Fixed
-- Replaced action `Write` with `Create` in `ProjectsAcl`, as `Write` is not a valid action and `Create` is the correct one. 
+- Replaced action `Write` with `Create` in `ProjectsAcl`, as `Write` is not a valid action and `Create` is the correct one.
 
 ## [7.3.0] - 2023-11-20
 ### Added
@@ -127,13 +131,13 @@ with no easy way to add a prefix. Also, it no longer expands metadata by default
 
 ### Added
 - Added `load` implementation for `VisionResource`s: `ObjectDetection`, `TextRegion`, `AssetLink`, `BoundingBox`,
-  `CdfRerourceRef`, `Polygon`, `Polyline`, `VisionExtractPredictions`, `FeatureParameters`.  
+  `CdfRerourceRef`, `Polygon`, `Polyline`, `VisionExtractPredictions`, `FeatureParameters`.
 - Missing `dump` and `load` methods for `ClientCredentials`.
 - Literal annotation for `source_type` and `target_type` in `Relationship`
 - In transformations, `NonceCredentials` was missing `load` method.
 - In transformations, `TransformationBlockedInfo` was missing `.dump` method
 - `capabilities` in `cognite.client.data_classes` with data classes for all CDF capabilities.
-- All `CogniteResource` and `CogniteResourcelist` objects have `.dump_yaml` methods, for example, `my_asset_list.dump_yaml()`.  
+- All `CogniteResource` and `CogniteResourcelist` objects have `.dump_yaml` methods, for example, `my_asset_list.dump_yaml()`.
 
 ### Removed
 - Deprecated methods `aggregate_metadata_keys` and `aggregate_metadata_values` on AssetsAPI.

--- a/cognite/client/_api/workflows.py
+++ b/cognite/client/_api/workflows.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from abc import ABC
 from typing import TYPE_CHECKING, Any, Literal, MutableSequence, Sequence, Tuple, Union
+from urllib.parse import quote
 
 from typing_extensions import TypeAlias
 
@@ -373,7 +374,7 @@ class WorkflowVersionAPI(BetaWorkflowAPIClient):
         self._warning.warn()
         try:
             response = self._get(
-                url_path=f"/workflows/{workflow_external_id}/versions/{version}",
+                url_path=f"/workflows/{quote(workflow_external_id, '')}/versions/{quote(version, '')}",
             )
         except CogniteAPIError as e:
             if e.code == 404:
@@ -498,7 +499,7 @@ class WorkflowAPI(BetaWorkflowAPIClient):
         """
         self._warning.warn()
         try:
-            response = self._get(url_path=self._RESOURCE_PATH + f"/{external_id}")
+            response = self._get(url_path=f"{self._RESOURCE_PATH}/{quote(external_id, '')}")
         except CogniteAPIError as e:
             if e.code == 404:
                 return None

--- a/cognite/client/_version.py
+++ b/cognite/client/_version.py
@@ -1,4 +1,4 @@
 from __future__ import annotations
 
-__version__ = "7.3.1"
+__version__ = "7.3.2"
 __api_subversion__ = "V20220125"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "cognite-sdk"
 
-version = "7.3.1"
+version = "7.3.2"
 description = "Cognite Python SDK"
 readme = "README.md"
 documentation = "https://cognite-sdk-python.readthedocs-hosted.com"


### PR DESCRIPTION
## Description

Workflows service allows arbitrary strings as workflow external id or version id. However, these are used as url path parameters and should be url-encoded. Fixing it now.

## Checklist:
- [ ] Tests added/updated.
- [ ] Documentation updated. Documentation is generated from docstrings - these must be updated according to your change.
  If a new method has been added it should be referenced in [cognite.rst](https://github.com/cognitedata/cognite-sdk-python/blob/master/docs/source/cognite.rst) in order to generate docs based on its docstring.
- [x] Changelog updated in [CHANGELOG.md](https://github.com/cognitedata/cognite-sdk-python/blob/master/CHANGELOG.md).
- [x] Version bumped. If triggering a new release is desired, bump the version number in [_version.py](https://github.com/cognitedata/cognite-sdk-python/blob/master/cognite/client/_version.py) and [pyproject.toml](https://github.com/cognitedata/cognite-sdk-python/blob/master/pyproject.toml) per [semantic versioning](https://semver.org/).
