### PR TITLE
Only run pypi version check once and make it async

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ Changes are grouped as follows
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
+## [7.15.0] - 2024-01-22
+### Improved
+- Only run pypi version check once, despite instantiating multiple clients. And make it async too.
+
 ## [7.14.0] - 2024-01-22
 ### Changed
 - Helper methods to get related resources on `Asset` class now accept `asset_ids` as part of keyword arguments.

--- a/cognite/client/_api/synthetic_time_series.py
+++ b/cognite/client/_api/synthetic_time_series.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import re
 from datetime import datetime
-from typing import TYPE_CHECKING, Any, Sequence, cast
+from typing import TYPE_CHECKING, Any, cast
 
 from cognite.client._api_client import APIClient
 from cognite.client.data_classes import Datapoints, DatapointsList, TimeSeries
@@ -72,9 +72,7 @@ class SyntheticDatapointsAPI(APIClient):
             limit = cast(int, float("inf"))
 
         tasks = []
-        expressions_to_iterate = (
-            expressions if isinstance(expressions, Sequence) and not isinstance(expressions, str) else [expressions]
-        )
+        expressions_to_iterate = expressions if isinstance(expressions, SequenceNotStr) else [expressions]
 
         for exp in expressions_to_iterate:
             expression, short_expression = self._build_expression(exp, variables, aggregate, granularity)

--- a/cognite/client/_version.py
+++ b/cognite/client/_version.py
@@ -1,4 +1,4 @@
 from __future__ import annotations
 
-__version__ = "7.14.0"
+__version__ = "7.15.0"
 __api_subversion__ = "V20220125"

--- a/cognite/client/utils/useful_types.py
+++ b/cognite/client/utils/useful_types.py
@@ -1,12 +1,13 @@
 from __future__ import annotations
 
-from typing import Any, Iterator, Protocol, Sequence, SupportsIndex, TypeVar, overload
+from typing import Any, Iterator, Protocol, Sequence, SupportsIndex, TypeVar, overload, runtime_checkable
 
 _T_co = TypeVar("_T_co", covariant=True)
 
 
 # Source from https://github.com/python/typing/issues/256#issuecomment-1442633430
 # This works because str.__contains__ does not accept object (either in typeshed or at runtime)
+@runtime_checkable
 class SequenceNotStr(Protocol[_T_co]):
     @overload
     def __getitem__(self, index: SupportsIndex, /) -> _T_co:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "cognite-sdk"
 
-version = "7.14.0"
+version = "7.15.0"
 description = "Cognite Python SDK"
 readme = "README.md"
 documentation = "https://cognite-sdk-python.readthedocs-hosted.com"


### PR DESCRIPTION
- Fix typing issue in synthetic_time_series.py
- Only run pypi version check once and make it async

## Description
Please describe the change you have made.

## Checklist:
- [ ] Tests added/updated.
- [ ] Documentation updated. Documentation is generated from docstrings - these must be updated according to your change.
  If a new method has been added it should be referenced in [cognite.rst](https://github.com/cognitedata/cognite-sdk-python/blob/master/docs/source/cognite.rst) in order to generate docs based on its docstring.
- [ ] Changelog updated in [CHANGELOG.md](https://github.com/cognitedata/cognite-sdk-python/blob/master/CHANGELOG.md).
- [ ] Version bumped. If triggering a new release is desired, bump the version number in [_version.py](https://github.com/cognitedata/cognite-sdk-python/blob/master/cognite/client/_version.py) and [pyproject.toml](https://github.com/cognitedata/cognite-sdk-python/blob/master/pyproject.toml) per [semantic versioning](https://semver.org/).
