### PR TITLE
Fix missing container error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,12 @@ Changes are grouped as follows
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
+## [7.8.3] - 2023-12-21
+### Fixed
+- Revert `SingleHopConnectionDefinition` from a string to child class of `ViewProperty`.
+- If a `ViewProperty` or `ViewPropertyApply` dumped before version `7.6` was dumped and loaded after `7.6`, the
+  user got a `KeyError: 'container'`. The `load` methods are now backwards compatible with the old format.
+
 ## [7.8.2] - 2023-12-21
 ### Fixed
 - Revert `SingleHopConnectionDefinitionApply` from a string to child class of `ViewPropertyApply`.

--- a/cognite/client/_version.py
+++ b/cognite/client/_version.py
@@ -1,4 +1,4 @@
 from __future__ import annotations
 
-__version__ = "7.8.2"
+__version__ = "7.8.3"
 __api_subversion__ = "V20220125"

--- a/cognite/client/data_classes/data_modeling/views.py
+++ b/cognite/client/data_classes/data_modeling/views.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import warnings
 from abc import ABC, abstractmethod
 from dataclasses import asdict, dataclass
 from typing import TYPE_CHECKING, Any, Literal, TypeVar, cast
@@ -302,6 +303,13 @@ class ViewProperty(CogniteObject, ABC):
     def _load(cls, resource: dict[str, Any], cognite_client: CogniteClient | None = None) -> Self:
         if "connectionType" in resource:
             return cast(Self, ConnectionDefinition.load(resource))
+        elif "direction" in resource:
+            warnings.warn(
+                "Connection Definition is missing field 'connectionType'. Loading default MultiEdgeConnection."
+                "This will be required in the next major version",
+                DeprecationWarning,
+            )
+            return cast(Self, MultiEdgeConnection.load(resource))
         else:
             return cast(Self, MappedProperty.load(resource))
 
@@ -315,6 +323,13 @@ class ViewPropertyApply(CogniteObject, ABC):
     def _load(cls, resource: dict[str, Any], cognite_client: CogniteClient | None = None) -> Self:
         if "connectionType" in resource:
             return cast(Self, ConnectionDefinitionApply.load(resource))
+        elif "direction" in resource:
+            warnings.warn(
+                "Connection Definition is missing field 'connectionType'. Loading default MultiEdgeConnection."
+                "This will be required in the next major version",
+                DeprecationWarning,
+            )
+            return cast(Self, MultiEdgeConnectionApply.load(resource))
         else:
             return cast(Self, MappedPropertyApply.load(resource))
 

--- a/cognite/client/data_classes/data_modeling/views.py
+++ b/cognite/client/data_classes/data_modeling/views.py
@@ -527,7 +527,7 @@ class MultiEdgeConnection(EdgeConnection):
         )
 
 
-SingleHopConnectionDefinition: TypeAlias = "MultiEdgeConnection"
+SingleHopConnectionDefinition: TypeAlias = MultiEdgeConnection
 
 
 @dataclass

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "cognite-sdk"
 
-version = "7.8.2"
+version = "7.8.3"
 description = "Cognite Python SDK"
 readme = "README.md"
 documentation = "https://cognite-sdk-python.readthedocs-hosted.com"

--- a/tests/tests_unit/test_data_classes/test_data_models/test_views.py
+++ b/tests/tests_unit/test_data_classes/test_data_models/test_views.py
@@ -169,3 +169,25 @@ class TestViewPropertyDefinition:
             "direction": "outwards",
             "connectionType": "multi_edge_connection",
         }
+
+    def test_load_view_property_apply_legacy(self) -> None:
+        # Before the introduction of the `connectionType` field, the `source` field was used to determine the type of
+        # the property. This test ensures that the old format is still supported.
+        legacy_view = {
+            "type": {"space": "IntegrationTestsImmutable", "externalId": "Person.roles"},
+            "source": {"space": "IntegrationTestsImmutable", "externalId": "Role", "version": "2", "type": "view"},
+            "name": "roles",
+            "description": None,
+            "edgeSource": None,
+            "direction": "outwards",
+        }
+
+        actual = ViewPropertyApply._load(legacy_view)
+
+        assert actual.dump() == {
+            "type": {"space": "IntegrationTestsImmutable", "externalId": "Person.roles"},
+            "source": {"space": "IntegrationTestsImmutable", "externalId": "Role", "version": "2", "type": "view"},
+            "name": "roles",
+            "direction": "outwards",
+            "connectionType": "multi_edge_connection",
+        }

--- a/tests/tests_unit/test_data_classes/test_data_models/test_views.py
+++ b/tests/tests_unit/test_data_classes/test_data_models/test_views.py
@@ -145,3 +145,27 @@ class TestViewPropertyDefinition:
             },
             "connection_type": "multi_reverse_direct_relation",
         }
+
+    def test_load_view_property_legacy(self) -> None:
+        # Before the introduction of the `connectionType` field, the `source` field was used to determine the type of
+        # the property. This test ensures that the old format is still supported.
+        legacy_view = {
+            "type": {"space": "IntegrationTestsImmutable", "externalId": "Person.roles"},
+            "source": {"space": "IntegrationTestsImmutable", "externalId": "Role", "version": "2", "type": "view"},
+            "name": "roles",
+            "description": None,
+            "edgeSource": None,
+            "direction": "outwards",
+        }
+
+        actual = ViewProperty._load(legacy_view)
+
+        assert actual.dump() == {
+            "type": {"space": "IntegrationTestsImmutable", "externalId": "Person.roles"},
+            "source": {"space": "IntegrationTestsImmutable", "externalId": "Role", "version": "2", "type": "view"},
+            "name": "roles",
+            "description": None,
+            "edgeSource": None,
+            "direction": "outwards",
+            "connectionType": "multi_edge_connection",
+        }


### PR DESCRIPTION
## Description
The [change](https://github.com/cognitedata/cognite-sdk-python/pull/1540/files#diff-b4cf0cf90c4945bdcbb69ad1dc0d6b91691ed3964a862b130c06de02946708a0L309) from #1540 is not backwards compatible and breaks multiple tools built on top of the SDK. 

## Checklist:
- [x] Tests added/updated.
- [ ] Documentation updated. Documentation is generated from docstrings - these must be updated according to your change.
  If a new method has been added it should be referenced in [cognite.rst](https://github.com/cognitedata/cognite-sdk-python/blob/master/docs/source/cognite.rst) in order to generate docs based on its docstring.
- [x] Changelog updated in [CHANGELOG.md](https://github.com/cognitedata/cognite-sdk-python/blob/master/CHANGELOG.md).
- [x] Version bumped. If triggering a new release is desired, bump the version number in [_version.py](https://github.com/cognitedata/cognite-sdk-python/blob/master/cognite/client/_version.py) and [pyproject.toml](https://github.com/cognitedata/cognite-sdk-python/blob/master/pyproject.toml) per [semantic versioning](https://semver.org/).
