### PR TITLE
Fix default json encoder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,11 @@ Changes are grouped as follows
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
+## [7.20.0] - 2024-02-13
+### Fixed
+- internal json encoder now understands CogniteObject and CogniteFilter objects, so that they are
+  correctly serialized when used in nested structures.
+
 ## [7.19.2] - 2024-02-13
 ### Fixed
 - Addressed `FutureWarning` coming from pandas dependency (granularity to pandas frequency translation of sec/min/hour and 'year start')

--- a/cognite/client/_api/geospatial.py
+++ b/cognite/client/_api/geospatial.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import json
 import numbers
 import urllib.parse
 from typing import Any, Iterator, Sequence, cast, overload
@@ -28,6 +27,7 @@ from cognite.client.data_classes.geospatial import (
     RasterMetadata,
 )
 from cognite.client.exceptions import CogniteConnectionError
+from cognite.client.utils import _json
 from cognite.client.utils._identifier import IdentifierSequence
 from cognite.client.utils.useful_types import SequenceNotStr
 
@@ -719,7 +719,7 @@ class GeospatialAPI(APIClient):
 
         try:
             for line in res.iter_lines():
-                yield Feature._load(json.loads(line))
+                yield Feature._load(_json.loads(line))
         except (ChunkedEncodingError, ConnectionError) as e:
             raise CogniteConnectionError(e)
 

--- a/cognite/client/_api/three_d.py
+++ b/cognite/client/_api/three_d.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import json
 from typing import TYPE_CHECKING, Any, Iterator, Sequence, cast, overload
 
 from cognite.client._api_client import APIClient
@@ -21,6 +20,7 @@ from cognite.client.data_classes import (
     ThreeDNode,
     ThreeDNodeList,
 )
+from cognite.client.utils import _json
 from cognite.client.utils._auxiliary import interpolate_and_url_encode, split_into_chunks, unpack_items_in_payload
 from cognite.client.utils._concurrency import execute_tasks
 from cognite.client.utils._identifier import IdentifierSequence, InternalId
@@ -627,7 +627,7 @@ class ThreeDAssetMappingAPI(APIClient):
         path = interpolate_and_url_encode(self._RESOURCE_PATH, model_id, revision_id)
         flt: dict[str, str | int | None] = {"nodeId": node_id, "assetId": asset_id}
         if intersects_bounding_box:
-            flt["intersectsBoundingBox"] = json.dumps(intersects_bounding_box.dump(camel_case=True))
+            flt["intersectsBoundingBox"] = _json.dumps(intersects_bounding_box)
         return self._list(
             list_cls=ThreeDAssetMappingList,
             resource_cls=ThreeDAssetMapping,

--- a/cognite/client/_api_client.py
+++ b/cognite/client/_api_client.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import functools
 import gzip
-import json as _json
 import logging
 import re
 import warnings
@@ -45,12 +44,12 @@ from cognite.client.data_classes._base import (
 from cognite.client.data_classes.aggregations import AggregationFilter, UniqueResultList
 from cognite.client.data_classes.filters import Filter
 from cognite.client.exceptions import CogniteAPIError, CogniteNotFoundError
+from cognite.client.utils import _json
 from cognite.client.utils._auxiliary import (
     get_current_sdk_version,
     get_user_agent,
     interpolate_and_url_encode,
     is_unlimited,
-    json_dump_default,
     split_into_chunks,
     unpack_items_in_payload,
 )
@@ -202,7 +201,7 @@ class APIClient:
 
         if json_payload:
             try:
-                data = _json.dumps(json_payload, default=json_dump_default, allow_nan=False)
+                data = _json.dumps(json_payload, allow_nan=False)
             except ValueError as e:
                 # A lot of work to give a more human friendly error message when nans and infs are present:
                 msg = "Out of range float values are not JSON compliant"

--- a/cognite/client/_version.py
+++ b/cognite/client/_version.py
@@ -1,4 +1,4 @@
 from __future__ import annotations
 
-__version__ = "7.19.2"
+__version__ = "7.20.0"
 __api_subversion__ = "V20220125"

--- a/cognite/client/data_classes/_base.py
+++ b/cognite/client/data_classes/_base.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import json
 from abc import ABC, abstractmethod
 from collections import UserList
 from collections.abc import Iterable
@@ -28,7 +27,8 @@ from typing import (
 from typing_extensions import Self, TypeAlias
 
 from cognite.client.exceptions import CogniteMissingClientError
-from cognite.client.utils._auxiliary import fast_dict_load, json_dump_default, load_yaml_or_json
+from cognite.client.utils import _json
+from cognite.client.utils._auxiliary import fast_dict_load, load_yaml_or_json
 from cognite.client.utils._identifier import IdentifierSequence
 from cognite.client.utils._importing import local_import
 from cognite.client.utils._pandas_helpers import (
@@ -59,7 +59,7 @@ def basic_instance_dump(obj: Any, camel_case: bool) -> dict[str, Any]:
 class CogniteResponse:
     def __str__(self) -> str:
         item = convert_and_isoformat_time_attrs(self.dump(camel_case=False))
-        return json.dumps(item, default=json_dump_default, indent=4)
+        return _json.dumps(item, indent=4)
 
     def __repr__(self) -> str:
         return str(self)
@@ -124,7 +124,7 @@ class CogniteObject:
 
     def __str__(self) -> str:
         item = convert_and_isoformat_time_attrs(self.dump(camel_case=False))
-        return json.dumps(item, default=json_dump_default, indent=4)
+        return _json.dumps(item, indent=4)
 
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         """Dump the instance into a json serializable Python data type.
@@ -290,7 +290,7 @@ class CogniteResourceList(UserList, Generic[T_CogniteResource], _WithClientMixin
 
     def __str__(self) -> str:
         item = convert_and_isoformat_time_attrs(self.dump(camel_case=False))
-        return json.dumps(item, default=json_dump_default, indent=4)
+        return _json.dumps(item, indent=4)
 
     # TODO: We inherit a lot from UserList that we don't actually support...
     def extend(self, other: Collection[Any]) -> None:  # type: ignore [override]
@@ -423,7 +423,7 @@ class CogniteUpdate:
         return type(self) is type(other) and self.dump() == other.dump()
 
     def __str__(self) -> str:
-        return json.dumps(self.dump(), default=json_dump_default, indent=4)
+        return _json.dumps(self.dump(), indent=4)
 
     def __repr__(self) -> str:
         return str(self)
@@ -574,13 +574,13 @@ class CogniteLabelUpdate(Generic[T_CogniteUpdate]):
         return external_ids if isinstance(external_ids, list) else [external_ids]
 
 
-class CogniteFilter:
+class CogniteFilter(ABC):
     def __eq__(self, other: Any) -> bool:
         return type(self) is type(other) and self.dump() == other.dump()
 
     def __str__(self) -> str:
         item = convert_and_isoformat_time_attrs(self.dump(camel_case=False))
-        return json.dumps(item, default=json_dump_default, indent=4)
+        return _json.dumps(item, indent=4)
 
     def __repr__(self) -> str:
         return str(self)
@@ -707,7 +707,7 @@ class CogniteSort:
         self.nulls = nulls
 
     def __str__(self) -> str:
-        return json.dumps(self.dump(camel_case=False), default=json_dump_default, indent=4)
+        return _json.dumps(self.dump(camel_case=False), indent=4)
 
     def __repr__(self) -> str:
         return str(self)

--- a/cognite/client/data_classes/data_modeling/core.py
+++ b/cognite/client/data_classes/data_modeling/core.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import json
 import warnings
 from abc import ABC
 from typing import TYPE_CHECKING, Any, Generic, Literal
@@ -17,7 +16,7 @@ from cognite.client.data_classes._base import (
     WriteableCogniteResourceList,
     basic_instance_dump,
 )
-from cognite.client.utils._auxiliary import json_dump_default
+from cognite.client.utils import _json
 from cognite.client.utils._importing import local_import
 
 if TYPE_CHECKING:
@@ -142,7 +141,7 @@ class DataModelingSort(CogniteObject):
         return type(other) is type(self) and self.dump() == other.dump()
 
     def __str__(self) -> str:
-        return json.dumps(self.dump(), default=json_dump_default, indent=4)
+        return _json.dumps(self, indent=4)
 
     def __repr__(self) -> str:
         return str(self)

--- a/cognite/client/data_classes/datapoints.py
+++ b/cognite/client/data_classes/datapoints.py
@@ -847,7 +847,7 @@ class DatapointsList(CogniteResourceList[Datapoints]):
         item = self.dump()
         for i in item:
             i["datapoints"] = convert_and_isoformat_time_attrs(i["datapoints"])
-        return _json.dumps(item, default=lambda x: x.__dict__, indent=4)
+        return _json.dumps(item, indent=4)
 
     def to_pandas(  # type: ignore [override]
         self,

--- a/cognite/client/data_classes/datapoints.py
+++ b/cognite/client/data_classes/datapoints.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import json
 import operator as op
 import typing
 import warnings
@@ -20,6 +19,7 @@ from typing import (
 )
 
 from cognite.client.data_classes._base import CogniteResource, CogniteResourceList
+from cognite.client.utils import _json
 from cognite.client.utils._auxiliary import find_duplicates, no_op
 from cognite.client.utils._identifier import Identifier
 from cognite.client.utils._importing import local_import
@@ -279,7 +279,7 @@ class DatapointsArray(CogniteResource):
         return id(self) == id(other)
 
     def __str__(self) -> str:
-        return json.dumps(self.dump(convert_timestamps=True), indent=4)
+        return _json.dumps(self.dump(convert_timestamps=True), indent=4)
 
     @overload
     def __getitem__(self, item: int) -> Datapoint:
@@ -491,7 +491,7 @@ class Datapoints(CogniteResource):
     def __str__(self) -> str:
         item = self.dump()
         item["datapoints"] = convert_and_isoformat_time_attrs(item["datapoints"])
-        return json.dumps(item, indent=4)
+        return _json.dumps(item, indent=4)
 
     def __len__(self) -> int:
         return len(self.timestamp)
@@ -765,7 +765,7 @@ class DatapointsArrayList(CogniteResourceList[DatapointsArray]):
         return super().get(id, external_id)
 
     def __str__(self) -> str:
-        return json.dumps(self.dump(convert_timestamps=True), indent=4)
+        return _json.dumps(self.dump(convert_timestamps=True), indent=4)
 
     def to_pandas(  # type: ignore [override]
         self,
@@ -847,7 +847,7 @@ class DatapointsList(CogniteResourceList[Datapoints]):
         item = self.dump()
         for i in item:
             i["datapoints"] = convert_and_isoformat_time_attrs(i["datapoints"])
-        return json.dumps(item, default=lambda x: x.__dict__, indent=4)
+        return _json.dumps(item, default=lambda x: x.__dict__, indent=4)
 
     def to_pandas(  # type: ignore [override]
         self,

--- a/cognite/client/data_classes/sequences.py
+++ b/cognite/client/data_classes/sequences.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import json
 import typing
 import warnings
 from abc import ABC
@@ -27,6 +26,7 @@ from cognite.client.data_classes._base import (
     WriteableCogniteResourceList,
 )
 from cognite.client.data_classes.shared import TimestampRange
+from cognite.client.utils import _json
 from cognite.client.utils._auxiliary import at_least_one_is_not_none
 from cognite.client.utils._importing import local_import
 from cognite.client.utils._text import convert_all_keys_to_camel_case
@@ -664,7 +664,7 @@ class SequenceRows(CogniteResource):
         self.external_id = external_id
 
     def __str__(self) -> str:
-        return json.dumps(self.dump(), indent=4)
+        return _json.dumps(self, indent=4)
 
     def __len__(self) -> int:
         return len(self.rows)
@@ -841,7 +841,7 @@ class SequenceRowsList(CogniteResourceList[SequenceRows]):
     _RESOURCE = SequenceRows
 
     def __str__(self) -> str:
-        return json.dumps(self.dump(), indent=4)
+        return _json.dumps(self, indent=4)
 
     @overload  # type: ignore[override]
     def to_pandas(

--- a/cognite/client/exceptions.py
+++ b/cognite/client/exceptions.py
@@ -1,11 +1,11 @@
 from __future__ import annotations
 
-import json
 import reprlib
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Callable
 
 from cognite.client._constants import _RUNNING_IN_BROWSER
+from cognite.client.utils import _json
 from cognite.client.utils._auxiliary import no_op
 
 if TYPE_CHECKING:
@@ -188,7 +188,7 @@ class CogniteAPIError(CogniteMultiException):
             msg += f"\nDuplicated: {self._truncate_elements(self.duplicated)}"
         msg += self._get_multi_exception_summary()
         if self.extra:
-            pretty_extra = json.dumps(self.extra, indent=4, sort_keys=True)
+            pretty_extra = _json.dumps(self.extra, indent=4, sort_keys=True)
             msg += f"\nAdditional error info: {pretty_extra}"
         return msg
 

--- a/cognite/client/utils/_auxiliary.py
+++ b/cognite/client/utils/_auxiliary.py
@@ -1,12 +1,9 @@
 from __future__ import annotations
 
 import functools
-import json
 import math
-import numbers
 import platform
 import warnings
-from decimal import Decimal
 from threading import Thread
 from typing import (
     TYPE_CHECKING,
@@ -20,6 +17,7 @@ from typing import (
 )
 from urllib.parse import quote
 
+from cognite.client.utils import _json
 from cognite.client.utils._text import (
     convert_all_keys_to_camel_case,
     convert_all_keys_to_snake_case,
@@ -73,7 +71,7 @@ def load_yaml_or_json(resource: str) -> Any:
 
         return yaml.safe_load(resource)
     except ImportError:
-        return json.loads(resource)
+        return _json.loads(resource)
 
 
 def basic_obj_dump(obj: Any, camel_case: bool) -> dict[str, Any]:
@@ -113,16 +111,6 @@ def handle_renamed_argument(
 def handle_deprecated_camel_case_argument(new_arg: T, old_arg_name: str, fn_name: str, kw_dct: dict[str, Any]) -> T:
     new_arg_name = to_snake_case(old_arg_name)
     return handle_renamed_argument(new_arg, new_arg_name, old_arg_name, fn_name, kw_dct)
-
-
-def json_dump_default(x: Any) -> Any:
-    if isinstance(x, numbers.Integral):
-        return int(x)
-    if isinstance(x, (Decimal, numbers.Real)):
-        return float(x)
-    if hasattr(x, "__dict__"):
-        return x.__dict__
-    raise TypeError(f"Object {x} of type {x.__class__} can't be serialized by the JSON encoder")
 
 
 def interpolate_and_url_encode(path: str, *args: Any) -> str:

--- a/cognite/client/utils/_json.py
+++ b/cognite/client/utils/_json.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+import json
+import numbers
+from decimal import Decimal
+from typing import Any, Callable
+
+__all__ = ["dumps", "loads"]
+
+
+def _default_json_encoder(obj: Any) -> Any:
+    if isinstance(obj, numbers.Integral):
+        return int(obj)
+    if isinstance(obj, (Decimal, numbers.Real)):
+        return float(obj)
+    from cognite.client.data_classes._base import CogniteObject
+
+    if isinstance(obj, CogniteObject):
+        return obj.dump(camel_case=True)
+
+    from cognite.client.data_classes._base import CogniteFilter
+
+    if isinstance(obj, CogniteFilter):
+        return obj.dump(camel_case=True)
+    raise TypeError(f"Object {obj} of type {obj.__class__} can't be serialized by the JSON encoder")
+
+
+def dumps(
+    obj: Any,
+    indent: int | None = None,
+    allow_nan: bool = True,
+    default: Callable[[Any], Any] = _default_json_encoder,
+    sort_keys: bool = False,
+) -> str:
+    return json.dumps(obj, default=default, indent=indent, allow_nan=allow_nan, sort_keys=sort_keys)
+
+
+loads = json.loads

--- a/cognite/client/utils/_json.py
+++ b/cognite/client/utils/_json.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import json
 import numbers
 from decimal import Decimal
-from typing import Any, Callable
+from typing import Any
 
 __all__ = ["dumps", "loads"]
 
@@ -29,10 +29,15 @@ def dumps(
     obj: Any,
     indent: int | None = None,
     allow_nan: bool = True,
-    default: Callable[[Any], Any] = _default_json_encoder,
     sort_keys: bool = False,
 ) -> str:
-    return json.dumps(obj, default=default, indent=indent, allow_nan=allow_nan, sort_keys=sort_keys)
+    return json.dumps(
+        obj,
+        default=_default_json_encoder,
+        indent=indent,
+        allow_nan=allow_nan,
+        sort_keys=sort_keys,
+    )
 
 
 loads = json.loads

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "cognite-sdk"
 
-version = "7.19.2"
+version = "7.20.0"
 description = "Cognite Python SDK"
 readme = "README.md"
 documentation = "https://cognite-sdk-python.readthedocs-hosted.com"

--- a/tests/tests_integration/test_api/test_data_modeling/test_instances.py
+++ b/tests/tests_integration/test_api/test_data_modeling/test_instances.py
@@ -324,7 +324,6 @@ class TestInstancesAPI:
         assert set(retrieved.nodes.as_ids()) == set(movie_nodes.as_ids())
         assert set(retrieved.edges.as_ids()) == set(movie_edges.as_ids())
 
-    @pytest.mark.xfail  # TODO: Unknown ids should not raise
     def test_retrieve_multiple_with_missing(self, cognite_client: CogniteClient, movie_nodes: NodeList) -> None:
         # Arrange
         ids_without_missing = movie_nodes.as_ids()
@@ -336,7 +335,6 @@ class TestInstancesAPI:
         # Assert
         assert retrieved.nodes.as_ids() == ids_without_missing
 
-    @pytest.mark.xfail  # TODO: Unknown ids should not raise
     def test_retrieve_non_existent(self, cognite_client: CogniteClient) -> None:
         assert cognite_client.data_modeling.instances.retrieve(("myNonExistingSpace", "myImaginaryNode")).nodes == []
 

--- a/tests/tests_integration/test_api/test_transformations/test_jobs.py
+++ b/tests/tests_integration/test_api/test_transformations/test_jobs.py
@@ -189,7 +189,6 @@ class TestTransformationJobsAPI:
         assert job.ignore_null_fields
 
     @pytest.mark.asyncio
-    @pytest.mark.skip("it just hangs")
     async def test_run_raw_transformation(self, cognite_client, new_raw_transformation):
         job = await new_raw_transformation.run_async(timeout=60)
 

--- a/tests/tests_unit/test_api/test_datapoints.py
+++ b/tests/tests_unit/test_api/test_datapoints.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import json
 import math
 import re
 from datetime import datetime, timezone
@@ -12,6 +11,7 @@ from cognite.client import CogniteClient
 from cognite.client._api.datapoints import DatapointsBin
 from cognite.client.data_classes import Datapoint, Datapoints, DatapointsList, LatestDatapointQuery
 from cognite.client.exceptions import CogniteAPIError, CogniteNotFoundError
+from cognite.client.utils import _json
 from cognite.client.utils._time import granularity_to_ms, import_zoneinfo
 from tests.utils import jsgz_load
 
@@ -55,7 +55,7 @@ def mock_retrieve_latest(rsps, cognite_client):
                     "datapoints": [{"timestamp": before - 1, "value": random()}],
                 }
             )
-        return 200, {}, json.dumps({"items": items})
+        return 200, {}, _json.dumps({"items": items})
 
     rsps.add_callback(
         rsps.POST,

--- a/tests/tests_unit/test_base.py
+++ b/tests/tests_unit/test_base.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import json
 from copy import deepcopy
 from decimal import Decimal
 from inspect import signature
@@ -34,6 +33,7 @@ from cognite.client.data_classes.events import Event, EventList
 from cognite.client.data_classes.geospatial import FeatureWrite, GeospatialComputedItem
 from cognite.client.exceptions import CogniteMissingClientError
 from cognite.client.testing import CogniteClientMock
+from cognite.client.utils import _json
 from tests.utils import FakeCogniteResourceGenerator, all_concrete_subclasses, all_subclasses
 
 
@@ -164,7 +164,7 @@ class TestCogniteObject:
         instance = instance_generator.create_instance(cognite_object_subclass)
 
         dumped = instance.dump(camel_case=True)
-        json_serialised = json.dumps(dumped)
+        json_serialised = _json.dumps(dumped)
         loaded = instance.load(json_serialised, cognite_client=cognite_mock_client_placeholder)
 
         assert loaded.dump() == instance.dump()
@@ -340,8 +340,8 @@ class TestCogniteResource:
         assert MyResource(1, "s") != MyResource(2, "t")
 
     def test_str_repr(self):
-        assert json.dumps({"var_a": 1}, indent=4) == str(MyResource(1))
-        assert json.dumps({"var_a": 1.0}, indent=4) == str(MyResource(Decimal(1)))
+        assert _json.dumps({"var_a": 1}, indent=4) == str(MyResource(1))
+        assert _json.dumps({"var_a": 1.0}, indent=4) == str(MyResource(Decimal(1)))
 
     @pytest.mark.dsl
     def test_to_pandas(self):
@@ -405,7 +405,7 @@ class TestCogniteResource:
         ).create_instance(cognite_resource_subclass)
 
         dumped = instance.dump(camel_case=True)
-        json_serialised = json.dumps(dumped)
+        json_serialised = _json.dumps(dumped)
         loaded = instance.load(json_serialised, cognite_client=cognite_mock_client_placeholder)
 
         assert loaded.dump() == instance.dump()
@@ -597,8 +597,8 @@ class TestCogniteResourceList:
         assert MyResource(id=2, external_id="2") == resource_list.get(id=2)
 
     def test_str_repr(self):
-        assert json.dumps([{"var_a": 1}], indent=4) == str(MyResourceList([MyResource(1)]))
-        assert json.dumps([{"var_a": 1.0}], indent=4) == str(MyResourceList([MyResource(Decimal(1))]))
+        assert _json.dumps([{"var_a": 1}], indent=4) == str(MyResourceList([MyResource(1)]))
+        assert _json.dumps([{"var_a": 1.0}], indent=4) == str(MyResourceList([MyResource(Decimal(1))]))
 
     def test_get_item_by_external_id(self):
         resource_list = MyResourceList([MyResource(id=1, external_id="1"), MyResource(id=2, external_id="2")])
@@ -663,11 +663,11 @@ class TestCogniteFilter:
         assert MyFilter() == MyFilter()
 
     def test_str(self):
-        assert json.dumps({"var_a": 1}, indent=4) == str(MyFilter(1))
-        assert json.dumps({"var_a": 1.0}, indent=4) == str(MyFilter(Decimal(1)))
+        assert _json.dumps({"var_a": 1}, indent=4) == str(MyFilter(1))
+        assert _json.dumps({"var_a": 1.0}, indent=4) == str(MyFilter(Decimal(1)))
 
     def test_repr(self):
-        assert json.dumps({"var_a": 1}, indent=4) == repr(MyFilter(1))
+        assert _json.dumps({"var_a": 1}, indent=4) == repr(MyFilter(1))
 
 
 class TestCogniteUpdate:
@@ -688,9 +688,9 @@ class TestCogniteUpdate:
         assert MyUpdate(1) != MyUpdate(1).string.set("1")
 
     def test_str(self):
-        assert json.dumps(MyUpdate(1).dump(), indent=4) == str(MyUpdate(1))
-        assert json.dumps(MyUpdate(1.0).dump(), indent=4) == str(MyUpdate(Decimal(1)))
-        assert json.dumps(MyUpdate(1).string.set("1").dump(), indent=4) == str(MyUpdate(1).string.set("1"))
+        assert _json.dumps(MyUpdate(1).dump(), indent=4) == str(MyUpdate(1))
+        assert _json.dumps(MyUpdate(1.0).dump(), indent=4) == str(MyUpdate(Decimal(1)))
+        assert _json.dumps(MyUpdate(1).string.set("1").dump(), indent=4) == str(MyUpdate(1).string.set("1"))
 
     def test_set_string(self):
         assert {"id": 1, "update": {"string": {"set": "bla"}}} == MyUpdate(1).string.set("bla").dump()
@@ -782,13 +782,13 @@ class TestCogniteResponse:
         assert {} == MyResponse().dump()
 
     def test_str(self):
-        assert json.dumps(MyResponse(1).dump(camel_case=False), indent=4, sort_keys=True) == str(MyResponse(1))
-        assert json.dumps(MyResponse(1.0).dump(camel_case=False), indent=4, sort_keys=True) == str(
+        assert _json.dumps(MyResponse(1).dump(camel_case=False), indent=4, sort_keys=True) == str(MyResponse(1))
+        assert _json.dumps(MyResponse(1.0).dump(camel_case=False), indent=4, sort_keys=True) == str(
             MyResponse(Decimal(1))
         )
 
     def test_repr(self):
-        assert json.dumps(MyResponse(1).dump(camel_case=False), indent=4, sort_keys=True) == repr(MyResponse(1))
+        assert _json.dumps(MyResponse(1).dump(camel_case=False), indent=4, sort_keys=True) == repr(MyResponse(1))
 
     def test_eq(self):
         assert MyResponse(1) == MyResponse(1)

--- a/tests/tests_unit/test_utils/test_auxiliary.py
+++ b/tests/tests_unit/test_utils/test_auxiliary.py
@@ -1,8 +1,6 @@
-import json
 import math
 import re
 import warnings
-from decimal import Decimal
 from itertools import zip_longest
 
 import pytest
@@ -15,12 +13,10 @@ from cognite.client.utils._auxiliary import (
     get_accepted_params,
     handle_deprecated_camel_case_argument,
     interpolate_and_url_encode,
-    json_dump_default,
     remove_duplicates_keep_order,
     split_into_chunks,
     split_into_n_parts,
 )
-from cognite.client.utils._importing import local_import
 
 
 @pytest.mark.parametrize(
@@ -75,50 +71,6 @@ class TestUrlEncode:
     def test_url_encode(self):
         assert "/bla/yes%2Fno/bla" == interpolate_and_url_encode("/bla/{}/bla", "yes/no")
         assert "/bla/123/bla/456" == interpolate_and_url_encode("/bla/{}/bla/{}", "123", "456")
-
-
-class TestJsonDumpDefault:
-    def test_json_serializable_Decimal(self):
-        with pytest.raises(TypeError):
-            json.dumps(Decimal(1))
-
-        assert json.dumps(Decimal(1), default=json_dump_default)
-
-    def test_json_not_serializable_sets(self):
-        with pytest.raises(TypeError):
-            json.dumps({1, 2})
-        with pytest.raises(TypeError):
-            json.dumps({1, 2})
-
-    @pytest.mark.dsl
-    def test_json_serializable_numpy(self):
-        np = local_import("numpy")
-        arr = np.array([1.2, 3.4], dtype=np.float32)
-        with pytest.raises(TypeError):
-            json.dumps(arr)
-        with pytest.raises(TypeError):
-            json.dumps(arr[0])
-        with pytest.raises(TypeError):  # core sdk makes it hard to serialize np.ndarray
-            assert json.dumps(arr, default=json_dump_default)
-        assert json.dumps(arr[0], default=json_dump_default)
-
-    def test_json_serializable_object(self):
-        class Obj:
-            def __init__(self):
-                self.x = 1
-
-        with pytest.raises(TypeError):
-            json.dumps(Obj())
-
-        assert json.dumps({"x": 1}) == json.dumps(Obj(), default=json_dump_default)
-
-    @pytest.mark.dsl
-    def test_json_serialiable_numpy_integer(self):
-        import numpy as np
-
-        inputs = [np.int32(1), np.int64(1)]
-        for input in inputs:
-            assert json.dumps(input, default=json_dump_default)
 
 
 class TestSplitIntoChunks:

--- a/tests/tests_unit/test_utils/test_json.py
+++ b/tests/tests_unit/test_utils/test_json.py
@@ -1,4 +1,3 @@
-import json
 from decimal import Decimal
 
 import pytest
@@ -10,25 +9,20 @@ from cognite.client.utils._importing import local_import
 
 class TestJsonDumpDefault:
     def test_json_serializable_Decimal(self):
-        with pytest.raises(TypeError):
-            json.dumps(Decimal(1))
-
         assert _json.dumps(Decimal(1))
 
     def test_json_not_serializable_sets(self):
         with pytest.raises(TypeError):
-            json.dumps({1, 2})
+            _json.dumps({1, 2})
         with pytest.raises(TypeError):
-            json.dumps({1, 2})
+            _json.dumps({1, 2})
 
     @pytest.mark.dsl
     def test_json_serializable_numpy(self):
         np = local_import("numpy")
         arr = np.array([1.2, 3.4], dtype=np.float32)
         with pytest.raises(TypeError):
-            json.dumps(arr)
-        with pytest.raises(TypeError):
-            json.dumps(arr[0])
+            _json.dumps(arr)
         with pytest.raises(TypeError):  # core sdk makes it hard to serialize np.ndarray
             assert _json.dumps(arr)
         assert _json.dumps(arr[0])
@@ -47,6 +41,4 @@ class TestJsonDumpDefault:
             def __init__(self, foo: int) -> None:
                 self.foo = foo
 
-        with pytest.raises(TypeError):
-            json.dumps(Obj(1))
         assert '{"foo": 1}' == _json.dumps(Obj(1))

--- a/tests/tests_unit/test_utils/test_json.py
+++ b/tests/tests_unit/test_utils/test_json.py
@@ -1,0 +1,52 @@
+import json
+from decimal import Decimal
+
+import pytest
+
+from cognite.client.data_classes._base import CogniteObject
+from cognite.client.utils import _json
+from cognite.client.utils._importing import local_import
+
+
+class TestJsonDumpDefault:
+    def test_json_serializable_Decimal(self):
+        with pytest.raises(TypeError):
+            json.dumps(Decimal(1))
+
+        assert _json.dumps(Decimal(1))
+
+    def test_json_not_serializable_sets(self):
+        with pytest.raises(TypeError):
+            json.dumps({1, 2})
+        with pytest.raises(TypeError):
+            json.dumps({1, 2})
+
+    @pytest.mark.dsl
+    def test_json_serializable_numpy(self):
+        np = local_import("numpy")
+        arr = np.array([1.2, 3.4], dtype=np.float32)
+        with pytest.raises(TypeError):
+            json.dumps(arr)
+        with pytest.raises(TypeError):
+            json.dumps(arr[0])
+        with pytest.raises(TypeError):  # core sdk makes it hard to serialize np.ndarray
+            assert _json.dumps(arr)
+        assert _json.dumps(arr[0])
+
+    @pytest.mark.dsl
+    def test_json_serialiable_numpy_integer(self):
+        import numpy as np
+
+        inputs = [np.int32(1), np.int64(1)]
+        for input in inputs:
+            assert _json.dumps(input)
+
+    @pytest.mark.dsl
+    def test_json_dump_cognite_object(self):
+        class Obj(CogniteObject):
+            def __init__(self, foo: int) -> None:
+                self.foo = foo
+
+        with pytest.raises(TypeError):
+            json.dumps(Obj(1))
+        assert '{"foo": 1}' == _json.dumps(Obj(1))

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -6,7 +6,6 @@ import enum
 import gzip
 import importlib
 import inspect
-import json
 import math
 import os
 import random
@@ -43,6 +42,7 @@ from cognite.client.data_classes.workflows import (
     WorkflowTaskParameters,
 )
 from cognite.client.testing import CogniteClientMock
+from cognite.client.utils import _json
 from cognite.client.utils._importing import local_import
 from cognite.client.utils._text import random_string
 
@@ -152,7 +152,7 @@ def tmp_set_envvar(envvar: str, value: str):
 
 
 def jsgz_load(s):
-    return json.loads(gzip.decompress(s).decode())
+    return _json.loads(gzip.decompress(s).decode())
 
 
 @contextmanager


### PR DESCRIPTION
default json encoder would just use `.__dict__()`, which won't work most of the time, so this change makes the encoder understand the CogniteObject and CogniteFilter interfaces, so that they will invoke `.dump()` instead.