### PR TITLE
Added note and link to docs ref property collision

### DIFF
--- a/cognite/client/data_classes/data_modeling/views.py
+++ b/cognite/client/data_classes/data_modeling/views.py
@@ -87,6 +87,14 @@ class ViewApply(ViewCore):
         filter (Filter | None): A filter Domain Specific Language (DSL) used to create advanced filter queries.
         implements (list[ViewId] | None): References to the views from where this view will inherit properties and edges.
         properties (dict[str, ViewPropertyApply] | None): No description.
+
+    !!! note "implements"
+        The order of elements (i.e., `ViewId`) in `implements` matters, as it indicates priority on how to handle
+        collisions of same properties from different views. 
+        See
+        [Containers, views, polymorphism, data models](https://docs.cognite.com/cdf/dm/dm_concepts/dm_containers_views_datamodels/#implemented-property-conflicts-and-precedence)
+        for more details.
+    
     """
 
     def __init__(

--- a/cognite/client/data_classes/data_modeling/views.py
+++ b/cognite/client/data_classes/data_modeling/views.py
@@ -88,13 +88,13 @@ class ViewApply(ViewCore):
         implements (list[ViewId] | None): References to the views from where this view will inherit properties and edges.
         properties (dict[str, ViewPropertyApply] | None): No description.
 
-    !!! note "implements"
-        The order of elements (i.e., `ViewId`) in `implements` matters, as it indicates priority on how to handle
-        collisions of same properties from different views. 
-        See
-        [Containers, views, polymorphism, data models](https://docs.cognite.com/cdf/dm/dm_concepts/dm_containers_views_datamodels/#implemented-property-conflicts-and-precedence)
+    .. note::
+        The order of elements (i.e., `ViewId`) in :code:`implements` matters, as it indicates priority on how to handle
+        collisions of same properties from different views.
+        See docs on
+        `implemented property conflicts <https://docs.cognite.com/cdf/dm/dm_concepts/dm_containers_views_datamodels/#implemented-property-conflicts-and-precedence>`_
         for more details.
-    
+
     """
 
     def __init__(


### PR DESCRIPTION
## Description
Added note to `ViewApply` `implements` docstring regarding order of elements in the `implements` list regarding priority on how property collision is handled.

## Checklist:
- [x] Tests added/updated.
- [x] Documentation updated. Documentation is generated from docstrings - these must be updated according to your change.
  If a new method has been added it should be referenced in [cognite.rst](https://github.com/cognitedata/cognite-sdk-python/blob/master/docs/source/cognite.rst) in order to generate docs based on its docstring.
- [ ] Changelog updated in [CHANGELOG.md](https://github.com/cognitedata/cognite-sdk-python/blob/master/CHANGELOG.md).
- [ ] Version bumped. If triggering a new release is desired, bump the version number in [_version.py](https://github.com/cognitedata/cognite-sdk-python/blob/master/cognite/client/_version.py) and [pyproject.toml](https://github.com/cognitedata/cognite-sdk-python/blob/master/pyproject.toml) per [semantic versioning](https://semver.org/).
