### PR TITLE
add `as_property_ref` to `View` and `Container`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,11 @@ Changes are grouped as follows
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
+## [7.13.3] - 2024-01-12
+### Added
+- `View.as_property_ref` and `Container.as_property_ref` to make it easier to create property references
+  (used to only be available on `ViewId` and `ContainerId`).
+
 ## [7.13.2] - 2024-01-11
 ### Fixed
 * When calling `ExtractinoPipeline.load` not having a `schedule` would raise a `KeyError` even though it is optional. This is now fixed.

--- a/cognite/client/_version.py
+++ b/cognite/client/_version.py
@@ -1,4 +1,4 @@
 from __future__ import annotations
 
-__version__ = "7.13.2"
+__version__ = "7.13.3"
 __api_subversion__ = "V20220125"

--- a/cognite/client/data_classes/data_modeling/containers.py
+++ b/cognite/client/data_classes/data_modeling/containers.py
@@ -67,6 +67,9 @@ class ContainerCore(DataModelingSchemaResource["ContainerApply"], ABC):
     def as_id(self) -> ContainerId:
         return ContainerId(self.space, self.external_id)
 
+    def as_property_ref(self, property: str) -> tuple[str, str, str]:
+        return self.as_id().as_property_ref(property)
+
 
 class ContainerApply(ContainerCore):
     """Represent the physical storage of data. This is the write format of the container

--- a/cognite/client/data_classes/data_modeling/ids.py
+++ b/cognite/client/data_classes/data_modeling/ids.py
@@ -129,7 +129,7 @@ class ContainerId(DataModelingId):
     def as_source_identifier(self) -> str:
         return self.external_id
 
-    def as_property_ref(self, property: str) -> tuple[str, ...]:
+    def as_property_ref(self, property: str) -> tuple[str, str, str]:
         return (self.space, self.as_source_identifier(), property)
 
 
@@ -140,7 +140,7 @@ class ViewId(VersionedDataModelingId):
     def as_source_identifier(self) -> str:
         return f"{self.external_id}/{self.version}"
 
-    def as_property_ref(self, property: str) -> tuple[str, ...]:
+    def as_property_ref(self, property: str) -> tuple[str, str, str]:
         return (self.space, self.as_source_identifier(), property)
 
 

--- a/cognite/client/data_classes/data_modeling/views.py
+++ b/cognite/client/data_classes/data_modeling/views.py
@@ -61,6 +61,9 @@ class ViewCore(DataModelingSchemaResource["ViewApply"], ABC):
             version=self.version,
         )
 
+    def as_property_ref(self, property: str) -> tuple[str, str, str]:
+        return self.as_id().as_property_ref(property)
+
 
 class ViewApply(ViewCore):
     """A group of properties. Write only version.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "cognite-sdk"
 
-version = "7.13.2"
+version = "7.13.3"
 description = "Cognite Python SDK"
 readme = "README.md"
 documentation = "https://cognite-sdk-python.readthedocs-hosted.com"

--- a/tests/tests_unit/test_data_classes/test_data_models/test_containers.py
+++ b/tests/tests_unit/test_data_classes/test_data_models/test_containers.py
@@ -1,6 +1,30 @@
 import pytest
 
-from cognite.client.data_classes.data_modeling.containers import Constraint, ContainerProperty, Index
+from cognite.client.data_classes.data_modeling.containers import (
+    Constraint,
+    Container,
+    ContainerApply,
+    ContainerProperty,
+    Index,
+)
+
+
+class TestContainer:
+    def test_as_property_ref(self) -> None:
+        params = dict(
+            space="sp",
+            externalId="ex",
+            properties={},
+            isGlobal=False,
+            lastUpdatedTime=123,
+            createdTime=12,
+            usedFor="node",
+        )
+        cont = Container.load(params)
+        cont_apply = ContainerApply.load(params)
+
+        assert cont.as_property_ref("foo") == ("sp", "ex", "foo")
+        assert cont_apply.as_property_ref("foo") == ("sp", "ex", "foo")
 
 
 class TestContainerProperty:

--- a/tests/tests_unit/test_data_classes/test_data_models/test_views.py
+++ b/tests/tests_unit/test_data_classes/test_data_models/test_views.py
@@ -1,5 +1,24 @@
-from cognite.client.data_classes.data_modeling import ViewId
+from cognite.client.data_classes.data_modeling import View, ViewApply, ViewId
 from cognite.client.data_classes.data_modeling.views import MappedProperty, ViewProperty, ViewPropertyApply
+
+
+class TestView:
+    def test_as_property_ref(self) -> None:
+        params = dict(
+            space="spa",
+            externalId="de",
+            version="69",
+            lastUpdatedTime=123,
+            createdTime=12,
+            writable=False,
+            usedFor="node",
+            isGlobal=False,
+        )
+        cont = View.load(params)
+        cont_apply = ViewApply.load(params)
+
+        assert cont.as_property_ref("bar") == ("spa", "de/69", "bar")
+        assert cont_apply.as_property_ref("bar") == ("spa", "de/69", "bar")
 
 
 class TestViewPropertyDefinition:


### PR DESCRIPTION
## [7.13.3] - 2024-01-12
### Added
- `View.as_property_ref` and `Container.as_property_ref` to make it easier to create property references
  (used to only be available on `ViewId` and `ContainerId`).

## Checklist:
- [x] Tests added/updated.
- [ ] Documentation updated. Documentation is generated from docstrings - these must be updated according to your change.
  If a new method has been added it should be referenced in [cognite.rst](https://github.com/cognitedata/cognite-sdk-python/blob/master/docs/source/cognite.rst) in order to generate docs based on its docstring.
- [x] Changelog updated in [CHANGELOG.md](https://github.com/cognitedata/cognite-sdk-python/blob/master/CHANGELOG.md).
- [x] Version bumped. If triggering a new release is desired, bump the version number in [_version.py](https://github.com/cognitedata/cognite-sdk-python/blob/master/cognite/client/_version.py) and [pyproject.toml](https://github.com/cognitedata/cognite-sdk-python/blob/master/pyproject.toml) per [semantic versioning](https://semver.org/).
