### PR TITLE
Bugfix `WorkflowDefinitionUpsert` storing built-in hash function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ Changes are grouped as follows
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
+## [7.5.2] - 2023-12-05
+### Fixed
+- The built-in `hash` function was mistakenly stored on `WorkflowDefinitionUpsert` instances after `__init__` and has been removed.
+
 ## [7.5.1] - 2023-12-01
 ### Changed
 - Raise an exception if `ClientConfig:base_url` is set to `None` or an empty string
@@ -32,8 +36,7 @@ Changes are grouped as follows
 
 ## [7.4.1] - 2023-11-28
 ### Fixed
-- Error in logic when creating a `Transformation`. This is causing when calling `client.transformations.update`. 
-  This is now fixed. 
+- Error in validation logic when creating a `Transformation` caused many calls to `client.transformations.update` to fail.
 
 ## [7.4.0] - 2023-11-27
 ### Changed

--- a/cognite/client/_version.py
+++ b/cognite/client/_version.py
@@ -1,4 +1,4 @@
 from __future__ import annotations
 
-__version__ = "7.5.1"
+__version__ = "7.5.2"
 __api_subversion__ = "V20220125"

--- a/cognite/client/data_classes/workflows.py
+++ b/cognite/client/data_classes/workflows.py
@@ -466,8 +466,8 @@ class FunctionTaskOutput(WorkflowTaskOutput):
 
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         return {
-            ("callId" if camel_case else "call_id"): self.call_id,
-            ("functionId" if camel_case else "function_id"): self.function_id,
+            "callId" if camel_case else "call_id": self.call_id,
+            "functionId" if camel_case else "function_id": self.function_id,
             "response": self.response,
         }
 
@@ -629,7 +629,6 @@ class WorkflowDefinitionUpsert(CogniteResource):
         tasks: list[WorkflowTask],
         description: str | None,
     ) -> None:
-        self.hash = hash
         self.tasks = tasks
         self.description = description
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "cognite-sdk"
 
-version = "7.5.1"
+version = "7.5.2"
 description = "Cognite Python SDK"
 readme = "README.md"
 documentation = "https://cognite-sdk-python.readthedocs-hosted.com"

--- a/tests/tests_integration/test_api/test_workflows.py
+++ b/tests/tests_integration/test_api/test_workflows.py
@@ -248,7 +248,7 @@ class TestWorkflowVersions:
 
             assert created_version.workflow_external_id == version.workflow_external_id
             assert created_version.workflow_definition.description == version.workflow_definition.description
-            assert created_version.workflow_definition.hash is not None
+            assert isinstance(created_version.workflow_definition.hash_, str)
         finally:
             if created_version is not None:
                 cognite_client.workflows.versions.delete(

--- a/tests/tests_unit/test_data_classes/test_workflows.py
+++ b/tests/tests_unit/test_data_classes/test_workflows.py
@@ -11,12 +11,24 @@ from cognite.client.data_classes.workflows import (
     FunctionTaskOutput,
     FunctionTaskParameters,
     TransformationTaskOutput,
+    TransformationTaskParameters,
+    WorkflowDefinition,
+    WorkflowDefinitionUpsert,
     WorkflowExecutionDetailed,
     WorkflowIds,
     WorkflowTask,
     WorkflowTaskOutput,
     WorkflowVersionId,
 )
+
+
+class TestWorkFlowDefinitions:
+    def test_upsert_variant_doesnt_accept_hash(self):
+        task = WorkflowTask(external_id="foo", parameters=TransformationTaskParameters(external_id="something"))
+        WorkflowDefinition(tasks=[task], description="desc", hash_="very-random")
+
+        with pytest.raises(TypeError, match="unexpected keyword argument 'hash_'$"):
+            WorkflowDefinitionUpsert(tasks=[task], description="desc", hash_="very-random")
 
 
 class TestWorkflowTaskOutput:


### PR DESCRIPTION
## Description
Belongs in the subclass only, the READ version (and not `hash`, but "hash from API").

Also adds a test.

## Checklist:
- [x] Tests added/updated.
- [x] Documentation updated. Documentation is generated from docstrings - these must be updated according to your change.
  If a new method has been added it should be referenced in [cognite.rst](https://github.com/cognitedata/cognite-sdk-python/blob/master/docs/source/cognite.rst) in order to generate docs based on its docstring.
- [x] Changelog updated in [CHANGELOG.md](https://github.com/cognitedata/cognite-sdk-python/blob/master/CHANGELOG.md).
- [x] Version bumped. If triggering a new release is desired, bump the version number in [_version.py](https://github.com/cognitedata/cognite-sdk-python/blob/master/cognite/client/_version.py) and [pyproject.toml](https://github.com/cognitedata/cognite-sdk-python/blob/master/pyproject.toml) per [semantic versioning](https://semver.org/).
