### PR TITLE
Asset/AssetList improve helper methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,13 @@ Changes are grouped as follows
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
+## [7.14.0] - 2024-01-22
+### Changed
+- Helper methods to get related resources on `Asset` class now accepts `asset_ids` as part of keyword arguments.
+### Added
+- Helper methods to get related resources on `AssetList` class now accept keyword arguments that are passed on to
+  the list endpoint (for server-side filtering).
+
 ## [7.13.8] - 2024-01-19
 ### Fixed
 - `FilesAPI.upload` when using `geo_location` (serialize error).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ Changes are grouped as follows
 
 ## [7.14.0] - 2024-01-22
 ### Changed
-- Helper methods to get related resources on `Asset` class now accepts `asset_ids` as part of keyword arguments.
+- Helper methods to get related resources on `Asset` class now accept `asset_ids` as part of keyword arguments.
 ### Added
 - Helper methods to get related resources on `AssetList` class now accept keyword arguments that are passed on to
   the list endpoint (for server-side filtering).

--- a/cognite/client/_api/sequences.py
+++ b/cognite/client/_api/sequences.py
@@ -797,9 +797,7 @@ class SequencesAPI(APIClient):
         last_updated_time: dict[str, Any] | TimestampRange | None = None,
         limit: int | None = DEFAULT_LIMIT_READ,
     ) -> SequenceList:
-        """`Iterate over sequences <https://developer.cognite.com/api#tag/Sequences/operation/advancedListSequences>`_
-
-        Fetches sequences as they are iterated over, so you keep a limited number of objects in memory.
+        """`List sequences <https://developer.cognite.com/api#tag/Sequences/operation/advancedListSequences>`_
 
         Args:
             name (str | None): Filter out sequences that do not have this *exact* name.
@@ -830,7 +828,7 @@ class SequencesAPI(APIClient):
                 >>> from cognite.client import CogniteClient
                 >>> c = CogniteClient()
                 >>> for seq in c.sequences:
-                ...     seq # do something with the sequences
+                ...     seq # do something with the sequence
 
             Iterate over chunks of sequences to reduce memory load::
 

--- a/cognite/client/_api/time_series.py
+++ b/cognite/client/_api/time_series.py
@@ -751,9 +751,7 @@ class TimeSeriesAPI(APIClient):
         partitions: int | None = None,
         limit: int | None = DEFAULT_LIMIT_READ,
     ) -> TimeSeriesList:
-        """`List over time series <https://developer.cognite.com/api#tag/Time-series/operation/listTimeSeries>`_
-
-        Fetches time series as they are iterated over, so you keep a limited number of objects in memory.
+        """`List time series <https://developer.cognite.com/api#tag/Time-series/operation/listTimeSeries>`_
 
         Args:
             name (str | None): Name of the time series. Often referred to as tag.
@@ -791,14 +789,14 @@ class TimeSeriesAPI(APIClient):
                 >>> from cognite.client import CogniteClient
                 >>> c = CogniteClient()
                 >>> for ts in c.time_series:
-                ...     ts # do something with the time_series
+                ...     ts # do something with the time series
 
             Iterate over chunks of time series to reduce memory load::
 
                 >>> from cognite.client import CogniteClient
                 >>> c = CogniteClient()
                 >>> for ts_list in c.time_series(chunk_size=2500):
-                ...     ts_list # do something with the time_series
+                ...     ts_list # do something with the time series
         """
         asset_subtree_ids_processed = process_asset_subtree_ids(asset_subtree_ids, asset_subtree_external_ids)
         data_set_ids_processed = process_data_set_ids(data_set_ids, data_set_external_ids)

--- a/cognite/client/_version.py
+++ b/cognite/client/_version.py
@@ -1,4 +1,4 @@
 from __future__ import annotations
 
-__version__ = "7.13.8"
+__version__ = "7.14.0"
 __api_subversion__ = "V20220125"

--- a/cognite/client/data_classes/assets.py
+++ b/cognite/client/data_classes/assets.py
@@ -552,7 +552,7 @@ class AssetList(WriteableCogniteResourceList[AssetWrite, Asset], IdTransformerMi
         """Retrieve all sequences related to these assets.
 
         Args:
-            **kwargs (Any): All extra keyword arguments are passed to time_series/list. Note: 'limit' can not be used.
+            **kwargs (Any): All extra keyword arguments are passed to sequences/list. Note: 'limit' can not be used.
         Returns:
             SequenceList: All sequences related to the assets in this AssetList.
         """
@@ -564,7 +564,7 @@ class AssetList(WriteableCogniteResourceList[AssetWrite, Asset], IdTransformerMi
         """Retrieve all events related to these assets.
 
         Args:
-            **kwargs (Any): All extra keyword arguments are passed to time_series/list. Note: 'sort', 'partitions' and 'limit' can not be used.
+            **kwargs (Any): All extra keyword arguments are passed to events/list. Note: 'sort', 'partitions' and 'limit' can not be used.
         Returns:
             EventList: All events related to the assets in this AssetList.
         """
@@ -576,7 +576,7 @@ class AssetList(WriteableCogniteResourceList[AssetWrite, Asset], IdTransformerMi
         """Retrieve all files metadata related to these assets.
 
         Args:
-            **kwargs (Any): All extra keyword arguments are passed to time_series/list. Note: 'limit' can not be used.
+            **kwargs (Any): All extra keyword arguments are passed to files/list. Note: 'limit' can not be used.
         Returns:
             FileMetadataList: Metadata about all files related to the assets in this AssetList.
         """

--- a/cognite/client/utils/_auxiliary.py
+++ b/cognite/client/utils/_auxiliary.py
@@ -178,6 +178,11 @@ def split_into_n_parts(seq: Sequence[T], *, n: int) -> Iterator[Sequence[T]]:
 
 
 @overload
+def split_into_chunks(collection: set, chunk_size: int) -> list[list]:
+    ...
+
+
+@overload
 def split_into_chunks(collection: list, chunk_size: int) -> list[list]:
     ...
 
@@ -187,7 +192,10 @@ def split_into_chunks(collection: dict, chunk_size: int) -> list[dict]:
     ...
 
 
-def split_into_chunks(collection: list | dict, chunk_size: int) -> list[list] | list[dict]:
+def split_into_chunks(collection: set | list | dict, chunk_size: int) -> list[list] | list[dict]:
+    if isinstance(collection, set):
+        collection = list(collection)
+
     if isinstance(collection, list):
         return [collection[i : i + chunk_size] for i in range(0, len(collection), chunk_size)]
 

--- a/cognite/client/utils/_auxiliary.py
+++ b/cognite/client/utils/_auxiliary.py
@@ -178,12 +178,7 @@ def split_into_n_parts(seq: Sequence[T], *, n: int) -> Iterator[Sequence[T]]:
 
 
 @overload
-def split_into_chunks(collection: set, chunk_size: int) -> list[list]:
-    ...
-
-
-@overload
-def split_into_chunks(collection: list, chunk_size: int) -> list[list]:
+def split_into_chunks(collection: set | list, chunk_size: int) -> list[list]:
     ...
 
 

--- a/cognite/client/utils/_auxiliary.py
+++ b/cognite/client/utils/_auxiliary.py
@@ -227,6 +227,12 @@ def find_duplicates(seq: Iterable[THashable]) -> set[THashable]:
     return {x for x in seq if x in seen or add(x)}
 
 
+def remove_duplicates_keep_order(seq: Sequence[THashable]) -> list[THashable]:
+    seen: set[THashable] = set()
+    add = seen.add
+    return [x for x in seq if x not in seen and not add(x)]
+
+
 def exactly_one_is_not_none(*args: Any) -> bool:
     return sum(a is not None for a in args) == 1
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "cognite-sdk"
 
-version = "7.13.8"
+version = "7.14.0"
 description = "Cognite Python SDK"
 readme = "README.md"
 documentation = "https://cognite-sdk-python.readthedocs-hosted.com"

--- a/tests/tests_unit/conftest.py
+++ b/tests/tests_unit/conftest.py
@@ -8,7 +8,8 @@ from cognite.client import ClientConfig, CogniteClient
 from cognite.client.credentials import Token
 
 
-@pytest.fixture
+# TODO: This class-scoped client causes side-effects between tests...
+@pytest.fixture(scope="class")
 def cognite_client():
     cnf = ClientConfig(client_name="any", project="dummy", credentials=Token("bla"))
     yield CogniteClient(cnf)

--- a/tests/tests_unit/conftest.py
+++ b/tests/tests_unit/conftest.py
@@ -8,7 +8,7 @@ from cognite.client import ClientConfig, CogniteClient
 from cognite.client.credentials import Token
 
 
-@pytest.fixture(scope="class")
+@pytest.fixture
 def cognite_client():
     cnf = ClientConfig(client_name="any", project="dummy", credentials=Token("bla"))
     yield CogniteClient(cnf)

--- a/tests/tests_unit/test_utils/test_auxiliary.py
+++ b/tests/tests_unit/test_utils/test_auxiliary.py
@@ -16,6 +16,7 @@ from cognite.client.utils._auxiliary import (
     handle_deprecated_camel_case_argument,
     interpolate_and_url_encode,
     json_dump_default,
+    remove_duplicates_keep_order,
     split_into_chunks,
     split_into_n_parts,
 )
@@ -140,6 +141,19 @@ class TestSplitIntoChunks:
         assert len(actual_output) == len(expected_output)
         for element in expected_output:
             assert element in actual_output
+
+
+class TestRemoveDuplicatesKeepOrder:
+    @pytest.mark.parametrize(
+        "inp, expected",
+        (
+            ([], []),
+            ((1, 1, 2, 1), [1, 2]),
+            ("abccba", ["a", "b", "c"]),
+        ),
+    )
+    def test_no_duplicates_asdffdsa(self, inp, expected):
+        assert expected == remove_duplicates_keep_order(inp)
 
 
 class TestFindDuplicates:


### PR DESCRIPTION
## [7.14.0] - 2024-01-22
### Changed
- Helper methods to get related resources on `Asset` class now accepts `asset_ids` as part of keyword arguments.
### Added
- Helper methods to get related resources on `AssetList` class now accept keyword arguments that are passed on to
  the list endpoint (for server-side filtering).