### PR TITLE
 Added chain to and direction argument to expression result sets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ Changes are grouped as follows
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
+## [7.5.0] - 2023-11-30
+### Added
+- `chain_to` to `NodeResultSetExpression` and `NodeResultSetExpression`, and `direction` to `NodeResultSetExpression`.
+
 ## [7.4.2] - 2023-11-28
 ### Improved
 - Quality of life improvement to `client.extraction_pipelines.runs.list` method. The `statuses` parameter now accepts

--- a/cognite/client/_version.py
+++ b/cognite/client/_version.py
@@ -1,4 +1,4 @@
 from __future__ import annotations
 
-__version__ = "7.4.2"
+__version__ = "7.5.0"
 __api_subversion__ = "V20220125"

--- a/cognite/client/data_classes/data_modeling/query.py
+++ b/cognite/client/data_classes/data_modeling/query.py
@@ -217,8 +217,10 @@ class NodeResultSetExpression(ResultSetExpression):
         limit (int | None): Limit the result set to this number of instances.
         through (list[str] | tuple[str, str, str] | None): Chain your result-expression through this view.
             The tuple must be on the form (space, view/version, property).
-        direction (Literal["outwards", "inwards"]): The direction to use when traversing direct relations. Only applicable when through is specified.
-        chain_to (Literal["destination", "source"]): Control which side of the edge to chain to. See below for more information.
+        direction (Literal["outwards", "inwards"]): The direction to use when traversing direct relations.
+            Only applicable when through is specified.
+        chain_to (Literal["destination", "source"]): Control which side of the edge to chain to.
+            See below for more information.
 
     The chain_to option is only applicable if the view referenced in the from field consists of edges.
 
@@ -235,7 +237,7 @@ class NodeResultSetExpression(ResultSetExpression):
         through: list[str] | tuple[str, str, str] | None = None,
         direction: Literal["outwards", "inwards"] = "outwards",
         chain_to: Literal["destination", "source"] = "destination",
-    ):
+    ) -> None:
         super().__init__(from_=from_, filter=filter, limit=limit, sort=sort, direction=direction, chain_to=chain_to)
         self.through = through
 
@@ -275,17 +277,18 @@ class EdgeResultSetExpression(ResultSetExpression):
     Args:
         from_ (str | None): Chain your result expression from this edge.
         max_distance (int | None): The largest - max - number of levels to traverse.
-        direction (Literal["outwards", "inwards"]):The direction to use when traversing.
+        direction (Literal["outwards", "inwards"]): The direction to use when traversing.
         filter (Filter | None): Filter the result set based on this filter.
         node_filter (Filter | None): Filter the result set based on this filter.
         termination_filter (Filter | None): Filter the result set based on this filter.
-        limit_each (int | None): Limit the number of returned edges for each of the source nodes in the result set. The indicated
-            uniform limit applies to the result set from the referenced from.
+        limit_each (int | None): Limit the number of returned edges for each of the source nodes in the result set.
+            The indicated uniform limit applies to the result set from the referenced from.
             limitEach only has meaning when you also specify maxDistance=1 and from.
         sort (list[InstanceSort] | None): Sort the result set based on this list of sort criteria.
         post_sort (list[InstanceSort] | None): Sort the result set based on this list of sort criteria.
         limit (int | None): Limit the result set to this number of instances.
-        chain_to (Literal["destination", "source"]): Control which side of the edge to chain to. See below for more information.
+        chain_to (Literal["destination", "source"]): Control which side of the edge to chain to.
+            See below for more information.
 
     The chain_to option is only applicable if the view referenced in the from field consists of edges.
 
@@ -307,7 +310,7 @@ class EdgeResultSetExpression(ResultSetExpression):
         post_sort: list[InstanceSort] | None = None,
         limit: int | None = None,
         chain_to: Literal["destination", "source"] = "destination",
-    ):
+    ) -> None:
         super().__init__(from_=from_, filter=filter, limit=limit, sort=sort, direction=direction, chain_to=chain_to)
         self.max_distance = max_distance
         self.node_filter = node_filter

--- a/cognite/client/data_classes/data_modeling/query.py
+++ b/cognite/client/data_classes/data_modeling/query.py
@@ -262,6 +262,8 @@ class NodeResultSetExpression(ResultSetExpression):
             }
         if self.chain_to:
             nodes["chainTo" if camel_case else "chain_to"] = self.chain_to
+        if self.direction:
+            nodes["direction"] = self.direction
 
         if self.sort:
             output["sort"] = [s.dump(camel_case=camel_case) for s in self.sort]

--- a/cognite/client/data_classes/data_modeling/query.py
+++ b/cognite/client/data_classes/data_modeling/query.py
@@ -220,12 +220,11 @@ class NodeResultSetExpression(ResultSetExpression):
         direction (Literal["outwards", "inwards"]): The direction to use when traversing direct relations.
             Only applicable when through is specified.
         chain_to (Literal["destination", "source"]): Control which side of the edge to chain to.
-            See below for more information.
-
-    The chain_to option is only applicable if the view referenced in the from field consists of edges.
-
-    source will chain to start if you're following edges outwards i.e direction=outwards. If you're following edges inwards i.e direction=inwards, it will chain to end.
-    destination (default) will chain to end if you're following edges outwards i.e direction=outwards. If you're following edges inwards i.e direction=inwards, it will chain to start.
+            The chain_to option is only applicable if the result rexpression referenced in `from`
+            contains edges. `source` will chain to start if you're following edges outwards i.e `direction=outwards`. If you're
+            following edges inwards i.e `direction=inwards`, it will chain to end. `destination` (default) will chain to
+            end if you're following edges outwards i.e `direction=outwards`. If you're following edges
+            inwards i.e, `direction=inwards`, it will chain to start.
     """
 
     def __init__(
@@ -290,12 +289,11 @@ class EdgeResultSetExpression(ResultSetExpression):
         post_sort (list[InstanceSort] | None): Sort the result set based on this list of sort criteria.
         limit (int | None): Limit the result set to this number of instances.
         chain_to (Literal["destination", "source"]): Control which side of the edge to chain to.
-            See below for more information.
-
-    The chain_to option is only applicable if the view referenced in the from field consists of edges.
-
-    source will chain to start if you're following edges outwards i.e direction=outwards. If you're following edges inwards i.e direction=inwards, it will chain to end.
-    destination (default) will chain to end if you're following edges outwards i.e direction=outwards. If you're following edges inwards i.e direction=inwards, it will chain to start.
+            The chain_to option is only applicable if the result rexpression referenced in `from`
+            contains edges. `source` will chain to start if you're following edges outwards i.e `direction=outwards`. If you're
+            following edges inwards i.e `direction=inwards`, it will chain to end. `destination` (default) will chain to
+            end if you're following edges outwards i.e `direction=outwards`. If you're following edges
+            inwards i.e, `direction=inwards`, it will chain to start.
 
     """
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "cognite-sdk"
 
-version = "7.4.2"
+version = "7.5.0"
 description = "Cognite Python SDK"
 readme = "README.md"
 documentation = "https://cognite-sdk-python.readthedocs-hosted.com"

--- a/tests/tests_unit/test_data_classes/test_data_models/test_queries.py
+++ b/tests/tests_unit/test_data_classes/test_data_models/test_queries.py
@@ -18,6 +18,7 @@ def result_set_expression_load_and_dump_equals_data() -> Iterator[ParameterSet]:
                 "identifier": "bla",
             },
             "chainTo": "destination",
+            "direction": "outwards",
         },
         "limit": 1,
     }
@@ -33,6 +34,7 @@ def result_set_expression_load_and_dump_equals_data() -> Iterator[ParameterSet]:
         "nodes": {
             "filter": {"range": {"lt": 2000, "property": ["IntegrationTestsImmutable", "Movie/2", "releaseYear"]}},
             "chainTo": "destination",
+            "direction": "outwards",
         }
     }
     loaded_node = q.NodeResultSetExpression(
@@ -128,6 +130,7 @@ def query_load_yaml_data() -> Iterator[ParameterSet]:
                     property: ["node", "externalId"]
                     value: {"parameter": "airplaneExternalId"}
             chainTo: destination
+            direction: outwards
         limit: 1
     lands_in_airports:
         edges:
@@ -142,6 +145,7 @@ def query_load_yaml_data() -> Iterator[ParameterSet]:
     airports:
         nodes:
             chainTo: destination
+            direction: outwards
             from: lands_in_airports
 parameters:
     airplaneExternalId: myFavouriteAirplane
@@ -178,6 +182,7 @@ select:
           - releaseYear
           value: 1994
       chainTo: destination
+      direction: outwards
 select:
   movies:
     sources:

--- a/tests/tests_unit/test_data_classes/test_data_models/test_queries.py
+++ b/tests/tests_unit/test_data_classes/test_data_models/test_queries.py
@@ -17,6 +17,7 @@ def result_set_expression_load_and_dump_equals_data() -> Iterator[ParameterSet]:
                 "view": {"type": "view", "space": "some", "externalId": "extid", "version": "v1"},
                 "identifier": "bla",
             },
+            "chainTo": "destination",
         },
         "limit": 1,
     }
@@ -30,7 +31,8 @@ def result_set_expression_load_and_dump_equals_data() -> Iterator[ParameterSet]:
 
     raw = {
         "nodes": {
-            "filter": {"range": {"lt": 2000, "property": ["IntegrationTestsImmutable", "Movie/2", "releaseYear"]}}
+            "filter": {"range": {"lt": 2000, "property": ["IntegrationTestsImmutable", "Movie/2", "releaseYear"]}},
+            "chainTo": "destination",
         }
     }
     loaded_node = q.NodeResultSetExpression(
@@ -45,6 +47,7 @@ def result_set_expression_load_and_dump_equals_data() -> Iterator[ParameterSet]:
             "filter": {
                 "equals": {"property": ["edge", "type"], "value": {"space": "MovieSpace", "externalId": "Movie.actors"}}
             },
+            "chainTo": "destination",
         }
     }
     loaded_edge = q.EdgeResultSetExpression(
@@ -124,6 +127,7 @@ def query_load_yaml_data() -> Iterator[ParameterSet]:
                 equals:
                     property: ["node", "externalId"]
                     value: {"parameter": "airplaneExternalId"}
+            chainTo: destination
         limit: 1
     lands_in_airports:
         edges:
@@ -134,8 +138,10 @@ def query_load_yaml_data() -> Iterator[ParameterSet]:
                 equals:
                     property: ["edge", "type"]
                     value: ["aviation", "lands-in"]
+            chainTo: destination
     airports:
         nodes:
+            chainTo: destination
             from: lands_in_airports
 parameters:
     airplaneExternalId: myFavouriteAirplane
@@ -171,6 +177,7 @@ select:
           - Movie/2
           - releaseYear
           value: 1994
+      chainTo: destination
 select:
   movies:
     sources:

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -308,8 +308,12 @@ class FakeCogniteResourceGenerator:
             # DataPointSubscriptionCreate requires either timeseries_ids or filter
             keyword_arguments.pop("filter", None)
         if resource_cls is Query:
+            key_count = min(len(keyword_arguments["select"]), len(keyword_arguments["with_"]))
+            keyword_arguments["with_"] = {
+                k: v for no, (k, v) in enumerate(keyword_arguments["with_"].items()) if no < key_count
+            }
             # keys in with must match keys in select
-            selects = list(keyword_arguments["select"].values())
+            selects = list(keyword_arguments["select"].values())[:key_count]
             new_selects = {}
             for i, key in enumerate(keyword_arguments["with_"]):
                 new_selects[key] = selects[i]

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -308,16 +308,12 @@ class FakeCogniteResourceGenerator:
             # DataPointSubscriptionCreate requires either timeseries_ids or filter
             keyword_arguments.pop("filter", None)
         if resource_cls is Query:
-            key_count = min(len(keyword_arguments["select"]), len(keyword_arguments["with_"]))
-            keyword_arguments["with_"] = {
-                k: v for no, (k, v) in enumerate(keyword_arguments["with_"].items()) if no < key_count
-            }
-            # keys in with must match keys in select
-            selects = list(keyword_arguments["select"].values())[:key_count]
-            new_selects = {}
-            for i, key in enumerate(keyword_arguments["with_"]):
-                new_selects[key] = selects[i]
-            keyword_arguments["select"] = new_selects
+            # The fake generator makes all dicts from 1-3 values, we need to make sure that the query is valid
+            # by making sure that the list of equal length, so we make both to length 1.
+            with_key, with_value = next(iter(keyword_arguments["with_"].items()))
+            select_value = next(iter(keyword_arguments["select"].values()))
+            keyword_arguments["with_"] = {with_key: with_value}
+            keyword_arguments["select"] = {with_key: select_value}
         elif resource_cls is Relationship:
             # Relationship must set the source and target type consistently with the source and target
             keyword_arguments["source_type"] = type(keyword_arguments["source"]).__name__


### PR DESCRIPTION
## Description
New parameter:
![image](https://github.com/cognitedata/cognite-sdk-python/assets/60234212/4d78be56-168d-4923-9dce-f8dd5cef7c80)


## Checklist:
- [x] Tests added/updated.
- [x] Documentation updated. Documentation is generated from docstrings - these must be updated according to your change.
  If a new method has been added it should be referenced in [cognite.rst](https://github.com/cognitedata/cognite-sdk-python/blob/master/docs/source/cognite.rst) in order to generate docs based on its docstring.
- [x] Changelog updated in [CHANGELOG.md](https://github.com/cognitedata/cognite-sdk-python/blob/master/CHANGELOG.md).
- [x] Version bumped. If triggering a new release is desired, bump the version number in [_version.py](https://github.com/cognitedata/cognite-sdk-python/blob/master/cognite/client/_version.py) and [pyproject.toml](https://github.com/cognitedata/cognite-sdk-python/blob/master/pyproject.toml) per [semantic versioning](https://semver.org/).
