### PR TITLE
Geospatial - added missing allowDimensionalityMismatch parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ Changes are grouped as follows
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
+## [7.5.0] - 2023-11-29
+### Added
+- `geospatial.search_features` and `geospatial.stream_features` now accept the `allow_dimensionality_mismatch` parameter.
+
 ## [7.4.1] - 2023-11-28
 ### Fixed
 - Error in logic when creating a `Transformation`. This is causing when calling `client.transformations.update`. 

--- a/cognite/client/_api/geospatial.py
+++ b/cognite/client/_api/geospatial.py
@@ -659,7 +659,7 @@ class GeospatialAPI(APIClient):
             filter (dict[str, Any] | None): the search filter
             properties (dict[str, Any] | None): the output property selection
             allow_crs_transformation (bool): If true, then input geometries will be transformed into the Coordinate Reference System defined in the feature type specification. When it is false, then requests with geometries in Coordinate Reference System different from the ones defined in the feature type will result in CogniteAPIError exception.
-            allow_dimensionality_mismatch (bool): Indicating if the spatial filter operators allow input geometries with a different dimensionality than the properties they are applied to. 
+            allow_dimensionality_mismatch (bool): Indicating if the spatial filter operators allow input geometries with a different dimensionality than the properties they are applied to.
         Yields:
             Feature: a generator for the filtered features
 

--- a/tests/tests_integration/test_api/test_geospatial.py
+++ b/tests/tests_integration/test_api/test_geospatial.py
@@ -299,6 +299,34 @@ class TestGeospatialAPI:
         )
         assert len(res) == 0
 
+    def test_search_feature_dimensionality_mismatch(self, cognite_client, test_feature_type, test_feature):
+        polygon_z = "POLYGONZ((2.276 48.858 3,2.278 48.859 3,2.2759 48.859 3,2.276 48.858 3))"
+        polygon = "POLYGON((2.276 48.858,2.278 48.859,2.275 48.859,2.276 48.858))"
+        res = cognite_client.geospatial.search_features(
+            feature_type_external_id=test_feature_type.external_id,
+            filter={"stWithin": {"property": "position", "value": {"wkt": polygon}}},
+            limit=10,
+        )
+        assert res[0].external_id == test_feature.external_id
+
+        try:
+            res = cognite_client.geospatial.search_features(
+                feature_type_external_id=test_feature_type.external_id,
+                filter={"stWithin": {"property": "position", "value": {"wkt": polygon_z}}},
+                limit=10,
+            )
+            raise pytest.fail("searching features with wrong dimensionality should raise exception")
+        except CogniteAPIError:
+            pass
+        res = cognite_client.geospatial.search_features(
+            feature_type_external_id=test_feature_type.external_id,
+            filter={"stWithin": {"property": "position", "value": {"wkt": polygon_z}}},
+            limit=10,
+            allow_dimensionality_mismatch=True,
+        )
+        assert len(res) == 1
+        assert res[0].external_id == test_feature.external_id
+
     def test_retrieve_multiple_feature_types_by_external_id(
         self, cognite_client, test_feature_type, another_test_feature_type
     ):
@@ -448,6 +476,34 @@ class TestGeospatialAPI:
         )
         feature_list = FeatureList(list(features))
         assert len(feature_list) == len(many_features)
+
+    def test_stream_features_dimensionality_mismatch(self, cognite_client, test_feature_type, test_feature):
+        polygon_z = "POLYGONZ((2.276 48.858 3,2.278 48.859 3,2.2759 48.859 3,2.276 48.858 3))"
+        polygon = "POLYGON((2.276 48.858,2.278 48.859,2.275 48.859,2.276 48.858))"
+        stream_res = cognite_client.geospatial.stream_features(
+            feature_type_external_id=test_feature_type.external_id,
+            filter={"stWithin": {"property": "position", "value": {"wkt": polygon}}},
+        )
+        res = [x for x in stream_res]
+        assert res[0].external_id == test_feature.external_id
+
+        try:
+            stream_res = cognite_client.geospatial.stream_features(
+                feature_type_external_id=test_feature_type.external_id,
+                filter={"stWithin": {"property": "position", "value": {"wkt": polygon_z}}},
+            )
+            _ = [x for x in stream_res]
+            raise pytest.fail("searching features with wrong dimensionality should raise exception")
+        except CogniteAPIError:
+            pass
+        stream_res = cognite_client.geospatial.stream_features(
+            feature_type_external_id=test_feature_type.external_id,
+            filter={"stWithin": {"property": "position", "value": {"wkt": polygon_z}}},
+            allow_dimensionality_mismatch=True,
+        )
+        res = [x for x in stream_res]
+        assert len(res) == 1
+        assert res[0].external_id == test_feature.external_id
 
     def test_list(self, cognite_client, test_feature_type, test_features):
         with set_request_limit(cognite_client.geospatial, 2):


### PR DESCRIPTION
## Description
Geospatial API comes with parameter "`allowDimensionalityMismatch`" for `search_features` and `stream_features`, which was missing in the python SDK. 
Added the parameter.

## Checklist:
- [x] Tests added/updated.
- [x] Documentation updated. Documentation is generated from docstrings - these must be updated according to your change.
  If a new method has been added it should be referenced in [cognite.rst](https://github.com/cognitedata/cognite-sdk-python/blob/master/docs/source/cognite.rst) in order to generate docs based on its docstring.
- [x] Changelog updated in [CHANGELOG.md](https://github.com/cognitedata/cognite-sdk-python/blob/master/CHANGELOG.md).
- [x] Version bumped. If triggering a new release is desired, bump the version number in [_version.py](https://github.com/cognitedata/cognite-sdk-python/blob/master/cognite/client/_version.py) and [pyproject.toml](https://github.com/cognitedata/cognite-sdk-python/blob/master/pyproject.toml) per [semantic versioning](https://semver.org/).
