### PR TITLE
add enable/disable endpoints for `UserProfilesAPI`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ Changes are grouped as follows
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
+## [7.9.0] - 2024-01-05
+### Added
+- You can now enable or disable user profiles for your CDF project with `client.iam.user_profiles.[enable/disable]`.
+
 ## [7.8.10] - 2024-01-04
 ### Changed
 - When using `OidcCredentials` to create a transformation, `cdf_project_name` is no longer optional as required

--- a/cognite/client/_api/units.py
+++ b/cognite/client/_api/units.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, MutableSequence, overload
+from typing import TYPE_CHECKING, overload
 
 from cognite.client._api_client import APIClient
 from cognite.client.data_classes.units import (
@@ -10,6 +10,7 @@ from cognite.client.data_classes.units import (
     UnitSystemList,
 )
 from cognite.client.utils._identifier import IdentifierSequence
+from cognite.client.utils.useful_types import SequenceNotStr
 
 if TYPE_CHECKING:
     from cognite.client import ClientConfig, CogniteClient
@@ -32,16 +33,16 @@ class UnitAPI(APIClient):
         ...
 
     @overload
-    def retrieve(self, external_id: MutableSequence[str], ignore_unknown_ids: bool = False) -> UnitList:
+    def retrieve(self, external_id: SequenceNotStr[str], ignore_unknown_ids: bool = False) -> UnitList:
         ...
 
     def retrieve(
-        self, external_id: str | MutableSequence[str], ignore_unknown_ids: bool = False
+        self, external_id: str | SequenceNotStr[str], ignore_unknown_ids: bool = False
     ) -> Unit | UnitList | None:
         """`Retrieve one or more unit <https://developer.cognite.com/api#tag/Units/operation/byIdsUnits>`_
 
         Args:
-            external_id (str | MutableSequence[str]): External ID or list of external IDs
+            external_id (str | SequenceNotStr[str]): External ID or list of external IDs
             ignore_unknown_ids (bool): Ignore external IDs that are not found rather than throw an exception.
 
         Returns:

--- a/cognite/client/_api/user_profiles.py
+++ b/cognite/client/_api/user_profiles.py
@@ -1,15 +1,24 @@
 from __future__ import annotations
 
-from typing import List, MutableSequence, cast, overload
+from typing import List, cast, overload
 
 from cognite.client._api_client import APIClient
 from cognite.client._constants import DEFAULT_LIMIT_READ
 from cognite.client.data_classes.user_profiles import UserProfile, UserProfileList
 from cognite.client.utils._identifier import UserIdentifierSequence
+from cognite.client.utils.useful_types import SequenceNotStr
 
 
 class UserProfilesAPI(APIClient):
     _RESOURCE_PATH = "/profiles"
+
+    def enable(self) -> None:
+        """Enable user profiles for the project"""
+        self._post("/update", json={"update": {"userProfilesConfiguration": {"set": {"enabled": True}}}})
+
+    def disable(self) -> None:
+        """Disable user profiles for the project"""
+        self._post("/update", json={"update": {"userProfilesConfiguration": {"set": {"enabled": False}}}})
 
     def me(self) -> UserProfile:
         """`Retrieve your own user profile <https://developer.cognite.com/api#tag/User-profiles/operation/getRequesterUserProfile>`_
@@ -36,19 +45,17 @@ class UserProfilesAPI(APIClient):
     def retrieve(self, user_identifier: str) -> UserProfile | None:
         ...
 
-    @overload  # Note, can't use Sequence[str], as str itself matches this requirement...
-    def retrieve(self, user_identifier: MutableSequence[str] | tuple[str, ...]) -> UserProfileList:
+    @overload
+    def retrieve(self, user_identifier: SequenceNotStr[str]) -> UserProfileList:
         ...
 
-    def retrieve(
-        self, user_identifier: str | MutableSequence[str] | tuple[str, ...]
-    ) -> UserProfile | UserProfileList | None:
+    def retrieve(self, user_identifier: str | SequenceNotStr[str]) -> UserProfile | UserProfileList | None:
         """`Retrieve user profiles by user identifier. <https://developer.cognite.com/api#tag/User-profiles/operation/getUserProfilesByIds>`_
 
         Retrieves one or more user profiles indexed by the user identifier in the same CDF project.
 
         Args:
-            user_identifier (str | MutableSequence[str] | tuple[str, ...]): The single user identifier (or sequence of) to retrieve profile(s) for.
+            user_identifier (str | SequenceNotStr[str]): The single user identifier (or sequence of) to retrieve profile(s) for.
 
         Returns:
             UserProfile | UserProfileList | None: UserProfileList if a sequence of user identifier were requested, else UserProfile. If a single user identifier is requested and it is not found, None is returned.

--- a/cognite/client/_api/user_profiles.py
+++ b/cognite/client/_api/user_profiles.py
@@ -4,7 +4,7 @@ from typing import List, cast, overload
 
 from cognite.client._api_client import APIClient
 from cognite.client._constants import DEFAULT_LIMIT_READ
-from cognite.client.data_classes.user_profiles import UserProfile, UserProfileList
+from cognite.client.data_classes.user_profiles import UserProfile, UserProfileList, UserProfilesConfiguration
 from cognite.client.utils._identifier import UserIdentifierSequence
 from cognite.client.utils.useful_types import SequenceNotStr
 
@@ -12,13 +12,15 @@ from cognite.client.utils.useful_types import SequenceNotStr
 class UserProfilesAPI(APIClient):
     _RESOURCE_PATH = "/profiles"
 
-    def enable(self) -> None:
+    def enable(self) -> UserProfilesConfiguration:
         """Enable user profiles for the project"""
-        self._post("/update", json={"update": {"userProfilesConfiguration": {"set": {"enabled": True}}}})
+        res = self._post("/update", json={"update": {"userProfilesConfiguration": {"set": {"enabled": True}}}})
+        return UserProfilesConfiguration.load(res.json()["userProfilesConfiguration"])
 
-    def disable(self) -> None:
+    def disable(self) -> UserProfilesConfiguration:
         """Disable user profiles for the project"""
-        self._post("/update", json={"update": {"userProfilesConfiguration": {"set": {"enabled": False}}}})
+        res = self._post("/update", json={"update": {"userProfilesConfiguration": {"set": {"enabled": False}}}})
+        return UserProfilesConfiguration.load(res.json()["userProfilesConfiguration"])
 
     def me(self) -> UserProfile:
         """`Retrieve your own user profile <https://developer.cognite.com/api#tag/User-profiles/operation/getRequesterUserProfile>`_

--- a/cognite/client/_version.py
+++ b/cognite/client/_version.py
@@ -1,4 +1,4 @@
 from __future__ import annotations
 
-__version__ = "7.8.10"
+__version__ = "7.9.0"
 __api_subversion__ = "V20220125"

--- a/cognite/client/data_classes/user_profiles.py
+++ b/cognite/client/data_classes/user_profiles.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any, Sequence, cast
 
+from typing_extensions import Self
+
 from cognite.client.data_classes._base import CogniteResource, CogniteResourceList
 from cognite.client.utils._text import to_camel_case
 
@@ -73,3 +75,12 @@ class UserProfileList(CogniteResourceList[UserProfile]):
             UserProfile | None: The requested item or None if not found.
         """
         return self._user_identifier_to_item.get(user_identifier)
+
+
+class UserProfilesConfiguration(CogniteResource):
+    def __init__(self, enabled: bool) -> None:
+        self.enabled = enabled
+
+    @classmethod
+    def _load(cls, resource: dict, cognite_client: CogniteClient | None = None) -> Self:
+        return cls(enabled=resource["enabled"])

--- a/cognite/client/utils/_identifier.py
+++ b/cognite/client/utils/_identifier.py
@@ -267,7 +267,7 @@ class DataModelingIdentifierSequence(IdentifierSequenceCore[DataModelingIdentifi
 class UserIdentifierSequence(IdentifierSequenceCore[UserIdentifier]):
     # TODO: Inferred type from inherited methods 'as_dicts' and 'as_primitives' wrongly include 'int'
     @classmethod
-    def load(cls, user_identifiers: str | Sequence[str]) -> UserIdentifierSequence:
+    def load(cls, user_identifiers: str | SequenceNotStr[str]) -> UserIdentifierSequence:
         if isinstance(user_identifiers, str):
             return cls([UserIdentifier(user_identifiers)], is_singleton=True)
 

--- a/docs/source/identity_and_access_management.rst
+++ b/docs/source/identity_and_access_management.rst
@@ -63,6 +63,14 @@ Revoke a session
 
 User Profiles
 ^^^^^^^^^^^^^^^^^^^
+Enable user profiles for project
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+.. automethod:: cognite.client._api.iam.UserProfilesAPI.enable
+
+Disable user profiles for project
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+.. automethod:: cognite.client._api.iam.UserProfilesAPI.disable
+
 Get my own user profile
 ~~~~~~~~~~~~~~~~~~~~~~~~
 .. automethod:: cognite.client._api.iam.UserProfilesAPI.me

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "cognite-sdk"
 
-version = "7.8.10"
+version = "7.9.0"
 description = "Cognite Python SDK"
 readme = "README.md"
 documentation = "https://cognite-sdk-python.readthedocs-hosted.com"

--- a/tests/tests_unit/test_api_client.py
+++ b/tests/tests_unit/test_api_client.py
@@ -382,6 +382,9 @@ class TestStandardRetrieveMultiple:
             status=400,
             json={"error": {"message": "Not Found", "missing": [{"id": 2}]}},
         )
+        # Second request may be skipped intentionally depending on which thread runs when:
+        rsps.assert_all_requests_are_fired = False
+
         with set_request_limit(api_client_with_token, 1):
             with pytest.raises(CogniteNotFoundError) as e:
                 api_client_with_token._retrieve_multiple(


### PR DESCRIPTION
## Description
- Add enable/disable endpoints for `UserProfilesAPI`
- Change a few `MutableSequence` to `SequenceNotStr`

## Checklist:
- [ ] Tests added/updated.
- [ ] Documentation updated. Documentation is generated from docstrings - these must be updated according to your change.
  If a new method has been added it should be referenced in [cognite.rst](https://github.com/cognitedata/cognite-sdk-python/blob/master/docs/source/cognite.rst) in order to generate docs based on its docstring.
- [ ] Changelog updated in [CHANGELOG.md](https://github.com/cognitedata/cognite-sdk-python/blob/master/CHANGELOG.md).
- [ ] Version bumped. If triggering a new release is desired, bump the version number in [_version.py](https://github.com/cognitedata/cognite-sdk-python/blob/master/cognite/client/_version.py) and [pyproject.toml](https://github.com/cognitedata/cognite-sdk-python/blob/master/pyproject.toml) per [semantic versioning](https://semver.org/).
