### PR TITLE
Update Workflow Version Upsert docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ Changes are grouped as follows
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
+## [7.4.2] - 2023-11-29
+### Fixed
+- Update `Workflow Version` upsert docs to reflect that `upsert` is called on the `version` subresource
+
 ## [7.4.1] - 2023-11-28
 ### Fixed
 - Error in logic when creating a `Transformation`. This is causing when calling `client.transformations.update`. 

--- a/cognite/client/_api/workflows.py
+++ b/cognite/client/_api/workflows.py
@@ -305,7 +305,7 @@ class WorkflowVersionAPI(BetaWorkflowAPIClient):
                 ...        description="This workflow has one step",
                 ...    ),
                 ... )
-                >>> res = c.workflows.upsert(new_version)
+                >>> res = c.workflows.versions.upsert(new_version)
         """
         self._warning.warn()
         if mode != "replace":

--- a/cognite/client/_version.py
+++ b/cognite/client/_version.py
@@ -1,4 +1,4 @@
 from __future__ import annotations
 
-__version__ = "7.4.1"
+__version__ = "7.4.2"
 __api_subversion__ = "V20220125"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "cognite-sdk"
 
-version = "7.4.1"
+version = "7.4.2"
 description = "Cognite Python SDK"
 readme = "README.md"
 documentation = "https://cognite-sdk-python.readthedocs-hosted.com"


### PR DESCRIPTION
## Description
The example was incorrect, upsert should be called on the Version subresource

## Checklist:
- [x] Tests added/updated.
- [x] Documentation updated. Documentation is generated from docstrings - these must be updated according to your change.
  If a new method has been added it should be referenced in [cognite.rst](https://github.com/cognitedata/cognite-sdk-python/blob/master/docs/source/cognite.rst) in order to generate docs based on its docstring.
- [x] Changelog updated in [CHANGELOG.md](https://github.com/cognitedata/cognite-sdk-python/blob/master/CHANGELOG.md).
- [x] Version bumped. If triggering a new release is desired, bump the version number in [_version.py](https://github.com/cognitedata/cognite-sdk-python/blob/master/cognite/client/_version.py) and [pyproject.toml](https://github.com/cognitedata/cognite-sdk-python/blob/master/pyproject.toml) per [semantic versioning](https://semver.org/).
