### PR TITLE
Allow node table expression through container ref

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ Changes are grouped as follows
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
+## [7.17.4] - 2024-02-07
+### Added
+- Allow using container property reference in `NodeResultSetExpression.through` in addition to view property reference
+
 ## [7.17.2] - 2024-02-04
 ### Fixed
 - Uploading files now accepts Labels again as part of file metadata. 

--- a/cognite/client/_version.py
+++ b/cognite/client/_version.py
@@ -1,4 +1,4 @@
 from __future__ import annotations
 
-__version__ = "7.17.2"
+__version__ = "7.17.4"
 __api_subversion__ = "V20220125"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "cognite-sdk"
 
-version = "7.17.2"
+version = "7.17.4"
 description = "Cognite Python SDK"
 readme = "README.md"
 documentation = "https://cognite-sdk-python.readthedocs-hosted.com"

--- a/tests/tests_unit/test_data_classes/test_data_models/test_queries.py
+++ b/tests/tests_unit/test_data_classes/test_data_models/test_queries.py
@@ -14,7 +14,7 @@ def result_set_expression_load_and_dump_equals_data() -> Iterator[ParameterSet]:
             "filter": {"equals": {"property": ["node", "externalId"], "value": {"parameter": "airplaneExternalId"}}},
             "from": "bla",
             "through": {
-                "view": {"type": "view", "space": "some", "externalId": "extid", "version": "v1"},
+                "source": {"type": "view", "space": "some", "externalId": "extid", "version": "v1"},
                 "identifier": "bla",
             },
             "chainTo": "destination",
@@ -28,7 +28,28 @@ def result_set_expression_load_and_dump_equals_data() -> Iterator[ParameterSet]:
         from_="bla",
         through=["some", "extid/v1", "bla"],
     )
-    yield pytest.param(raw, loaded_node, id="Documentation Example")
+    yield pytest.param(raw, loaded_node, id="NTE with through view reference")
+
+    raw = {
+        "nodes": {
+            "filter": {"equals": {"property": ["node", "externalId"], "value": {"parameter": "airplaneExternalId"}}},
+            "from": "bla",
+            "through": {
+                "source": {"type": "container", "space": "some", "externalId": "extid"},
+                "identifier": "bla",
+            },
+            "chainTo": "destination",
+            "direction": "outwards",
+        },
+        "limit": 1,
+    }
+    loaded_node = q.NodeResultSetExpression(
+        filter=f.Equals(property=["node", "externalId"], value={"parameter": "airplaneExternalId"}),
+        limit=1,
+        from_="bla",
+        through=["some", "extid", "bla"],
+    )
+    yield pytest.param(raw, loaded_node, id="NTE with through container reference")
 
     raw = {
         "nodes": {


### PR DESCRIPTION
## Description
[DMS api will change how we define NodeResultSetExpression.through](https://github.com/cognitedata/service-contracts/pull/2431)

After merging the api changes - we can reference both a view and container property in through

## Checklist:
- [ ] Tests added/updated.
- [ ] Documentation updated. Documentation is generated from docstrings - these must be updated according to your change.
  If a new method has been added it should be referenced in [cognite.rst](https://github.com/cognitedata/cognite-sdk-python/blob/master/docs/source/cognite.rst) in order to generate docs based on its docstring.
- [ ] Changelog updated in [CHANGELOG.md](https://github.com/cognitedata/cognite-sdk-python/blob/master/CHANGELOG.md).
- [ ] Version bumped. If triggering a new release is desired, bump the version number in [_version.py](https://github.com/cognitedata/cognite-sdk-python/blob/master/cognite/client/_version.py) and [pyproject.toml](https://github.com/cognitedata/cognite-sdk-python/blob/master/pyproject.toml) per [semantic versioning](https://semver.org/).
