### PR TITLE
Fix import in docs for filters.Not

### DIFF
--- a/cognite/client/data_classes/filters.py
+++ b/cognite/client/data_classes/filters.py
@@ -297,7 +297,7 @@ class Not(CompoundFilter):
 
         Negate an Equals filter:
 
-            >>> from cognite.client.data_classes.filters import Or, Equals
+            >>> from cognite.client.data_classes.filters import Equals, Not
             >>> filter = Not(Equals(("some", "property"), 42))
     """
 


### PR DESCRIPTION
## Description
The `Not` filter had imports for `Or` and `Equals` in the docs, when it should have `Not` and `Equals.

Since this is just docs, I don't think we need a new version of the SDK. The public docs should be re-built when this PR is merged.

## Checklist:
- [ ] Tests added/updated.
- [ ] Documentation updated. Documentation is generated from docstrings - these must be updated according to your change.
  If a new method has been added it should be referenced in [cognite.rst](https://github.com/cognitedata/cognite-sdk-python/blob/master/docs/source/cognite.rst) in order to generate docs based on its docstring.
- [ ] Changelog updated in [CHANGELOG.md](https://github.com/cognitedata/cognite-sdk-python/blob/master/CHANGELOG.md).
- [ ] Version bumped. If triggering a new release is desired, bump the version number in [_version.py](https://github.com/cognitedata/cognite-sdk-python/blob/master/cognite/client/_version.py) and [pyproject.toml](https://github.com/cognitedata/cognite-sdk-python/blob/master/pyproject.toml) per [semantic versioning](https://semver.org/).
