### PR TITLE
Update user profile docs url

### DIFF
--- a/cognite/client/_api/user_profiles.py
+++ b/cognite/client/_api/user_profiles.py
@@ -12,7 +12,7 @@ class UserProfilesAPI(APIClient):
     _RESOURCE_PATH = "/profiles"
 
     def me(self) -> UserProfile:
-        """`Retrieve your own user profile <https://developer.cognite.com/api#tag/User-profiles/paths/~1profiles~1me/get>`_
+        """`Retrieve your own user profile <https://developer.cognite.com/api#tag/User-profiles/operation/getRequesterUserProfile>`_
 
         Retrieves the user profile of the principal issuing the request, i.e. the principal *this* CogniteClient was instantiated with.
 
@@ -43,7 +43,7 @@ class UserProfilesAPI(APIClient):
     def retrieve(
         self, user_identifier: str | MutableSequence[str] | tuple[str, ...]
     ) -> UserProfile | UserProfileList | None:
-        """`Retrieve user profiles by user identifier. <https://developer.cognite.com/api#tag/User-profiles/paths/~1profiles~1byids/post>`_
+        """`Retrieve user profiles by user identifier. <https://developer.cognite.com/api#tag/User-profiles/operation/getUserProfilesByIds>`_
 
         Retrieves one or more user profiles indexed by the user identifier in the same CDF project.
 
@@ -81,7 +81,7 @@ class UserProfilesAPI(APIClient):
         return UserProfileList(cast(List[UserProfile], [profiles.get(user) for user in user_identifier]))
 
     def search(self, name: str, limit: int = DEFAULT_LIMIT_READ) -> UserProfileList:
-        """`Search for user profiles <https://developer.cognite.com/api#tag/User-profiles/paths/~1profiles~1search/post>`_
+        """`Search for user profiles <https://developer.cognite.com/api#tag/User-profiles/operation/userProfilesSearch>`_
         Primarily meant for human-centric use-cases and data exploration, not for programs, as the result set ordering and match criteria threshold may change over time.
 
         Args:
@@ -107,7 +107,7 @@ class UserProfilesAPI(APIClient):
         )
 
     def list(self, limit: int | None = DEFAULT_LIMIT_READ) -> UserProfileList:
-        """`List user profiles <https://developer.cognite.com/api#tag/User-profiles/paths/~1profiles/get>`_
+        """`List user profiles <https://developer.cognite.com/api#tag/User-profiles/operation/listUserProfiles>`_
 
         List all user profiles in the current CDF project. The results are ordered alphabetically by name.
 


### PR DESCRIPTION
## Description
The url for user profiles in the api docs has been updated to be consistent with the rest of the endpoints, now using operationId instead of using the path directly. See changes [here](https://github.com/cognitedata/service-contracts/pull/2388).


## Checklist:
- [ ] Tests added/updated.
- [ ] Documentation updated. Documentation is generated from docstrings - these must be updated according to your change.
  If a new method has been added it should be referenced in [cognite.rst](https://github.com/cognitedata/cognite-sdk-python/blob/master/docs/source/cognite.rst) in order to generate docs based on its docstring.
- [ ] Changelog updated in [CHANGELOG.md](https://github.com/cognitedata/cognite-sdk-python/blob/master/CHANGELOG.md).
- [ ] Version bumped. If triggering a new release is desired, bump the version number in [_version.py](https://github.com/cognitedata/cognite-sdk-python/blob/master/cognite/client/_version.py) and [pyproject.toml](https://github.com/cognitedata/cognite-sdk-python/blob/master/pyproject.toml) per [semantic versioning](https://semver.org/).
