### PR TITLE
Make `cdf_project_name` required in `OidcCredentials` (transformations)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,11 @@ Changes are grouped as follows
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
+## [7.8.10] - 2024-01-04
+### Changed
+- When using `OidcCredentials` to create a transformation, `cdf_project_name` is no longer optional as required
+  by the API.
+
 ## [7.8.9] - 2024-01-04
 ### Fixed
 - Pyodide-users of the SDK can now create Transformations with non-nonce credentials without a `pyodide.JsException`

--- a/cognite/client/_version.py
+++ b/cognite/client/_version.py
@@ -1,4 +1,4 @@
 from __future__ import annotations
 
-__version__ = "7.8.9"
+__version__ = "7.8.10"
 __api_subversion__ = "V20220125"

--- a/cognite/client/data_classes/transformations/common.py
+++ b/cognite/client/data_classes/transformations/common.py
@@ -290,8 +290,8 @@ class OidcCredentials:
         client_secret (str): Your application's client secret
         scopes (str | list[str]): A list of scopes or a comma-separated string (for backwards compatibility).
         token_uri (str): OAuth token url
+        cdf_project_name (str): Name of CDF project
         audience (str | None): Audience (optional)
-        cdf_project_name (str | None): Name of CDF project (optional)
     """
 
     def __init__(
@@ -300,8 +300,8 @@ class OidcCredentials:
         client_secret: str,
         scopes: str | list[str],
         token_uri: str,
+        cdf_project_name: str,
         audience: str | None = None,
-        cdf_project_name: str | None = None,
     ) -> None:
         self.client_id = client_id
         self.client_secret = client_secret
@@ -355,8 +355,8 @@ class OidcCredentials:
             client_secret=data["clientSecret"],
             scopes=data["scopes"],
             token_uri=data["tokenUri"],
+            cdf_project_name=data["cdfProjectName"],
             audience=data.get("audience"),
-            cdf_project_name=data.get("cdfProjectName"),
         )
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "cognite-sdk"
 
-version = "7.8.9"
+version = "7.8.10"
 description = "Cognite Python SDK"
 readme = "README.md"
 documentation = "https://cognite-sdk-python.readthedocs-hosted.com"

--- a/tests/tests_unit/test_transformations/test_common.py
+++ b/tests/tests_unit/test_transformations/test_common.py
@@ -7,12 +7,16 @@ from cognite.client.data_classes.transformations.common import OidcCredentials
 
 @pytest.fixture
 def oidc_credentials():
-    return OidcCredentials(client_id="id", client_secret="secret", scopes=["impersonation"], token_uri="url")
+    return OidcCredentials(
+        client_id="id", client_secret="secret", scopes=["impersonation"], token_uri="url", cdf_project_name="xyz"
+    )
 
 
 @pytest.mark.parametrize("scopes", ("comma,separated,scopes", ["comma", "separated", "scopes"]))
 def test_oidc_credentials(scopes):
-    oidc_credentials = OidcCredentials(client_id="id", client_secret="secret", scopes=scopes, token_uri="url")
+    oidc_credentials = OidcCredentials(
+        client_id="id", client_secret="secret", scopes=scopes, token_uri="url", cdf_project_name="zyx"
+    )
     assert oidc_credentials.scopes == "comma,separated,scopes"
 
 


### PR DESCRIPTION
## [7.8.10] - 2024-01-04
### Changed
- When using `OidcCredentials` to create a transformation, `cdf_project_name` is no longer optional as required
  by the API.