### PR TITLE
bump `pyodide-http` version

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -2469,4 +2469,4 @@ yaml = ["PyYAML"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8"
-content-hash = "5f2085fadba7c28b78bc8991f3402cd8dd93363bf16b9f2a1040496e975da78c"
+content-hash = "ed5ea869e4e8ca929baa155635a2aacd42a5d806b195bc8518a92bae3da2a1d9"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ backports-zoneinfo = { version = ">=0.2.1",  python = "<3.9", extras = ["tzdata"
 tzdata = {version = ">=2023.3", markers = "sys_platform == 'win32'", optional = true }
 geopandas = { version = ">=0.10.0", optional = true }
 shapely = { version = ">=1.7.0", optional = true }
-pyodide-http = {version = "^0.2.0", optional = true }
+pyodide-http = {version = "^0.2.1", optional = true }
 graphlib-backport = {version = "^1.0.0", python = "<3.9"}
 PyYAML = {version = "^6.0", optional = true}
 


### PR DESCRIPTION
## Description
Fixes broken `user-agent` header for `pyodide` users.

Consider this not important enough to warrant a new release.