### PR TITLE
Revise partitions+generator logic and move max_workers to global_config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,14 @@ Changes are grouped as follows
 - `Removed` for now removed features.
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
- 
+
+
+## [7.5.4] - 2023-12-06
+### Changed
+- The `partitions` parameter is no longer respected when using generator methods to list resources
+- The `max_workers` config option has been moved from ClientConfig to the global config.
+- The default for the `max_workers` option has been changed from 10 to 5.
+
 ## [7.5.3] - 2023-12-06
 ### Added
 - Support for `subworkflow` tasks in `workflows`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,6 @@ Changes are grouped as follows
 ### Changed
 - The `partitions` parameter is no longer respected when using generator methods to list resources
 - The `max_workers` config option has been moved from ClientConfig to the global config.
-- The default for the `max_workers` option has been changed from 10 to 5.
 
 ## [7.5.3] - 2023-12-06
 ### Added

--- a/cognite/client/_api_client.py
+++ b/cognite/client/_api_client.py
@@ -5,6 +5,7 @@ import gzip
 import json as _json
 import logging
 import re
+import warnings
 from collections import UserList
 from json.decoder import JSONDecodeError
 from typing import (
@@ -406,123 +407,73 @@ class APIClient:
         verify_limit(limit)
         if is_unlimited(limit):
             limit = None
-        resource_path = resource_path or self._RESOURCE_PATH
-
         if partitions:
-            if limit is not None:
-                raise ValueError("When using partitions, limit should be `None`, `-1` or `inf`.")
-            if sort is not None:
-                raise ValueError("When using sort, partitions is not supported.")
+            warnings.warn("passing `partitions` to a generator method is not supported, so it's being ignored")
+            # set chunk_size to None in order to not break the existing API.
+            # TODO: Remove this and support for partitions (in combo with generator) in the next major version
+            chunk_size = None
 
-            yield from self._list_generator_partitioned(
-                partitions=partitions,
-                resource_cls=resource_cls,
-                resource_path=resource_path,
-                filter=filter,
-                other_params=other_params,
-                headers=headers,
-            )
+        resource_path = resource_path or self._RESOURCE_PATH
+        total_items_retrieved = 0
+        current_limit = self._LIST_LIMIT
+        if chunk_size and chunk_size <= self._LIST_LIMIT:
+            current_limit = chunk_size
+        next_cursor = initial_cursor
+        filter = filter or {}
+        current_items = []
+        while True:
+            if limit:
+                num_of_remaining_items = limit - total_items_retrieved
+                if num_of_remaining_items < current_limit:
+                    current_limit = num_of_remaining_items
 
-        else:
-            total_items_retrieved = 0
-            current_limit = self._LIST_LIMIT
-            if chunk_size and chunk_size <= self._LIST_LIMIT:
-                current_limit = chunk_size
-            next_cursor = initial_cursor
-            filter = filter or {}
-            current_items = []
-            while True:
-                if limit:
-                    num_of_remaining_items = limit - total_items_retrieved
-                    if num_of_remaining_items < current_limit:
-                        current_limit = num_of_remaining_items
+            if method == "GET":
+                params = filter.copy()
+                params["limit"] = current_limit
+                params["cursor"] = next_cursor
+                if sort is not None:
+                    params["sort"] = sort
+                params.update(other_params or {})
+                res = self._get(url_path=url_path or resource_path, params=params, headers=headers)
 
-                if method == "GET":
-                    params = filter.copy()
-                    params["limit"] = current_limit
-                    params["cursor"] = next_cursor
-                    if sort is not None:
-                        params["sort"] = sort
-                    params.update(other_params or {})
-                    res = self._get(url_path=url_path or resource_path, params=params, headers=headers)
-
-                elif method == "POST":
-                    body: dict[str, Any] = {"limit": current_limit, "cursor": next_cursor, **(other_params or {})}
-                    if filter:
-                        body["filter"] = filter
-                    if advanced_filter:
-                        body["advancedFilter"] = (
-                            advanced_filter.dump(camel_case_property=True)
-                            if isinstance(advanced_filter, Filter)
-                            else advanced_filter
-                        )
-                    if sort is not None:
-                        body["sort"] = sort
-                    res = self._post(
-                        url_path=url_path or resource_path + "/list",
-                        json=body,
-                        headers=headers,
-                        api_subversion=api_subversion,
+            elif method == "POST":
+                body: dict[str, Any] = {"limit": current_limit, "cursor": next_cursor, **(other_params or {})}
+                if filter:
+                    body["filter"] = filter
+                if advanced_filter:
+                    body["advancedFilter"] = (
+                        advanced_filter.dump(camel_case_property=True)
+                        if isinstance(advanced_filter, Filter)
+                        else advanced_filter
                     )
-                else:
-                    raise ValueError(f"_list_generator parameter `method` must be GET or POST, not {method}")
-                last_received_items = res.json()["items"]
-                total_items_retrieved += len(last_received_items)
+                if sort is not None:
+                    body["sort"] = sort
+                res = self._post(
+                    url_path=url_path or resource_path + "/list",
+                    json=body,
+                    headers=headers,
+                    api_subversion=api_subversion,
+                )
+            else:
+                raise ValueError(f"_list_generator parameter `method` must be GET or POST, not {method}")
+            last_received_items = res.json()["items"]
+            total_items_retrieved += len(last_received_items)
 
-                if not chunk_size:
-                    for item in last_received_items:
-                        yield resource_cls._load(item, cognite_client=self._cognite_client)
-                else:
-                    current_items.extend(last_received_items)
-                    if len(current_items) >= chunk_size:
-                        items_to_yield = current_items[:chunk_size]
-                        current_items = current_items[chunk_size:]
-                        yield list_cls._load(items_to_yield, cognite_client=self._cognite_client)
+            if not chunk_size:
+                for item in last_received_items:
+                    yield resource_cls._load(item, cognite_client=self._cognite_client)
+            else:
+                current_items.extend(last_received_items)
+                if len(current_items) >= chunk_size:
+                    items_to_yield = current_items[:chunk_size]
+                    current_items = current_items[chunk_size:]
+                    yield list_cls._load(items_to_yield, cognite_client=self._cognite_client)
 
-                next_cursor = res.json().get("nextCursor")
-                if total_items_retrieved == limit or next_cursor is None:
-                    if chunk_size and current_items:
-                        yield list_cls._load(current_items, cognite_client=self._cognite_client)
-                    break
-
-    def _list_generator_partitioned(
-        self,
-        partitions: int,
-        resource_cls: type[T_CogniteResource],
-        resource_path: str,
-        filter: dict | None = None,
-        other_params: dict | None = None,
-        headers: dict | None = None,
-    ) -> Iterator[T_CogniteResource]:
-        next_cursors = {i + 1: None for i in range(partitions)}
-
-        def get_partition(partition_num: int) -> list[dict[str, Any]]:
-            next_cursor = next_cursors[partition_num]
-
-            body = {
-                "filter": filter or {},
-                "limit": self._LIST_LIMIT,
-                "cursor": next_cursor,
-                "partition": f"{partition_num}/{partitions}",
-                **(other_params or {}),
-            }
-            res = self._post(url_path=resource_path + "/list", json=body, headers=headers)
             next_cursor = res.json().get("nextCursor")
-            next_cursors[partition_num] = next_cursor
-
-            return res.json()["items"]
-
-        while len(next_cursors) > 0:
-            tasks_summary = execute_tasks(
-                get_partition, [(partition,) for partition in next_cursors], max_workers=partitions, fail_fast=True
-            )
-            tasks_summary.raise_compound_exception_if_failed_tasks()
-
-            for item in tasks_summary.joined_results():
-                yield resource_cls._load(item, cognite_client=self._cognite_client)
-
-            # Remove None from cursor dict
-            next_cursors = {partition: next_cursors[partition] for partition in next_cursors if next_cursors[partition]}
+            if total_items_retrieved == limit or next_cursor is None:
+                if chunk_size and current_items:
+                    yield list_cls._load(current_items, cognite_client=self._cognite_client)
+                break
 
     def _list(
         self,

--- a/cognite/client/_api_client.py
+++ b/cognite/client/_api_client.py
@@ -816,7 +816,13 @@ class APIClient:
             if isinstance(el, CogniteResource):
                 dumped = el.dump()
                 if "external_id" in dumped:
+                    if "space" in dumped:
+                        return f"{dumped['space']}:{dumped['external_id']}"
                     return dumped["external_id"]
+                if "externalId" in dumped:
+                    if "space" in dumped:
+                        return f"{dumped['space']}:{dumped['externalId']}"
+                    return dumped["externalId"]
                 return dumped
             return el
 

--- a/cognite/client/_api_client.py
+++ b/cognite/client/_api_client.py
@@ -579,7 +579,7 @@ class APIClient:
             return retrieved_items
 
         tasks = [(f"{i + 1}/{partitions}",) for i in range(partitions)]
-        tasks_summary = execute_tasks(get_partition, tasks, max_workers=partitions, fail_fast=True)
+        tasks_summary = execute_tasks(get_partition, tasks, max_workers=self._config.max_workers, fail_fast=True)
         tasks_summary.raise_compound_exception_if_failed_tasks()
 
         return list_cls._load(tasks_summary.joined_results(), cognite_client=self._cognite_client)

--- a/cognite/client/_version.py
+++ b/cognite/client/_version.py
@@ -1,4 +1,4 @@
 from __future__ import annotations
 
-__version__ = "7.5.3"
+__version__ = "7.5.4"
 __api_subversion__ = "V20220125"

--- a/cognite/client/config.py
+++ b/cognite/client/config.py
@@ -41,7 +41,7 @@ class GlobalConfig:
         self.max_connection_pool_size: int = 50
         self.disable_ssl: bool = False
         self.proxies: dict[str, str] | None = {}
-        self.max_workers: int = 5
+        self.max_workers: int = 10
 
 
 global_config = GlobalConfig()

--- a/cognite/client/config.py
+++ b/cognite/client/config.py
@@ -27,7 +27,7 @@ class GlobalConfig:
             Defaults to 50.
         disable_ssl (bool): Whether or not to disable SSL. Defaults to False
         proxies (Dict[str, str]): Dictionary mapping from protocol to url. e.g. {"https": "http://10.10.1.10:1080"}
-        max_workers (int | None): Max number of workers to spawn when parallelizing API calls. Defaults to 10.
+        max_workers (int | None): Max number of workers to spawn when parallelizing API calls. Defaults to 5.
     """
 
     def __init__(self) -> None:
@@ -41,7 +41,7 @@ class GlobalConfig:
         self.max_connection_pool_size: int = 50
         self.disable_ssl: bool = False
         self.proxies: dict[str, str] | None = {}
-        self.max_workers: int = 10
+        self.max_workers: int = 5
 
 
 global_config = GlobalConfig()
@@ -56,8 +56,8 @@ class ClientConfig:
         credentials (CredentialProvider): Credentials. e.g. Token, ClientCredentials.
         api_subversion (str | None): API subversion
         base_url (str | None): Base url to send requests to. Defaults to "https://api.cognitedata.com"
-        max_workers (int | None): DEPRECATED. use global_config.max_workers instead.
-            Max number of workers to spawn when parallelizing data fetching. Defaults to 10.
+        max_workers (int | None): DEPRECATED. Use global_config.max_workers instead.
+            Max number of workers to spawn when parallelizing data fetching. Defaults to 5.
         headers (dict[str, str] | None): Additional headers to add to all requests.
         timeout (int | None): Timeout on requests sent to the api. Defaults to 30 seconds.
         file_transfer_timeout (int | None): Timeout on file upload/download requests. Defaults to 600 seconds.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "cognite-sdk"
 
-version = "7.5.3"
+version = "7.5.4"
 description = "Cognite Python SDK"
 readme = "README.md"
 documentation = "https://cognite-sdk-python.readthedocs-hosted.com"

--- a/tests/tests_unit/test_api_client.py
+++ b/tests/tests_unit/test_api_client.py
@@ -664,6 +664,24 @@ class TestStandardList:
         assert 2002 == total_resources
 
     @pytest.mark.usefixtures("mock_get_for_autopaging")
+    def test_standard_list_generator_vs_partitions(self, api_client_with_token):
+        total_resources = 0
+        for resource_chunk in api_client_with_token._list_generator(
+            list_cls=SomeResourceList,
+            resource_cls=SomeResource,
+            resource_path=URL_PATH,
+            method="GET",
+            partitions=1,
+            limit=2000,
+            chunk_size=1001,
+        ):
+            # TODO: chunk_size is ignored when partitions is set, fix in next major version
+            assert isinstance(resource_chunk, SomeResource)
+            total_resources += 1
+
+        assert 2000 == total_resources
+
+    @pytest.mark.usefixtures("mock_get_for_autopaging")
     def test_standard_list_autopaging(self, api_client_with_token):
         res = api_client_with_token._list(
             list_cls=SomeResourceList, resource_cls=SomeResource, resource_path=URL_PATH, method="GET"


### PR DESCRIPTION
Current implementation of partitions+generator will keep `n_partitions*chunk_size` items in memory. With this change we will
1) Ignore partitions when using generator as it really only makes sense when using `list`
2) always fetch LIST_LIMIT items when using generator, and just yield `chunk_size` items, to avoid excessive requests being fired.

On max_workers, we have moved that to global_config, but will still accept it in ClientConfig (although with a deprecatio warning).

## Description
Please describe the change you have made.

## Checklist:
- [ ] Tests added/updated.
- [ ] Documentation updated. Documentation is generated from docstrings - these must be updated according to your change.
  If a new method has been added it should be referenced in [cognite.rst](https://github.com/cognitedata/cognite-sdk-python/blob/master/docs/source/cognite.rst) in order to generate docs based on its docstring.
- [ ] Changelog updated in [CHANGELOG.md](https://github.com/cognitedata/cognite-sdk-python/blob/master/CHANGELOG.md).
- [ ] Version bumped. If triggering a new release is desired, bump the version number in [_version.py](https://github.com/cognitedata/cognite-sdk-python/blob/master/cognite/client/_version.py) and [pyproject.toml](https://github.com/cognitedata/cognite-sdk-python/blob/master/pyproject.toml) per [semantic versioning](https://semver.org/).
