### PR TITLE
Fix `DMLApplyResult.__str__`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ Changes are grouped as follows
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
+## [7.20.1] - 2024-02-19
+### Fixed
+- `DMLApplyResult` no longer fails when converted to a string (representation).
+
 ## [7.20.0] - 2024-02-13
 ### Fixed
 - internal json encoder now understands CogniteObject and CogniteFilter objects, so that they are

--- a/cognite/client/_version.py
+++ b/cognite/client/_version.py
@@ -1,4 +1,4 @@
 from __future__ import annotations
 
-__version__ = "7.20.0"
+__version__ = "7.20.1"
 __api_subversion__ = "V20220125"

--- a/cognite/client/data_classes/data_modeling/graphql.py
+++ b/cognite/client/data_classes/data_modeling/graphql.py
@@ -7,6 +7,7 @@ from typing_extensions import Self
 
 from cognite.client.data_classes._base import CogniteObject
 from cognite.client.data_classes.data_modeling.ids import DataModelId
+from cognite.client.utils import _json
 
 if TYPE_CHECKING:
     from cognite.client import CogniteClient
@@ -19,8 +20,11 @@ class DMLApplyResult(CogniteObject):
     version: str
     name: str | None
     description: str | None
-    created_time: int
-    last_updated_time: int
+    created_time: str
+    last_updated_time: str
+
+    def __str__(self) -> str:
+        return _json.dumps(self.dump(camel_case=False), indent=4)
 
     def as_id(self) -> DataModelId:
         return DataModelId(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "cognite-sdk"
 
-version = "7.20.0"
+version = "7.20.1"
 description = "Cognite Python SDK"
 readme = "README.md"
 documentation = "https://cognite-sdk-python.readthedocs-hosted.com"

--- a/tests/tests_unit/test_data_classes/test_data_models/test_graphql.py
+++ b/tests/tests_unit/test_data_classes/test_data_models/test_graphql.py
@@ -1,0 +1,16 @@
+from cognite.client.data_classes.data_modeling.graphql import DMLApplyResult
+
+
+def test_dmlapplyresult_is_str_convertable() -> None:
+    # Bug prior to 7.20.1 would try to convert non-integer timestamps 'created_time' and 'last_updated_time'
+    # from millis since epoch and fail (already string-formatted nicely):
+    res = DMLApplyResult(
+        space="test-space",
+        external_id="test-xid",
+        version="v1",
+        name="foo",
+        description="bar",
+        created_time="2024-02-18T22:49:54.932Z",
+        last_updated_time="2024-02-18T22:55:20.660Z",
+    )
+    assert str(res)


### PR DESCRIPTION
## [7.20.1] - 2024-02-19
### Fixed
- `DMLApplyResult` no longer fails when converted to a string (representation).


## Checklist:
- [x] Tests added/updated.
- [ ] Documentation updated. Documentation is generated from docstrings - these must be updated according to your change.
  If a new method has been added it should be referenced in [cognite.rst](https://github.com/cognitedata/cognite-sdk-python/blob/master/docs/source/cognite.rst) in order to generate docs based on its docstring.
- [x] Changelog updated in [CHANGELOG.md](https://github.com/cognitedata/cognite-sdk-python/blob/master/CHANGELOG.md).
- [x] Version bumped. If triggering a new release is desired, bump the version number in [_version.py](https://github.com/cognitedata/cognite-sdk-python/blob/master/cognite/client/_version.py) and [pyproject.toml](https://github.com/cognitedata/cognite-sdk-python/blob/master/pyproject.toml) per [semantic versioning](https://semver.org/).
