### PR TITLE
Make property access simpler on instances

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,12 @@ Changes are grouped as follows
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
+## [7.23.0] - 2024-02-23
+### Added
+- Make properties on instances (`Node`, `Edge`) easier to work with, by implementing support for direct indexing (and a `.get` method).
+  If the instances have properties from no source or multiple sources, an error is raised instead. Example usage: `instance["my_prop"]`
+  (short-cut for: `instance.properties[ViewId("space", "ext.id", "version")]["my_prop"]`)
+
 ## [7.22.0] - 2024-02-21
 ### Added
 - Data point subscriptions reaches General Availability (GA).

--- a/cognite/client/_api/data_modeling/instances.py
+++ b/cognite/client/_api/data_modeling/instances.py
@@ -271,7 +271,7 @@ class InstancesAPI(APIClient):
         Fetches nodes as they are iterated over, so you keep a limited number of nodes in memory.
 
         Returns:
-            Iterator[Node]: yields Instances one by one.
+            Iterator[Node]: yields nodes one by one.
         """
         return self(None, "node")
 
@@ -721,7 +721,10 @@ class InstancesAPI(APIClient):
                 >>> from cognite.client import CogniteClient
                 >>> from cognite.client.data_classes.data_modeling import ViewId
                 >>> client = CogniteClient()
-                >>> res = client.data_modeling.instances.search(ViewId("mySpace", "PersonView", "v1"), query="Arnold", properties=["name"])
+                >>> res = client.data_modeling.instances.search(
+                ...     ViewId("mySpace", "PersonView", "v1"),
+                ...     query="Arnold",
+                ...     properties=["name"])
 
             Search for Quentin in the person view in the name property, but only born after 1970:
 

--- a/cognite/client/_version.py
+++ b/cognite/client/_version.py
@@ -1,4 +1,4 @@
 from __future__ import annotations
 
-__version__ = "7.22.0"
+__version__ = "7.23.0"
 __api_subversion__ = "20230101"

--- a/cognite/client/data_classes/data_modeling/_validation.py
+++ b/cognite/client/data_classes/data_modeling/_validation.py
@@ -20,7 +20,7 @@ RESERVED_EXTERNAL_IDS = frozenset(
         "PageInfo",
         "File",
         "Sequence",
-        "TimeSerie",
+        "TimeSeries",
     }
 )
 RESERVED_SPACE_IDS = frozenset({"space", "cdf", "dms", "pg3", "shared", "system", "node", "edge"})

--- a/cognite/client/data_classes/data_modeling/instances.py
+++ b/cognite/client/data_classes/data_modeling/instances.py
@@ -39,9 +39,7 @@ from cognite.client.data_classes.data_modeling.core import (
     DataModelingSort,
     WritableDataModelingResource,
 )
-from cognite.client.data_classes.data_modeling.data_types import (
-    DirectRelationReference,
-)
+from cognite.client.data_classes.data_modeling.data_types import DirectRelationReference
 from cognite.client.data_classes.data_modeling.ids import (
     ContainerId,
     EdgeId,
@@ -197,7 +195,7 @@ class Properties(MutableMapping[ViewIdentifier, MutableMapping[PropertyIdentifie
             for view_id_str, properties in view_properties.items():
                 view_tuple = tuple(view_id_str.split("/", 1))
                 if len(view_tuple) != 2:
-                    raise ValueError("View id must be in the format <external_id>/<version>")
+                    raise ValueError(f"View id must be in the format <external_id>/<version>, not {view_id_str!r}")
                 view_id = ViewId.load((space, *view_tuple))
                 props[view_id] = properties
         return cls(props)
@@ -346,13 +344,17 @@ class Instance(WritableInstanceCore[T_CogniteResource], ABC):
         except TypeError:
             self.__raise_if_non_singular_source(attr)
 
-    def __setitem__(self, attr: str, item: PropertyValue) -> None:
+    def __setitem__(self, attr: str, value: PropertyValue) -> None:
+        if attr in self._RESERVED_PROPERTIES:
+            raise RuntimeError(f"Can't set reserved attribute {attr!r}. Hint: You may use `instance.{attr} = value`")
         try:
-            self._prop_lookup[attr] = item
+            self._prop_lookup[attr] = value
         except TypeError:
             self.__raise_if_non_singular_source(attr)
 
     def __delitem__(self, attr: str) -> None:
+        if attr in self._RESERVED_PROPERTIES:
+            raise RuntimeError(f"Can't delete reserved attribute {attr!r}. Hint: You may use `del instance.{attr}`")
         try:
             del self._prop_lookup[attr]
         except TypeError:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "cognite-sdk"
 
-version = "7.22.0"
+version = "7.23.0"
 description = "Cognite Python SDK"
 readme = "README.md"
 documentation = "https://cognite-sdk-python.readthedocs-hosted.com"

--- a/tests/tests_unit/test_api/test_data_modeling/test_instances.py
+++ b/tests/tests_unit/test_api/test_data_modeling/test_instances.py
@@ -1,13 +1,9 @@
 from __future__ import annotations
 
-from typing import Any
-
 import pytest
 
 from cognite.client._api.data_modeling.instances import InstancesAPI
-from cognite.client.data_classes.data_modeling import Edge, Node
 from cognite.client.data_classes.data_modeling.ids import ViewId
-from cognite.client.data_classes.data_modeling.instances import Instance
 from tests.tests_unit.test_api.test_data_modeling.conftest import make_test_view
 
 SINGLE_SRC_DUMP = {"source": {"space": "a", "externalId": "b", "version": "c", "type": "view"}}
@@ -39,116 +35,3 @@ def test_instances_api_dump_instance_source(sources, expected):
     # ViewIdentifier = Union[ViewId, Tuple[str, str], Tuple[str, str, str]]
     # ViewIdentifier | Sequence[ViewIdentifier] | View | Sequence[View]
     assert expected == InstancesAPI._dump_instance_source(sources)
-
-
-@pytest.fixture
-def empty_node_dump():
-    return {
-        "space": "space",
-        "externalId": "xid",
-        "version": 1,
-        "lastUpdatedTime": 2,
-        "createdTime": 3,
-    }
-
-
-@pytest.fixture
-def empty_edge_dump():
-    return {
-        "space": "space",
-        "externalId": "xid",
-        "version": 4,
-        "lastUpdatedTime": 5,
-        "createdTime": 6,
-        "type": {"space": "foo-space", "externalId": "bar-xid"},
-        "startNode": {"space": "the-space", "externalId": "the-xid"},
-        "endNode": {"space": "the-space", "externalId": "the-xid"},
-    }
-
-
-@pytest.mark.parametrize("instance_type", (Node, Edge))
-def test_instances__quick_property_access_single_source(
-    instance_type: type[Instance],
-    empty_node_dump: dict[str, Any],
-    empty_edge_dump: dict[str, Any],
-):
-    # Note: 'property' in this test refers to an instance property, not a Python property
-    resource = {Node: empty_node_dump, Edge: empty_edge_dump}[instance_type]
-    resource["properties"] = {"space": {"view/v8": {"prop1": 1, "prop2": "two", "3prop": [1, 2, 3]}}}
-    inst = instance_type.load(resource)
-
-    # Non-property should fail __getitem__ and __setitem__:
-    with pytest.raises(KeyError):
-        inst["space"]
-    with pytest.raises(RuntimeError):
-        inst["space"] = "more-space"
-
-    assert hasattr(inst, "id") is False
-    assert hasattr(inst, "space") is True
-    assert inst.space == "space"
-    inst.space = "more-space"
-    assert inst.space == "more-space"
-
-    # Property should work fine with both access/set/delete protocols:
-    assert inst.prop1 == 1
-    assert inst["prop1"] == 1
-
-    inst.prop1 = 5
-    assert inst["prop1"] == 5
-
-    inst["prop1"] = 1
-    assert inst.prop1 == 1
-
-    del inst.prop1
-    assert inst.get("prop1") is None
-    assert inst.get("prop1", "missing") == "missing"
-    with pytest.raises(KeyError):
-        inst["prop1"]
-    assert inst.prop2 == "two"
-    del inst["prop2"]
-    with pytest.raises(AttributeError):
-        inst.prop2
-
-
-@pytest.mark.parametrize("instance_type", (Node, Edge))
-def test_instances__quick_property_access_no_source(
-    instance_type: type[Instance],
-    empty_node_dump: dict[str, Any],
-    empty_edge_dump: dict[str, Any],
-):
-    # Note: 'property' in this test refers to an instance property, not a Python property
-    resource = {Node: empty_node_dump, Edge: empty_edge_dump}[instance_type]
-    resource["properties"] = {}
-    inst = instance_type.load(resource)
-
-    # Non-property should fail __getitem__ and __setitem__:
-    with pytest.raises(RuntimeError):
-        inst["space"]
-    with pytest.raises(RuntimeError):
-        inst["space"] = "more-space"
-
-    assert hasattr(inst, "id") is False
-    assert hasattr(inst, "space") is True
-    assert inst.space == "space"
-    inst.space = "more-space"
-    assert inst.space == "more-space"
-
-    # No source, so no properties. Everything should fail:
-    with pytest.raises(AttributeError):
-        inst.prop1
-    with pytest.raises(RuntimeError):
-        inst["prop1"]
-
-    with pytest.raises(AttributeError):
-        inst.prop1 = 5
-    with pytest.raises(RuntimeError):
-        inst["prop1"] = 1
-
-    with pytest.raises(AttributeError):
-        del inst.prop1
-    with pytest.raises(RuntimeError):
-        del inst["prop1"]
-    with pytest.raises(RuntimeError):
-        inst.get("prop1")
-    with pytest.raises(RuntimeError):
-        inst.get("prop1", "missing")


### PR DESCRIPTION
## [7.23.0] - 2024-02-23
### Added
- Make properties on instances (`Node`, `Edge`) easier to work with, by implementing support for direct indexing (and a `.get` method).
  If the instances have properties from no source or multiple sources, an error is raised instead. Example usage: `instance["my_prop"]`
  (short-cut for: `instance.properties[ViewId("space", "ext.id", "version")]["my_prop"]`)

## TODO
- [x] implement item access `[]` (`__getitem__`++) on `Instance`
- [X] ~~implement attribute item access `__getattr__`++ on `Instance`~~ reverted
- [ ] ~~Add great examples to appropriate methods to showcase the simplified property access!~~ Did not find a good place to write such examples 😢 
- [x] Tests added/updated.
- [x] Changelog updated.
- [x] Version bumped.