### PR TITLE
Fix `retrieve_dataframe_in_tz` raising on certain `datetime` inputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,11 @@ Changes are grouped as follows
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
+## [7.5.7] - 2023-12-12
+### Fixed
+- Certain combinations of `start`/`end` and `granularity` would cause `retrieve_dataframe_in_tz` to raise due to
+  a bug in the calender-arithmetic (`MonthAligner`).
+
 ## [7.5.6] - 2023-12-11
 ### Added
 - Missing legacy scopes for `Capability`: `LegacySpaceScope` and `LegacyDataModelScope`.

--- a/cognite/client/_version.py
+++ b/cognite/client/_version.py
@@ -1,4 +1,4 @@
 from __future__ import annotations
 
-__version__ = "7.5.6"
+__version__ = "7.5.7"
 __api_subversion__ = "V20220125"

--- a/cognite/client/utils/_time.py
+++ b/cognite/client/utils/_time.py
@@ -335,7 +335,7 @@ class MonthAligner(DateTimeAligner):
     def add_units(cls, date: datetime, units: int) -> datetime:
         """
         Adds 'units' number of months to 'date', ignoring timezone. The resulting date might not be valid,
-        for example Jan 31 + 1 unit, as April only has 30 days. In such cases, datetime will raise a ValueError.
+        for example Jan 29 + 1 unit in a non-leap year. In such cases, datetime will raise a ValueError.
         """
         extra_years, month = divmod(date.month + units - 1, 12)
         return date.replace(year=date.year + extra_years, month=month + 1)
@@ -382,7 +382,7 @@ class QuarterAligner(DateTimeAligner):
     def add_units(cls, date: datetime, units: int) -> datetime:
         """
         Adds 'units' number of quarters to 'date', ignoring timezone. The resulting date might not be valid,
-        for example Feb 29 in a non-leap year. In such cases, datetime will raise a ValueError.
+        for example Jan 31 + 1 unit, as April only has 30 days. In such cases, datetime will raise a ValueError.
         """
         extra_years, month = divmod(date.month + 3 * units, 12)
         return date.replace(year=date.year + extra_years, month=month)

--- a/cognite/client/utils/_time.py
+++ b/cognite/client/utils/_time.py
@@ -320,8 +320,8 @@ class MonthAligner(DateTimeAligner):
         """
         if date == datetime(year=date.year, month=date.month, day=1, tzinfo=date.tzinfo):
             return date
-        extra, month = divmod(date.month + 1, 12)
-        return cls.normalize(date.replace(year=date.year + extra, month=month, day=1))
+        extra, month = divmod(date.month, 12)  # this works because month is one-indexed
+        return cls.normalize(date.replace(year=date.year + extra, month=month + 1, day=1))
 
     @classmethod
     def floor(cls, date: datetime) -> datetime:

--- a/cognite/client/utils/_time.py
+++ b/cognite/client/utils/_time.py
@@ -333,8 +333,12 @@ class MonthAligner(DateTimeAligner):
 
     @classmethod
     def add_units(cls, date: datetime, units: int) -> datetime:
-        extra_years, month = divmod(date.month + units, 12)
-        return date.replace(year=date.year + extra_years, month=month)
+        """
+        Adds 'units' number of months to 'date', ignoring timezone. The resulting date might not be valid,
+        for example Jan 31 + 1 unit, as April only has 30 days. In such cases, datetime will raise a ValueError.
+        """
+        extra_years, month = divmod(date.month + units - 1, 12)
+        return date.replace(year=date.year + extra_years, month=month + 1)
 
 
 class QuarterAligner(DateTimeAligner):
@@ -376,6 +380,10 @@ class QuarterAligner(DateTimeAligner):
 
     @classmethod
     def add_units(cls, date: datetime, units: int) -> datetime:
+        """
+        Adds 'units' number of quarters to 'date', ignoring timezone. The resulting date might not be valid,
+        for example Feb 29 in a non-leap year. In such cases, datetime will raise a ValueError.
+        """
         extra_years, month = divmod(date.month + 3 * units, 12)
         return date.replace(year=date.year + extra_years, month=month)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "cognite-sdk"
 
-version = "7.5.6"
+version = "7.5.7"
 description = "Cognite Python SDK"
 readme = "README.md"
 documentation = "https://cognite-sdk-python.readthedocs-hosted.com"

--- a/tests/tests_unit/test_utils/test_time.py
+++ b/tests/tests_unit/test_utils/test_time.py
@@ -28,6 +28,11 @@ from cognite.client.utils._time import (
     to_fixed_utc_intervals,
     to_pandas_freq,
     validate_timezone,
+    DayAligner,
+    WeekAligner,
+    MonthAligner,
+    QuarterAligner,
+    YearAligner,
 )
 from tests.utils import cdf_aggregate, tmp_set_envvar
 
@@ -664,3 +669,19 @@ class TestPandasDateRangeTz:
 
         # Assert
         assert len(index) == expected_length
+
+
+class TestDateTimeAligner:
+    # TODO: DayAligner
+    # TODO: WeekAligner
+    # TODO: MonthAligner
+    # TODO: QuarterAligner
+    # TODO: YearAligner
+
+    def test_month_aligner__ceil(self):
+        assert MonthAligner.ceil(datetime(2023, 11, 1)) == datetime(2023, 11, 1)
+        assert MonthAligner.ceil(datetime(2023, 10, 15)) == datetime(2023, 11, 1)
+        assert MonthAligner.ceil(datetime(2023, 12, 15)) == datetime(2024, 1, 1)
+        assert MonthAligner.ceil(datetime(2024, 1, 10)) == datetime(2024, 2, 1)
+        # Bug prior to 7.5.7 would cause this to raise:
+        assert MonthAligner.ceil(datetime(2023, 11, 2)) == datetime(2023, 12, 1)

--- a/tests/tests_unit/test_utils/test_time.py
+++ b/tests/tests_unit/test_utils/test_time.py
@@ -674,21 +674,39 @@ class TestDateTimeAligner:
     # TODO: QuarterAligner
     # TODO: YearAligner
 
-    def test_month_aligner__ceil(self):
-        assert MonthAligner.ceil(datetime(2023, 11, 1)) == datetime(2023, 11, 1)
-        assert MonthAligner.ceil(datetime(2023, 10, 15)) == datetime(2023, 11, 1)
-        assert MonthAligner.ceil(datetime(2023, 12, 15)) == datetime(2024, 1, 1)
-        assert MonthAligner.ceil(datetime(2024, 1, 10)) == datetime(2024, 2, 1)
-        # Bug prior to 7.5.7 would cause this to raise:
-        assert MonthAligner.ceil(datetime(2023, 11, 2)) == datetime(2023, 12, 1)
+    @pytest.mark.parametrize(
+        "dt, expected",
+        (
+            (datetime(2023, 11, 1), datetime(2023, 11, 1)),
+            (datetime(2023, 10, 15), datetime(2023, 11, 1)),
+            (datetime(2023, 12, 15), datetime(2024, 1, 1)),
+            (datetime(2024, 1, 10), datetime(2024, 2, 1)),
+            # Bug prior to 7.5.7 would cause this to raise:
+            (datetime(2023, 11, 2), datetime(2023, 12, 1)),
+        ),
+    )
+    def test_month_aligner__ceil(self, dt, expected):
+        assert expected == MonthAligner.ceil(dt)
 
-    def test_month_aligner__add_unites(self):
-        assert MonthAligner.add_units(datetime(2023, 7, 2), 12) == datetime(2024, 7, 2)
-        assert MonthAligner.add_units(datetime(2023, 7, 2), 12 * 12) == datetime(2035, 7, 2)
-        assert MonthAligner.add_units(datetime(2023, 7, 2), -12 * 2) == datetime(2021, 7, 2)
+    def test_month_aligner_ceil__invalid_date(self):
+        with pytest.raises(ValueError, match="^day is out of range for month$"):
+            MonthAligner.add_units(datetime(2023, 7, 31), 2)  # sept has 30 days
+
+    @pytest.mark.parametrize(
+        "dt, n_units, expected",
+        (
+            (datetime(2023, 7, 2), 12, datetime(2024, 7, 2)),
+            (datetime(2023, 7, 2), 12 * 12, datetime(2035, 7, 2)),
+            (datetime(2023, 7, 2), -12 * 2, datetime(2021, 7, 2)),
+            # Bug prior to 7.5.7 would cause these to raise:
+            (datetime(2023, 11, 15), 1, datetime(2023, 12, 15)),
+            (datetime(2023, 12, 15), 0, datetime(2023, 12, 15)),
+            (datetime(2024, 1, 15), -1, datetime(2023, 12, 15)),
+        ),
+    )
+    def test_month_aligner__add_unites(self, dt, n_units, expected):
+        assert expected == MonthAligner.add_units(dt, n_units)
+
+    def test_month_aligner_add_unites__invalid_date(self):
         with pytest.raises(ValueError, match="^day is out of range for month$"):
             MonthAligner.add_units(datetime(2023, 1, 29), 1)  # 2023 = non-leap year
-        # Bug prior to 7.5.7 would cause these to raise:
-        assert MonthAligner.add_units(datetime(2023, 11, 15), 1) == datetime(2023, 12, 15)
-        assert MonthAligner.add_units(datetime(2023, 12, 15), 0) == datetime(2023, 12, 15)
-        assert MonthAligner.add_units(datetime(2024, 1, 15), -1) == datetime(2023, 12, 15)


### PR DESCRIPTION
## [7.5.7] - 2023-12-12
### Fixed
- Certain combinations of `start`/`end` and `granularity` would cause `retrieve_dataframe_in_tz` to raise due to
  a bug in the calender-arithmetic (`MonthAligner`).

Found by @janne123456789 

## Checklist:
- [x] Tests added/updated.
- [x] Documentation updated. Documentation is generated from docstrings - these must be updated according to your change.
  If a new method has been added it should be referenced in [cognite.rst](https://github.com/cognitedata/cognite-sdk-python/blob/master/docs/source/cognite.rst) in order to generate docs based on its docstring.
- [x] Changelog updated in [CHANGELOG.md](https://github.com/cognitedata/cognite-sdk-python/blob/master/CHANGELOG.md).
- [x] Version bumped. If triggering a new release is desired, bump the version number in [_version.py](https://github.com/cognitedata/cognite-sdk-python/blob/master/cognite/client/_version.py) and [pyproject.toml](https://github.com/cognitedata/cognite-sdk-python/blob/master/pyproject.toml) per [semantic versioning](https://semver.org/).
