### PR TITLE
include example documentation on edge properties in views

### DIFF
--- a/docs/source/data_modeling.rst
+++ b/docs/source/data_modeling.rst
@@ -63,6 +63,69 @@ Apply view
 ^^^^^^^^^^^^^^^^^
 .. automethod:: cognite.client._api.data_modeling.views.ViewsAPI.apply
 
+Example on creating a view with a direct relation and edge relation
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+.. code:: python
+    from cognite.client import CogniteClient
+    from cognite.client.data_classes.data_modeling import (
+        ContainerId,
+        DirectRelationReference,
+        MappedPropertyApply,
+        ViewApply,
+        ViewId,
+    )
+    from cognite.client.data_classes.data_modeling.views import (
+        MultiEdgeConnectionApply,
+    )
+
+    c = CogniteClient()
+
+    movie_view = ViewApply(
+        space="imdb",
+        external_id="Movie",
+        version="1",
+        name="Movie",
+        properties={
+            "name": MappedPropertyApply(
+                container=ContainerId("imdb", "Movie"),
+                name="name",
+                container_property_identifier="name",
+            ),
+            "actors": MultiEdgeConnectionApply(
+                type=DirectRelationReference(
+                    space="imdb", external_id="Movie.actors"
+                ),
+                source=ViewId("imdb", "Actor", "1"),
+                name="actors",
+                direction="outwards",
+            ),
+        },
+    )
+    actor_view = ViewApply(
+        space="imdb",
+        external_id="Actor",
+        version="1",
+        name="Actor",
+        properties={
+            "name": MappedPropertyApply(
+                container=ContainerId("imdb", "Actor"),
+                name="name",
+                container_property_identifier="name",
+            ),
+            "movies": MultiEdgeConnectionApply(
+                type=DirectRelationReference(
+                    space="imdb", external_id="Movie.actors"
+                ),
+                source=ViewId("imdb", "Movie", "1"),
+                name="movies",
+                direction="inwards",
+            ),
+        },
+    )
+
+    c.data_modeling.views.apply([movie_view, actor_view])
+
+
 Delete views
 ^^^^^^^^^^^^^^^^^^
 .. automethod:: cognite.client._api.data_modeling.views.ViewsAPI.delete


### PR DESCRIPTION
## Description
Added examples of how to write edge properties for views using the MultiEdgeConnectionApply object. Hard coded into the data_modeling.rst file (please forgive if it's better suited elsewhere 🙏 ). 

## Checklist:
- [ ] Tests added/updated.
- [ ] Documentation updated. Documentation is generated from docstrings - these must be updated according to your change.
  If a new method has been added it should be referenced in [cognite.rst](https://github.com/cognitedata/cognite-sdk-python/blob/master/docs/source/cognite.rst) in order to generate docs based on its docstring.
- [ ] Changelog updated in [CHANGELOG.md](https://github.com/cognitedata/cognite-sdk-python/blob/master/CHANGELOG.md).
- [ ] Version bumped. If triggering a new release is desired, bump the version number in [_version.py](https://github.com/cognitedata/cognite-sdk-python/blob/master/cognite/client/_version.py) and [pyproject.toml](https://github.com/cognitedata/cognite-sdk-python/blob/master/pyproject.toml) per [semantic versioning](https://semver.org/).
