### PR TITLE
Fix geo_location handling for documents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ Changes are grouped as follows
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
-## [7.18.0] - 2024-02-08
+## [7.24.3] - 2024-02-27
 ### Fixed
 - Fix handling of GeometryCollection objects in the Documents API.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ Changes are grouped as follows
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
+## [7.18.0] - 2024-02-08
+### Fixed
+- Fix handling of GeometryCollection objects in the Documents API.
+
 ## [7.24.2] - 2024-02-25
 ### Fixed
 - [Pyodide/WASM only] The list method for raw rows now works for non-finite queries (got broken in `7.24.1`).

--- a/cognite/client/_version.py
+++ b/cognite/client/_version.py
@@ -1,4 +1,4 @@
 from __future__ import annotations
 
-__version__ = "7.18.0"
+__version__ = "7.24.3"
 __api_subversion__ = "20230101"

--- a/cognite/client/_version.py
+++ b/cognite/client/_version.py
@@ -1,4 +1,4 @@
 from __future__ import annotations
 
-__version__ = "7.24.2"
+__version__ = "7.18.0"
 __api_subversion__ = "20230101"

--- a/cognite/client/data_classes/_base.py
+++ b/cognite/client/data_classes/_base.py
@@ -619,7 +619,7 @@ class Geometry(CogniteObject):
     """Represents the points, curves and surfaces in the coordinate space.
 
     Args:
-        type (Literal["Point", "MultiPoint", "LineString", "MultiLineString", "Polygon", "MultiPolygon"]): The geometry type.
+        type (Literal['Point', 'MultiPoint', 'LineString', 'MultiLineString', 'Polygon', 'MultiPolygon']): The geometry type.
         coordinates (list): An array of the coordinates of the geometry. The structure of the elements in this array is determined by the type of geometry.
         geometries (Collection[Geometry] | None): No description.
 

--- a/cognite/client/data_classes/_base.py
+++ b/cognite/client/data_classes/_base.py
@@ -619,7 +619,7 @@ class Geometry(CogniteObject):
     """Represents the points, curves and surfaces in the coordinate space.
 
     Args:
-        type (Literal['Point', 'MultiPoint', 'LineString', 'MultiLineString', 'Polygon', 'MultiPolygon']): The geometry type.
+        type (Literal["Point", "MultiPoint", "LineString", "MultiLineString", "Polygon", "MultiPolygon"]): The geometry type.
         coordinates (list): An array of the coordinates of the geometry. The structure of the elements in this array is determined by the type of geometry.
         geometries (Collection[Geometry] | None): No description.
 

--- a/cognite/client/data_classes/documents.py
+++ b/cognite/client/data_classes/documents.py
@@ -27,7 +27,7 @@ class DocumentsGeoJsonGeometry(CogniteObject):
     """Represents the points, curves and surfaces in the coordinate space.
 
     Args:
-        type (Literal['Point', 'MultiPoint', 'LineString', 'MultiLineString', 'Polygon', 'MultiPolygon', 'GeometryCollection']): The geometry type.
+        type (Literal["Point", "MultiPoint", "LineString", "MultiLineString", "Polygon", "MultiPolygon", "GeometryCollection"]): The geometry type.
         coordinates (list | None): An array of the coordinates of the geometry. The structure of the elements in this array is determined by the type of geometry.
         geometries (Collection[Geometry] | None): No description.
 

--- a/cognite/client/data_classes/documents.py
+++ b/cognite/client/data_classes/documents.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, List, Literal, Union, cast
+from typing import TYPE_CHECKING, Any, Collection, List, Literal, Union, cast
 
 from typing_extensions import Self, TypeAlias
 
@@ -11,16 +11,105 @@ from cognite.client.data_classes._base import (
     CogniteResourceList,
     CogniteSort,
     EnumProperty,
+    Geometry,
     IdTransformerMixin,
     NoCaseConversionPropertyList,
 )
 from cognite.client.data_classes.aggregations import UniqueResult
 from cognite.client.data_classes.labels import Label, LabelDefinition
-from cognite.client.data_classes.shared import GeoLocation
 from cognite.client.utils._text import convert_all_keys_to_snake_case
 
 if TYPE_CHECKING:
     from cognite.client import CogniteClient
+
+
+class DocumentsGeoJsonGeometry(CogniteObject):
+    """Represents the points, curves and surfaces in the coordinate space.
+
+    Args:
+        type (Literal['Point', 'MultiPoint', 'LineString', 'MultiLineString', 'Polygon', 'MultiPolygon', 'GeometryCollection']): The geometry type.
+        coordinates (list | None): An array of the coordinates of the geometry. The structure of the elements in this array is determined by the type of geometry.
+        geometries (Collection[Geometry] | None): No description.
+
+    Examples:
+        Point:
+            Coordinates of a point in 2D space, described as an array of 2 numbers.
+
+            Example: `[4.306640625, 60.205710352530346]`
+
+        LineString:
+            Coordinates of a line described by a list of two or more points.
+            Each point is defined as a pair of two numbers in an array, representing coordinates of a point in 2D space.
+
+            Example: `[[30, 10], [10, 30], [40, 40]]`
+
+        Polygon:
+            List of one or more linear rings representing a shape.
+            A linear ring is the boundary of a surface or the boundary of a hole in a surface. It is defined as a list consisting of 4 or more Points, where the first and last Point is equivalent.
+            Each Point is defined as an array of 2 numbers, representing coordinates of a point in 2D space.
+
+            Example: `[[[35, 10], [45, 45], [15, 40], [10, 20], [35, 10]], [[20, 30], [35, 35], [30, 20], [20, 30]]]`
+            type: array
+
+        MultiPoint:
+            List of Points. Each Point is defined as an array of 2 numbers, representing coordinates of a point in 2D space.
+
+            Example: `[[35, 10], [45, 45]]`
+
+        MultiLineString:
+                List of lines where each line (LineString) is defined as a list of two or more points.
+                Each point is defined as a pair of two numbers in an array, representing coordinates of a point in 2D space.
+
+                Example: `[[[30, 10], [10, 30]], [[35, 10], [10, 30], [40, 40]]]`
+
+        MultiPolygon:
+            List of multiple polygons.
+            Each polygon is defined as a list of one or more linear rings representing a shape.
+            A linear ring is the boundary of a surface or the boundary of a hole in a surface. It is defined as a list consisting of 4 or more Points, where the first and last Point is equivalent.
+            Each Point is defined as an array of 2 numbers, representing coordinates of a point in 2D space.
+
+            Example: `[[[[30, 20], [45, 40], [10, 40], [30, 20]]], [[[15, 5], [40, 10], [10, 20], [5, 10], [15, 5]]]]`
+
+        GeometryCollection:
+            List of geometries as described above.
+    """
+
+    _VALID_TYPES = frozenset(
+        {"Point", "MultiPoint", "LineString", "MultiLineString", "Polygon", "MultiPolygon", "GeometryCollection"}
+    )
+
+    def __init__(
+        self,
+        type: Literal[
+            "Point", "MultiPoint", "LineString", "MultiLineString", "Polygon", "MultiPolygon", "GeometryCollection"
+        ],
+        coordinates: list | None = None,
+        geometries: Collection[Geometry] | None = None,
+    ) -> None:
+        if type not in self._VALID_TYPES:
+            raise ValueError(f"type must be one of {self._VALID_TYPES}")
+        self.type = type
+        self.coordinates = coordinates
+        self.geometries = geometries and list(geometries)
+
+    @classmethod
+    def _load(
+        cls, raw_geometry: dict[str, Any], cognite_client: CogniteClient | None = None
+    ) -> DocumentsGeoJsonGeometry:
+        instance = cls(
+            type=raw_geometry["type"],
+            coordinates=raw_geometry.get("coordinates"),
+            geometries=raw_geometry.get("geometries"),
+        )
+        if isinstance(instance.geometries, list):
+            instance.geometries = [Geometry.load(geometry) for geometry in instance.geometries]
+        return instance
+
+    def dump(self, camel_case: bool = True) -> dict[str, Any]:
+        output = super().dump(camel_case)
+        if self.geometries:
+            output["geometries"] = [g.dump(camel_case) for g in self.geometries]
+        return output
 
 
 class SourceFile(CogniteObject):
@@ -36,7 +125,7 @@ class SourceFile(CogniteObject):
         size (int | None): The size of the file in bytes.
         asset_ids (list[int] | None): The ids of the assets related to this file.
         labels (list[Label | str | LabelDefinition] | None): A list of labels associated with this document's source file in CDF.
-        geo_location (GeoLocation | None): The geolocation of the source file.
+        geo_location (DocumentsGeoJsonGeometry | None): The geolocation of the source file.
         dataset_id (int | None): The id if the dataset this file belongs to, if any.
         security_categories (list[int] | None): The security category IDs required to access this file.
         metadata (dict[str, str] | None): Custom, application specific metadata. String key -> String value.
@@ -54,7 +143,7 @@ class SourceFile(CogniteObject):
         size: int | None = None,
         asset_ids: list[int] | None = None,
         labels: list[Label | str | LabelDefinition] | None = None,
-        geo_location: GeoLocation | None = None,
+        geo_location: DocumentsGeoJsonGeometry | None = None,
         dataset_id: int | None = None,
         security_categories: list[int] | None = None,
         metadata: dict[str, str] | None = None,
@@ -79,7 +168,7 @@ class SourceFile(CogniteObject):
     def _load(cls, resource: dict, cognite_client: CogniteClient | None = None) -> SourceFile:
         instance = cls(**convert_all_keys_to_snake_case(resource), cognite_client=cognite_client)
         if isinstance(instance.geo_location, dict):
-            instance.geo_location = GeoLocation.load(instance.geo_location)
+            instance.geo_location = DocumentsGeoJsonGeometry.load(instance.geo_location)
         return instance
 
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
@@ -117,7 +206,7 @@ class Document(CogniteResource):
         truncated_content (str | None): The truncated content of the document.
         asset_ids (list[int] | None): The ids of any assets referred to in the document.
         labels (list[Label | str | LabelDefinition] | None): The labels attached to the document.
-        geo_location (GeoLocation | None): The geolocation of the document.
+        geo_location (DocumentsGeoJsonGeometry | None): The geolocation of the document.
         cognite_client (CogniteClient | None): No description.
         **_ (Any): No description.
     """
@@ -141,7 +230,7 @@ class Document(CogniteResource):
         truncated_content: str | None = None,
         asset_ids: list[int] | None = None,
         labels: list[Label | str | LabelDefinition] | None = None,
-        geo_location: GeoLocation | None = None,
+        geo_location: DocumentsGeoJsonGeometry | None = None,
         cognite_client: CogniteClient | None = None,
         **_: Any,
     ) -> None:
@@ -171,7 +260,7 @@ class Document(CogniteResource):
         if isinstance(instance.source_file, dict):
             instance.source_file = SourceFile.load(instance.source_file)
         if isinstance(instance.geo_location, dict):
-            instance.geo_location = GeoLocation.load(instance.geo_location)
+            instance.geo_location = DocumentsGeoJsonGeometry.load(instance.geo_location)
         return instance
 
     def dump(self, camel_case: bool = True) -> dict[str, Any]:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "cognite-sdk"
 
-version = "7.24.2"
+version = "7.18.0"
 description = "Cognite Python SDK"
 readme = "README.md"
 documentation = "https://cognite-sdk-python.readthedocs-hosted.com"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "cognite-sdk"
 
-version = "7.18.0"
+version = "7.24.3"
 description = "Cognite Python SDK"
 readme = "README.md"
 documentation = "https://cognite-sdk-python.readthedocs-hosted.com"

--- a/tests/tests_unit/test_api/test_documents.py
+++ b/tests/tests_unit/test_api/test_documents.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+import re
+
+import pytest
+
+from cognite.client.data_classes import Document
+
+
+@pytest.fixture
+def mock_documents_response(rsps, cognite_client):
+    response_body = {
+        "items": [
+            {
+                "id": 952558513813,
+                "sourceFile": {
+                    "name": "04.pdf",
+                    "source": "foo",
+                    "hash": "4ad0156942d1c26a4aa74fe6d52c082c6871b33b0e933f40566f6740fdae0ebb",
+                    "assetIds": [2728768807111995],
+                    "metadata": {"myKey": "myValue"},
+                    "geoLocation": {
+                        "type": "Polygon",
+                        "coordinates": [[[3.0, 1.0], [4.0, 4.0], [2.0, 4.0], [1.0, 2.0], [3.0, 1.0]]],
+                    },
+                },
+                "externalId": "7a05f794-d6b0-413a-a0ff-c03eb38d9e83",
+                "title": "Sample Scanned Image",
+                "author": "Paperless 800-387-9001",
+                "producer": "Imaging Dept.",
+                "mimeType": "application/pdf",
+                "extension": "pdf",
+                "pageCount": 1,
+                "type": "PDF",
+                "language": "en",
+                "truncatedContent": "test",
+                "assetIds": [2728768807111995, 7234953846172358],
+                "labels": [],
+                "createdTime": 1659617852965,
+                "modifiedTime": 970589816000,
+                "lastIndexedTime": 1707210718089,
+                "geoLocation": {
+                    "type": "GeometryCollection",
+                    "geometries": [
+                        {"type": "Point", "coordinates": [-2.3, 50.8]},
+                        {
+                            "type": "Polygon",
+                            "coordinates": [[[3.0, 1.0], [4.0, 4.0], [2.0, 4.0], [1.0, 2.0], [3.0, 1.0]]],
+                        },
+                    ],
+                },
+            }
+        ]
+    }
+
+    url_pattern = re.compile(re.escape(cognite_client.documents._get_base_url_with_base_path()) + "/.+")
+    rsps.assert_all_requests_are_fired = False
+
+    rsps.add(rsps.POST, url_pattern, status=200, json=response_body)
+    rsps.add(rsps.GET, url_pattern, status=200, json=response_body)
+    yield rsps
+
+
+class TestDocumentsAPI:
+    def test_list(self, cognite_client, mock_documents_response):
+        documents = cognite_client.documents.list()
+        assert len(documents) == 1
+        document = documents[0]
+        assert isinstance(document, Document)
+        assert mock_documents_response.calls[0].response.json()["items"][0] == document.dump(camel_case=True)


### PR DESCRIPTION
## Description
The geo_location fields in the Documents API differ from those in the Files API because they contain the Geometry objects directly, without a Feature object to wrap them. The Documents API also supports GeometryCollection objects in addition to the standard set of Geometry types.

## Checklist:
- [x] Tests added/updated.
- [x] Documentation updated. Documentation is generated from docstrings - these must be updated according to your change.
  If a new method has been added it should be referenced in [cognite.rst](https://github.com/cognitedata/cognite-sdk-python/blob/master/docs/source/cognite.rst) in order to generate docs based on its docstring.
- [x] Changelog updated in [CHANGELOG.md](https://github.com/cognitedata/cognite-sdk-python/blob/master/CHANGELOG.md).
- [x] Version bumped. If triggering a new release is desired, bump the version number in [_version.py](https://github.com/cognitedata/cognite-sdk-python/blob/master/cognite/client/_version.py) and [pyproject.toml](https://github.com/cognitedata/cognite-sdk-python/blob/master/pyproject.toml) per [semantic versioning](https://semver.org/).
