### PR TITLE
Improve aggregated properties for AssetsAPI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,14 @@ Changes are grouped as follows
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
-## [7.8.0] - 2023-12-20
+## [7.8.1] - 2023-12-21
+### Fixed
+- Calling `to_pandas` with `expand_aggregates=True` on an Asset with aggregated properties would yield a pandas DataFrame
+  with the column name `0` instead of `"value"`.
+### Improved
+- Specification of aggregated properties to `AssetsAPI.[list,filter,__call__]`.
+
+## [7.8.0] - 2023-12-21
 ### Added
 - Instance classes `Node`, `Edge`, `NodeList` and `EdgeList` now supports a new flag `expand_properties` in their `to_pandas` method,
   that makes it much simpler to work with the fetched properties. Additionally, `remove_property_prefix` allows easy prefix

--- a/cognite/client/_version.py
+++ b/cognite/client/_version.py
@@ -1,4 +1,4 @@
 from __future__ import annotations
 
-__version__ = "7.8.0"
+__version__ = "7.8.1"
 __api_subversion__ = "V20220125"

--- a/cognite/client/data_classes/assets.py
+++ b/cognite/client/data_classes/assets.py
@@ -276,7 +276,7 @@ class Asset(CogniteResource):
         pd = local_import("pandas")
         col = df.squeeze()
         aggregates = convert_dict_to_case(col.pop("aggregates"), camel_case)
-        return pd.concat((col, pd.Series(aggregates).add_prefix(aggregates_prefix))).to_frame()
+        return pd.concat((col, pd.Series(aggregates).add_prefix(aggregates_prefix))).to_frame(name="value")
 
 
 class AssetUpdate(CogniteUpdate):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "cognite-sdk"
 
-version = "7.8.0"
+version = "7.8.1"
 description = "Cognite Python SDK"
 readme = "README.md"
 documentation = "https://cognite-sdk-python.readthedocs-hosted.com"

--- a/tests/tests_unit/test_api/test_assets.py
+++ b/tests/tests_unit/test_api/test_assets.py
@@ -3,8 +3,9 @@ import re
 import pytest
 
 from cognite.client._api.assets import Asset, AssetList, AssetUpdate
-from cognite.client.data_classes import AssetFilter, Label, LabelFilter, TimestampRange
+from cognite.client.data_classes import AggregateResultItem, AssetFilter, Label, LabelFilter, TimestampRange
 from cognite.client.exceptions import CogniteAPIError
+from cognite.client.utils._text import convert_all_keys_to_snake_case
 from tests.utils import jsgz_load
 
 EXAMPLE_ASSET = {
@@ -343,6 +344,19 @@ class TestPandasIntegration:
         assert "metadata" not in df.columns
         assert 1 == df.loc["id"][0]
         assert "metadata-value" == df.loc["metadata-key"][0]
+
+    def test_expand_aggregates(self):
+        agg_props = {"childCount": 0, "depth": 4, "path": [{"id": 35927223}, {"id": 20283836}, {"id": 296}]}
+        asset = Asset(name="foo", aggregates=AggregateResultItem._load(agg_props))
+        expanded = asset.to_pandas(expand_aggregates=True)
+        not_expanded = asset.to_pandas(expand_aggregates=False)
+
+        assert expanded.columns == ["value"]  # This was wrongly col=0 prior to 7.8.1
+        assert not_expanded.columns == ["value"]
+        assert convert_all_keys_to_snake_case(agg_props) == not_expanded.loc["aggregates"].item()
+        assert agg_props["childCount"] == expanded.loc["aggregates.child_count"].item()
+        assert agg_props["depth"] == expanded.loc["aggregates.depth"].item()
+        assert agg_props["path"] == expanded.loc["aggregates.path"].item()
 
     # need subtree here to get list, since to_pandas on a single Asset gives int for id, but on AssetList it gives int64
     def test_asset_id_from_to_pandas(self, cognite_client, mock_get_subtree):


### PR DESCRIPTION
## Description
- Started out as a bugfix for Asset.to_pandas(), then while writing a test, I realized aggregates properties needed some love

## Checklist:
- [x] Tests added/updated.
- [x] Documentation updated. Documentation is generated from docstrings - these must be updated according to your change.
  If a new method has been added it should be referenced in [cognite.rst](https://github.com/cognitedata/cognite-sdk-python/blob/master/docs/source/cognite.rst) in order to generate docs based on its docstring.
- [x] Changelog updated in [CHANGELOG.md](https://github.com/cognitedata/cognite-sdk-python/blob/master/CHANGELOG.md).
- [x] Version bumped. If triggering a new release is desired, bump the version number in [_version.py](https://github.com/cognitedata/cognite-sdk-python/blob/master/cognite/client/_version.py) and [pyproject.toml](https://github.com/cognitedata/cognite-sdk-python/blob/master/pyproject.toml) per [semantic versioning](https://semver.org/).
