### PR TITLE
update outdated guide on client instantiation + remove API key reference

### DIFF
--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -2,9 +2,8 @@ Quickstart
 ==========
 Instantiate a new client
 ------------------------
-Use this code to instantiate a client and get your login status. CDF returns an object with
-attributes that describe which project and service account your API key belongs to. The :code:`client_name`
-is a user-defined string intended to give the client a unique identifier. You
+Use this code to instantiate a client in order to execute API calls to Cognite Data Fusion (CDF).
+The :code:`client_name` is a user-defined string intended to give the client a unique identifier. You
 can provide the :code:`client_name` by passing it directly to the :ref:`ClientConfig <class_client_ClientConfig>` constructor.
 
 The Cognite API uses OpenID Connect (OIDC) to authenticate.

--- a/docs/source/settings.rst
+++ b/docs/source/settings.rst
@@ -2,9 +2,22 @@ Settings
 ========
 Client configuration
 --------------------
-You can pass configuration arguments directly to the :ref:`cognite_client:CogniteClient` constructor, for example
-to configure the base url of your requests and additional headers. For a list of all configuration arguments,
-see the :ref:`cognite_client:CogniteClient` class definition.
+You can pass configuration arguments directly to the :ref:`ClientConfig <class_client_ClientConfig>` constructor, for example
+to configure the base url of your requests or any additional headers. For a list of all configuration arguments,
+see the :ref:`ClientConfig <class_client_ClientConfig>` class definition.
+
+To initialise a ``CogniteClient``, simply pass this configuration object, (an instance of ``ClientConfig``) to it:
+
+.. code:: python
+
+    from cognite.client import CogniteClient, ClientConfig
+    from cognite.client.credentials import Token
+    my_config = ClientConfig(
+        client_name="my-client",
+        project="myproj",
+        credentials=Token("verysecret"),
+    )
+    client = CogniteClient(my_config)
 
 Global configuration
 --------------------
@@ -25,13 +38,14 @@ You can set global configuration options like this:
     global_config.max_connection_pool_size = 10
     global_config.status_forcelist = {429, 502, 503, 504}
 
-These must be set prior to instantiating a CogniteClient in order for them to take effect.
+These must be set prior to instantiating a ``CogniteClient`` in order for them to take effect.
 
 Concurrency and connection pooling
 ----------------------------------
 This library does not expose API limits to the user. If your request exceeds API limits, the SDK splits your
 request into chunks and performs the sub-requests in parallel. To control how many concurrent requests you send
-to the API, you can either pass the :code:`max_workers` attribute when you instantiate the :ref:`cognite_client:CogniteClient` or set the :code:`max_workers` config option.
+to the API, you can either pass the :code:`max_workers` attribute to :ref:`ClientConfig <class_client_ClientConfig>` before
+you instantiate the :ref:`cognite_client:CogniteClient` from it, or set the global :code:`max_workers` config option.
 
 If you are working with multiple instances of :ref:`cognite_client:CogniteClient`, all instances will share the same connection pool.
 If you have several instances, you can increase the max connection pool size to reuse connections if you are performing a large amount of concurrent requests.

--- a/tests/tests_unit/test_data_classes/test_assets.py
+++ b/tests/tests_unit/test_data_classes/test_assets.py
@@ -6,7 +6,7 @@ import textwrap
 import time
 from contextlib import redirect_stdout
 from pathlib import Path
-from unittest import mock
+from unittest import TestCase, mock
 from unittest.mock import call
 
 import pytest
@@ -127,7 +127,7 @@ class TestAssetList:
 
         resources = getattr(assets, method)()
         expected = [r1, r2, r3]
-        assert expected == resources
+        TestCase().assertCountEqual(expected, resources)  # Asserts equal, but ignores ordering
 
     @pytest.mark.dsl
     def test_to_pandas_nullable_int(self, cognite_client):


### PR DESCRIPTION
## Description
I saw a post on Cognite Hub referencing our documentation, which hasn't been updated after the introduction of the `ClientConfig` addition.

https://hub.cognite.com/developer-and-user-community-134/sdk-questions-around-global-config-2310?postid=7448#post7448

## Checklist:
- [x] Documentation updated. Documentation is generated from docstrings - these must be updated according to your change.