### PR TITLE
fixed to_pandas expand_properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ Changes are grouped as follows
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
+## [7.13.5] - 2024-01-13
+### Fixed
+* When calling `to_pandas` with `expand_properties=True` on an instance with no properties, the SDK will ignore the properties and return a dataframe with the other instance data.
+
 ## [7.13.4] - 2024-01-11
 ### Fixed
 * When calling `WorkflowExecution.load` not having a `schedule` would raise a `KeyError` even though it is optional. This is now fixed.

--- a/cognite/client/_version.py
+++ b/cognite/client/_version.py
@@ -1,4 +1,4 @@
 from __future__ import annotations
 
-__version__ = "7.13.4"
+__version__ = "7.13.5"
 __api_subversion__ = "V20220125"

--- a/cognite/client/data_classes/data_modeling/core.py
+++ b/cognite/client/data_classes/data_modeling/core.py
@@ -113,7 +113,7 @@ class DataModelingInstancesList(WriteableCogniteResourceList, Generic[T_WriteCla
             return df
 
         prop_df = local_import("pandas").json_normalize(df.pop("properties"), max_level=2)
-        if remove_property_prefix:
+        if remove_property_prefix and not prop_df.empty:
             # We only do/allow this if we have a single source:
             view_id, *extra = set(vid for item in self for vid in item.properties)
             if not extra:

--- a/cognite/client/data_classes/data_modeling/instances.py
+++ b/cognite/client/data_classes/data_modeling/instances.py
@@ -334,7 +334,7 @@ class Instance(WritableInstanceCore[T_CogniteResource], ABC):
         pd = local_import("pandas")
         col = df.squeeze()
         prop_df = pd.json_normalize(col.pop("properties"), max_level=2)
-        if remove_property_prefix:
+        if remove_property_prefix and not prop_df.empty:
             # We only do/allow this if we have a single source:
             view_id, *extra = self.properties.keys()
             if not extra:

--- a/tests/tests_unit/test_data_classes/test_data_models/test_instances.py
+++ b/tests/tests_unit/test_data_classes/test_data_models/test_instances.py
@@ -176,13 +176,19 @@ class TestInstancesToPandas:
         self, node_dumped: dict[str, Any], edge_dumped: dict[str, Any], inst_cls: type[Node] | type[Edge]
     ) -> None:
         raw = node_dumped if inst_cls is Node else edge_dumped
+        raw_no_properties = raw.copy()
+        raw_no_properties["properties"] = {}
         not_expanded = inst_cls._load(raw).to_pandas(expand_properties=False)
         expanded = inst_cls._load(raw).to_pandas(expand_properties=True, remove_property_prefix=True)
         expanded_with_prefix = inst_cls._load(raw).to_pandas(expand_properties=True, remove_property_prefix=False)
+        expanded_with_empty_properties = inst_cls._load(raw_no_properties).to_pandas(
+            expand_properties=True, remove_property_prefix=True
+        )
 
         assert "properties" in not_expanded.index
         assert "properties" not in expanded.index
         assert "properties" not in expanded_with_prefix.index
+        assert "properties" not in expanded_with_empty_properties.index
 
         assert raw["properties"] == not_expanded.loc["properties"].item()
 


### PR DESCRIPTION
## Description
Please describe the change you have made.

## Checklist:
- [x] Tests added/updated.
- [x] Documentation updated. Documentation is generated from docstrings - these must be updated according to your change.
  If a new method has been added it should be referenced in [cognite.rst](https://github.com/cognitedata/cognite-sdk-python/blob/master/docs/source/cognite.rst) in order to generate docs based on its docstring.
- [x] Changelog updated in [CHANGELOG.md](https://github.com/cognitedata/cognite-sdk-python/blob/master/CHANGELOG.md).
- [x] Version bumped. If triggering a new release is desired, bump the version number in [_version.py](https://github.com/cognitedata/cognite-sdk-python/blob/master/cognite/client/_version.py) and [pyproject.toml](https://github.com/cognitedata/cognite-sdk-python/blob/master/pyproject.toml) per [semantic versioning](https://semver.org/).
