### PR TITLE
Remove experimental warning for time series subscriptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,17 @@ Changes are grouped as follows
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
+## [7.22.0] - 2024-02-21
+### Added
+- Data point subscriptions reaches General Availability (GA).
+  - Use the new [Data point subscriptions](https://developer.cognite.com/dev/concepts/data_point_subscriptions/)
+    feature to configure a subscription to listen to changes in one or more
+    time series (in ingestion order).
+    The feature is intended to be used where data points consumers need to keep up to date with
+    changes to one or more time series without the need to read the entire time series again.
+### Changed
+- Removed the `ignore_unknown_ids` flag from `client.time_series.subscriptions.retrieve()` to stay consistent with other resource types.
+
 ## [7.21.1] - 2024-02-20
 ### Fixed
 - Data Workflows: mark parameter `jobId` as optional in `TransformationTaskOutput`, as it may not be populated in case of a failure.
@@ -252,7 +263,7 @@ Changes are grouped as follows
 
 ## [7.7.1] - 2023-12-20
 ### Fixed
-- Missing legacy capability ACLs: `modelHostingAcl` and `genericsAcl`.  
+- Missing legacy capability ACLs: `modelHostingAcl` and `genericsAcl`.
 - The `IAMAPI.compare_capabilities` fails with a `AttributeError: 'UnknownAcl' object has no attribute '_capability_name'`
   if the user has an unknwon ACL. This is now fixed by skipping comparison of unknown ACLs and issuing a warning.
 

--- a/cognite/client/_api/datapoints_subscriptions.py
+++ b/cognite/client/_api/datapoints_subscriptions.py
@@ -15,7 +15,6 @@ from cognite.client.data_classes.datapoints_subscriptions import (
     TimeSeriesIDList,
     _DatapointSubscriptionBatchWithPartitions,
 )
-from cognite.client.utils._experimental import FeaturePreviewWarning
 from cognite.client.utils._identifier import IdentifierSequence
 from cognite.client.utils.useful_types import SequenceNotStr
 
@@ -28,13 +27,9 @@ class DatapointsSubscriptionAPI(APIClient):
 
     def __init__(self, config: ClientConfig, api_version: str | None, cognite_client: CogniteClient) -> None:
         super().__init__(config, api_version, cognite_client)
-        self._api_subversion = "beta"
-        self._warning = FeaturePreviewWarning(
-            api_maturity="beta", sdk_maturity="alpha", feature_name="DataPoint Subscriptions"
-        )
 
     def create(self, subscription: DataPointSubscriptionWrite) -> DatapointSubscription:
-        """`Create a subscription <https://pr-2221.specs.preview.cogniteapp.com/20230101-beta.json.html#tag/Data-point-subscriptions/operation/postSubscriptions>`_
+        """`Create a subscription <https://api-docs.cognite.com/20230101/tag/Data-point-subscriptions/operation/postSubscriptions>`_
 
         Create a subscription that can be used to listen for changes in data points for a set of time series.
 
@@ -70,7 +65,6 @@ class DatapointsSubscriptionAPI(APIClient):
                 ...     name="My subscription for Numeric time series")
                 >>> created = client.time_series.subscriptions.create(sub)
         """
-        self._warning.warn()
 
         return self._create_multiple(
             subscription,
@@ -80,7 +74,7 @@ class DatapointsSubscriptionAPI(APIClient):
         )
 
     def delete(self, external_id: str | SequenceNotStr[str], ignore_unknown_ids: bool = False) -> None:
-        """`Delete subscription(s). This operation cannot be undone. <https://pr-2221.specs.preview.cogniteapp.com/20230101-beta.json.html#tag/Data-point-subscriptions/operation/deleteSubscriptions>`_
+        """`Delete subscription(s). This operation cannot be undone. <https://api-docs.cognite.com/20230101/tag/Data-point-subscriptions/operation/deleteSubscriptions>`_
 
         Args:
             external_id (str | SequenceNotStr[str]): External ID or list of external IDs of subscriptions to delete.
@@ -94,7 +88,6 @@ class DatapointsSubscriptionAPI(APIClient):
                 >>> client = CogniteClient()
                 >>> client.time_series.subscriptions.delete("my_subscription")
         """
-        self._warning.warn()
 
         self._delete_multiple(
             identifiers=IdentifierSequence.load(external_ids=external_id),
@@ -103,7 +96,7 @@ class DatapointsSubscriptionAPI(APIClient):
         )
 
     def retrieve(self, external_id: str, ignore_unknown_ids: bool = False) -> DatapointSubscription | None:
-        """`Retrieve one subscription by external ID. <https://pr-2221.specs.preview.cogniteapp.com/20230101-beta.json.html#tag/Data-point-subscriptions/operation/getSubscriptionsByIds>`_
+        """`Retrieve one subscription by external ID. <https://api-docs.cognite.com/20230101/tag/Data-point-subscriptions/operation/getSubscriptionsByIds>`_
 
         Args:
             external_id (str): External ID of the subscription to retrieve.
@@ -120,7 +113,6 @@ class DatapointsSubscriptionAPI(APIClient):
                 >>> client = CogniteClient()
                 >>> res = client.time_series.subscriptions.retrieve("my_subscription")
         """
-        self._warning.warn()
 
         result = self._retrieve_multiple(
             list_cls=DatapointSubscriptionList,
@@ -134,7 +126,7 @@ class DatapointsSubscriptionAPI(APIClient):
             return None
 
     def list_member_time_series(self, external_id: str, limit: int | None = DEFAULT_LIMIT_READ) -> TimeSeriesIDList:
-        """`List time series in a subscription <https://api-docs.cognite.com/20230101-beta/tag/Data-point-subscriptions/operation/listSubscriptionMembers>`_
+        """`List time series in a subscription <https://api-docs.cognite.com/20230101/tag/Data-point-subscriptions/operation/listSubscriptionMembers>`_
 
         Retrieve a list of time series (IDs) that the subscription is currently retrieving updates from
 
@@ -155,7 +147,6 @@ class DatapointsSubscriptionAPI(APIClient):
                 >>> members = client.time_series.subscriptions.list_member_time_series("my_subscription")
                 >>> timeseries_external_ids = members.as_external_ids()
         """
-        self._warning.warn()
 
         return self._list(
             method="GET",
@@ -167,7 +158,7 @@ class DatapointsSubscriptionAPI(APIClient):
         )
 
     def update(self, update: DataPointSubscriptionUpdate) -> DatapointSubscription:
-        """`Update a subscriptions <https://pr-2221.specs.preview.cogniteapp.com/20230101-beta.json.html#tag/Data-point-subscriptions/operation/updateSubscriptions>`_
+        """`Update a subscriptions <https://api-docs.cognite.com/20230101/tag/Data-point-subscriptions/operation/updateSubscriptions>`_
 
         Update a subscription. Note that Fields that are not included in the request are not changed.
         Furthermore, the subscription partition cannot be changed.
@@ -197,7 +188,6 @@ class DatapointsSubscriptionAPI(APIClient):
                 >>> update = DataPointSubscriptionUpdate("my_subscription").time_series_ids.add(["MyNewTimeSeriesExternalId"])
                 >>> updated = client.time_series.subscriptions.update(update)
         """
-        self._warning.warn()
 
         return self._update_multiple(
             items=update,
@@ -215,7 +205,7 @@ class DatapointsSubscriptionAPI(APIClient):
         poll_timeout: int = 5,
         cursor: str | None = None,
     ) -> Iterator[DatapointSubscriptionBatch]:
-        """`Iterate over data from a given subscription. <https://pr-2221.specs.preview.cogniteapp.com/20230101-beta.json.html#tag/Data-point-subscriptions/operation/listSubscriptionData>`_
+        """`Iterate over data from a given subscription. <https://api-docs.cognite.com/20230101/tag/Data-point-subscriptions/operation/listSubscriptionData>`_
 
         Data can be ingested datapoints and time ranges where data is deleted. This endpoint will also return changes to
         the subscription itself, that is, if time series are added or removed from the subscription.
@@ -256,7 +246,6 @@ class DatapointsSubscriptionAPI(APIClient):
                 ...     print(f"Removed {len(batch.subscription_changes.removed)} timeseries")
                 ...     print(f"Changed timeseries data in {len(batch.updates)} updates")
         """
-        self._warning.warn()
 
         current_partitions = [DatapointSubscriptionPartition.create((partition, cursor))]
         while True:
@@ -281,7 +270,7 @@ class DatapointsSubscriptionAPI(APIClient):
             current_partitions = batch.partitions
 
     def list(self, limit: int | None = DEFAULT_LIMIT_READ) -> DatapointSubscriptionList:
-        """`List data point subscriptions <https://pr-2221.specs.preview.cogniteapp.com/20230101-beta.json.html#tag/Data-point-subscriptions/operation/listSubscriptions>`_
+        """`List data point subscriptions <https://api-docs.cognite.com/20230101/tag/Data-point-subscriptions/operation/listSubscriptions>`_
 
         Args:
             limit (int | None): Maximum number of subscriptions to return. Defaults to 25. Set to -1, float("inf") or None to return all items.
@@ -297,7 +286,6 @@ class DatapointsSubscriptionAPI(APIClient):
                 >>> subscriptions = client.time_series.subscriptions.list(limit=5)
 
         """
-        self._warning.warn()
 
         return self._list(
             method="GET", limit=limit, list_cls=DatapointSubscriptionList, resource_cls=DatapointSubscription

--- a/cognite/client/_api/datapoints_subscriptions.py
+++ b/cognite/client/_api/datapoints_subscriptions.py
@@ -95,12 +95,11 @@ class DatapointsSubscriptionAPI(APIClient):
             wrap_ids=True,
         )
 
-    def retrieve(self, external_id: str, ignore_unknown_ids: bool = False) -> DatapointSubscription | None:
+    def retrieve(self, external_id: str) -> DatapointSubscription | None:
         """`Retrieve one subscription by external ID. <https://api-docs.cognite.com/20230101/tag/Data-point-subscriptions/operation/getSubscriptionsByIds>`_
 
         Args:
             external_id (str): External ID of the subscription to retrieve.
-            ignore_unknown_ids (bool): Whether to ignore IDs and external IDs that are not found rather than throw an exception.
 
         Returns:
             DatapointSubscription | None: The requested subscription.
@@ -118,7 +117,7 @@ class DatapointsSubscriptionAPI(APIClient):
             list_cls=DatapointSubscriptionList,
             resource_cls=DatapointSubscription,
             identifiers=IdentifierSequence.load(external_ids=[external_id]),
-            ignore_unknown_ids=ignore_unknown_ids,
+            ignore_unknown_ids=True,
         )
         if result:
             return result[0]

--- a/cognite/client/_version.py
+++ b/cognite/client/_version.py
@@ -1,4 +1,4 @@
 from __future__ import annotations
 
-__version__ = "7.21.1"
+__version__ = "7.22.0"
 __api_subversion__ = "20230101"

--- a/cognite/client/data_classes/datapoints_subscriptions.py
+++ b/cognite/client/data_classes/datapoints_subscriptions.py
@@ -291,7 +291,6 @@ class DatapointsUpdate:
                 {
                     "id": data["timeSeries"]["id"],
                     "externalId": data["timeSeries"].get("externalId"),
-                    "isString": isinstance(values[0]["value"], str),
                     "datapoints": values,
                 }
             )

--- a/docs/source/time_series.rst
+++ b/docs/source/time_series.rst
@@ -131,13 +131,6 @@ Data Points Data classes
 
 Data Point Subscriptions
 ---------------------------
-.. warning::
-    DataPoint Subscription is a new feature:
-      * The API specification is in beta.
-      * The SDK implementation is in alpha.
-
-    Thus, breaking changes may occur without further notice, see :ref:`appendix-alpha-beta-features` for more information.
-
 
 Create data point subscriptions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "cognite-sdk"
 
-version = "7.21.1"
+version = "7.22.0"
 description = "Cognite Python SDK"
 readme = "README.md"
 documentation = "https://cognite-sdk-python.readthedocs-hosted.com"

--- a/tests/tests_integration/test_api/test_datapoint_subscriptions.py
+++ b/tests/tests_integration/test_api/test_datapoint_subscriptions.py
@@ -62,7 +62,7 @@ def time_series_external_ids(all_time_series_external_ids):
 @pytest.fixture(scope="session")
 def subscription(cognite_client: CogniteClient, all_time_series_external_ids: list[str]) -> DatapointSubscription:
     external_id = "PYSDKDataPointSubscriptionTest"
-    sub = cognite_client.time_series.subscriptions.retrieve(external_id, ignore_unknown_ids=True)
+    sub = cognite_client.time_series.subscriptions.retrieve(external_id)
     if sub is not None:
         return sub
     new_sub = DataPointSubscriptionWrite(
@@ -108,9 +108,7 @@ class TestDatapointSubscriptions:
             assert sorted(new_subscription.time_series_ids) == sorted(retrieved_time_series_external_ids)
 
             cognite_client.time_series.subscriptions.delete(new_subscription.external_id)
-            retrieved_deleted = cognite_client.time_series.subscriptions.retrieve(
-                new_subscription.external_id, ignore_unknown_ids=True
-            )
+            retrieved_deleted = cognite_client.time_series.subscriptions.retrieve(new_subscription.external_id)
             assert retrieved_deleted is None
 
     def test_update_subscription(self, cognite_client: CogniteClient, time_series_external_ids: list[str]):


### PR DESCRIPTION
## Description
Move Data point subscriptions to GA.

- Removed `isString` from the Datapoints object that is created from the subscription upserts. `isString` can't be reliably set based on the data point values, since data points with status `bad` can have values like `"NaN"` and `"Infinity"` which are sent as strings in json.
- Remove the `ignore_unknown_ids` flag from the `client.time_series.subscriptions.retrieve` function to stay consistent with other resources types. This function will now return `None` if the subscription does not exist.
- Removed the experimental warning in the docs.
- Removed the python warnings for  subscriptions.

## Checklist:
- [x] Tests added/updated.
- [x] Documentation updated. Documentation is generated from docstrings - these must be updated according to your change.
  If a new method has been added it should be referenced in [cognite.rst](https://github.com/cognitedata/cognite-sdk-python/blob/master/docs/source/cognite.rst) in order to generate docs based on its docstring.
- [x] Changelog updated in [CHANGELOG.md](https://github.com/cognitedata/cognite-sdk-python/blob/master/CHANGELOG.md).
- [x] Version bumped. If triggering a new release is desired, bump the version number in [_version.py](https://github.com/cognitedata/cognite-sdk-python/blob/master/cognite/client/_version.py) and [pyproject.toml](https://github.com/cognitedata/cognite-sdk-python/blob/master/pyproject.toml) per [semantic versioning](https://semver.org/).
