### PR TITLE
fixed_labels_on_file_upload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,11 @@ Changes are grouped as follows
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
+## [7.17.2] - 2024-02-04
+### Fixed
+- Uploading files will now accept Labels as part of file Metadata.
+This has not been possible after v 7.0.0.
+
 ## [7.17.1] - 2024-02-02
 ### Fixed
 - An (extreme) edge case where an empty, unnecessary API request for datapoints would be sent leading to a `CogniteAPIError`.

--- a/cognite/client/_version.py
+++ b/cognite/client/_version.py
@@ -1,4 +1,4 @@
 from __future__ import annotations
 
-__version__ = "7.17.1"
+__version__ = "7.17.2"
 __api_subversion__ = "V20220125"

--- a/cognite/client/data_classes/labels.py
+++ b/cognite/client/data_classes/labels.py
@@ -190,6 +190,8 @@ class Label(CogniteObject):
             elif isinstance(label, dict):
                 if "externalId" in label:
                     return Label(label["externalId"])
+                if "external_id" in label:
+                    return Label(label["external_id"])
             raise ValueError(f"Could not parse label: {label}")
 
         if labels is None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "cognite-sdk"
 
-version = "7.17.1"
+version = "7.17.2"
 description = "Cognite Python SDK"
 readme = "README.md"
 documentation = "https://cognite-sdk-python.readthedocs-hosted.com"

--- a/tests/tests_unit/test_api/test_files.py
+++ b/tests/tests_unit/test_api/test_files.py
@@ -429,6 +429,10 @@ class TestFilesAPI:
         path = os.path.join(os.path.dirname(__file__), "files_for_test_upload", "file_for_test_upload_1.txt")
         cognite_client.files.upload(path, external_id="blabla", name="bla", data_set_id=42)
 
+    def test_upload_with_label(self, cognite_client, mock_file_upload_response):
+        path = os.path.join(os.path.dirname(__file__), "files_for_test_upload", "file_for_test_upload_1.txt")
+        cognite_client.files.upload(path, external_id="blabla", name="bla", data_set_id=42, labels=[Label("PUMP")])
+
     def test_upload_no_name(self, cognite_client, mock_file_upload_response):
         dir = os.path.join(os.path.dirname(__file__), "files_for_test_upload")
         path = os.path.join(dir, "file_for_test_upload_1.txt")


### PR DESCRIPTION
## Description
From v7.0.0 it has not been possible to call client.files.upload with Labels. This PR is a minimal change to solve this problem quickly, a more thorough investigation about other possible consequences of the dump-methods should be done in a separate PR.

The main problem comes from the dump method used in FilesAPI._upload_file_from_path where the methond upload_bytes is called, dumping FileMetadata with camel_case=False. This fails in Label._load_list where "ExternalId" is in CamelCase. The instance checks in _load_list can probably be removed. Other consequences of the dump method and camel-case vs snake-case can also potentially be an issue.

## Checklist:
- [x] Tests added/updated.
- [x] Documentation updated. Documentation is generated from docstrings - these must be updated according to your change.
  If a new method has been added it should be referenced in [cognite.rst](https://github.com/cognitedata/cognite-sdk-python/blob/master/docs/source/cognite.rst) in order to generate docs based on its docstring.
- [x] Changelog updated in [CHANGELOG.md](https://github.com/cognitedata/cognite-sdk-python/blob/master/CHANGELOG.md).
- [x] Version bumped. If triggering a new release is desired, bump the version number in [_version.py](https://github.com/cognitedata/cognite-sdk-python/blob/master/cognite/client/_version.py) and [pyproject.toml](https://github.com/cognitedata/cognite-sdk-python/blob/master/pyproject.toml) per [semantic versioning](https://semver.org/).
