### PR TITLE
bugfix: creating transformations for WASM users

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,11 @@ Changes are grouped as follows
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
+## [7.8.9] - 2024-01-04
+### Fixed
+- Pyodide-users of the SDK can now create Transformations with non-nonce credentials without a `pyodide.JsException`
+  exception being raised.
+
 ## [7.8.8] - 2024-01-03
 ### Added
 - Support for `workflows.cancel`.

--- a/cognite/client/_constants.py
+++ b/cognite/client/_constants.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
-import sys
+try:
+    from pyodide.ffi import IN_BROWSER  # type: ignore [import-not-found]
+except ModuleNotFoundError:
+    IN_BROWSER = False
 
-_RUNNING_IN_BROWSER = sys.platform == "emscripten" and "pyodide" in sys.modules
-
+_RUNNING_IN_BROWSER = IN_BROWSER
 DEFAULT_LIMIT_READ = 25
 # Max JavaScript-safe integer 2^53 - 1
 MAX_VALID_INTERNAL_ID = 9007199254740991

--- a/cognite/client/_version.py
+++ b/cognite/client/_version.py
@@ -1,4 +1,4 @@
 from __future__ import annotations
 
-__version__ = "7.8.8"
+__version__ = "7.8.9"
 __api_subversion__ = "V20220125"

--- a/cognite/client/data_classes/transformations/__init__.py
+++ b/cognite/client/data_classes/transformations/__init__.py
@@ -26,7 +26,7 @@ from cognite.client.data_classes.transformations.common import (
 from cognite.client.data_classes.transformations.jobs import TransformationJob, TransformationJobList
 from cognite.client.data_classes.transformations.schedules import TransformationSchedule
 from cognite.client.data_classes.transformations.schema import TransformationSchemaColumnList
-from cognite.client.exceptions import CogniteAPIError
+from cognite.client.exceptions import CogniteAPIError, PyodideJsException
 from cognite.client.utils._text import convert_all_keys_to_camel_case
 
 if TYPE_CHECKING:
@@ -299,6 +299,10 @@ class Transformation(CogniteResource):
                     "\nProvided OIDC credentials will be passed on to the transformation service."
                 )
                 warnings.warn(msg, UserWarning)
+            except PyodideJsException:
+                # CORS policy blocks call to get token with the provided credentials (url not Fusion,
+                # but e.g. Microsoft), so we must pass the credentials on to the backend
+                pass
         return ret
 
     def run(self, wait: bool = True, timeout: float | None = None) -> TransformationJob:

--- a/cognite/client/exceptions.py
+++ b/cognite/client/exceptions.py
@@ -5,6 +5,7 @@ import reprlib
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Callable
 
+from cognite.client._constants import _RUNNING_IN_BROWSER
 from cognite.client.utils._auxiliary import no_op
 
 if TYPE_CHECKING:
@@ -348,3 +349,14 @@ class ModelFailedException(Exception):
 
 class CogniteAuthorizationError(CogniteAPIError):
     ...
+
+
+if _RUNNING_IN_BROWSER:
+    from pyodide.ffi import JsException  # type: ignore [import-not-found]
+else:
+
+    class JsException(Exception):  # type: ignore [no-redef]
+        ...
+
+
+PyodideJsException = JsException

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "cognite-sdk"
 
-version = "7.8.8"
+version = "7.8.9"
 description = "Cognite Python SDK"
 readme = "README.md"
 documentation = "https://cognite-sdk-python.readthedocs-hosted.com"


### PR DESCRIPTION
## [7.8.9] - 2024-01-04
### Fixed
- Pyodide-users of the SDK can now create Transformations with non-nonce credentials without a `pyodide.JsException`
  exception being raised.