### PR TITLE
rename workflow orchestration -> data workflows

### DIFF
--- a/docs/source/workflow_orchestration.rst
+++ b/docs/source/workflow_orchestration.rst
@@ -1,8 +1,8 @@
-Workflow Orchestration
+Data Workflows
 ======================
 
 .. warning::
-    Workflow Orchestration is a new feature:
+    Data Workflows is a new feature:
       * The API specification is in beta.
       * The SDK implementation is in alpha.
 
@@ -72,7 +72,7 @@ Update Status of Async Task
 .. automethod:: cognite.client._api.workflows.WorkflowTaskAPI.update
 
 
-Workflow Orchestration data classes
+Data Workflows data classes
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. automodule:: cognite.client.data_classes.workflows
     :members:


### PR DESCRIPTION
In preparation for Public Beta in upcoming release: Rename from Workflow Orchestration to Data Workflows (decided as new name for the service) 