### PR TITLE
fix files/upload for files using geo_location

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,25 +17,29 @@ Changes are grouped as follows
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
+## [7.13.8] - 2024-01-19
+### Fixed
+- `FilesAPI.upload` when using `geo_location` (serialize error).
+
 ## [7.13.7] - 2024-01-19
 ### Fixed
-* Type hints for all `.update` and `.upsert` methods accept Write classes in addition to Read and Update classes.
-* Missing overloading of the `.update` methods on `client.three_d.models.update`, `client.transformations.update`,
+- Type hints for all `.update` and `.upsert` methods accept Write classes in addition to Read and Update classes.
+- Missing overloading of the `.update` methods on `client.three_d.models.update`, `client.transformations.update`,
   `client.transformations.schedules.update`, `client.relationships.update`, and `client.data_sets.update`.
 
 ## [7.13.6] - 2024-01-18
 ### Added
-- Helper method `as_tuple` to `NodeId` and `EdgeId`. 
+- Helper method `as_tuple` to `NodeId` and `EdgeId`.
 
 ## [7.13.5] - 2024-01-16
 ### Added
-- EdgeConnection, MultiEdgeConnection, MultiReverseDirectRelation and their corresponding Apply View dataclasses are now importable from `cognite.client.dataclasses.data_modeling`. 
+- EdgeConnection, MultiEdgeConnection, MultiReverseDirectRelation and their corresponding Apply View dataclasses are now importable from `cognite.client.dataclasses.data_modeling`.
 
 ## [7.13.4] - 2024-01-11
 ### Fixed
-* When calling `WorkflowExecution.load` not having a `schedule` would raise a `KeyError` even though it is optional. This is now fixed.
-* When calling `Datapoints.load` not having a `isString` would raise a `KeyError` even though it is optional. This is now fixed.
-* Most `CogniteResourceList.as_write()` would raise a `CogniteMissingClientError` when called from a class with missing cognite_client. This is now fixed.
+- When calling `WorkflowExecution.load` not having a `schedule` would raise a `KeyError` even though it is optional. This is now fixed.
+- When calling `Datapoints.load` not having a `isString` would raise a `KeyError` even though it is optional. This is now fixed.
+- Most `CogniteResourceList.as_write()` would raise a `CogniteMissingClientError` when called from a class with missing cognite_client. This is now fixed.
 
 ## [7.13.3] - 2024-01-12
 ### Added
@@ -44,7 +48,7 @@ Changes are grouped as follows
 
 ## [7.13.2] - 2024-01-11
 ### Fixed
-* When calling `ExtractinoPipeline.load` not having a `schedule` would raise a `KeyError` even though it is optional. This is now fixed.
+- When calling `ExtractinoPipeline.load` not having a `schedule` would raise a `KeyError` even though it is optional. This is now fixed.
 
 ## [7.13.1] - 2024-01-10
 ### Improved

--- a/cognite/client/_api/raw.py
+++ b/cognite/client/_api/raw.py
@@ -384,7 +384,8 @@ class RawRowsAPI(APIClient):
                 >>> from cognite.client import CogniteClient
                 >>> from cognite.client.data_classes import RowWrite
                 >>> c = CogniteClient()
-                >>> rows = [RowWrite(key="r1", columns={"col1": "val1", "col2": "val1"}), RowWrite(key="r2", columns={"col1": "val2", "col2": "val2"})]
+                >>> rows = [RowWrite(key="r1", columns={"col1": "val1", "col2": "val1"}),
+                ...         RowWrite(key="r2", columns={"col1": "val2", "col2": "val2"})]
                 >>> c.raw.rows.insert("db1", "table1", rows)
         """
         chunks = self._process_row_input(row)

--- a/cognite/client/_version.py
+++ b/cognite/client/_version.py
@@ -1,4 +1,4 @@
 from __future__ import annotations
 
-__version__ = "7.13.7"
+__version__ = "7.13.8"
 __api_subversion__ = "V20220125"

--- a/cognite/client/data_classes/files.py
+++ b/cognite/client/data_classes/files.py
@@ -60,8 +60,11 @@ class FileMetadataCore(WriteableCogniteResource["FileMetadataWrite"], ABC):
         source_modified_time: int | None = None,
         security_categories: Sequence[int] | None = None,
     ) -> None:
-        if geo_location is not None and not isinstance(geo_location, GeoLocation):
-            raise TypeError("FileMetadata.geo_location should be of type GeoLocation")
+        if geo_location is not None:
+            if isinstance(geo_location, dict):
+                geo_location = GeoLocation.load(geo_location)
+            if not isinstance(geo_location, GeoLocation):
+                raise TypeError("FileMetadata.geo_location should be of type GeoLocation")
         self.external_id = external_id
         self.name = name
         self.directory = directory

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "cognite-sdk"
 
-version = "7.13.7"
+version = "7.13.8"
 description = "Cognite Python SDK"
 readme = "README.md"
 documentation = "https://cognite-sdk-python.readthedocs-hosted.com"


### PR DESCRIPTION
## [7.13.8] - 2024-01-19
### Fixed
- `FilesAPI.upload` when using `geo_location` (serialize error).

## Checklist:
- [ ] Tests added/updated.
- [ ] Documentation updated. Documentation is generated from docstrings - these must be updated according to your change.
  If a new method has been added it should be referenced in [cognite.rst](https://github.com/cognitedata/cognite-sdk-python/blob/master/docs/source/cognite.rst) in order to generate docs based on its docstring.
- [x] Changelog updated in [CHANGELOG.md](https://github.com/cognitedata/cognite-sdk-python/blob/master/CHANGELOG.md).
- [x] Version bumped. If triggering a new release is desired, bump the version number in [_version.py](https://github.com/cognitedata/cognite-sdk-python/blob/master/cognite/client/_version.py) and [pyproject.toml](https://github.com/cognitedata/cognite-sdk-python/blob/master/pyproject.toml) per [semantic versioning](https://semver.org/).
