### PR TITLE
Replaced c = CogniteClient() with client = CogniteClient

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,10 +17,6 @@ Changes are grouped as follows
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
-## [7.20.2] - 2024-02-19
-### Improved
-- Updated documentation to use `client = CogniteClient()` instead of `c = CogniteClient()`.
-
 ## [7.20.1] - 2024-02-19
 ### Fixed
 - `DMLApplyResult` no longer fails when converted to a string (representation).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ Changes are grouped as follows
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
+## [7.20.2] - 2024-02-19
+### Improved
+- Updated documentation to use `client = CogniteClient()` instead of `c = CogniteClient()`.
+
 ## [7.20.1] - 2024-02-19
 ### Fixed
 - `DMLApplyResult` no longer fails when converted to a string (representation).
@@ -2166,11 +2170,11 @@ allowing the method to take arbitrarily long lists for `source_external_ids` and
   ```python
   # using a single string
   my_update = AssetUpdate(id=1).labels.add("PUMP").labels.remove("VALVE")
-  res = c.assets.update(my_update)
+  res = client.assets.update(my_update)
 
   # using a list of strings
   my_update = AssetUpdate(id=1).labels.add(["PUMP", "ROTATING_EQUIPMENT"]).labels.remove(["VALVE"])
-  res = c.assets.update(my_update)
+  res = client.assets.update(my_update)
   ```
 
 ## [2.0.0] - 2020-07-21
@@ -2201,7 +2205,7 @@ allowing the method to take arbitrarily long lists for `source_external_ids` and
 
   # attach/detach labels to/from assets
   my_update = AssetUpdate(id=1).labels.add(["PUMP"]).labels.remove(["VALVE"])
-  res = c.assets.update(my_update)
+  res = client.assets.update(my_update)
   ```
 
 ### Fixed

--- a/cognite/client/_api/assets.py
+++ b/cognite/client/_api/assets.py
@@ -207,14 +207,14 @@ class AssetsAPI(APIClient):
             Get asset by id::
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
-                >>> res = c.assets.retrieve(id=1)
+                >>> client = CogniteClient()
+                >>> res = client.assets.retrieve(id=1)
 
             Get asset by external id::
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
-                >>> res = c.assets.retrieve(external_id="1")
+                >>> client = CogniteClient()
+                >>> res = client.assets.retrieve(external_id="1")
         """
         identifier = IdentifierSequence.load(ids=id, external_ids=external_id).as_singleton()
         return self._retrieve_multiple(list_cls=AssetList, resource_cls=Asset, identifiers=identifier)
@@ -240,14 +240,14 @@ class AssetsAPI(APIClient):
             Get assets by id::
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
-                >>> res = c.assets.retrieve_multiple(ids=[1, 2, 3])
+                >>> client = CogniteClient()
+                >>> res = client.assets.retrieve_multiple(ids=[1, 2, 3])
 
             Get assets by external id::
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
-                >>> res = c.assets.retrieve_multiple(external_ids=["abc", "def"], ignore_unknown_ids=True)
+                >>> client = CogniteClient()
+                >>> res = client.assets.retrieve_multiple(external_ids=["abc", "def"], ignore_unknown_ids=True)
         """
         identifiers = IdentifierSequence.load(ids=ids, external_ids=external_ids)
         return self._retrieve_multiple(
@@ -268,8 +268,8 @@ class AssetsAPI(APIClient):
             Aggregate assets:
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
-                >>> aggregate_by_prefix = c.assets.aggregate(filter={"external_id_prefix": "prefix"})
+                >>> client = CogniteClient()
+                >>> aggregate_by_prefix = client.assets.aggregate(filter={"external_id_prefix": "prefix"})
         """
         warnings.warn(
             f"This method is deprecated. Use {self.__class__.__name__}.aggregate_count instead.", DeprecationWarning
@@ -297,17 +297,17 @@ class AssetsAPI(APIClient):
         Count the number of assets in your CDF project:
 
             >>> from cognite.client import CogniteClient
-            >>> c = CogniteClient()
-            >>> count = c.assets.aggregate_count()
+            >>> client = CogniteClient()
+            >>> count = client.assets.aggregate_count()
 
         Count the number of assets with the metadata key "timezone" in your CDF project:
 
             >>> from cognite.client import CogniteClient
             >>> from cognite.client.data_classes.filters import ContainsAny
             >>> from cognite.client.data_classes.assets import AssetProperty
-            >>> c = CogniteClient()
+            >>> client = CogniteClient()
             >>> has_timezone = ContainsAny(AssetProperty.metadata, "timezone")
-            >>> asset_count = c.assets.aggregate_count(advanced_filter=has_timezone)
+            >>> asset_count = client.assets.aggregate_count(advanced_filter=has_timezone)
 
         """
         self._validate_filter(advanced_filter)
@@ -341,17 +341,17 @@ class AssetsAPI(APIClient):
 
                 >>> from cognite.client import CogniteClient
                 >>> from cognite.client.data_classes.assets import AssetProperty
-                >>> c = CogniteClient()
-                >>> label_count = c.assets.aggregate_cardinality_values(AssetProperty.labels)
+                >>> client = CogniteClient()
+                >>> label_count = client.assets.aggregate_cardinality_values(AssetProperty.labels)
 
             Count the number of timezones (metadata key) for assets with the word "critical" in the description in your CDF project:
 
                 >>> from cognite.client import CogniteClient
                 >>> from cognite.client.data_classes.filters import Search
                 >>> from cognite.client.data_classes.assets import AssetProperty
-                >>> c = CogniteClient()
+                >>> client = CogniteClient()
                 >>> is_critical = Search(AssetProperty.description, "critical")
-                >>> critical_assets = c.assets.aggregate_cardinality_values(
+                >>> critical_assets = client.assets.aggregate_cardinality_values(
                 ...     AssetProperty.metadata_key("timezone"),
                 ...     advanced_filter=is_critical)
         """
@@ -388,8 +388,8 @@ class AssetsAPI(APIClient):
 
                 >>> from cognite.client import CogniteClient
                 >>> from cognite.client.data_classes.assets import AssetProperty
-                >>> c = CogniteClient()
-                >>> key_count = c.assets.aggregate_cardinality_properties(AssetProperty.metadata)
+                >>> client = CogniteClient()
+                >>> key_count = client.assets.aggregate_cardinality_properties(AssetProperty.metadata)
         """
         self._validate_filter(advanced_filter)
         return self._advanced_aggregate(
@@ -427,8 +427,8 @@ class AssetsAPI(APIClient):
 
             >>> from cognite.client import CogniteClient
             >>> from cognite.client.data_classes.assets import AssetProperty
-            >>> c = CogniteClient()
-            >>> result = c.assets.aggregate_unique_values(AssetProperty.metadata_key("timezone"))
+            >>> client = CogniteClient()
+            >>> result = client.assets.aggregate_unique_values(AssetProperty.metadata_key("timezone"))
             >>> print(result.unique)
 
         Get the different labels with count used for assets created after 2020-01-01 in your CDF project:
@@ -438,9 +438,9 @@ class AssetsAPI(APIClient):
             >>> from cognite.client.data_classes.assets import AssetProperty
             >>> from cognite.client.utils import timestamp_to_ms
             >>> from datetime import datetime
-            >>> c = CogniteClient()
+            >>> client = CogniteClient()
             >>> created_after_2020 = flt.Range(AssetProperty.created_time, gte=timestamp_to_ms(datetime(2020, 1, 1)))
-            >>> result = c.assets.aggregate_unique_values(AssetProperty.labels, advanced_filter=created_after_2020)
+            >>> result = client.assets.aggregate_unique_values(AssetProperty.labels, advanced_filter=created_after_2020)
             >>> print(result.unique)
 
         Get the different labels with count for assets updated after 2020-01-01 in your CDF project, but exclude all labels that
@@ -450,10 +450,10 @@ class AssetsAPI(APIClient):
             >>> from cognite.client.data_classes.assets import AssetProperty
             >>> from cognite.client.data_classes import aggregations as aggs
             >>> from cognite.client.data_classes import filters as flt
-            >>> c = CogniteClient()
+            >>> client = CogniteClient()
             >>> not_test = aggs.Not(aggs.Prefix("test"))
             >>> created_after_2020 = flt.Range(AssetProperty.last_updated_time, gte=timestamp_to_ms(datetime(2020, 1, 1)))
-            >>> result = c.assets.aggregate_unique_values(AssetProperty.labels, advanced_filter=created_after_2020, aggregate_filter=not_test)
+            >>> result = client.assets.aggregate_unique_values(AssetProperty.labels, advanced_filter=created_after_2020, aggregate_filter=not_test)
             >>> print(result.unique)
 
         """
@@ -494,8 +494,8 @@ class AssetsAPI(APIClient):
 
                 >>> from cognite.client import CogniteClient
                 >>> from cognite.client.data_classes.assets import AssetProperty
-                >>> c = CogniteClient()
-                >>> result = c.assets.aggregate_unique_properties(AssetProperty.metadata)
+                >>> client = CogniteClient()
+                >>> result = client.assets.aggregate_unique_properties(AssetProperty.metadata)
         """
         self._validate_filter(advanced_filter)
         return self._advanced_aggregate(
@@ -532,17 +532,17 @@ class AssetsAPI(APIClient):
 
                 >>> from cognite.client import CogniteClient
                 >>> from cognite.client.data_classes import AssetWrite
-                >>> c = CogniteClient()
+                >>> client = CogniteClient()
                 >>> assets = [AssetWrite(name="asset1"), AssetWrite(name="asset2")]
-                >>> res = c.assets.create(assets)
+                >>> res = client.assets.create(assets)
 
             Create asset with label::
 
                 >>> from cognite.client import CogniteClient
                 >>> from cognite.client.data_classes import Asset, Label
-                >>> c = CogniteClient()
+                >>> client = CogniteClient()
                 >>> asset = AssetWrite(name="my_pump", labels=[Label(external_id="PUMP")])
-                >>> res = c.assets.create(asset)
+                >>> res = client.assets.create(asset)
         """
         assert_type(asset, "asset", [AssetCore, Sequence])
 
@@ -606,16 +606,16 @@ class AssetsAPI(APIClient):
 
                 >>> from cognite.client import CogniteClient
                 >>> from cognite.client.data_classes import Asset
-                >>> c = CogniteClient()
+                >>> client = CogniteClient()
                 >>> assets = [
                 ...     Asset(external_id="root", name="root"),
                 ...     Asset(external_id="child1", parent_external_id="root", name="child1"),
                 ...     Asset(external_id="child2", parent_external_id="root", name="child2")]
-                >>> res = c.assets.create_hierarchy(assets)
+                >>> res = client.assets.create_hierarchy(assets)
 
             Create an asset hierarchy, but run update for existing assets:
 
-                >>> res = c.assets.create_hierarchy(assets, upsert=True, upsert_mode="patch")
+                >>> res = client.assets.create_hierarchy(assets, upsert=True, upsert_mode="patch")
 
             Patch will only update the parameters you have defined on your assets. Note that specifically setting
             something to ``None`` is the same as not setting it. For ``metadata``, this will extend your existing
@@ -700,8 +700,8 @@ class AssetsAPI(APIClient):
             Delete assets by id or external id::
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
-                >>> c.assets.delete(id=[1,2,3], external_id="3")
+                >>> client = CogniteClient()
+                >>> client.assets.delete(id=[1,2,3], external_id="3")
         """
         self._delete_multiple(
             identifiers=IdentifierSequence.load(ids=id, external_ids=external_id),
@@ -734,48 +734,48 @@ class AssetsAPI(APIClient):
 
                 >>> from cognite.client import CogniteClient
                 >>> from cognite.client.data_classes import AssetUpdate
-                >>> c = CogniteClient()
+                >>> client = CogniteClient()
                 >>> my_update = AssetUpdate(id=1).description.set("New description").metadata.add({"key": "value"})
-                >>> res1 = c.assets.update(my_update)
+                >>> res1 = client.assets.update(my_update)
                 >>> # Remove an already set field like so
                 >>> another_update = AssetUpdate(id=1).description.set(None)
-                >>> res2 = c.assets.update(another_update)
+                >>> res2 = client.assets.update(another_update)
 
             Remove the metadata on an asset::
 
                 >>> from cognite.client import CogniteClient
                 >>> from cognite.client.data_classes import AssetUpdate
-                >>> c = CogniteClient()
+                >>> client = CogniteClient()
                 >>> my_update = AssetUpdate(id=1).metadata.add({"key": "value"})
-                >>> res1 = c.assets.update(my_update)
+                >>> res1 = client.assets.update(my_update)
                 >>> another_update = AssetUpdate(id=1).metadata.set(None)
                 >>> # The same result can be achieved with:
                 >>> another_update2 = AssetUpdate(id=1).metadata.set({})
-                >>> res2 = c.assets.update(another_update)
+                >>> res2 = client.assets.update(another_update)
 
             Attach labels to an asset::
 
                 >>> from cognite.client import CogniteClient
                 >>> from cognite.client.data_classes import AssetUpdate
-                >>> c = CogniteClient()
+                >>> client = CogniteClient()
                 >>> my_update = AssetUpdate(id=1).labels.add(["PUMP", "VERIFIED"])
-                >>> res = c.assets.update(my_update)
+                >>> res = client.assets.update(my_update)
 
             Detach a single label from an asset::
 
                 >>> from cognite.client import CogniteClient
                 >>> from cognite.client.data_classes import AssetUpdate
-                >>> c = CogniteClient()
+                >>> client = CogniteClient()
                 >>> my_update = AssetUpdate(id=1).labels.remove("PUMP")
-                >>> res = c.assets.update(my_update)
+                >>> res = client.assets.update(my_update)
 
             Replace all labels for an asset::
 
                 >>> from cognite.client import CogniteClient
                 >>> from cognite.client.data_classes import AssetUpdate
-                >>> c = CogniteClient()
+                >>> client = CogniteClient()
                 >>> my_update = AssetUpdate(id=1).labels.set("PUMP")
-                >>> res = c.assets.update(my_update)
+                >>> res = client.assets.update(my_update)
         """
         return self._update_multiple(list_cls=AssetList, resource_cls=Asset, update_cls=AssetUpdate, items=item)
 
@@ -809,11 +809,11 @@ class AssetsAPI(APIClient):
 
                 >>> from cognite.client import CogniteClient
                 >>> from cognite.client.data_classes import Asset
-                >>> c = CogniteClient()
-                >>> existing_asset = c.assets.retrieve(id=1)
+                >>> client = CogniteClient()
+                >>> existing_asset = client.assets.retrieve(id=1)
                 >>> existing_asset.description = "New description"
                 >>> new_asset = Asset(external_id="new_asset", description="New asset")
-                >>> res = c.assets.upsert([existing_asset, new_asset], mode="replace")
+                >>> res = client.assets.upsert([existing_asset, new_asset], mode="replace")
         """
         return self._upsert_multiple(
             item,
@@ -853,9 +853,9 @@ class AssetsAPI(APIClient):
 
                 >>> from cognite.client import CogniteClient
                 >>> from cognite.client.data_classes import filters as flt
-                >>> c = CogniteClient()
+                >>> client = CogniteClient()
                 >>> in_timezone = flt.Prefix(["metadata", "timezone"], "Europe")
-                >>> res = c.assets.filter(filter=in_timezone, sort=("external_id", "asc"))
+                >>> res = client.assets.filter(filter=in_timezone, sort=("external_id", "asc"))
 
             Note that you can check the API documentation above to see which properties you can filter on
             with which filters.
@@ -866,9 +866,9 @@ class AssetsAPI(APIClient):
                 >>> from cognite.client import CogniteClient
                 >>> from cognite.client.data_classes import filters as flt
                 >>> from cognite.client.data_classes.assets import AssetProperty, SortableAssetProperty
-                >>> c = CogniteClient()
+                >>> client = CogniteClient()
                 >>> in_timezone = flt.Prefix(AssetProperty.metadata_key("timezone"), "Europe")
-                >>> res = c.assets.filter(
+                >>> res = client.assets.filter(
                 ...     filter=in_timezone,
                 ...     sort=(SortableAssetProperty.external_id, "asc"))
 
@@ -914,33 +914,33 @@ class AssetsAPI(APIClient):
             Search for assets by fuzzy search on name::
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
-                >>> res = c.assets.search(name="some name")
+                >>> client = CogniteClient()
+                >>> res = client.assets.search(name="some name")
 
             Search for assets by exact search on name::
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
-                >>> res = c.assets.search(filter={"name": "some name"})
+                >>> client = CogniteClient()
+                >>> res = client.assets.search(filter={"name": "some name"})
 
             Search for assets by improved multi-field fuzzy search::
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
-                >>> res = c.assets.search(query="TAG 30 XV")
+                >>> client = CogniteClient()
+                >>> res = client.assets.search(query="TAG 30 XV")
 
             Search for assets using multiple filters, finding all assets with name similar to `xyz` with parent asset `123` or `456` with source `some source`::
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
-                >>> res = c.assets.search(name="xyz",filter={"parent_ids": [123,456],"source": "some source"})
+                >>> client = CogniteClient()
+                >>> res = client.assets.search(name="xyz",filter={"parent_ids": [123,456],"source": "some source"})
 
             Search for an asset with an attached label:
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
+                >>> client = CogniteClient()
                 >>> my_label_filter = LabelFilter(contains_all=["PUMP"])
-                >>> res = c.assets.search(name="xyz",filter=AssetFilter(labels=my_label_filter))
+                >>> res = client.assets.search(name="xyz",filter=AssetFilter(labels=my_label_filter))
         """
         return self._search(
             list_cls=AssetList,
@@ -1043,30 +1043,30 @@ class AssetsAPI(APIClient):
             List assets::
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
-                >>> asset_list = c.assets.list(limit=5)
+                >>> client = CogniteClient()
+                >>> asset_list = client.assets.list(limit=5)
 
             Iterate over assets::
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
-                >>> for asset in c.assets:
+                >>> client = CogniteClient()
+                >>> for asset in client.assets:
                 ...     asset # do something with the asset
 
             Iterate over chunks of assets to reduce memory load::
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
-                >>> for asset_list in c.assets(chunk_size=2500):
+                >>> client = CogniteClient()
+                >>> for asset_list in client.assets(chunk_size=2500):
                 ...     asset_list # do something with the assets
 
             Filter assets based on labels::
 
                 >>> from cognite.client import CogniteClient
                 >>> from cognite.client.data_classes import LabelFilter
-                >>> c = CogniteClient()
+                >>> client = CogniteClient()
                 >>> my_label_filter = LabelFilter(contains_all=["PUMP", "VERIFIED"])
-                >>> asset_list = c.assets.list(labels=my_label_filter)
+                >>> asset_list = client.assets.list(labels=my_label_filter)
         """
         agg_props = self._process_aggregated_props(aggregated_properties)
         asset_subtree_ids_processed = process_asset_subtree_ids(asset_subtree_ids, asset_subtree_external_ids)

--- a/cognite/client/_api/assets.py
+++ b/cognite/client/_api/assets.py
@@ -631,7 +631,7 @@ class AssetsAPI(APIClient):
 
                 >>> from cognite.client.exceptions import CogniteAssetHierarchyError
                 >>> try:
-                ...     res = c.assets.create_hierarchy(assets)
+                ...     res = client.assets.create_hierarchy(assets)
                 ... except CogniteAssetHierarchyError as err:
                 ...     if err.invalid:
                 ...         ...  # do something
@@ -645,7 +645,7 @@ class AssetsAPI(APIClient):
 
                 >>> from cognite.client.exceptions import CogniteAPIError
                 >>> try:
-                ...     c.assets.create_hierarchy(assets)
+                ...     client.assets.create_hierarchy(assets)
                 ... except CogniteAPIError as err:
                 ...     created = err.successful
                 ...     maybe_created = err.unknown
@@ -667,7 +667,7 @@ class AssetsAPI(APIClient):
                 >>> from pathlib import Path
                 >>> hierarchy = AssetHierarchy(assets)
                 >>> if hierarchy.is_valid():
-                ...     res = c.assets.create_hierarchy(hierarchy)
+                ...     res = client.assets.create_hierarchy(hierarchy)
                 ... else:
                 ...     hierarchy.validate_and_report(output_file=Path("report.txt"))
         """

--- a/cognite/client/_api/data_modeling/containers.py
+++ b/cognite/client/_api/data_modeling/containers.py
@@ -103,15 +103,15 @@ class ContainersAPI(APIClient):
         Examples:
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
-                >>> res = c.data_modeling.containers.retrieve(('mySpace', 'myContainer'))
+                >>> client = CogniteClient()
+                >>> res = client.data_modeling.containers.retrieve(('mySpace', 'myContainer'))
 
             Fetch using the ContainerId::
 
                 >>> from cognite.client import CogniteClient
                 >>> from cognite.client.data_classes.data_modeling import ContainerId
-                >>> c = CogniteClient()
-                >>> res = c.data_modeling.containers.retrieve(ContainerId(space='mySpace', external_id='myContainer'))
+                >>> client = CogniteClient()
+                >>> res = client.data_modeling.containers.retrieve(ContainerId(space='mySpace', external_id='myContainer'))
         """
         identifier = _load_identifier(ids, "container")
         return self._retrieve_multiple(
@@ -133,8 +133,8 @@ class ContainersAPI(APIClient):
             Delete containers by id::
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
-                >>> c.data_modeling.containers.delete(("mySpace", "myContainer"))
+                >>> client = CogniteClient()
+                >>> client.data_modeling.containers.delete(("mySpace", "myContainer"))
         """
         deleted_containers = cast(
             list,
@@ -159,8 +159,8 @@ class ContainersAPI(APIClient):
             Delete constraints by id::
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
-                >>> c.data_modeling.containers.delete_constraints(
+                >>> client = CogniteClient()
+                >>> client.data_modeling.containers.delete_constraints(
                 ...     [(ContainerId("mySpace", "myContainer"), "myConstraint")]
                 ... )
         """
@@ -178,8 +178,8 @@ class ContainersAPI(APIClient):
             Delete indexes by id::
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
-                >>> c.data_modeling.containers.delete_indexes(
+                >>> client = CogniteClient()
+                >>> client.data_modeling.containers.delete_indexes(
                 ...     [(ContainerId("mySpace", "myContainer"), "myIndex")]
                 ... )
         """
@@ -229,21 +229,21 @@ class ContainersAPI(APIClient):
             List containers and limit to 5:
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
-                >>> container_list = c.data_modeling.containers.list(limit=5)
+                >>> client = CogniteClient()
+                >>> container_list = client.data_modeling.containers.list(limit=5)
 
             Iterate over containers::
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
-                >>> for container in c.data_modeling.containers:
+                >>> client = CogniteClient()
+                >>> for container in client.data_modeling.containers:
                 ...     container # do something with the container
 
             Iterate over chunks of containers to reduce memory load::
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
-                >>> for container_list in c.data_modeling.containers(chunk_size=10):
+                >>> client = CogniteClient()
+                >>> for container_list in client.data_modeling.containers(chunk_size=10):
                 ...     container_list # do something with the containers
         """
         filter = ContainerFilter(space, include_global)
@@ -279,10 +279,10 @@ class ContainersAPI(APIClient):
 
                 >>> from cognite.client import CogniteClient
                 >>> from cognite.client.data_classes.data_modeling import ContainerApply, ContainerProperty, Text
-                >>> c = CogniteClient()
+                >>> client = CogniteClient()
                 >>> container = [ContainerApply(space="mySpace", external_id="myContainer",
                 ...     properties={"name": ContainerProperty(type=Text(), name="name")})]
-                >>> res = c.data_modeling.containers.apply(container)
+                >>> res = client.data_modeling.containers.apply(container)
         """
         return self._create_multiple(
             list_cls=ContainerList,

--- a/cognite/client/_api/data_modeling/data_models.py
+++ b/cognite/client/_api/data_modeling/data_models.py
@@ -114,8 +114,8 @@ class DataModelsAPI(APIClient):
         Examples:
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
-                >>> res = c.data_modeling.data_models.retrieve(("mySpace", "myDataModel", "v1"))
+                >>> client = CogniteClient()
+                >>> res = client.data_modeling.data_models.retrieve(("mySpace", "myDataModel", "v1"))
 
         """
         identifier = _load_identifier(ids, "data_model")
@@ -139,8 +139,8 @@ class DataModelsAPI(APIClient):
             Delete data model by id::
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
-                >>> c.data_modeling.data_models.delete(("mySpace", "myDataModel", "v1"))
+                >>> client = CogniteClient()
+                >>> client.data_modeling.data_models.delete(("mySpace", "myDataModel", "v1"))
         """
         deleted_data_models = cast(
             list,
@@ -200,21 +200,21 @@ class DataModelsAPI(APIClient):
             List 5 data model:
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
-                >>> data_model_list = c.data_modeling.data_models.list(limit=5)
+                >>> client = CogniteClient()
+                >>> data_model_list = client.data_modeling.data_models.list(limit=5)
 
             Iterate over data model:
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
-                >>> for data_model in c.data_modeling.data_models:
+                >>> client = CogniteClient()
+                >>> for data_model in client.data_modeling.data_models:
                 ...     data_model # do something with the data_model
 
             Iterate over chunks of data model to reduce memory load:
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
-                >>> for data_model_list in c.data_modeling.data_models(chunk_size=10):
+                >>> client = CogniteClient()
+                >>> for data_model_list in client.data_modeling.data_models(chunk_size=10):
                 ...     data_model_list # do something with the data model
         """
         filter = DataModelFilter(space, inline_views, all_versions, include_global)
@@ -250,10 +250,10 @@ class DataModelsAPI(APIClient):
 
                 >>> from cognite.client import CogniteClient
                 >>> from cognite.client.data_classes.data_modeling import DataModelApply
-                >>> c = CogniteClient()
+                >>> client = CogniteClient()
                 >>> data_models = [DataModelApply(space="mySpace",external_id="myDataModel",version="v1"),
                 ... DataModelApply(space="mySpace",external_id="myOtherDataModel",version="v1")]
-                >>> res = c.data_modeling.data_models.apply(data_models)
+                >>> res = client.data_modeling.data_models.apply(data_models)
         """
         return self._create_multiple(
             list_cls=DataModelList,

--- a/cognite/client/_api/data_modeling/graphql.py
+++ b/cognite/client/_api/data_modeling/graphql.py
@@ -80,8 +80,8 @@ class DataModelingGraphQLAPI(APIClient):
             Apply DML::
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
-                >>> res = c.data_modeling.graphql.apply_dml(
+                >>> client = CogniteClient()
+                >>> res = client.data_modeling.graphql.apply_dml(
                 ...     id=("mySpaceExternalId", "myModelExternalId", "1"),
                 ...     dml="type MyType { id: String! }",
                 ...     name="My model name",
@@ -151,8 +151,8 @@ class DataModelingGraphQLAPI(APIClient):
             Execute a graphql query against a given data model::
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
-                >>> res = c.data_modeling.graphql.query(
+                >>> client = CogniteClient()
+                >>> res = client.data_modeling.graphql.query(
                 ...     id=("mySpace", "myDataModel", "v1"),
                 ...     query="listThings { items { thingProperty } }",
                 ... )

--- a/cognite/client/_api/data_modeling/instances.py
+++ b/cognite/client/_api/data_modeling/instances.py
@@ -298,8 +298,8 @@ class InstancesAPI(APIClient):
             Retrieve instances by id:
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
-                >>> res = c.data_modeling.instances.retrieve(
+                >>> client = CogniteClient()
+                >>> res = client.data_modeling.instances.retrieve(
                 ...     nodes=("mySpace", "myNodeExternalId"),
                 ...     edges=("mySpace", "myEdgeExternalId"),
                 ...     sources=("mySpace", "myViewExternalId", "myViewVersion"))
@@ -308,8 +308,8 @@ class InstancesAPI(APIClient):
 
                 >>> from cognite.client import CogniteClient
                 >>> from cognite.client.data_classes.data_modeling import NodeId, EdgeId, ViewId
-                >>> c = CogniteClient()
-                >>> res = c.data_modeling.instances.retrieve(
+                >>> client = CogniteClient()
+                >>> res = client.data_modeling.instances.retrieve(
                 ...     NodeId("mySpace", "myNode"),
                 ...     EdgeId("mySpace", "myEdge"),
                 ...     ViewId("mySpace", "myViewExternalId", "myViewVersion"))
@@ -318,8 +318,8 @@ class InstancesAPI(APIClient):
 
                 >>> from cognite.client import CogniteClient
                 >>> from cognite.client.data_classes.data_modeling import NodeId, EdgeId
-                >>> c = CogniteClient()
-                >>> res = c.data_modeling.instances.retrieve(
+                >>> client = CogniteClient()
+                >>> res = client.data_modeling.instances.retrieve(
                 ...     NodeId("mySpace", "myNode"),
                 ...     EdgeId("mySpace", "myEdge"),
                 ...     sources=("myspace", "myView"))
@@ -391,24 +391,24 @@ class InstancesAPI(APIClient):
             Delete instances by id:
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
-                >>> c.data_modeling.instances.delete(nodes=("mySpace", "myNode"))
+                >>> client = CogniteClient()
+                >>> client.data_modeling.instances.delete(nodes=("mySpace", "myNode"))
 
             Delete nodes and edges using the built in data class
 
                 >>> from cognite.client import CogniteClient
                 >>> from cognite.client.data_classes.data_modeling import NodeId, EdgeId
-                >>> c = CogniteClient()
-                >>> c.data_modeling.instances.delete(NodeId('mySpace', 'myNode'), EdgeId('mySpace', 'myEdge'))
+                >>> client = CogniteClient()
+                >>> client.data_modeling.instances.delete(NodeId('mySpace', 'myNode'), EdgeId('mySpace', 'myEdge'))
 
             Delete all nodes from a NodeList
 
                 >>> from cognite.client import CogniteClient
                 >>> from cognite.client.data_classes.data_modeling import NodeId, EdgeId
-                >>> c = CogniteClient()
-                >>> my_view = c.data_modeling.views.retrieve('mySpace', 'myView')
-                >>> my_nodes = c.data_modeling.instances.list(instance_type='node', sources=my_view, limit=None)
-                >>> c.data_modeling.instances.delete(nodes=my_nodes.as_ids())
+                >>> client = CogniteClient()
+                >>> my_view = client.data_modeling.views.retrieve('mySpace', 'myView')
+                >>> my_nodes = client.data_modeling.instances.list(instance_type='node', sources=my_view, limit=None)
+                >>> client.data_modeling.instances.delete(nodes=my_nodes.as_ids())
         """
         identifiers = self._load_node_and_edge_ids(nodes, edges)
         deleted_instances = cast(
@@ -453,7 +453,7 @@ class InstancesAPI(APIClient):
                 >>> from cognite.client.data_classes.data_modeling import ViewId
                 >>> from cognite.client.data_classes.filters import Range
                 >>>
-                >>> c = CogniteClient()
+                >>> client = CogniteClient()
                 >>> def just_print_the_result(result: QueryResult) -> None:
                 ...     print(result)
                 ...
@@ -463,7 +463,7 @@ class InstancesAPI(APIClient):
                 ...     with_={"movies": NodeResultSetExpression(filter=filter)},
                 ...     select={"movies": Select([SourceSelector(view_id, ["releaseYear"])])}
                 ... )
-                >>> subscription_context = c.data_modeling.instances.subscribe(query, just_print_the_result)
+                >>> subscription_context = client.data_modeling.instances.subscribe(query, just_print_the_result)
                 >>> subscription_context.cancel()
         """
         for result_set_expression in query.with_.values():
@@ -577,9 +577,9 @@ class InstancesAPI(APIClient):
 
                 >>> from cognite.client import CogniteClient
                 >>> from cognite.client.data_classes.data_modeling import EdgeApply, NodeOrEdgeData, NodeApply
-                >>> c = CogniteClient()
+                >>> client = CogniteClient()
                 >>> nodes = [NodeApply("mySpace", "myNodeId")]
-                >>> res = c.data_modeling.instances.apply(nodes)
+                >>> res = client.data_modeling.instances.apply(nodes)
 
             Create two nodes with data with a one-to-many edge
 
@@ -617,13 +617,13 @@ class InstancesAPI(APIClient):
                 ...     start_node=("actors", "arnold_schwarzenegger"),
                 ...     end_node=("movies", "Terminator"),
                 ... )
-                >>> res = c.data_modeling.instances.apply([actor, movie], [actor_to_movie])
+                >>> res = client.data_modeling.instances.apply([actor, movie], [actor_to_movie])
 
             Create new edge and automatically create end nodes.
 
                 >>> from cognite.client import CogniteClient
                 >>> from cognite.client.data_classes.data_modeling import EdgeApply
-                >>> c = CogniteClient()
+                >>> client = CogniteClient()
                 >>> actor_to_movie = EdgeApply(
                 ...     space="actors",
                 ...     external_id="relation:arnold_schwarzenegger:terminator",
@@ -631,7 +631,7 @@ class InstancesAPI(APIClient):
                 ...     start_node=("actors", "arnold_schwarzenegger"),
                 ...     end_node=("movies", "Terminator"),
                 ... )
-                >>> res = c.data_modeling.instances.apply(
+                >>> res = client.data_modeling.instances.apply(
                 ...     edges=actor_to_movie,
                 ...     auto_create_start_nodes=True,
                 ...     auto_create_end_nodes=True
@@ -720,17 +720,17 @@ class InstancesAPI(APIClient):
 
                 >>> from cognite.client import CogniteClient
                 >>> from cognite.client.data_classes.data_modeling import ViewId
-                >>> c = CogniteClient()
-                >>> res = c.data_modeling.instances.search(ViewId("mySpace", "PersonView", "v1"), query="Arnold", properties=["name"])
+                >>> client = CogniteClient()
+                >>> res = client.data_modeling.instances.search(ViewId("mySpace", "PersonView", "v1"), query="Arnold", properties=["name"])
 
             Search for Quentin in the person view in the name property, but only born after 1970:
 
                 >>> from cognite.client import CogniteClient
                 >>> from cognite.client.data_classes.data_modeling import ViewId
                 >>> from cognite.client.data_classes import filters
-                >>> c = CogniteClient()
+                >>> client = CogniteClient()
                 >>> born_after_1970 = filters.Range(["mySpace", "PersonView/v1", "birthYear"], gt=1970)
-                >>> res = c.data_modeling.instances.search(
+                >>> res = client.data_modeling.instances.search(
                 ...     ViewId("mySpace", "PersonView", "v1"),
                 ...     query="Quentin",
                 ...     properties=["name"],
@@ -834,10 +834,10 @@ class InstancesAPI(APIClient):
 
                 >>> from cognite.client import CogniteClient
                 >>> from cognite.client.data_classes.data_modeling import ViewId, aggregations as aggs
-                >>> c = CogniteClient()
+                >>> client = CogniteClient()
                 >>> avg_run_time = aggs.Avg("runTimeMinutes")
                 >>> view_id = ViewId("mySpace", "PersonView", "v1")
-                >>> res = c.data_modeling.instances.aggregate(view_id, avg_run_time, group_by="releaseYear")
+                >>> res = client.data_modeling.instances.aggregate(view_id, avg_run_time, group_by="releaseYear")
 
         """
         if instance_type not in ("node", "edge"):
@@ -932,10 +932,10 @@ class InstancesAPI(APIClient):
 
                 >>> from cognite.client import CogniteClient
                 >>> from cognite.client.data_classes.data_modeling import aggregations as aggs, ViewId
-                >>> c = CogniteClient()
+                >>> client = CogniteClient()
                 >>> birth_by_decade = aggs.Histogram("birthYear", interval=10.0)
                 >>> view_id = ViewId("mySpace", "PersonView", "v1")
-                >>> res = c.data_modeling.instances.histogram(view_id, birth_by_decade)
+                >>> res = client.data_modeling.instances.histogram(view_id, birth_by_decade)
         """
         if instance_type not in ("node", "edge"):
             raise ValueError(f"Invalid instance type: {instance_type}")
@@ -991,7 +991,7 @@ class InstancesAPI(APIClient):
                 >>> from cognite.client.data_classes.data_modeling.query import Query, Select, NodeResultSetExpression, EdgeResultSetExpression, SourceSelector
                 >>> from cognite.client.data_classes.filters import Range, Equals
                 >>> from cognite.client.data_classes.data_modeling.ids import ViewId
-                >>> c = CogniteClient()
+                >>> client = CogniteClient()
                 >>> movie_id = ViewId("mySpace", "MovieView", "v1")
                 >>> actor_id = ViewId("mySpace", "ActorView", "v1")
                 >>> query = Query(
@@ -1005,7 +1005,7 @@ class InstancesAPI(APIClient):
                 ...             [SourceSelector(actor_id, ["name"])], sort=[InstanceSort(actor_id.as_property_ref("name"))]),
                 ...     },
                 ... )
-                >>> res = c.data_modeling.instances.query(query)
+                >>> res = client.data_modeling.instances.query(query)
         """
         return self._query_or_sync(query, "query")
 
@@ -1029,7 +1029,7 @@ class InstancesAPI(APIClient):
                 >>> from cognite.client.data_classes.data_modeling.query import Query, Select, NodeResultSetExpression, EdgeResultSetExpression, SourceSelector
                 >>> from cognite.client.data_classes.filters import Range, Equals
                 >>> from cognite.client.data_classes.data_modeling.ids import ViewId
-                >>> c = CogniteClient()
+                >>> client = CogniteClient()
                 >>> movie_id = ViewId("mySpace", "MovieView", "v1")
                 >>> actor_id = ViewId("mySpace", "ActorView", "v1")
                 >>> query = Query(
@@ -1043,10 +1043,10 @@ class InstancesAPI(APIClient):
                 ...             [SourceSelector(actor_id, ["name"])], sort=[InstanceSort(actor_id.as_property_ref("name"))]),
                 ...     },
                 ... )
-                >>> res = c.data_modeling.instances.sync(query)
+                >>> res = client.data_modeling.instances.sync(query)
                 >>> # Added a new movie with actors released before 2000
                 >>> query.cursors = res.cursors
-                >>> res_new = c.data_modeling.instances.sync(query)
+                >>> res_new = client.data_modeling.instances.sync(query)
 
             In the last example, the res_new will only contain the actors that have been added with the new movie.
         """
@@ -1118,12 +1118,12 @@ class InstancesAPI(APIClient):
             List instances and limit to 5:
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
-                >>> instance_list = c.data_modeling.instances.list(limit=5)
+                >>> client = CogniteClient()
+                >>> instance_list = client.data_modeling.instances.list(limit=5)
 
             List some instances in the space 'my-space':
 
-                >>> instance_list = c.data_modeling.instances.list(space="my-space")
+                >>> instance_list = client.data_modeling.instances.list(space="my-space")
 
             List instances and sort by some property:
 
@@ -1132,16 +1132,16 @@ class InstancesAPI(APIClient):
                 ...     property=('space', 'view_xid/view_version', 'some_property'),
                 ...     direction="descending",
                 ...     nulls_first=True)
-                >>> instance_list = c.data_modeling.instances.list(sort=property_sort)
+                >>> instance_list = client.data_modeling.instances.list(sort=property_sort)
 
             Iterate over instances (note: returns nodes):
 
-                >>> for instance in c.data_modeling.instances:
+                >>> for instance in client.data_modeling.instances:
                 ...     instance # do something with the instance
 
             Iterate over chunks of instances to reduce memory load:
 
-                >>> for instance_list in c.data_modeling.instances(chunk_size=100):
+                >>> for instance_list in client.data_modeling.instances(chunk_size=100):
                 ...     instance_list # do something with the instances
         """
         self._validate_filter(filter)

--- a/cognite/client/_api/data_modeling/spaces.py
+++ b/cognite/client/_api/data_modeling/spaces.py
@@ -83,14 +83,14 @@ class SpacesAPI(APIClient):
         Examples:
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
-                >>> res = c.data_modeling.spaces.retrieve(space='mySpace')
+                >>> client = CogniteClient()
+                >>> res = client.data_modeling.spaces.retrieve(space='mySpace')
 
             Get multiple spaces by id:
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
-                >>> res = c.data_modeling.spaces.retrieve(spaces=["MySpace", "MyAwesomeSpace", "MyOtherSpace"])
+                >>> client = CogniteClient()
+                >>> res = client.data_modeling.spaces.retrieve(spaces=["MySpace", "MyAwesomeSpace", "MyOtherSpace"])
 
         """
         identifier = _load_space_identifier(spaces)
@@ -113,8 +113,8 @@ class SpacesAPI(APIClient):
             Delete spaces by id::
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
-                >>> c.data_modeling.spaces.delete(spaces=["mySpace", "myOtherSpace"])
+                >>> client = CogniteClient()
+                >>> client.data_modeling.spaces.delete(spaces=["mySpace", "myOtherSpace"])
         """
         deleted_spaces = cast(
             list,
@@ -146,21 +146,21 @@ class SpacesAPI(APIClient):
             List spaces and filter on max start time::
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
-                >>> space_list = c.data_modeling.spaces.list(limit=5)
+                >>> client = CogniteClient()
+                >>> space_list = client.data_modeling.spaces.list(limit=5)
 
             Iterate over spaces::
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
-                >>> for space in c.data_modeling.spaces:
+                >>> client = CogniteClient()
+                >>> for space in client.data_modeling.spaces:
                 ...     space # do something with the space
 
             Iterate over chunks of spaces to reduce memory load::
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
-                >>> for space_list in c.data_modeling.spaces(chunk_size=2500):
+                >>> client = CogniteClient()
+                >>> for space_list in client.data_modeling.spaces(chunk_size=2500):
                 ...     space_list # do something with the spaces
         """
         return self._list(
@@ -194,10 +194,10 @@ class SpacesAPI(APIClient):
 
                 >>> from cognite.client import CogniteClient
                 >>> from cognite.client.data_classes.data_modeling import SpaceApply
-                >>> c = CogniteClient()
+                >>> client = CogniteClient()
                 >>> spaces = [SpaceApply(space="mySpace", description="My first space", name="My Space"),
                 ... SpaceApply(space="myOtherSpace", description="My second space", name="My Other Space")]
-                >>> res = c.data_modeling.spaces.apply(spaces)
+                >>> res = client.data_modeling.spaces.apply(spaces)
         """
         return self._create_multiple(
             list_cls=SpaceList,

--- a/cognite/client/_api/data_modeling/views.py
+++ b/cognite/client/_api/data_modeling/views.py
@@ -110,8 +110,8 @@ class ViewsAPI(APIClient):
         Examples:
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
-                >>> res = c.data_modeling.views.retrieve(('mySpace', 'myView', 'v1'))
+                >>> client = CogniteClient()
+                >>> res = client.data_modeling.views.retrieve(('mySpace', 'myView', 'v1'))
 
         """
         identifier = _load_identifier(ids, "view")
@@ -139,8 +139,8 @@ class ViewsAPI(APIClient):
             Delete views by id::
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
-                >>> c.data_modeling.views.delete(('mySpace', 'myView', 'v1'))
+                >>> client = CogniteClient()
+                >>> client.data_modeling.views.delete(('mySpace', 'myView', 'v1'))
         """
         deleted_views = cast(
             list,
@@ -178,21 +178,21 @@ class ViewsAPI(APIClient):
             List 5 views::
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
-                >>> view_list = c.data_modeling.views.list(limit=5)
+                >>> client = CogniteClient()
+                >>> view_list = client.data_modeling.views.list(limit=5)
 
             Iterate over views::
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
-                >>> for view in c.data_modeling.views:
+                >>> client = CogniteClient()
+                >>> for view in client.data_modeling.views:
                 ...     view # do something with the view
 
             Iterate over chunks of views to reduce memory load::
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
-                >>> for view_list in c.data_modeling.views(chunk_size=10):
+                >>> client = CogniteClient()
+                >>> for view_list in client.data_modeling.views(chunk_size=10):
                 ...     view_list # do something with the views
         """
         filter_ = ViewFilter(space, include_inherited_properties, all_versions, include_global)
@@ -224,7 +224,7 @@ class ViewsAPI(APIClient):
 
                 >>> from cognite.client import CogniteClient
                 >>> from cognite.client.data_classes.data_modeling import ViewApply, MappedPropertyApply, ContainerId
-                >>> c = CogniteClient()
+                >>> client = CogniteClient()
                 >>> views = [
                 ...     ViewApply(
                 ...         space="mySpace",
@@ -238,7 +238,7 @@ class ViewsAPI(APIClient):
                 ...         }
                 ...    )
                 ... ]
-                >>> res = c.data_modeling.views.apply(views)
+                >>> res = client.data_modeling.views.apply(views)
 
 
             Create views with edge relations::
@@ -252,7 +252,7 @@ class ViewsAPI(APIClient):
                 ...     ViewApply,
                 ...     ViewId
                 ... )
-                >>> c = CogniteClient()
+                >>> client = CogniteClient()
                 >>> movie_view = ViewApply(
                 ...     space="imdb",
                 ...     external_id="Movie",
@@ -295,7 +295,7 @@ class ViewsAPI(APIClient):
                 ...         ),
                 ...     }
                 ... )
-                >>> res = c.data_modeling.views.apply([movie_view, actor_view])
+                >>> res = client.data_modeling.views.apply([movie_view, actor_view])
         """
         return self._create_multiple(
             list_cls=ViewList,

--- a/cognite/client/_api/data_sets.py
+++ b/cognite/client/_api/data_sets.py
@@ -100,9 +100,9 @@ class DataSetsAPI(APIClient):
 
                 >>> from cognite.client import CogniteClient
                 >>> from cognite.client.data_classes import DataSetWrite
-                >>> c = CogniteClient()
+                >>> client = CogniteClient()
                 >>> data_sets = [DataSetWrite(name="1st level"), DataSetWrite(name="2nd level")]
-                >>> res = c.data_sets.create(data_sets)
+                >>> res = client.data_sets.create(data_sets)
         """
         return self._create_multiple(
             list_cls=DataSetList, resource_cls=DataSet, items=data_set, input_resource_cls=DataSetWrite
@@ -123,14 +123,14 @@ class DataSetsAPI(APIClient):
             Get data set by id::
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
-                >>> res = c.data_sets.retrieve(id=1)
+                >>> client = CogniteClient()
+                >>> res = client.data_sets.retrieve(id=1)
 
             Get data set by external id::
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
-                >>> res = c.data_sets.retrieve(external_id="1")
+                >>> client = CogniteClient()
+                >>> res = client.data_sets.retrieve(external_id="1")
         """
         identifiers = IdentifierSequence.load(ids=id, external_ids=external_id).as_singleton()
         return self._retrieve_multiple(list_cls=DataSetList, resource_cls=DataSet, identifiers=identifiers)
@@ -156,14 +156,14 @@ class DataSetsAPI(APIClient):
             Get data sets by id::
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
-                >>> res = c.data_sets.retrieve_multiple(ids=[1, 2, 3])
+                >>> client = CogniteClient()
+                >>> res = client.data_sets.retrieve_multiple(ids=[1, 2, 3])
 
             Get data sets by external id::
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
-                >>> res = c.data_sets.retrieve_multiple(external_ids=["abc", "def"], ignore_unknown_ids=True)
+                >>> client = CogniteClient()
+                >>> res = client.data_sets.retrieve_multiple(external_ids=["abc", "def"], ignore_unknown_ids=True)
         """
         identifiers = IdentifierSequence.load(ids=ids, external_ids=external_ids)
         return self._retrieve_multiple(
@@ -184,8 +184,8 @@ class DataSetsAPI(APIClient):
             Aggregate data_sets:
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
-                >>> aggregate_protected = c.data_sets.aggregate(filter={"write_protected": True})
+                >>> client = CogniteClient()
+                >>> aggregate_protected = client.data_sets.aggregate(filter={"write_protected": True})
         """
 
         return self._aggregate(filter=filter, cls=CountAggregate)
@@ -214,18 +214,18 @@ class DataSetsAPI(APIClient):
             Update a data set that you have fetched. This will perform a full update of the data set::
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
-                >>> data_set = c.data_sets.retrieve(id=1)
+                >>> client = CogniteClient()
+                >>> data_set = client.data_sets.retrieve(id=1)
                 >>> data_set.description = "New description"
-                >>> res = c.data_sets.update(data_set)
+                >>> res = client.data_sets.update(data_set)
 
             Perform a partial update on a data set, updating the description and removing a field from metadata::
 
                 >>> from cognite.client import CogniteClient
                 >>> from cognite.client.data_classes import DataSetUpdate
-                >>> c = CogniteClient()
+                >>> client = CogniteClient()
                 >>> my_update = DataSetUpdate(id=1).description.set("New description").metadata.remove(["key"])
-                >>> res = c.data_sets.update(my_update)
+                >>> res = client.data_sets.update(my_update)
         """
         return self._update_multiple(list_cls=DataSetList, resource_cls=DataSet, update_cls=DataSetUpdate, items=item)
 
@@ -256,21 +256,21 @@ class DataSetsAPI(APIClient):
             List data sets and filter on write_protected::
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
-                >>> data_sets_list = c.data_sets.list(limit=5, write_protected=False)
+                >>> client = CogniteClient()
+                >>> data_sets_list = client.data_sets.list(limit=5, write_protected=False)
 
             Iterate over data sets::
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
-                >>> for data_set in c.data_sets:
+                >>> client = CogniteClient()
+                >>> for data_set in client.data_sets:
                 ...     data_set # do something with the data_set
 
             Iterate over chunks of data sets to reduce memory load::
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
-                >>> for data_set_list in c.data_sets(chunk_size=2500):
+                >>> client = CogniteClient()
+                >>> for data_set_list in client.data_sets(chunk_size=2500):
                 ...     data_set_list # do something with the list
         """
 

--- a/cognite/client/_api/datapoints.py
+++ b/cognite/client/_api/datapoints.py
@@ -1185,27 +1185,27 @@ class DatapointsAPI(APIClient):
             be the first element::
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
-                >>> res = c.time_series.data.retrieve_latest(id=1)[0]
+                >>> client = CogniteClient()
+                >>> res = client.time_series.data.retrieve_latest(id=1)[0]
 
             You can also get the first datapoint before a specific time::
 
-                >>> res = c.time_series.data.retrieve_latest(id=1, before="2d-ago")[0]
+                >>> res = client.time_series.data.retrieve_latest(id=1, before="2d-ago")[0]
 
             You can also retrieve the datapoint in a different unit or unit system::
 
-                >>> res = c.time_series.data.retrieve_latest(id=1, target_unit="temperature:deg_f")[0]
-                >>> res = c.time_series.data.retrieve_latest(id=1, target_unit_system="Imperial")[0]
+                >>> res = client.time_series.data.retrieve_latest(id=1, target_unit="temperature:deg_f")[0]
+                >>> res = client.time_series.data.retrieve_latest(id=1, target_unit_system="Imperial")[0]
 
             You may also pass an instance of LatestDatapointQuery:
 
                 >>> from cognite.client.data_classes import LatestDatapointQuery
-                >>> res = c.time_series.data.retrieve_latest(id=LatestDatapointQuery(id=1, before=60_000))[0]
+                >>> res = client.time_series.data.retrieve_latest(id=LatestDatapointQuery(id=1, before=60_000))[0]
 
             If you need the latest datapoint for multiple time series, simply give a list of ids. Note that we are
             using external ids here, but either will work::
 
-                >>> res = c.time_series.data.retrieve_latest(external_id=["abc", "def"])
+                >>> res = client.time_series.data.retrieve_latest(external_id=["abc", "def"])
                 >>> latest_abc = res[0][0]
                 >>> latest_def = res[1][0]
 
@@ -1218,7 +1218,7 @@ class DatapointsAPI(APIClient):
                 ...     LatestDatapointQuery(id=456, before="1w-ago"),
                 ...     LatestDatapointQuery(id=789, before=datetime(2018,1,1, tzinfo=timezone.utc)),
                 ...     LatestDatapointQuery(id=987, target_unit="temperature:deg_f")]
-                >>> res = c.time_series.data.retrieve_latest(
+                >>> res = client.time_series.data.retrieve_latest(
                 ...     id=id_queries,
                 ...     external_id=LatestDatapointQuery(
                 ...         external_id="abc", before="3h-ago", target_unit_system="Imperial")
@@ -1258,16 +1258,16 @@ class DatapointsAPI(APIClient):
 
                 >>> from cognite.client import CogniteClient
                 >>> from datetime import datetime, timezone
-                >>> c = CogniteClient()
+                >>> client = CogniteClient()
                 >>> # With datetime objects:
                 >>> datapoints = [
                 ...     (datetime(2018,1,1, tzinfo=timezone.utc), 1000),
                 ...     (datetime(2018,1,2, tzinfo=timezone.utc), 2000),
                 ... ]
-                >>> c.time_series.data.insert(datapoints, id=1)
+                >>> client.time_series.data.insert(datapoints, id=1)
                 >>> # With ms since epoch:
                 >>> datapoints = [(150000000000, 1000), (160000000000, 2000)]
-                >>> c.time_series.data.insert(datapoints, id=2)
+                >>> client.time_series.data.insert(datapoints, id=2)
 
             Or they can be a list of dictionaries::
 
@@ -1275,15 +1275,15 @@ class DatapointsAPI(APIClient):
                 ...     {"timestamp": 150000000000, "value": 1000},
                 ...     {"timestamp": 160000000000, "value": 2000},
                 ... ]
-                >>> c.time_series.data.insert(datapoints, external_id="abcd")
+                >>> client.time_series.data.insert(datapoints, external_id="abcd")
 
             Or they can be a Datapoints or DatapointsArray object (with raw datapoints only). Note that the id or external_id
             set on these objects are not inspected/used (as they belong to the "from-time-series", and not the "to-time-series"),
             and so you must explicitly pass the identifier of the time series you want to insert into, which in this example is
             `external_id="foo"`::
 
-                >>> data = c.time_series.data.retrieve(external_id="abc", start="1w-ago", end="now")
-                >>> c.time_series.data.insert(data, external_id="foo")
+                >>> data = client.time_series.data.retrieve(external_id="abc", start="1w-ago", end="now")
+                >>> client.time_series.data.insert(data, external_id="foo")
         """
         post_dps_object = Identifier.of_either(id, external_id).as_dict()
         dps_to_post: Sequence[dict[str, int | float | str | datetime]] | Sequence[
@@ -1357,8 +1357,8 @@ class DatapointsAPI(APIClient):
             Deleting the last week of data from a time series::
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
-                >>> c.time_series.data.delete_range(start="1w-ago", end="now", id=1)
+                >>> client = CogniteClient()
+                >>> client.time_series.data.delete_range(start="1w-ago", end="now", id=1)
         """
         start_ms = timestamp_to_ms(start)
         end_ms = timestamp_to_ms(end)
@@ -1380,10 +1380,10 @@ class DatapointsAPI(APIClient):
             Each element in the list ranges must be specify either id or external_id, and a range::
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
+                >>> client = CogniteClient()
                 >>> ranges = [{"id": 1, "start": "2d-ago", "end": "now"},
                 ...           {"external_id": "abc", "start": "2d-ago", "end": "now"}]
-                >>> c.time_series.data.delete_ranges(ranges)
+                >>> client.time_series.data.delete_ranges(ranges)
         """
         valid_ranges = []
         for time_range in ranges:

--- a/cognite/client/_api/datapoints_subscriptions.py
+++ b/cognite/client/_api/datapoints_subscriptions.py
@@ -50,9 +50,9 @@ class DatapointsSubscriptionAPI(APIClient):
 
                 >>> from cognite.client import CogniteClient
                 >>> from cognite.client.data_classes import DataPointSubscriptionWrite
-                >>> c = CogniteClient()
+                >>> client = CogniteClient()
                 >>> sub = DataPointSubscriptionWrite("mySubscription", partition_count=1, time_series_ids=["myFistTimeSeries", "mySecondTimeSeries"], name="My subscription")
-                >>> created = c.time_series.subscriptions.create(sub)
+                >>> created = client.time_series.subscriptions.create(sub)
 
             Create a filter defined subscription for all numeric time series:
 
@@ -60,7 +60,7 @@ class DatapointsSubscriptionAPI(APIClient):
                 >>> from cognite.client.data_classes import DataPointSubscriptionWrite
                 >>> from cognite.client.data_classes import filters as flt
                 >>> from cognite.client.data_classes.datapoints_subscriptions import DatapointSubscriptionFilterProperties
-                >>> c = CogniteClient()
+                >>> client = CogniteClient()
                 >>> prop = DatapointSubscriptionFilterProperties.is_string
                 >>> numeric_timeseries = flt.Equals(prop, False)
                 >>> sub = DataPointSubscriptionWrite(
@@ -68,7 +68,7 @@ class DatapointsSubscriptionAPI(APIClient):
                 ...     partition_count=1,
                 ...     filter=numeric_timeseries,
                 ...     name="My subscription for Numeric time series")
-                >>> created = c.time_series.subscriptions.create(sub)
+                >>> created = client.time_series.subscriptions.create(sub)
         """
         self._warning.warn()
 
@@ -91,8 +91,8 @@ class DatapointsSubscriptionAPI(APIClient):
             Delete a subscription by external ID:
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
-                >>> c.time_series.subscriptions.delete("my_subscription")
+                >>> client = CogniteClient()
+                >>> client.time_series.subscriptions.delete("my_subscription")
         """
         self._warning.warn()
 
@@ -117,8 +117,8 @@ class DatapointsSubscriptionAPI(APIClient):
             Retrieve a subscription by external ID:
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
-                >>> res = c.time_series.subscriptions.retrieve("my_subscription")
+                >>> client = CogniteClient()
+                >>> res = client.time_series.subscriptions.retrieve("my_subscription")
         """
         self._warning.warn()
 
@@ -151,8 +151,8 @@ class DatapointsSubscriptionAPI(APIClient):
 
                 >>> from cognite.client import CogniteClient
                 >>> from cognite.client.data_classes import DataPointSubscriptionUpdate
-                >>> c = CogniteClient()
-                >>> members = c.time_series.subscriptions.list_member_time_series("my_subscription")
+                >>> client = CogniteClient()
+                >>> members = client.time_series.subscriptions.list_member_time_series("my_subscription")
                 >>> timeseries_external_ids = members.as_external_ids()
         """
         self._warning.warn()
@@ -184,18 +184,18 @@ class DatapointsSubscriptionAPI(APIClient):
 
                 >>> from cognite.client import CogniteClient
                 >>> from cognite.client.data_classes import DataPointSubscriptionUpdate
-                >>> c = CogniteClient()
+                >>> client = CogniteClient()
                 >>> update = DataPointSubscriptionUpdate("my_subscription").name.set("My New Name")
-                >>> updated = c.time_series.subscriptions.update(update)
+                >>> updated = client.time_series.subscriptions.update(update)
 
 
             Add a time series to a preexisting subscription:
 
                 >>> from cognite.client import CogniteClient
                 >>> from cognite.client.data_classes import DataPointSubscriptionUpdate
-                >>> c = CogniteClient()
+                >>> client = CogniteClient()
                 >>> update = DataPointSubscriptionUpdate("my_subscription").time_series_ids.add(["MyNewTimeSeriesExternalId"])
-                >>> updated = c.time_series.subscriptions.update(update)
+                >>> updated = client.time_series.subscriptions.update(update)
         """
         self._warning.warn()
 
@@ -240,8 +240,8 @@ class DatapointsSubscriptionAPI(APIClient):
             Iterate over changes to subscription timeseries since the beginning until there is no more data:
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
-                >>> for batch in c.time_series.subscriptions.iterate_data("my_subscription"):
+                >>> client = CogniteClient()
+                >>> for batch in client.time_series.subscriptions.iterate_data("my_subscription"):
                 ...     print(f"Added {len(batch.subscription_changes.added)} timeseries")
                 ...     print(f"Removed {len(batch.subscription_changes.removed)} timeseries")
                 ...     print(f"Changed timeseries data in {len(batch.updates)} updates")
@@ -251,7 +251,7 @@ class DatapointsSubscriptionAPI(APIClient):
             Iterate continuously over all changes to the subscription newer than 3 days:
 
                 >>> import time
-                >>> for batch in c.time_series.subscriptions.iterate_data("my_subscription", "3d-ago"):
+                >>> for batch in client.time_series.subscriptions.iterate_data("my_subscription", "3d-ago"):
                 ...     print(f"Added {len(batch.subscription_changes.added)} timeseries")
                 ...     print(f"Removed {len(batch.subscription_changes.removed)} timeseries")
                 ...     print(f"Changed timeseries data in {len(batch.updates)} updates")
@@ -293,8 +293,8 @@ class DatapointsSubscriptionAPI(APIClient):
             List 5 subscriptions:
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
-                >>> subscriptions = c.time_series.subscriptions.list(limit=5)
+                >>> client = CogniteClient()
+                >>> subscriptions = client.time_series.subscriptions.list(limit=5)
 
         """
         self._warning.warn()

--- a/cognite/client/_api/documents.py
+++ b/cognite/client/_api/documents.py
@@ -535,7 +535,7 @@ class DocumentsAPI(APIClient):
                 >>> from pathlib import Path
                 >>> client = CogniteClient()
                 >>> with Path("my_file.txt").open("wb") as buffer:
-                ...     c.documents.retrieve_content_buffer(id=123, buffer=buffer)
+                ...     client.documents.retrieve_content_buffer(id=123, buffer=buffer)
         """
         with self._do_request(
             "GET", f"{self._RESOURCE_PATH}/{id}/content", stream=True, accept="text/plain"

--- a/cognite/client/_api/documents.py
+++ b/cognite/client/_api/documents.py
@@ -62,13 +62,13 @@ class DocumentPreviewAPI(APIClient):
             Download image preview of page 5 of file with id 123:
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
-                >>> content = c.documents.previews.download_page_as_png_bytes(id=123, page_number=5)
+                >>> client = CogniteClient()
+                >>> content = client.documents.previews.download_page_as_png_bytes(id=123, page_number=5)
 
             Download an image preview and display using IPython.display.Image (for example in a Jupyter Notebook):
 
                 >>> from IPython.display import Image
-                >>> binary_png = c.documents.previews.download_page_as_png_bytes(id=123, page_number=5)
+                >>> binary_png = client.documents.previews.download_page_as_png_bytes(id=123, page_number=5)
                 >>> Image(binary_png)
         """
         res = self._do_request(
@@ -92,8 +92,8 @@ class DocumentPreviewAPI(APIClient):
             Download Image preview of page 5 of file with id 123 to folder "previews":
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
-                >>> c.documents.previews.download_page_as_png("previews", id=123, page_number=5)
+                >>> client = CogniteClient()
+                >>> client.documents.previews.download_page_as_png("previews", id=123, page_number=5)
         """
         if isinstance(path, IO):
             content = self.download_page_as_png_bytes(id)
@@ -127,8 +127,8 @@ class DocumentPreviewAPI(APIClient):
             Download PDF preview of file with id 123:
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
-                >>> content = c.documents.previews.download_document_as_pdf_bytes(id=123)
+                >>> client = CogniteClient()
+                >>> content = client.documents.previews.download_document_as_pdf_bytes(id=123)
         """
         res = self._do_request("GET", f"{self._RESOURCE_PATH}/{id}/preview/pdf", accept="application/pdf")
         return res.content
@@ -150,8 +150,8 @@ class DocumentPreviewAPI(APIClient):
             Download PDF preview of file with id 123 to folder "previews":
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
-                >>> c.documents.previews.download_document_as_pdf("previews", id=123)
+                >>> client = CogniteClient()
+                >>> client.documents.previews.download_document_as_pdf("previews", id=123)
         """
         if isinstance(path, IO):
             content = self.download_document_as_pdf_bytes(id)
@@ -181,8 +181,8 @@ class DocumentPreviewAPI(APIClient):
             Retrieve the PDF preview download link for document with id 123:
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
-                >>> link = c.documents.previews.retrieve_pdf_link(id=123)
+                >>> client = CogniteClient()
+                >>> link = client.documents.previews.retrieve_pdf_link(id=123)
         """
         res = self._get(f"{self._RESOURCE_PATH}/{id}/preview/pdf/temporarylink")
         return TemporaryLink.load(res.json())
@@ -271,17 +271,17 @@ class DocumentsAPI(APIClient):
             Count the number of documents in your CDF project:
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
-                >>> count = c.documents.aggregate_count()
+                >>> client = CogniteClient()
+                >>> count = client.documents.aggregate_count()
 
             Count the number of PDF documents in your CDF project:
 
                 >>> from cognite.client import CogniteClient
                 >>> from cognite.client.data_classes import filters
                 >>> from cognite.client.data_classes.documents import DocumentProperty
-                >>> c = CogniteClient()
+                >>> client = CogniteClient()
                 >>> is_pdf = filters.Equals(DocumentProperty.mime_type, "application/pdf")
-                >>> pdf_count = c.documents.aggregate_count(filter=is_pdf)
+                >>> pdf_count = client.documents.aggregate_count(filter=is_pdf)
         """
         self._validate_filter(filter)
         return self._advanced_aggregate(
@@ -312,27 +312,27 @@ class DocumentsAPI(APIClient):
 
                 >>> from cognite.client import CogniteClient
                 >>> from cognite.client.data_classes.documents import DocumentProperty
-                >>> c = CogniteClient()
-                >>> count = c.documents.aggregate_cardinality_values(DocumentProperty.type)
+                >>> client = CogniteClient()
+                >>> count = client.documents.aggregate_cardinality_values(DocumentProperty.type)
 
             Count the number of authors of plain/text documents in your CDF project:
 
                 >>> from cognite.client import CogniteClient
                 >>> from cognite.client.data_classes import filters
                 >>> from cognite.client.data_classes.documents import DocumentProperty
-                >>> c = CogniteClient()
+                >>> client = CogniteClient()
                 >>> is_plain_text = filters.Equals(DocumentProperty.mime_type, "text/plain")
-                >>> plain_text_author_count = c.documents.aggregate_cardinality_values(DocumentProperty.author, filter=is_plain_text)
+                >>> plain_text_author_count = client.documents.aggregate_cardinality_values(DocumentProperty.author, filter=is_plain_text)
 
             Count the number of types of documents in your CDF project but exclude documents that start with "text":
 
                 >>> from cognite.client import CogniteClient
                 >>> from cognite.client.data_classes.documents import DocumentProperty
                 >>> from cognite.client.data_classes import aggregations
-                >>> c = CogniteClient()
+                >>> client = CogniteClient()
                 >>> agg = aggregations
                 >>> is_not_text = agg.Not(agg.Prefix("text"))
-                >>> type_count_excluded_text = c.documents.aggregate_cardinality_values(DocumentProperty.type, aggregate_filter=is_not_text)
+                >>> type_count_excluded_text = client.documents.aggregate_cardinality_values(DocumentProperty.type, aggregate_filter=is_not_text)
         """
         self._validate_filter(filter)
 
@@ -368,8 +368,8 @@ class DocumentsAPI(APIClient):
 
                 >>> from cognite.client import CogniteClient
                 >>> from cognite.client.data_classes.documents import SourceFileProperty
-                >>> c = CogniteClient()
-                >>> count = c.documents.aggregate_cardinality_properties(SourceFileProperty.metadata)
+                >>> client = CogniteClient()
+                >>> count = client.documents.aggregate_cardinality_properties(SourceFileProperty.metadata)
         """
         self._validate_filter(filter)
 
@@ -407,8 +407,8 @@ class DocumentsAPI(APIClient):
 
                 >>> from cognite.client import CogniteClient
                 >>> from cognite.client.data_classes.documents import DocumentProperty
-                >>> c = CogniteClient()
-                >>> result = c.documents.aggregate_unique_values(DocumentProperty.mime_type)
+                >>> client = CogniteClient()
+                >>> result = client.documents.aggregate_unique_values(DocumentProperty.mime_type)
                 >>> unique_types = result.unique
 
             Get the different languages with count for documents with external id prefix "abc":
@@ -416,9 +416,9 @@ class DocumentsAPI(APIClient):
                 >>> from cognite.client import CogniteClient
                 >>> from cognite.client.data_classes import filters
                 >>> from cognite.client.data_classes.documents import DocumentProperty
-                >>> c = CogniteClient()
+                >>> client = CogniteClient()
                 >>> is_abc = filters.Prefix(DocumentProperty.external_id, "abc")
-                >>> result = c.documents.aggregate_unique_values(DocumentProperty.language, filter=is_abc)
+                >>> result = client.documents.aggregate_unique_values(DocumentProperty.language, filter=is_abc)
                 >>> unique_languages = result.unique
 
             Get the unique mime types with count of documents, but exclude mime types that start with text:
@@ -426,10 +426,10 @@ class DocumentsAPI(APIClient):
                 >>> from cognite.client import CogniteClient
                 >>> from cognite.client.data_classes.documents import DocumentProperty
                 >>> from cognite.client.data_classes import aggregations
-                >>> c = CogniteClient()
+                >>> client = CogniteClient()
                 >>> agg = aggregations
                 >>> is_not_text = agg.Not(agg.Prefix("text"))
-                >>> result = c.documents.aggregate_unique_values(DocumentProperty.mime_type, aggregate_filter=is_not_text)
+                >>> result = client.documents.aggregate_unique_values(DocumentProperty.mime_type, aggregate_filter=is_not_text)
                 >>> unique_mime_types = result.unique
         """
         self._validate_filter(filter)
@@ -468,8 +468,8 @@ class DocumentsAPI(APIClient):
 
                 >>> from cognite.client import CogniteClient
                 >>> from cognite.client.data_classes.documents import SourceFileProperty
-                >>> c = CogniteClient()
-                >>> result = c.documents.aggregate_unique_values(SourceFileProperty.metadata)
+                >>> client = CogniteClient()
+                >>> result = client.documents.aggregate_unique_values(SourceFileProperty.metadata)
         """
         self._validate_filter(filter)
 
@@ -506,8 +506,8 @@ class DocumentsAPI(APIClient):
             Retrieve the content of a document with id 123:
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
-                >>> content = c.documents.retrieve_content(id=123)
+                >>> client = CogniteClient()
+                >>> content = client.documents.retrieve_content(id=123)
         """
         response = self._do_request("GET", f"{self._RESOURCE_PATH}/{id}/content", accept="text/plain")
         return response.content
@@ -533,7 +533,7 @@ class DocumentsAPI(APIClient):
 
                 >>> from cognite.client import CogniteClient
                 >>> from pathlib import Path
-                >>> c = CogniteClient()
+                >>> client = CogniteClient()
                 >>> with Path("my_file.txt").open("wb") as buffer:
                 ...     c.documents.retrieve_content_buffer(id=123, buffer=buffer)
         """
@@ -597,9 +597,9 @@ class DocumentsAPI(APIClient):
                 >>> from cognite.client import CogniteClient
                 >>> from cognite.client.data_classes import filters
                 >>> from cognite.client.data_classes.documents import DocumentProperty
-                >>> c = CogniteClient()
+                >>> client = CogniteClient()
                 >>> is_pdf = filters.Equals(DocumentProperty.mime_type, "application/pdf")
-                >>> documents = c.documents.search("pump 123", filter=is_pdf)
+                >>> documents = client.documents.search("pump 123", filter=is_pdf)
 
             Find all documents with exact text 'CPLEX Error 1217: No Solution exists.'
             in plain text files created the last week in your CDF project and highlight the matches:
@@ -609,11 +609,11 @@ class DocumentsAPI(APIClient):
                 >>> from cognite.client.data_classes import filters
                 >>> from cognite.client.data_classes.documents import DocumentProperty
                 >>> from cognite.client.utils import timestamp_to_ms
-                >>> c = CogniteClient()
+                >>> client = CogniteClient()
                 >>> is_plain_text = filters.Equals(DocumentProperty.mime_type, "text/plain")
                 >>> last_week = filters.Range(DocumentProperty.created_time,
                 ...     gt=timestamp_to_ms(datetime.now() - timedelta(days=7)))
-                >>> documents = c.documents.search('"CPLEX Error 1217: No Solution exists."',
+                >>> documents = client.documents.search('"CPLEX Error 1217: No Solution exists."',
                 ...     highlight=True,
                 ...     filter=filters.And(is_plain_text, last_week))
         """
@@ -667,16 +667,16 @@ class DocumentsAPI(APIClient):
                 >>> from cognite.client import CogniteClient
                 >>> from cognite.client.data_classes import filters
                 >>> from cognite.client.data_classes.documents import DocumentProperty
-                >>> c = CogniteClient()
+                >>> client = CogniteClient()
                 >>> is_pdf = filters.Equals(DocumentProperty.mime_type, "application/pdf")
-                >>> pdf_documents = c.documents.list(filter=is_pdf)
+                >>> pdf_documents = client.documents.list(filter=is_pdf)
 
             Iterate over all documents in your CDF project:
 
                 >>> from cognite.client import CogniteClient
                 >>> from cognite.client.data_classes.documents import DocumentProperty
-                >>> c = CogniteClient()
-                >>> for document in c.documents:
+                >>> client = CogniteClient()
+                >>> for document in client.documents:
                 ...    print(document.name)
         """
         self._validate_filter(filter)

--- a/cognite/client/_api/events.py
+++ b/cognite/client/_api/events.py
@@ -159,14 +159,14 @@ class EventsAPI(APIClient):
             Get event by id::
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
-                >>> res = c.events.retrieve(id=1)
+                >>> client = CogniteClient()
+                >>> res = client.events.retrieve(id=1)
 
             Get event by external id::
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
-                >>> res = c.events.retrieve(external_id="1")
+                >>> client = CogniteClient()
+                >>> res = client.events.retrieve(external_id="1")
         """
         identifiers = IdentifierSequence.load(ids=id, external_ids=external_id).as_singleton()
         return self._retrieve_multiple(list_cls=EventList, resource_cls=Event, identifiers=identifiers)
@@ -192,14 +192,14 @@ class EventsAPI(APIClient):
             Get events by id::
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
-                >>> res = c.events.retrieve_multiple(ids=[1, 2, 3])
+                >>> client = CogniteClient()
+                >>> res = client.events.retrieve_multiple(ids=[1, 2, 3])
 
             Get events by external id::
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
-                >>> res = c.events.retrieve_multiple(external_ids=["abc", "def"])
+                >>> client = CogniteClient()
+                >>> res = client.events.retrieve_multiple(external_ids=["abc", "def"])
         """
         identifiers = IdentifierSequence.load(ids=ids, external_ids=external_ids)
         return self._retrieve_multiple(
@@ -220,8 +220,8 @@ class EventsAPI(APIClient):
             Aggregate events:
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
-                >>> aggregate_type = c.events.aggregate(filter={"type": "failure"})
+                >>> client = CogniteClient()
+                >>> aggregate_type = client.events.aggregate(filter={"type": "failure"})
         """
         warnings.warn(
             "This method is deprecated. Use aggregate_count, aggregate_unique_values, aggregate_cardinality_values, aggregate_cardinality_properties, or aggregate_unique_properties instead.",
@@ -253,8 +253,8 @@ class EventsAPI(APIClient):
 
             >>> from cognite.client import CogniteClient
             >>> from cognite.client.data_classes.events import EventProperty
-            >>> c = CogniteClient()
-            >>> result = c.events.aggregate_unique_values(EventProperty.type)
+            >>> client = CogniteClient()
+            >>> result = client.events.aggregate_unique_values(EventProperty.type)
             >>> print(result.unique)
 
         Get the unique types of events after 2020-01-01 in your CDF project:
@@ -264,9 +264,9 @@ class EventsAPI(APIClient):
             >>> from cognite.client.data_classes.events import EventProperty
             >>> from cognite.client.utils import timestamp_to_ms
             >>> from datetime import datetime
-            >>> c = CogniteClient()
+            >>> client = CogniteClient()
             >>> is_after_2020 = filters.Range(EventProperty.start_time, gte=timestamp_to_ms(datetime(2020, 1, 1)))
-            >>> result = c.events.aggregate_unique_values(EventProperty.type, advanced_filter=is_after_2020)
+            >>> result = client.events.aggregate_unique_values(EventProperty.type, advanced_filter=is_after_2020)
             >>> print(result.unique)
 
         Get the unique types of events after 2020-01-01 in your CDF project, but exclude all types that start with
@@ -275,11 +275,11 @@ class EventsAPI(APIClient):
             >>> from cognite.client import CogniteClient
             >>> from cognite.client.data_classes.events import EventProperty
             >>> from cognite.client.data_classes import aggregations
-            >>> c = CogniteClient()
+            >>> client = CogniteClient()
             >>> agg = aggregations
             >>> not_planned = agg.Not(agg.Prefix("planned"))
             >>> is_after_2020 = filters.Range(EventProperty.start_time, gte=timestamp_to_ms(datetime(2020, 1, 1)))
-            >>> result = c.events.aggregate_unique_values(EventProperty.type, advanced_filter=is_after_2020, aggregate_filter=not_planned)
+            >>> result = client.events.aggregate_unique_values(EventProperty.type, advanced_filter=is_after_2020, aggregate_filter=not_planned)
             >>> print(result.unique)
 
         """
@@ -314,17 +314,17 @@ class EventsAPI(APIClient):
             Count the number of events in your CDF project:
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
-                >>> count = c.events.aggregate_count()
+                >>> client = CogniteClient()
+                >>> count = client.events.aggregate_count()
 
             Count the number of workorder events in your CDF project:
 
                 >>> from cognite.client import CogniteClient
                 >>> from cognite.client.data_classes import filters
                 >>> from cognite.client.data_classes.events import EventProperty
-                >>> c = CogniteClient()
+                >>> client = CogniteClient()
                 >>> is_workorder = filters.Equals(EventProperty.type, "workorder")
-                >>> workorder_count = c.events.aggregate_count(advanced_filter=is_workorder)
+                >>> workorder_count = client.events.aggregate_count(advanced_filter=is_workorder)
         """
         self._validate_filter(advanced_filter)
         return self._advanced_aggregate(
@@ -357,17 +357,17 @@ class EventsAPI(APIClient):
 
             >>> from cognite.client import CogniteClient
             >>> from cognite.client.data_classes.events import EventProperty
-            >>> c = CogniteClient()
-            >>> type_count = c.events.aggregate_cardinality_values(EventProperty.type)
+            >>> client = CogniteClient()
+            >>> type_count = client.events.aggregate_cardinality_values(EventProperty.type)
 
         Count the number of types of events linked to asset 123 in your CDF project:
 
             >>> from cognite.client import CogniteClient
             >>> from cognite.client.data_classes import filters
             >>> from cognite.client.data_classes.events import EventProperty
-            >>> c = CogniteClient()
+            >>> client = CogniteClient()
             >>> is_asset = filters.ContainsAny(EventProperty.asset_ids, 123)
-            >>> plain_text_author_count = c.events.aggregate_cardinality_values(EventProperty.type, advanced_filter=is_asset)
+            >>> plain_text_author_count = client.events.aggregate_cardinality_values(EventProperty.type, advanced_filter=is_asset)
 
         """
         self._validate_filter(advanced_filter)
@@ -404,8 +404,8 @@ class EventsAPI(APIClient):
 
                 >>> from cognite.client import CogniteClient
                 >>> from cognite.client.data_classes.events import EventProperty
-                >>> c = CogniteClient()
-                >>> type_count = c.events.aggregate_cardinality_properties(EventProperty.metadata)
+                >>> client = CogniteClient()
+                >>> type_count = client.events.aggregate_cardinality_properties(EventProperty.metadata)
 
         """
         self._validate_filter(advanced_filter)
@@ -442,8 +442,8 @@ class EventsAPI(APIClient):
 
                 >>> from cognite.client import CogniteClient
                 >>> from cognite.client.data_classes.events import EventProperty
-                >>> c = CogniteClient()
-                >>> result = c.events.aggregate_unique_properties(EventProperty.metadata)
+                >>> client = CogniteClient()
+                >>> result = client.events.aggregate_unique_properties(EventProperty.metadata)
                 >>> print(result.unique)
         """
         self._validate_filter(advanced_filter)
@@ -478,9 +478,9 @@ class EventsAPI(APIClient):
 
                 >>> from cognite.client import CogniteClient
                 >>> from cognite.client.data_classes import EventWrite
-                >>> c = CogniteClient()
+                >>> client = CogniteClient()
                 >>> events = [EventWrite(start_time=0, end_time=1), EventWrite(start_time=2, end_time=3)]
-                >>> res = c.events.create(events)
+                >>> res = client.events.create(events)
         """
         return self._create_multiple(list_cls=EventList, resource_cls=Event, items=event, input_resource_cls=EventWrite)
 
@@ -502,8 +502,8 @@ class EventsAPI(APIClient):
             Delete events by id or external id::
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
-                >>> c.events.delete(id=[1,2,3], external_id="3")
+                >>> client = CogniteClient()
+                >>> client.events.delete(id=[1,2,3], external_id="3")
         """
         self._delete_multiple(
             identifiers=IdentifierSequence.load(ids=id, external_ids=external_id),
@@ -535,18 +535,18 @@ class EventsAPI(APIClient):
             Update an event that you have fetched. This will perform a full update of the event::
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
-                >>> event = c.events.retrieve(id=1)
+                >>> client = CogniteClient()
+                >>> event = client.events.retrieve(id=1)
                 >>> event.description = "New description"
-                >>> res = c.events.update(event)
+                >>> res = client.events.update(event)
 
             Perform a partial update on a event, updating the description and adding a new field to metadata::
 
                 >>> from cognite.client import CogniteClient
                 >>> from cognite.client.data_classes import EventUpdate
-                >>> c = CogniteClient()
+                >>> client = CogniteClient()
                 >>> my_update = EventUpdate(id=1).description.set("New description").metadata.add({"key": "value"})
-                >>> res = c.events.update(my_update)
+                >>> res = client.events.update(my_update)
         """
         return self._update_multiple(list_cls=EventList, resource_cls=Event, update_cls=EventUpdate, items=item)
 
@@ -572,8 +572,8 @@ class EventsAPI(APIClient):
             Search for events::
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
-                >>> res = c.events.search(description="some description")
+                >>> client = CogniteClient()
+                >>> res = client.events.search(description="some description")
         """
         return self._search(list_cls=EventList, search={"description": description}, filter=filter or {}, limit=limit)
 
@@ -607,11 +607,11 @@ class EventsAPI(APIClient):
 
                 >>> from cognite.client import CogniteClient
                 >>> from cognite.client.data_classes import Event
-                >>> c = CogniteClient()
-                >>> existing_event = c.events.retrieve(id=1)
+                >>> client = CogniteClient()
+                >>> existing_event = client.events.retrieve(id=1)
                 >>> existing_event.description = "New description"
                 >>> new_event = Event(external_id="new_event", description="New event")
-                >>> res = c.events.upsert([existing_event, new_event], mode="replace")
+                >>> res = client.events.upsert([existing_event, new_event], mode="replace")
         """
         return self._upsert_multiple(
             item,
@@ -649,10 +649,10 @@ class EventsAPI(APIClient):
 
                 >>> from cognite.client import CogniteClient
                 >>> from cognite.client.data_classes import filters as flt
-                >>> c = CogniteClient()
+                >>> client = CogniteClient()
                 >>> is_workorder = flt.Prefix("external_id", "workorder")
                 >>> has_failure = flt.Search("description", "failure")
-                >>> res = c.events.filter(
+                >>> res = client.events.filter(
                 ...     filter=flt.And(is_workorder, has_failure), sort=("start_time", "desc"))
 
             Note that you can check the API documentation above to see which properties you can filter on
@@ -664,10 +664,10 @@ class EventsAPI(APIClient):
                 >>> from cognite.client import CogniteClient
                 >>> from cognite.client.data_classes import filters as flt
                 >>> from cognite.client.data_classes.events import EventProperty, SortableEventProperty
-                >>> c = CogniteClient()
+                >>> client = CogniteClient()
                 >>> is_workorder = flt.Prefix(EventProperty.external_id, "workorder")
                 >>> has_failure = flt.Search(EventProperty.description, "failure")
-                >>> res = c.events.filter(
+                >>> res = client.events.filter(
                 ...     filter=flt.And(is_workorder, has_failure),
                 ...     sort=(SortableEventProperty.start_time, "desc"))
         """
@@ -738,21 +738,21 @@ class EventsAPI(APIClient):
             List events and filter on max start time::
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
-                >>> event_list = c.events.list(limit=5, start_time={"max": 1500000000})
+                >>> client = CogniteClient()
+                >>> event_list = client.events.list(limit=5, start_time={"max": 1500000000})
 
             Iterate over events::
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
-                >>> for event in c.events:
+                >>> client = CogniteClient()
+                >>> for event in client.events:
                 ...     event # do something with the event
 
             Iterate over chunks of events to reduce memory load::
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
-                >>> for event_list in c.events(chunk_size=2500):
+                >>> client = CogniteClient()
+                >>> for event_list in client.events(chunk_size=2500):
                 ...     event_list # do something with the events
         """
         asset_subtree_ids_processed = process_asset_subtree_ids(asset_subtree_ids, asset_subtree_external_ids)

--- a/cognite/client/_api/extractionpipelines.py
+++ b/cognite/client/_api/extractionpipelines.py
@@ -61,14 +61,14 @@ class ExtractionPipelinesAPI(APIClient):
             Get extraction pipeline by id::
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
-                >>> res = c.extraction_pipelines.retrieve(id=1)
+                >>> client = CogniteClient()
+                >>> res = client.extraction_pipelines.retrieve(id=1)
 
             Get extraction pipeline by external id::
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
-                >>> res = c.extraction_pipelines.retrieve(external_id="1")
+                >>> client = CogniteClient()
+                >>> res = client.extraction_pipelines.retrieve(external_id="1")
         """
 
         identifiers = IdentifierSequence.load(ids=id, external_ids=external_id).as_singleton()
@@ -97,14 +97,14 @@ class ExtractionPipelinesAPI(APIClient):
             Get ExtractionPipelines by id::
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
-                >>> res = c.extraction_pipelines.retrieve_multiple(ids=[1, 2, 3])
+                >>> client = CogniteClient()
+                >>> res = client.extraction_pipelines.retrieve_multiple(ids=[1, 2, 3])
 
             Get assets by external id::
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
-                >>> res = c.extraction_pipelines.retrieve_multiple(external_ids=["abc", "def"], ignore_unknown_ids=True)
+                >>> client = CogniteClient()
+                >>> res = client.extraction_pipelines.retrieve_multiple(external_ids=["abc", "def"], ignore_unknown_ids=True)
         """
         identifiers = IdentifierSequence.load(ids=ids, external_ids=external_ids)
         return self._retrieve_multiple(
@@ -128,8 +128,8 @@ class ExtractionPipelinesAPI(APIClient):
             List ExtractionPipelines::
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
-                >>> ep_list = c.extraction_pipelines.list(limit=5)
+                >>> client = CogniteClient()
+                >>> ep_list = client.extraction_pipelines.list(limit=5)
         """
 
         return self._list(list_cls=ExtractionPipelineList, resource_cls=ExtractionPipeline, method="GET", limit=limit)
@@ -167,9 +167,9 @@ class ExtractionPipelinesAPI(APIClient):
 
                 >>> from cognite.client import CogniteClient
                 >>> from cognite.client.data_classes import ExtractionPipelineWrite
-                >>> c = CogniteClient()
+                >>> client = CogniteClient()
                 >>> extpipes = [ExtractionPipelineWrite(name="extPipe1",...), ExtractionPipelineWrite(name="extPipe2",...)]
-                >>> res = c.extraction_pipelines.create(extpipes)
+                >>> res = client.extraction_pipelines.create(extpipes)
         """
         assert_type(extraction_pipeline, "extraction_pipeline", [ExtractionPipelineCore, Sequence])
 
@@ -194,8 +194,8 @@ class ExtractionPipelinesAPI(APIClient):
             Delete extraction pipelines by id or external id::
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
-                >>> c.extraction_pipelines.delete(id=[1,2,3], external_id="3")
+                >>> client = CogniteClient()
+                >>> client.extraction_pipelines.delete(id=[1,2,3], external_id="3")
         """
         self._delete_multiple(identifiers=IdentifierSequence.load(id, external_id), wrap_ids=True, extra_body_fields={})
 
@@ -231,10 +231,10 @@ class ExtractionPipelinesAPI(APIClient):
             Update an extraction pipeline that you have fetched. This will perform a full update of the extraction pipeline::
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
+                >>> client = CogniteClient()
                 >>> update = ExtractionPipelineUpdate(id=1)
                 >>> update.description.set("Another new extpipe")
-                >>> res = c.extraction_pipelines.update(update)
+                >>> res = client.extraction_pipelines.update(update)
         """
         return self._update_multiple(
             list_cls=ExtractionPipelineList,
@@ -278,21 +278,21 @@ class ExtractionPipelineRunsAPI(APIClient):
             List extraction pipeline runs::
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
-                >>> runsList = c.extraction_pipelines.runs.list(external_id="test ext id", limit=5)
+                >>> client = CogniteClient()
+                >>> runsList = client.extraction_pipelines.runs.list(external_id="test ext id", limit=5)
 
             Filter extraction pipeline runs on a given status::
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
-                >>> runsList = c.extraction_pipelines.runs.list(external_id="test ext id", statuses=["seen"], statuslimit=5)
+                >>> client = CogniteClient()
+                >>> runsList = client.extraction_pipelines.runs.list(external_id="test ext id", statuses=["seen"], statuslimit=5)
 
             Get all failed pipeline runs in the last 24 hours for pipeline 'extId':
 
                 >>> from cognite.client import CogniteClient
                 >>> from cognite.client.data_classes import ExtractionPipelineRun
-                >>> c = CogniteClient()
-                >>> res = c.extraction_pipelines.runs.list(external_id="extId", statuses="failure", created_time="24h-ago")
+                >>> client = CogniteClient()
+                >>> res = client.extraction_pipelines.runs.list(external_id="extId", statuses="failure", created_time="24h-ago")
         """
         if isinstance(created_time, str):
             created_time = TimestampRange(min=timestamp_to_ms(created_time))
@@ -353,8 +353,8 @@ class ExtractionPipelineRunsAPI(APIClient):
 
                 >>> from cognite.client import CogniteClient
                 >>> from cognite.client.data_classes import ExtractionPipelineRunWrite
-                >>> c = CogniteClient()
-                >>> res = c.extraction_pipelines.runs.create(
+                >>> client = CogniteClient()
+                >>> res = client.extraction_pipelines.runs.create(
                 ...     ExtractionPipelineRunWrite(status="success", extpipe_external_id="extId"))
         """
         assert_type(run, "run", [ExtractionPipelineRunCore, Sequence])
@@ -389,8 +389,8 @@ class ExtractionPipelineConfigsAPI(APIClient):
             Retrieve latest config revision::
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
-                >>> res = c.extraction_pipelines.config.retrieve("extId")
+                >>> client = CogniteClient()
+                >>> res = client.extraction_pipelines.config.retrieve("extId")
         """
         response = self._get(
             "/extpipes/config", params={"externalId": external_id, "activeAtTime": active_at_time, "revision": revision}
@@ -411,8 +411,8 @@ class ExtractionPipelineConfigsAPI(APIClient):
             Retrieve a list of config revisions::
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
-                >>> res = c.extraction_pipelines.config.list("extId")
+                >>> client = CogniteClient()
+                >>> res = client.extraction_pipelines.config.list("extId")
         """
         response = self._get("/extpipes/config/revisions", params={"externalId": external_id})
         return ExtractionPipelineConfigRevisionList.load(response.json()["items"], cognite_client=self._cognite_client)
@@ -432,8 +432,8 @@ class ExtractionPipelineConfigsAPI(APIClient):
 
                 >>> from cognite.client import CogniteClient
                 >>> from cognite.client.data_classes import ExtractionPipelineConfigWrite
-                >>> c = CogniteClient()
-                >>> res = c.extraction_pipelines.config.create(ExtractionPipelineConfigWrite(external_id="extId", config="my config contents"))
+                >>> client = CogniteClient()
+                >>> res = client.extraction_pipelines.config.create(ExtractionPipelineConfigWrite(external_id="extId", config="my config contents"))
         """
         if isinstance(config, ExtractionPipelineConfig):
             config = config.as_write()
@@ -455,8 +455,8 @@ class ExtractionPipelineConfigsAPI(APIClient):
             Revert a config revision::
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
-                >>> res = c.extraction_pipelines.config.revert("extId", 5)
+                >>> client = CogniteClient()
+                >>> res = client.extraction_pipelines.config.revert("extId", 5)
         """
         response = self._post("/extpipes/config/revert", json={"externalId": external_id, "revision": revision})
         return ExtractionPipelineConfig.load(response.json(), cognite_client=self._cognite_client)

--- a/cognite/client/_api/files.py
+++ b/cognite/client/_api/files.py
@@ -158,9 +158,9 @@ class FilesAPI(APIClient):
 
                 >>> from cognite.client import CogniteClient
                 >>> from cognite.client.data_classes import FileMetadataWrite
-                >>> c = CogniteClient()
+                >>> client = CogniteClient()
                 >>> file_metadata = FileMetadataWrite(name="MyFile")
-                >>> res = c.files.create(file_metadata)
+                >>> res = client.files.create(file_metadata)
 
         """
         if isinstance(file_metadata, FileMetadata):
@@ -188,14 +188,14 @@ class FilesAPI(APIClient):
             Get file metadata by id::
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
-                >>> res = c.files.retrieve(id=1)
+                >>> client = CogniteClient()
+                >>> res = client.files.retrieve(id=1)
 
             Get file metadata by external id::
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
-                >>> res = c.files.retrieve(external_id="1")
+                >>> client = CogniteClient()
+                >>> res = client.files.retrieve(external_id="1")
         """
         identifiers = IdentifierSequence.load(ids=id, external_ids=external_id).as_singleton()
         return self._retrieve_multiple(list_cls=FileMetadataList, resource_cls=FileMetadata, identifiers=identifiers)
@@ -221,14 +221,14 @@ class FilesAPI(APIClient):
             Get file metadatas by id::
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
-                >>> res = c.files.retrieve_multiple(ids=[1, 2, 3])
+                >>> client = CogniteClient()
+                >>> res = client.files.retrieve_multiple(ids=[1, 2, 3])
 
             Get file_metadatas by external id::
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
-                >>> res = c.files.retrieve_multiple(external_ids=["abc", "def"])
+                >>> client = CogniteClient()
+                >>> res = client.files.retrieve_multiple(external_ids=["abc", "def"])
         """
         identifiers = IdentifierSequence.load(ids=ids, external_ids=external_ids)
         return self._retrieve_multiple(
@@ -252,8 +252,8 @@ class FilesAPI(APIClient):
             List files metadata and filter on external id prefix::
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
-                >>> aggregate_uploaded = c.files.aggregate(filter={"uploaded": True})
+                >>> client = CogniteClient()
+                >>> aggregate_uploaded = client.files.aggregate(filter={"uploaded": True})
         """
 
         return self._aggregate(filter=filter, cls=CountAggregate)
@@ -272,8 +272,8 @@ class FilesAPI(APIClient):
             Delete files by id or external id::
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
-                >>> c.files.delete(id=[1,2,3], external_id="3")
+                >>> client = CogniteClient()
+                >>> client.files.delete(id=[1,2,3], external_id="3")
         """
         self._delete_multiple(identifiers=IdentifierSequence.load(ids=id, external_ids=external_id), wrap_ids=True)
 
@@ -306,34 +306,34 @@ class FilesAPI(APIClient):
             Update file metadata that you have fetched. This will perform a full update of the file metadata::
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
-                >>> file_metadata = c.files.retrieve(id=1)
+                >>> client = CogniteClient()
+                >>> file_metadata = client.files.retrieve(id=1)
                 >>> file_metadata.description = "New description"
-                >>> res = c.files.update(file_metadata)
+                >>> res = client.files.update(file_metadata)
 
             Perform a partial update on file metadata, updating the source and adding a new field to metadata::
 
                 >>> from cognite.client import CogniteClient
                 >>> from cognite.client.data_classes import FileMetadataUpdate
-                >>> c = CogniteClient()
+                >>> client = CogniteClient()
                 >>> my_update = FileMetadataUpdate(id=1).source.set("new source").metadata.add({"key": "value"})
-                >>> res = c.files.update(my_update)
+                >>> res = client.files.update(my_update)
 
             Attach labels to a files::
 
                 >>> from cognite.client import CogniteClient
                 >>> from cognite.client.data_classes import FileMetadataUpdate
-                >>> c = CogniteClient()
+                >>> client = CogniteClient()
                 >>> my_update = FileMetadataUpdate(id=1).labels.add(["PUMP", "VERIFIED"])
-                >>> res = c.files.update(my_update)
+                >>> res = client.files.update(my_update)
 
             Detach a single label from a file::
 
                 >>> from cognite.client import CogniteClient
                 >>> from cognite.client.data_classes import FileMetadataUpdate
-                >>> c = CogniteClient()
+                >>> client = CogniteClient()
                 >>> my_update = FileMetadataUpdate(id=1).labels.remove("PUMP")
-                >>> res = c.files.update(my_update)
+                >>> res = client.files.update(my_update)
         """
         return self._update_multiple(
             list_cls=FileMetadataList,
@@ -365,15 +365,15 @@ class FilesAPI(APIClient):
             Search for a file::
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
-                >>> res = c.files.search(name="some name")
+                >>> client = CogniteClient()
+                >>> res = client.files.search(name="some name")
 
             Search for an asset with an attached label:
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
+                >>> client = CogniteClient()
                 >>> my_label_filter = LabelFilter(contains_all=["WELL LOG"])
-                >>> res = c.assets.search(name="xyz",filter=FileMetadataFilter(labels=my_label_filter))
+                >>> res = client.assets.search(name="xyz",filter=FileMetadataFilter(labels=my_label_filter))
         """
         return self._search(list_cls=FileMetadataList, search={"name": name}, filter=filter or {}, limit=limit)
 
@@ -424,35 +424,35 @@ class FilesAPI(APIClient):
             Upload a file in a given path::
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
-                >>> res = c.files.upload("/path/to/file", name="my_file")
+                >>> client = CogniteClient()
+                >>> res = client.files.upload("/path/to/file", name="my_file")
 
             If name is omitted, this method will use the name of the file
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
-                >>> res = c.files.upload("/path/to/file")
+                >>> client = CogniteClient()
+                >>> res = client.files.upload("/path/to/file")
 
             You can also upload all files in a directory by setting path to the path of a directory::
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
-                >>> res = c.files.upload("/path/to/my/directory")
+                >>> client = CogniteClient()
+                >>> res = client.files.upload("/path/to/my/directory")
 
             Upload a file with a label::
 
                 >>> from cognite.client import CogniteClient
                 >>> from cognite.client.data_classes import Label
-                >>> c = CogniteClient()
-                >>> res = c.files.upload("/path/to/file", name="my_file", labels=[Label(external_id="WELL LOG")])
+                >>> client = CogniteClient()
+                >>> res = client.files.upload("/path/to/file", name="my_file", labels=[Label(external_id="WELL LOG")])
 
             Upload a file with a geo_location::
 
                 >>> from cognite.client import CogniteClient
                 >>> from cognite.client.data_classes import GeoLocation, Geometry
-                >>> c = CogniteClient()
+                >>> client = CogniteClient()
                 >>> geometry = Geometry(type="LineString", coordinates=[[30, 10], [10, 30], [40, 40]])
-                >>> res = c.files.upload("/path/to/file", geo_location=GeoLocation(type="Feature", geometry=geometry))
+                >>> res = client.files.upload("/path/to/file", geo_location=GeoLocation(type="Feature", geometry=geometry))
 
         """
         file_metadata = FileMetadata(
@@ -552,8 +552,8 @@ class FilesAPI(APIClient):
             Upload a file from memory::
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
-                >>> res = c.files.upload_bytes(b"some content", name="my_file", asset_ids=[1,2,3])
+                >>> client = CogniteClient()
+                >>> res = client.files.upload_bytes(b"some content", name="my_file", asset_ids=[1,2,3])
         """
         if isinstance(content, str):
             content = content.encode("utf-8")
@@ -690,12 +690,12 @@ class FilesAPI(APIClient):
             Download files by id and external id into directory 'my_directory'::
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
-                >>> c.files.download(directory="my_directory", id=[1,2,3], external_id=["abc", "def"])
+                >>> client = CogniteClient()
+                >>> client.files.download(directory="my_directory", id=[1,2,3], external_id=["abc", "def"])
 
             Download files by id to the current directory::
 
-                >>> c.files.download(directory=".", id=[1,2,3])
+                >>> client.files.download(directory=".", id=[1,2,3])
         """
         directory = Path(directory)
         if not directory.is_dir():
@@ -828,8 +828,8 @@ class FilesAPI(APIClient):
 
             Download a file by id:
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
-                >>> c.files.download_to_path("~/mydir/my_downloaded_file.txt", id=123)
+                >>> client = CogniteClient()
+                >>> client.files.download_to_path("~/mydir/my_downloaded_file.txt", id=123)
         """
         if isinstance(path, str):
             path = Path(path)
@@ -851,8 +851,8 @@ class FilesAPI(APIClient):
             Download a file's content into memory::
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
-                >>> file_content = c.files.download_bytes(id=1)
+                >>> client = CogniteClient()
+                >>> file_content = client.files.download_bytes(id=1)
 
         Returns:
             bytes: No description."""
@@ -921,38 +921,38 @@ class FilesAPI(APIClient):
             List files metadata and filter on external id prefix::
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
-                >>> file_list = c.files.list(limit=5, external_id_prefix="prefix")
+                >>> client = CogniteClient()
+                >>> file_list = client.files.list(limit=5, external_id_prefix="prefix")
 
             Iterate over files metadata::
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
-                >>> for file_metadata in c.files:
+                >>> client = CogniteClient()
+                >>> for file_metadata in client.files:
                 ...     file_metadata # do something with the file metadata
 
             Iterate over chunks of files metadata to reduce memory load::
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
-                >>> for file_list in c.files(chunk_size=2500):
+                >>> client = CogniteClient()
+                >>> for file_list in client.files(chunk_size=2500):
                 ...     file_list # do something with the files
 
             Filter files based on labels::
 
                 >>> from cognite.client import CogniteClient
                 >>> from cognite.client.data_classes import LabelFilter
-                >>> c = CogniteClient()
+                >>> client = CogniteClient()
                 >>> my_label_filter = LabelFilter(contains_all=["WELL LOG", "VERIFIED"])
-                >>> file_list = c.files.list(labels=my_label_filter)
+                >>> file_list = client.files.list(labels=my_label_filter)
 
             Filter files based on geoLocation::
 
                 >>> from cognite.client import CogniteClient
                 >>> from cognite.client.data_classes import GeoLocationFilter, GeometryFilter
-                >>> c = CogniteClient()
+                >>> client = CogniteClient()
                 >>> my_geo_location_filter = GeoLocationFilter(relation="intersects", shape=GeometryFilter(type="Point", coordinates=[35,10]))
-                >>> file_list = c.files.list(geo_location=my_geo_location_filter)
+                >>> file_list = client.files.list(geo_location=my_geo_location_filter)
         """
         asset_subtree_ids_processed = process_asset_subtree_ids(asset_subtree_ids, asset_subtree_external_ids)
         data_set_ids_processed = process_data_set_ids(data_set_ids, data_set_external_ids)

--- a/cognite/client/_api/functions.py
+++ b/cognite/client/_api/functions.py
@@ -167,16 +167,13 @@ class FunctionsAPI(APIClient):
 
             Create function with predefined function object named `handle` with dependencies::
 
-                >>> from cognite.client import CogniteClient
-                >>> client = CogniteClient()
-                >>>
                 >>> def handle(client, data):
                 >>>     """
                 >>>     [requirements]
                 >>>     numpy
                 >>>     [/requirements]
                 >>>     """
-                >>>     ...
+                >>>     pass
                 >>>
                 >>> function = client.functions.create(name="myfunction", function_handle=handle)
 

--- a/cognite/client/_api/functions.py
+++ b/cognite/client/_api/functions.py
@@ -146,8 +146,8 @@ class FunctionsAPI(APIClient):
             Create function with source code in folder::
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
-                >>> function = c.functions.create(
+                >>> client = CogniteClient()
+                >>> function = client.functions.create(
                 ...     name="myfunction",
                 ...     folder="path/to/code",
                 ...     function_path="path/to/function.py")
@@ -155,20 +155,20 @@ class FunctionsAPI(APIClient):
             Create function with file_id from already uploaded source code::
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
-                >>> function = c.functions.create(
+                >>> client = CogniteClient()
+                >>> function = client.functions.create(
                 ...     name="myfunction", file_id=123, function_path="path/to/function.py")
 
             Create function with predefined function object named `handle`::
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
-                >>> function = c.functions.create(name="myfunction", function_handle=handle)
+                >>> client = CogniteClient()
+                >>> function = client.functions.create(name="myfunction", function_handle=handle)
 
             Create function with predefined function object named `handle` with dependencies::
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
+                >>> client = CogniteClient()
                 >>>
                 >>> def handle(client, data):
                 >>>     """
@@ -178,7 +178,7 @@ class FunctionsAPI(APIClient):
                 >>>     """
                 >>>     ...
                 >>>
-                >>> function = c.functions.create(name="myfunction", function_handle=handle)
+                >>> function = client.functions.create(name="myfunction", function_handle=handle)
 
             .. note::
                 When using a predefined function object, you can list dependencies between the tags `[requirements]` and `[/requirements]` in the function's docstring. The dependencies will be parsed and validated in accordance with requirement format specified in `PEP 508 <https://peps.python.org/pep-0508/>`_.
@@ -245,8 +245,8 @@ class FunctionsAPI(APIClient):
             Delete functions by id or external id::
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
-                >>> c.functions.delete(id=[1,2,3], external_id="function3")
+                >>> client = CogniteClient()
+                >>> client.functions.delete(id=[1,2,3], external_id="function3")
         """
         self._delete_multiple(identifiers=IdentifierSequence.load(ids=id, external_ids=external_id), wrap_ids=True)
 
@@ -279,8 +279,8 @@ class FunctionsAPI(APIClient):
             List functions::
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
-                >>> functions_list = c.functions.list()
+                >>> client = CogniteClient()
+                >>> functions_list = client.functions.list()
         """
         if is_unlimited(limit):
             limit = self._LIST_LIMIT_CEILING
@@ -312,14 +312,14 @@ class FunctionsAPI(APIClient):
             Get function by id::
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
-                >>> res = c.functions.retrieve(id=1)
+                >>> client = CogniteClient()
+                >>> res = client.functions.retrieve(id=1)
 
             Get function by external id::
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
-                >>> res = c.functions.retrieve(external_id="abc")
+                >>> client = CogniteClient()
+                >>> res = client.functions.retrieve(external_id="abc")
         """
         identifier = IdentifierSequence.load(ids=id, external_ids=external_id).as_singleton()
         return self._retrieve_multiple(identifiers=identifier, resource_cls=Function, list_cls=FunctionList)
@@ -345,14 +345,14 @@ class FunctionsAPI(APIClient):
             Get function by id::
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
-                >>> res = c.functions.retrieve_multiple(ids=[1, 2, 3])
+                >>> client = CogniteClient()
+                >>> res = client.functions.retrieve_multiple(ids=[1, 2, 3])
 
             Get functions by external id::
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
-                >>> res = c.functions.retrieve_multiple(external_ids=["func1", "func2"])
+                >>> client = CogniteClient()
+                >>> res = client.functions.retrieve_multiple(external_ids=["func1", "func2"])
         """
         assert_type(ids, "id", [Sequence], allow_none=True)
         assert_type(external_ids, "external_id", [Sequence], allow_none=True)
@@ -386,15 +386,15 @@ class FunctionsAPI(APIClient):
             Call a function by id::
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
-                >>> call = c.functions.call(id=1)
+                >>> client = CogniteClient()
+                >>> call = client.functions.call(id=1)
 
             Call a function directly on the `Function` object::
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
-                >>> func = c.functions.retrieve(id=1)
-                >>> call = func.call()
+                >>> client = CogniteClient()
+                >>> func = client.functions.retrieve(id=1)
+                >>> call = funclient.call()
         """
         identifier = IdentifierSequence.load(ids=id, external_ids=external_id).as_singleton()[0]
         id = _get_function_internal_id(self._cognite_client, identifier)
@@ -421,8 +421,8 @@ class FunctionsAPI(APIClient):
             Call a function by id::
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
-                >>> limits = c.functions.limits()
+                >>> client = CogniteClient()
+                >>> limits = client.functions.limits()
         """
         res = self._get("/functions/limits")
         return FunctionsLimits.load(res.json())
@@ -523,8 +523,8 @@ class FunctionsAPI(APIClient):
             Call activate::
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
-                >>> status = c.functions.activate()
+                >>> client = CogniteClient()
+                >>> status = client.functions.activate()
         """
         res = self._post("/functions/status")
         return FunctionsStatus.load(res.json())
@@ -540,8 +540,8 @@ class FunctionsAPI(APIClient):
             Call status::
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
-                >>> status = c.functions.status()
+                >>> client = CogniteClient()
+                >>> status = client.functions.status()
         """
         res = self._get("/functions/status")
         return FunctionsStatus.load(res.json())
@@ -757,15 +757,15 @@ class FunctionCallsAPI(APIClient):
             List function calls::
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
-                >>> calls = c.functions.calls.list(function_id=1)
+                >>> client = CogniteClient()
+                >>> calls = client.functions.calls.list(function_id=1)
 
             List function calls directly on a function object::
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
-                >>> func = c.functions.retrieve(id=1)
-                >>> calls = func.list_calls()
+                >>> client = CogniteClient()
+                >>> func = client.functions.retrieve(id=1)
+                >>> calls = funclient.list_calls()
 
         """
         identifier = _get_function_identifier(function_id, function_external_id)
@@ -801,15 +801,15 @@ class FunctionCallsAPI(APIClient):
             Retrieve single function call by id::
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
-                >>> call = c.functions.calls.retrieve(call_id=2, function_id=1)
+                >>> client = CogniteClient()
+                >>> call = client.functions.calls.retrieve(call_id=2, function_id=1)
 
             Retrieve function call directly on a function object::
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
-                >>> func = c.functions.retrieve(id=1)
-                >>> call = func.retrieve_call(id=2)
+                >>> client = CogniteClient()
+                >>> func = client.functions.retrieve(id=1)
+                >>> call = funclient.retrieve_call(id=2)
         """
         identifier = _get_function_identifier(function_id, function_external_id)
         function_id = _get_function_internal_id(self._cognite_client, identifier)
@@ -841,14 +841,14 @@ class FunctionCallsAPI(APIClient):
             Retrieve function call response by call ID::
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
-                >>> response = c.functions.calls.get_response(call_id=2, function_id=1)
+                >>> client = CogniteClient()
+                >>> response = client.functions.calls.get_response(call_id=2, function_id=1)
 
             Retrieve function call response directly on a call object::
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
-                >>> call = c.functions.calls.retrieve(call_id=2, function_id=1)
+                >>> client = CogniteClient()
+                >>> call = client.functions.calls.retrieve(call_id=2, function_id=1)
                 >>> response = call.get_response()
 
         """
@@ -876,14 +876,14 @@ class FunctionCallsAPI(APIClient):
             Retrieve function call logs by call ID::
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
-                >>> logs = c.functions.calls.get_logs(call_id=2, function_id=1)
+                >>> client = CogniteClient()
+                >>> logs = client.functions.calls.get_logs(call_id=2, function_id=1)
 
             Retrieve function call logs directly on a call object::
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
-                >>> call = c.functions.calls.retrieve(call_id=2, function_id=1)
+                >>> client = CogniteClient()
+                >>> call = client.functions.calls.retrieve(call_id=2, function_id=1)
                 >>> logs = call.get_logs()
 
         """
@@ -915,8 +915,8 @@ class FunctionSchedulesAPI(APIClient):
             Get function schedule by id::
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
-                >>> res = c.functions.schedules.retrieve(id=1)
+                >>> client = CogniteClient()
+                >>> res = client.functions.schedules.retrieve(id=1)
 
         """
         identifier = IdentifierSequence.load(ids=id).as_singleton()
@@ -951,15 +951,15 @@ class FunctionSchedulesAPI(APIClient):
             List function schedules::
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
-                >>> schedules = c.functions.schedules.list()
+                >>> client = CogniteClient()
+                >>> schedules = client.functions.schedules.list()
 
             List schedules directly on a function object to get only schedules associated with this particular function:
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
-                >>> func = c.functions.retrieve(id=1)
-                >>> schedules = func.list_schedules(limit=None)
+                >>> client = CogniteClient()
+                >>> func = client.functions.retrieve(id=1)
+                >>> schedules = funclient.list_schedules(limit=None)
 
         """
         if function_id or function_external_id:
@@ -1017,8 +1017,8 @@ class FunctionSchedulesAPI(APIClient):
                 >>> import os
                 >>> from cognite.client import CogniteClient
                 >>> from cognite.client.data_classes import ClientCredentials
-                >>> c = CogniteClient()
-                >>> schedule = c.functions.schedules.create(
+                >>> client = CogniteClient()
+                >>> schedule = client.functions.schedules.create(
                 ...     name="My schedule",
                 ...     function_id=123,
                 ...     cron_expression="*/5 * * * *",
@@ -1032,7 +1032,7 @@ class FunctionSchedulesAPI(APIClient):
             client credentials, *this is not a recommended way to create schedules*, as it will create an explicit dependency
             on your user account, which it will run the function "on behalf of" (until the schedule is eventually removed)::
 
-                >>> schedule = c.functions.schedules.create(
+                >>> schedule = client.functions.schedules.create(
                 ...     name="My schedule",
                 ...     function_id=456,
                 ...     cron_expression="*/5 * * * *",
@@ -1067,8 +1067,8 @@ class FunctionSchedulesAPI(APIClient):
             Delete function schedule::
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
-                >>> c.functions.schedules.delete(id = 123)
+                >>> client = CogniteClient()
+                >>> client.functions.schedules.delete(id = 123)
 
         """
         url = f"{self._RESOURCE_PATH}/delete"
@@ -1087,8 +1087,8 @@ class FunctionSchedulesAPI(APIClient):
             Get schedule input data::
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
-                >>> c.functions.schedules.get_input_data(id=123)
+                >>> client = CogniteClient()
+                >>> client.functions.schedules.get_input_data(id=123)
         """
         url = f"{self._RESOURCE_PATH}/{id}/input_data"
         res = self._get(url)

--- a/cognite/client/_api/geospatial.py
+++ b/cognite/client/_api/geospatial.py
@@ -76,7 +76,7 @@ class GeospatialAPI(APIClient):
 
                 >>> from cognite.client import CogniteClient
                 >>> from cognite.client.data_classes.geospatial import FeatureTypeWrite
-                >>> c = CogniteClient()
+                >>> client = CogniteClient()
                 >>> feature_types = [
                 ...     FeatureTypeWrite(external_id="wells", properties={"location": {"type": "POINT", "srid": 4326}})
                 ...     FeatureTypeWrite(
@@ -85,7 +85,7 @@ class GeospatialAPI(APIClient):
                 ...       search_spec={"name_index": {"properties": ["name"]}}
                 ...     )
                 ... ]
-                >>> res = c.geospatial.create_feature_types(feature_types)
+                >>> res = client.geospatial.create_feature_types(feature_types)
         """
         return self._create_multiple(
             list_cls=FeatureTypeList,
@@ -108,8 +108,8 @@ class GeospatialAPI(APIClient):
             Delete feature type definitions external id:
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
-                >>> c.geospatial.delete_feature_types(external_id=["wells", "cities"])
+                >>> client = CogniteClient()
+                >>> client.geospatial.delete_feature_types(external_id=["wells", "cities"])
         """
         extra_body_fields = {"recursive": True} if recursive else {}
         self._delete_multiple(
@@ -131,8 +131,8 @@ class GeospatialAPI(APIClient):
             Iterate over feature type definitions:
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
-                >>> for feature_type in c.geospatial.list_feature_types():
+                >>> client = CogniteClient()
+                >>> for feature_type in client.geospatial.list_feature_types():
                 ...     feature_type # do something with the feature type definition
         """
         return self._list(
@@ -165,8 +165,8 @@ class GeospatialAPI(APIClient):
             Get Type by external id:
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
-                >>> res = c.geospatial.retrieve_feature_types(external_id="1")
+                >>> client = CogniteClient()
+                >>> res = client.geospatial.retrieve_feature_types(external_id="1")
         """
         identifiers = IdentifierSequence.load(ids=None, external_ids=external_id)
         return self._retrieve_multiple(
@@ -192,8 +192,8 @@ class GeospatialAPI(APIClient):
 
                 >>> from cognite.client.data_classes.geospatial import Patches
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
-                >>> res = c.geospatial.patch_feature_types(
+                >>> client = CogniteClient()
+                >>> res = client.geospatial.patch_feature_types(
                 ...    patch=FeatureTypePatch(
                 ...       external_id="wells",
                 ...       property_patches=Patches(add={"altitude": {"type": "DOUBLE"}}),
@@ -210,8 +210,8 @@ class GeospatialAPI(APIClient):
 
                 >>> from cognite.client.data_classes.geospatial import Patches
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
-                >>> res = c.geospatial.patch_feature_types(
+                >>> client = CogniteClient()
+                >>> res = client.geospatial.patch_feature_types(
                 ...    patch=FeatureTypePatch(
                 ...         external_id="wells",
                 ...         search_spec_patches=Patches(add={"location_idx": {"properties": ["location"]}})
@@ -277,7 +277,7 @@ class GeospatialAPI(APIClient):
 
                 >>> from cognite.client import CogniteClient
                 >>> from cognite.client.data_classes.geospatial import FeatureTypeWrite, FeatureWrite
-                >>> c = CogniteClient()
+                >>> client = CogniteClient()
                 >>> feature_types = [
                 ...     FeatureTypeWrite(
                 ...         external_id="my_feature_type",
@@ -287,8 +287,8 @@ class GeospatialAPI(APIClient):
                 ...         }
                 ...     )
                 ... ]
-                >>> res = c.geospatial.create_feature_types(feature_types)
-                >>> res = c.geospatial.create_features(
+                >>> res = client.geospatial.create_feature_types(feature_types)
+                >>> res = client.geospatial.create_features(
                 ...     feature_type_external_id="my_feature_type",
                 ...     feature=FeatureWrite(
                 ...         external_id="my_feature",
@@ -329,8 +329,8 @@ class GeospatialAPI(APIClient):
             Delete feature type definitions external id:
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
-                >>> c.geospatial.delete_features(
+                >>> client = CogniteClient()
+                >>> client.geospatial.delete_features(
                 ...     feature_type_external_id="my_feature_type",
                 ...     external_id=my_feature
                 ... )
@@ -380,8 +380,8 @@ class GeospatialAPI(APIClient):
             Retrieve one feature by its external id:
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
-                >>> c.geospatial.retrieve_features(
+                >>> client = CogniteClient()
+                >>> client.geospatial.retrieve_features(
                 ...     feature_type_external_id="my_feature_type",
                 ...     external_id="my_feature"
                 ... )
@@ -420,12 +420,12 @@ class GeospatialAPI(APIClient):
             Update one feature:
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
-                >>> my_feature = c.geospatial.create_features(
+                >>> client = CogniteClient()
+                >>> my_feature = client.geospatial.create_features(
                 ...     feature_type_external_id="my_feature_type",
                 ...     feature=Feature(external_id="my_feature", temperature=12.4)
                 ... )
-                >>> my_updated_feature = c.geospatial.update_features(
+                >>> my_updated_feature = client.geospatial.update_features(
                 ...     feature_type_external_id="my_feature_type",
                 ...     feature=Feature(external_id="my_feature", temperature=6.237)
                 ... )
@@ -478,11 +478,11 @@ class GeospatialAPI(APIClient):
             List features:
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
-                >>> my_feature_type = c.geospatial.retrieve_feature_types(
+                >>> client = CogniteClient()
+                >>> my_feature_type = client.geospatial.retrieve_feature_types(
                 ...     external_id="my_feature_type"
                 ... )
-                >>> my_feature = c.geospatial.create_features(
+                >>> my_feature = client.geospatial.create_features(
                 ...     feature_type_external_id=my_feature_type,
                 ...     feature=Feature(
                 ...         external_id="my_feature",
@@ -490,7 +490,7 @@ class GeospatialAPI(APIClient):
                 ...         location={"wkt": "POINT(0 1)"}
                 ...     )
                 ... )
-                >>> res = c.geospatial.list_features(
+                >>> res = client.geospatial.list_features(
                 ...     feature_type_external_id="my_feature_type",
                 ...     filter={"range": {"property": "temperature", "gt": 12.0}}
                 ... )
@@ -499,7 +499,7 @@ class GeospatialAPI(APIClient):
 
             Search for features and select output properties:
 
-                >>> res = c.geospatial.list_features(
+                >>> res = client.geospatial.list_features(
                 ...     feature_type_external_id=my_feature_type,
                 ...     filter={},
                 ...     properties={"temperature": {}, "pressure": {}}
@@ -507,7 +507,7 @@ class GeospatialAPI(APIClient):
 
             Search for features with spatial filters:
 
-                >>> res = c.geospatial.list_features(
+                >>> res = client.geospatial.list_features(
                 ...     feature_type_external_id=my_feature_type,
                 ...     filter={"stWithin": {
                 ...         "property": "location",
@@ -562,11 +562,11 @@ class GeospatialAPI(APIClient):
             Search for features:
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
-                >>> my_feature_type = c.geospatial.retrieve_feature_types(
+                >>> client = CogniteClient()
+                >>> my_feature_type = client.geospatial.retrieve_feature_types(
                 ...     external_id="my_feature_type"
                 ... )
-                >>> my_feature = c.geospatial.create_features(
+                >>> my_feature = client.geospatial.create_features(
                 ...     feature_type_external_id=my_feature_type,
                 ...     feature=Feature(
                 ...         external_id="my_feature",
@@ -574,7 +574,7 @@ class GeospatialAPI(APIClient):
                 ...         location={"wkt": "POINT(0 1)"}
                 ...     )
                 ... )
-                >>> res = c.geospatial.search_features(
+                >>> res = client.geospatial.search_features(
                 ...     feature_type_external_id="my_feature_type",
                 ...     filter={"range": {"property": "temperature", "gt": 12.0}}
                 ... )
@@ -583,7 +583,7 @@ class GeospatialAPI(APIClient):
 
             Search for features and select output properties:
 
-                >>> res = c.geospatial.search_features(
+                >>> res = client.geospatial.search_features(
                 ...     feature_type_external_id=my_feature_type,
                 ...     filter={},
                 ...     properties={"temperature": {}, "pressure": {}}
@@ -591,7 +591,7 @@ class GeospatialAPI(APIClient):
 
             Search for features and do CRS conversion on an output property:
 
-                >>> res = c.geospatial.search_features(
+                >>> res = client.geospatial.search_features(
                 ...     feature_type_external_id=my_feature_type,
                 ...     filter={},
                 ...     properties={"location": {"srid": 3995}}
@@ -599,7 +599,7 @@ class GeospatialAPI(APIClient):
 
             Search for features and order results:
 
-                >>> res = c.geospatial.search_features(
+                >>> res = client.geospatial.search_features(
                 ...     feature_type_external_id=my_feature_type,
                 ...     filter={},
                 ...     order_by=[
@@ -609,7 +609,7 @@ class GeospatialAPI(APIClient):
 
             Search for features with spatial filters:
 
-                >>> res = c.geospatial.search_features(
+                >>> res = client.geospatial.search_features(
                 ...     feature_type_external_id=my_feature_type,
                 ...     filter={"stWithin": {
                 ...         "property": "location",
@@ -619,7 +619,7 @@ class GeospatialAPI(APIClient):
 
             Combining multiple filters:
 
-                >>> res = c.geospatial.search_features(
+                >>> res = client.geospatial.search_features(
                 ...     feature_type_external_id=my_feature_type,
                 ...     filter={"and": [
                 ...         {"range": {"property": "temperature", "gt": 12.0}},
@@ -630,7 +630,7 @@ class GeospatialAPI(APIClient):
                 ...     ]}
                 ... )
 
-                >>> res = c.geospatial.search_features(
+                >>> res = client.geospatial.search_features(
                 ...     feature_type_external_id=my_feature_type,
                 ...     filter={"or": [
                 ...         {"range": {"property": "temperature", "gt": 12.0}},
@@ -686,12 +686,12 @@ class GeospatialAPI(APIClient):
             Stream features:
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
-                >>> my_feature = c.geospatial.create_features(
+                >>> client = CogniteClient()
+                >>> my_feature = client.geospatial.create_features(
                 ...     feature_type_external_id="my_feature_type",
                 ...     feature=Feature(external_id="my_feature", temperature=12.4)
                 ... )
-                >>> features = c.geospatial.stream_features(
+                >>> features = client.geospatial.stream_features(
                 ...     feature_type_external_id="my_feature_type",
                 ...     filter={"range": {"property": "temperature", "gt": 12.0}}
                 ... )
@@ -700,7 +700,7 @@ class GeospatialAPI(APIClient):
 
             Stream features and select output properties:
 
-                >>> features = c.geospatial.stream_features(
+                >>> features = client.geospatial.stream_features(
                 ...     feature_type_external_id="my_feature_type",
                 ...     filter={},
                 ...     properties={"temperature": {}, "pressure": {}}
@@ -749,12 +749,12 @@ class GeospatialAPI(APIClient):
             Aggregate property of features:
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
-                >>> my_feature = c.geospatial.create_features(
+                >>> client = CogniteClient()
+                >>> my_feature = client.geospatial.create_features(
                 ...     feature_type_external_id="my_feature_type",
                 ...     feature=Feature(external_id="my_feature", temperature=12.4)
                 ... )
-                >>> res = c.geospatial.aggregate_features(
+                >>> res = client.geospatial.aggregate_features(
                 ...     feature_type_external_id="my_feature_type",
                 ...     filter={"range": {"property": "temperature", "gt": 12.0}},
                 ...     group_by=["category"],
@@ -794,8 +794,8 @@ class GeospatialAPI(APIClient):
             Get two CRS definitions:
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
-                >>> crs = c.geospatial.get_coordinate_reference_systems(srids=[4326, 4327])
+                >>> client = CogniteClient()
+                >>> crs = client.geospatial.get_coordinate_reference_systems(srids=[4326, 4327])
         """
         if isinstance(srids, (int, numbers.Integral)):
             srids_processed: Sequence[numbers.Integral | int] = [srids]
@@ -822,8 +822,8 @@ class GeospatialAPI(APIClient):
             Fetch all custom CRSs:
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
-                >>> crs = c.geospatial.list_coordinate_reference_systems(only_custom=True)
+                >>> client = CogniteClient()
+                >>> crs = client.geospatial.list_coordinate_reference_systems(only_custom=True)
         """
         res = self._get(url_path=f"{self._RESOURCE_PATH}/crs", params={"filterCustom": only_custom})
         return CoordinateReferenceSystemList.load(res.json()["items"], cognite_client=self._cognite_client)
@@ -850,7 +850,7 @@ class GeospatialAPI(APIClient):
 
                 >>> from cognite.client import CogniteClient
                 >>> from cognite.client.data_classes import CoordinateReferenceSystemWrite
-                >>> c = CogniteClient()
+                >>> client = CogniteClient()
                 >>> custom_crs = CoordinateReferenceSystemWrite(
                 ...     srid = 121111,
                 ...     wkt=(
@@ -884,7 +884,7 @@ class GeospatialAPI(APIClient):
                 ...          '+towgs84=-168,-60,320,0,0,0,0 +pm=paris +units=m +no_defs'
                 ...     )
                 ... )
-                >>> crs = c.geospatial.create_coordinate_reference_systems(custom_crs)
+                >>> crs = client.geospatial.create_coordinate_reference_systems(custom_crs)
         """
         if isinstance(crs, CoordinateReferenceSystem):
             crs = [crs.as_write()]
@@ -910,8 +910,8 @@ class GeospatialAPI(APIClient):
             Delete a custom CRS:
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
-                >>> crs = c.geospatial.delete_coordinate_reference_systems(srids=[121111])
+                >>> client = CogniteClient()
+                >>> crs = client.geospatial.delete_coordinate_reference_systems(srids=[121111])
         """
         if isinstance(srids, (int, numbers.Integral)):
             srids_processed: Sequence[numbers.Integral | int] = [srids]
@@ -955,11 +955,11 @@ class GeospatialAPI(APIClient):
             Put a raster in a feature raster property:
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
+                >>> client = CogniteClient()
                 >>> feature_type = ...
                 >>> feature = ...
                 >>> raster_property_name = ...
-                >>> metadata = c.geospatial.put_raster(feature_type.external_id, feature.external_id,
+                >>> metadata = client.geospatial.put_raster(feature_type.external_id, feature.external_id,
                 ...         raster_property_name, "XYZ", 3857, file)
         """
         query_params = f"format={raster_format}&srid={raster_srid}"
@@ -1002,11 +1002,11 @@ class GeospatialAPI(APIClient):
             Delete a raster in a feature raster property:
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
+                >>> client = CogniteClient()
                 >>> feature_type = ...
                 >>> feature = ...
                 >>> raster_property_name = ...
-                >>> c.geospatial.delete_raster(feature_type.external_id, feature.external_id, raster_property_name)
+                >>> client.geospatial.delete_raster(feature_type.external_id, feature.external_id, raster_property_name)
         """
         url_path = (
             self._raster_resource_path(feature_type_external_id, feature_external_id, raster_property_name) + "/delete"
@@ -1050,11 +1050,11 @@ class GeospatialAPI(APIClient):
             Get a raster from a feature raster property:
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
+                >>> client = CogniteClient()
                 >>> feature_type = ...
                 >>> feature = ...
                 >>> raster_property_name = ...
-                >>> raster_data = c.geospatial.get_raster(feature_type.external_id, feature.external_id,
+                >>> raster_data = client.geospatial.get_raster(feature_type.external_id, feature.external_id,
                 ...    raster_property_name, "XYZ", {"SIGNIFICANT_DIGITS": "4"})
         """
         url_path = self._raster_resource_path(feature_type_external_id, feature_external_id, raster_property_name)
@@ -1091,9 +1091,9 @@ class GeospatialAPI(APIClient):
 
                 >>> from cognite.client import CogniteClient
                 >>> from cognite.client.data_classes.geospatial import GeospatialGeometryTransformComputeFunction, GeospatialGeometryValueComputeFunction
-                >>> c = CogniteClient()
+                >>> client = CogniteClient()
                 >>> compute_function = GeospatialGeometryTransformComputeFunction(GeospatialGeometryValueComputeFunction("SRID=4326;POLYGON((0 0,10 0,10 10,0 10,0 0))"), srid=23031)
-                >>> compute_result = c.geospatial.compute(output = {"output": compute_function})
+                >>> compute_result = client.geospatial.compute(output = {"output": compute_function})
         """
         res = self._do_request(
             "POST",

--- a/cognite/client/_api/iam.py
+++ b/cognite/client/_api/iam.py
@@ -252,8 +252,8 @@ class GroupsAPI(APIClient):
             List groups::
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
-                >>> res = c.iam.groups.list()
+                >>> client = CogniteClient()
+                >>> res = client.iam.groups.list()
         """
         res = self._get(self._RESOURCE_PATH, params={"all": all})
         return GroupList.load(res.json()["items"], cognite_client=self._cognite_client)
@@ -281,10 +281,10 @@ class GroupsAPI(APIClient):
                 >>> from cognite.client import CogniteClient
                 >>> from cognite.client.data_classes import GroupWrite
                 >>> from cognite.client.data_classes.capabilities import GroupsAcl
-                >>> c = CogniteClient()
+                >>> client = CogniteClient()
                 >>> my_capabilities = [GroupsAcl([GroupsAcl.Action.List], GroupsAcl.Scope.All())]
                 >>> my_group = GroupWrite(name="My Group", capabilities=my_capabilities)
-                >>> res = c.iam.groups.create(my_group)
+                >>> res = client.iam.groups.create(my_group)
         """
         return self._create_multiple(list_cls=GroupList, resource_cls=Group, items=group, input_resource_cls=GroupWrite)
 
@@ -299,8 +299,8 @@ class GroupsAPI(APIClient):
             Delete group::
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
-                >>> c.iam.groups.delete(1)
+                >>> client = CogniteClient()
+                >>> client.iam.groups.delete(1)
         """
         self._delete_multiple(identifiers=IdentifierSequence.load(ids=id), wrap_ids=False)
 
@@ -322,8 +322,8 @@ class SecurityCategoriesAPI(APIClient):
             List security categories::
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
-                >>> res = c.iam.security_categories.list()
+                >>> client = CogniteClient()
+                >>> res = client.iam.security_categories.list()
         """
         return self._list(list_cls=SecurityCategoryList, resource_cls=SecurityCategory, method="GET", limit=limit)
 
@@ -358,9 +358,9 @@ class SecurityCategoriesAPI(APIClient):
 
                 >>> from cognite.client import CogniteClient
                 >>> from cognite.client.data_classes import SecurityCategoryWrite
-                >>> c = CogniteClient()
+                >>> client = CogniteClient()
                 >>> my_category = SecurityCategoryWrite(name="My Category")
-                >>> res = c.iam.security_categories.create(my_category)
+                >>> res = client.iam.security_categories.create(my_category)
         """
         return self._create_multiple(
             list_cls=SecurityCategoryList,
@@ -380,8 +380,8 @@ class SecurityCategoriesAPI(APIClient):
             Delete security category::
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
-                >>> c.iam.security_categories.delete(1)
+                >>> client = CogniteClient()
+                >>> client.iam.security_categories.delete(1)
         """
         self._delete_multiple(identifiers=IdentifierSequence.load(ids=id), wrap_ids=False)
 
@@ -400,8 +400,8 @@ class TokenAPI(APIClient):
             Inspect token::
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
-                >>> res = c.iam.token.inspect()
+                >>> client = CogniteClient()
+                >>> res = client.iam.token.inspect()
         """
         return TokenInspection.load(self._get("/api/v1/token/inspect").json(), self._cognite_client)
 

--- a/cognite/client/_api/labels.py
+++ b/cognite/client/_api/labels.py
@@ -77,21 +77,21 @@ class LabelsAPI(APIClient):
             List Labels and filter on name::
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
-                >>> label_list = c.labels.list(limit=5, name="Pump")
+                >>> client = CogniteClient()
+                >>> label_list = client.labels.list(limit=5, name="Pump")
 
             Iterate over label definitions::
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
-                >>> for label in c.labels:
+                >>> client = CogniteClient()
+                >>> for label in client.labels:
                 ...     label # do something with the label definition
 
             Iterate over chunks of label definitions to reduce memory load::
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
-                >>> for label_list in c.labels(chunk_size=2500):
+                >>> client = CogniteClient()
+                >>> for label_list in client.labels(chunk_size=2500):
                 ...     label_list # do something with the type definitions
         """
         data_set_ids_processed = process_data_set_ids(data_set_ids, data_set_external_ids)
@@ -131,9 +131,9 @@ class LabelsAPI(APIClient):
 
                 >>> from cognite.client import CogniteClient
                 >>> from cognite.client.data_classes import LabelDefinitionWrite
-                >>> c = CogniteClient()
+                >>> client = CogniteClient()
                 >>> labels = [LabelDefinitionWrite(external_id="ROTATING_EQUIPMENT", name="Rotating equipment"), LabelDefinitionWrite(external_id="PUMP", name="pump")]
-                >>> res = c.labels.create(labels)
+                >>> res = client.labels.create(labels)
         """
         if isinstance(label, Sequence):
             if len(label) > 0 and not isinstance(label[0], LabelDefinitionCore):
@@ -154,7 +154,7 @@ class LabelsAPI(APIClient):
             Delete label definitions by external id::
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
-                >>> c.labels.delete(external_id=["big_pump", "small_pump"])
+                >>> client = CogniteClient()
+                >>> client.labels.delete(external_id=["big_pump", "small_pump"])
         """
         self._delete_multiple(identifiers=IdentifierSequence.load(external_ids=external_id), wrap_ids=True)

--- a/cognite/client/_api/raw.py
+++ b/cognite/client/_api/raw.py
@@ -84,8 +84,8 @@ class RawDatabasesAPI(APIClient):
             Create a new database::
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
-                >>> res = c.raw.databases.create("db1")
+                >>> client = CogniteClient()
+                >>> res = client.raw.databases.create("db1")
         """
         assert_type(name, "name", [str, Sequence])
         if isinstance(name, str):
@@ -106,8 +106,8 @@ class RawDatabasesAPI(APIClient):
             Delete a list of databases::
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
-                >>> c.raw.databases.delete(["db1", "db2"])
+                >>> client = CogniteClient()
+                >>> client.raw.databases.delete(["db1", "db2"])
         """
         assert_type(name, "name", [str, Sequence])
         if isinstance(name, str):
@@ -137,21 +137,21 @@ class RawDatabasesAPI(APIClient):
             List the first 5 databases::
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
-                >>> db_list = c.raw.databases.list(limit=5)
+                >>> client = CogniteClient()
+                >>> db_list = client.raw.databases.list(limit=5)
 
             Iterate over databases::
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
-                >>> for db in c.raw.databases:
+                >>> client = CogniteClient()
+                >>> for db in client.raw.databases:
                 ...     db # do something with the db
 
             Iterate over chunks of databases to reduce memory load::
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
-                >>> for db_list in c.raw.databases(chunk_size=2500):
+                >>> client = CogniteClient()
+                >>> for db_list in client.raw.databases(chunk_size=2500):
                 ...     db_list # do something with the dbs
         """
         return self._list(list_cls=DatabaseList, resource_cls=Database, method="GET", limit=limit)
@@ -208,8 +208,8 @@ class RawTablesAPI(APIClient):
             Create a new table in a database::
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
-                >>> res = c.raw.tables.create("db1", "table1")
+                >>> client = CogniteClient()
+                >>> res = client.raw.tables.create("db1", "table1")
         """
         assert_type(name, "name", [str, Sequence])
         if isinstance(name, str):
@@ -236,8 +236,8 @@ class RawTablesAPI(APIClient):
             Delete a list of tables::
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
-                >>> res = c.raw.tables.delete("db1", ["table1", "table2"])
+                >>> client = CogniteClient()
+                >>> res = client.raw.tables.delete("db1", ["table1", "table2"])
         """
         assert_type(name, "name", [str, Sequence])
         if isinstance(name, str):
@@ -287,21 +287,21 @@ class RawTablesAPI(APIClient):
             List the first 5 tables::
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
-                >>> table_list = c.raw.tables.list("db1", limit=5)
+                >>> client = CogniteClient()
+                >>> table_list = client.raw.tables.list("db1", limit=5)
 
             Iterate over tables::
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
-                >>> for table in c.raw.tables(db_name="db1"):
+                >>> client = CogniteClient()
+                >>> for table in client.raw.tables(db_name="db1"):
                 ...     table # do something with the table
 
             Iterate over chunks of tables to reduce memory load::
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
-                >>> for table_list in c.raw.tables(db_name="db1", chunk_size=2500):
+                >>> client = CogniteClient()
+                >>> for table_list in client.raw.tables(db_name="db1", chunk_size=2500):
                 ...     table_list # do something with the tables
         """
         tb = self._list(
@@ -383,10 +383,10 @@ class RawRowsAPI(APIClient):
 
                 >>> from cognite.client import CogniteClient
                 >>> from cognite.client.data_classes import RowWrite
-                >>> c = CogniteClient()
+                >>> client = CogniteClient()
                 >>> rows = [RowWrite(key="r1", columns={"col1": "val1", "col2": "val1"}),
                 ...         RowWrite(key="r2", columns={"col1": "val2", "col2": "val2"})]
-                >>> c.raw.rows.insert("db1", "table1", rows)
+                >>> client.raw.rows.insert("db1", "table1", rows)
         """
         chunks = self._process_row_input(row)
 
@@ -423,9 +423,9 @@ class RawRowsAPI(APIClient):
                 >>> import pandas as pd
                 >>> from cognite.client import CogniteClient
                 >>>
-                >>> c = CogniteClient()
+                >>> client = CogniteClient()
                 >>> df = pd.DataFrame(data={"a": 1, "b": 2}, index=["r1", "r2", "r3"])
-                >>> res = c.raw.rows.insert_dataframe("db1", "table1", df)
+                >>> res = client.raw.rows.insert_dataframe("db1", "table1", df)
         """
         if not dataframe.index.is_unique:
             raise ValueError("Dataframe index is not unique (used for the row keys)")
@@ -465,9 +465,9 @@ class RawRowsAPI(APIClient):
             Delete rows from table::
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
+                >>> client = CogniteClient()
                 >>> keys_to_delete = ["k1", "k2", "k3"]
-                >>> c.raw.rows.delete("db1", "table1", keys_to_delete)
+                >>> client.raw.rows.delete("db1", "table1", keys_to_delete)
         """
         assert_type(key, "key", [str, Sequence])
         if isinstance(key, str):
@@ -504,8 +504,8 @@ class RawRowsAPI(APIClient):
             Retrieve a row with key 'k1' from table 't1' in database 'db1'::
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
-                >>> row = c.raw.rows.retrieve("db1", "t1", "k1")
+                >>> client = CogniteClient()
+                >>> row = client.raw.rows.retrieve("db1", "t1", "k1")
         """
         return self._retrieve(
             cls=Row,
@@ -552,8 +552,8 @@ class RawRowsAPI(APIClient):
             Get dataframe::
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
-                >>> df = c.raw.rows.retrieve_dataframe("db1", "t1", limit=5)
+                >>> client = CogniteClient()
+                >>> df = client.raw.rows.retrieve_dataframe("db1", "t1", limit=5)
         """
         pd = local_import("pandas")
         rows = self.list(db_name, table_name, min_last_updated_time, max_last_updated_time, columns, limit)
@@ -588,21 +588,21 @@ class RawRowsAPI(APIClient):
             List rows::
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
-                >>> row_list = c.raw.rows.list("db1", "t1", limit=5)
+                >>> client = CogniteClient()
+                >>> row_list = client.raw.rows.list("db1", "t1", limit=5)
 
             Iterate over rows::
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
-                >>> for row in c.raw.rows(db_name="db1", table_name="t1", columns=["col1","col2"]):
+                >>> client = CogniteClient()
+                >>> for row in client.raw.rows(db_name="db1", table_name="t1", columns=["col1","col2"]):
                 ...     row # do something with the row
 
             Iterate over chunks of rows to reduce memory load::
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
-                >>> for row_list in c.raw.rows(db_name="db1", table_name="t1", chunk_size=2500):
+                >>> client = CogniteClient()
+                >>> for row_list in client.raw.rows(db_name="db1", table_name="t1", chunk_size=2500):
                 ...     row_list # do something with the rows
         """
         if is_unlimited(limit):

--- a/cognite/client/_api/relationships.py
+++ b/cognite/client/_api/relationships.py
@@ -169,8 +169,8 @@ class RelationshipsAPI(APIClient):
             Get relationship by external id:
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
-                >>> res = c.relationships.retrieve(external_id="1")
+                >>> client = CogniteClient()
+                >>> res = client.relationships.retrieve(external_id="1")
         """
         identifiers = IdentifierSequence.load(ids=None, external_ids=external_id).as_singleton()
         return self._retrieve_multiple(
@@ -199,8 +199,8 @@ class RelationshipsAPI(APIClient):
             Get relationships by external id::
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
-                >>> res = c.relationships.retrieve_multiple(external_ids=["abc", "def"])
+                >>> client = CogniteClient()
+                >>> res = client.relationships.retrieve_multiple(external_ids=["abc", "def"])
         """
         identifiers = IdentifierSequence.load(ids=None, external_ids=external_ids)
         return self._retrieve_multiple(
@@ -258,14 +258,14 @@ class RelationshipsAPI(APIClient):
             List relationships::
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
-                >>> relationship_list = c.relationships.list(limit=5)
+                >>> client = CogniteClient()
+                >>> relationship_list = client.relationships.list(limit=5)
 
             Iterate over relationships::
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
-                >>> for relationship in c.relationships:
+                >>> client = CogniteClient()
+                >>> for relationship in client.relationships:
                 ...     relationship # do something with the relationship
         """
         data_set_ids_processed = process_data_set_ids(data_set_ids, data_set_external_ids)
@@ -360,7 +360,7 @@ class RelationshipsAPI(APIClient):
 
                 >>> from cognite.client import CogniteClient
                 >>> from cognite.client.data_classes import Relationship
-                >>> c = CogniteClient()
+                >>> client = CogniteClient()
                 >>> flowrel1 = Relationship(
                 ...     external_id="flow_1",
                 ...     source_external_id="source_ext_id",
@@ -379,7 +379,7 @@ class RelationshipsAPI(APIClient):
                 ...     confidence=0.1,
                 ...     data_set_id=1234
                 ... )
-                >>> res = c.relationships.create([flowrel1,flowrel2])
+                >>> res = client.relationships.create([flowrel1,flowrel2])
         """
         assert_type(relationship, "relationship", [RelationshipCore, Sequence])
         if isinstance(relationship, Sequence):
@@ -422,37 +422,37 @@ class RelationshipsAPI(APIClient):
             Update a data set that you have fetched. This will perform a full update of the data set::
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
-                >>> rel = c.relationships.retrieve(external_id="flow1")
+                >>> client = CogniteClient()
+                >>> rel = client.relationships.retrieve(external_id="flow1")
                 >>> rel.confidence = 0.75
-                >>> res = c.relationships.update(rel)
+                >>> res = client.relationships.update(rel)
 
             Perform a partial update on a relationship, setting a source_external_id and a confidence::
 
                 >>> from cognite.client import CogniteClient
                 >>> from cognite.client.data_classes import RelationshipUpdate
-                >>> c = CogniteClient()
+                >>> client = CogniteClient()
                 >>> my_update = RelationshipUpdate(external_id="flow_1").source_external_id.set("alternate_source").confidence.set(0.97)
-                >>> res1 = c.relationships.update(my_update)
+                >>> res1 = client.relationships.update(my_update)
                 >>> # Remove an already set optional field like so
                 >>> another_update = RelationshipUpdate(external_id="flow_1").confidence.set(None)
-                >>> res2 = c.relationships.update(another_update)
+                >>> res2 = client.relationships.update(another_update)
 
             Attach labels to a relationship::
 
                 >>> from cognite.client import CogniteClient
                 >>> from cognite.client.data_classes import RelationshipUpdate
-                >>> c = CogniteClient()
+                >>> client = CogniteClient()
                 >>> my_update = RelationshipUpdate(external_id="flow_1").labels.add(["PUMP", "VERIFIED"])
-                >>> res = c.relationships.update(my_update)
+                >>> res = client.relationships.update(my_update)
 
             Detach a single label from a relationship::
 
                 >>> from cognite.client import CogniteClient
                 >>> from cognite.client.data_classes import RelationshipUpdate
-                >>> c = CogniteClient()
+                >>> client = CogniteClient()
                 >>> my_update = RelationshipUpdate(external_id="flow_1").labels.remove("PUMP")
-                >>> res = c.relationships.update(my_update)
+                >>> res = client.relationships.update(my_update)
         """
         return self._update_multiple(
             list_cls=RelationshipList, resource_cls=Relationship, update_cls=RelationshipUpdate, items=item
@@ -494,11 +494,11 @@ class RelationshipsAPI(APIClient):
 
                 >>> from cognite.client import CogniteClient
                 >>> from cognite.client.data_classes import Relationship
-                >>> c = CogniteClient()
-                >>> existing_relationship = c.relationships.retrieve(id=1)
+                >>> client = CogniteClient()
+                >>> existing_relationship = client.relationships.retrieve(id=1)
                 >>> existing_relationship.description = "New description"
                 >>> new_relationship = Relationship(external_id="new_relationship", source_external_id="new_source")
-                >>> res = c.relationships.upsert([existing_relationship, new_relationship], mode="replace")
+                >>> res = client.relationships.upsert([existing_relationship, new_relationship], mode="replace")
         """
         return self._upsert_multiple(
             item,
@@ -520,8 +520,8 @@ class RelationshipsAPI(APIClient):
             Delete relationships by external id::
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
-                >>> c.relationships.delete(external_id=["a","b"])
+                >>> client = CogniteClient()
+                >>> client.relationships.delete(external_id=["a","b"])
         """
         self._delete_multiple(
             identifiers=IdentifierSequence.load(external_ids=external_id),

--- a/cognite/client/_api/sequences.py
+++ b/cognite/client/_api/sequences.py
@@ -161,14 +161,14 @@ class SequencesAPI(APIClient):
             Get sequence by id::
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
-                >>> res = c.sequences.retrieve(id=1)
+                >>> client = CogniteClient()
+                >>> res = client.sequences.retrieve(id=1)
 
             Get sequence by external id::
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
-                >>> res = c.sequences.retrieve()
+                >>> client = CogniteClient()
+                >>> res = client.sequences.retrieve()
         """
         identifiers = IdentifierSequence.load(ids=id, external_ids=external_id).as_singleton()
         return self._retrieve_multiple(list_cls=SequenceList, resource_cls=Sequence, identifiers=identifiers)
@@ -194,14 +194,14 @@ class SequencesAPI(APIClient):
             Get sequences by id::
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
-                >>> res = c.sequences.retrieve_multiple(ids=[1, 2, 3])
+                >>> client = CogniteClient()
+                >>> res = client.sequences.retrieve_multiple(ids=[1, 2, 3])
 
             Get sequences by external id::
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
-                >>> res = c.sequences.retrieve_multiple(external_ids=["abc", "def"])
+                >>> client = CogniteClient()
+                >>> res = client.sequences.retrieve_multiple(external_ids=["abc", "def"])
         """
         identifiers = IdentifierSequence.load(ids=ids, external_ids=external_ids)
         return self._retrieve_multiple(
@@ -222,8 +222,8 @@ class SequencesAPI(APIClient):
             Aggregate sequences::
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
-                >>> res = c.sequences.aggregate(filter={"external_id_prefix": "prefix"})
+                >>> client = CogniteClient()
+                >>> res = client.sequences.aggregate(filter={"external_id_prefix": "prefix"})
         """
         warnings.warn(
             "This method will be deprecated in the next major release. Use aggregate_count instead.", DeprecationWarning
@@ -249,17 +249,17 @@ class SequencesAPI(APIClient):
             Count the number of time series in your CDF project:
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
-                >>> count = c.sequences.aggregate_count()
+                >>> client = CogniteClient()
+                >>> count = client.sequences.aggregate_count()
 
             Count the number of sequences with external id prefixed with "mapping:" in your CDF project:
 
                 >>> from cognite.client import CogniteClient
                 >>> from cognite.client.data_classes import filters
                 >>> from cognite.client.data_classes.sequences import SequenceProperty
-                >>> c = CogniteClient()
+                >>> client = CogniteClient()
                 >>> is_mapping = filters.Prefix(SequenceProperty.external_id, "mapping:")
-                >>> count = c.sequences.aggregate_count(advanced_filter=is_mapping)
+                >>> count = client.sequences.aggregate_count(advanced_filter=is_mapping)
 
         """
         self._validate_filter(advanced_filter)
@@ -294,8 +294,8 @@ class SequencesAPI(APIClient):
 
                 >>> from cognite.client import CogniteClient
                 >>> from cognite.client.data_classes.sequences import SequenceProperty
-                >>> c = CogniteClient()
-                >>> count = c.sequences.aggregate_cardinality_values(SequenceProperty.metadata_key("efficiency"))
+                >>> client = CogniteClient()
+                >>> count = client.sequences.aggregate_cardinality_values(SequenceProperty.metadata_key("efficiency"))
 
             Count the number of timezones (metadata key) for sequences with the word "critical" in the description
             in your CDF project, but exclude timezones from america:
@@ -303,10 +303,10 @@ class SequencesAPI(APIClient):
                 >>> from cognite.client import CogniteClient
                 >>> from cognite.client.data_classes import filters, aggregations as aggs
                 >>> from cognite.client.data_classes.sequences import SequenceProperty
-                >>> c = CogniteClient()
+                >>> client = CogniteClient()
                 >>> not_america = aggs.Not(aggs.Prefix("america"))
                 >>> is_critical = filters.Search(SequenceProperty.description, "critical")
-                >>> timezone_count = c.sequences.aggregate_cardinality_values(
+                >>> timezone_count = client.sequences.aggregate_cardinality_values(
                 ...     SequenceProperty.metadata_key("timezone"),
                 ...     advanced_filter=is_critical,
                 ...     aggregate_filter=not_america)
@@ -345,8 +345,8 @@ class SequencesAPI(APIClient):
 
                 >>> from cognite.client import CogniteClient
                 >>> from cognite.client.data_classes.sequences import SequenceProperty
-                >>> c = CogniteClient()
-                >>> count = c.sequences.aggregate_cardinality_values(SequenceProperty.metadata)
+                >>> client = CogniteClient()
+                >>> count = client.sequences.aggregate_cardinality_values(SequenceProperty.metadata)
         """
         self._validate_filter(advanced_filter)
         return self._advanced_aggregate(
@@ -382,8 +382,8 @@ class SequencesAPI(APIClient):
 
                 >>> from cognite.client import CogniteClient
                 >>> from cognite.client.data_classes.sequences import SequenceProperty
-                >>> c = CogniteClient()
-                >>> result = c.sequences.aggregate_unique_values(SequenceProperty.metadata_key("timezone"))
+                >>> client = CogniteClient()
+                >>> result = client.sequences.aggregate_unique_values(SequenceProperty.metadata_key("timezone"))
                 >>> print(result.unique)
 
             Get the different metadata keys with count used for sequences created after 2020-01-01 in your CDF project:
@@ -393,9 +393,9 @@ class SequencesAPI(APIClient):
                 >>> from cognite.client.data_classes.sequences import SequenceProperty
                 >>> from cognite.client.utils import timestamp_to_ms
                 >>> from datetime import datetime
-                >>> c = CogniteClient()
+                >>> client = CogniteClient()
                 >>> created_after_2020 = filters.Range(SequenceProperty.created_time, gte=timestamp_to_ms(datetime(2020, 1, 1)))
-                >>> result = c.sequences.aggregate_unique_values(SequenceProperty.metadata, advanced_filter=created_after_2020)
+                >>> result = client.sequences.aggregate_unique_values(SequenceProperty.metadata, advanced_filter=created_after_2020)
                 >>> print(result.unique)
 
             Get the different metadata keys with count for sequences updated after 2020-01-01 in your CDF project, but exclude all metadata keys that
@@ -404,10 +404,10 @@ class SequencesAPI(APIClient):
                 >>> from cognite.client import CogniteClient
                 >>> from cognite.client.data_classes.sequences import SequenceProperty
                 >>> from cognite.client.data_classes import aggregations as aggs, filters
-                >>> c = CogniteClient()
+                >>> client = CogniteClient()
                 >>> not_test = aggs.Not(aggs.Prefix("test"))
                 >>> created_after_2020 = filters.Range(SequenceProperty.last_updated_time, gte=timestamp_to_ms(datetime(2020, 1, 1)))
-                >>> result = c.sequences.aggregate_unique_values(SequenceProperty.metadata, advanced_filter=created_after_2020, aggregate_filter=not_test)
+                >>> result = client.sequences.aggregate_unique_values(SequenceProperty.metadata, advanced_filter=created_after_2020, aggregate_filter=not_test)
                 >>> print(result.unique)
         """
         self._validate_filter(advanced_filter)
@@ -453,8 +453,8 @@ class SequencesAPI(APIClient):
 
                 >>> from cognite.client import CogniteClient
                 >>> from cognite.client.data_classes.sequences import SequenceProperty
-                >>> c = CogniteClient()
-                >>> result = c.sequences.aggregate_unique_properties(SequenceProperty.metadata)
+                >>> client = CogniteClient()
+                >>> result = client.sequences.aggregate_unique_properties(SequenceProperty.metadata)
         """
         self._validate_filter(advanced_filter)
         return self._advanced_aggregate(
@@ -491,16 +491,16 @@ class SequencesAPI(APIClient):
 
                 >>> from cognite.client import CogniteClient
                 >>> from cognite.client.data_classes import SequenceWrite, SequenceColumnWrite
-                >>> c = CogniteClient()
+                >>> client = CogniteClient()
                 >>> column_def = [
                 ...     SequenceColumnWrite(value_type="String", external_id="user", description="some description"),
                 ...     SequenceColumnWrite(value_type="Double", external_id="amount")
                 ... ]
-                >>> seq = c.sequences.create(SequenceWrite(external_id="my_sequence", columns=column_def))
+                >>> seq = client.sequences.create(SequenceWrite(external_id="my_sequence", columns=column_def))
 
             Create a new sequence with the same column specifications as an existing sequence::
 
-                >>> seq2 = c.sequences.create(SequenceWrite(external_id="my_copied_sequence", columns=column_def))
+                >>> seq2 = client.sequences.create(SequenceWrite(external_id="my_copied_sequence", columns=column_def))
 
         """
         assert_type(sequence, "sequences", [typing.Sequence, SequenceCore])
@@ -527,8 +527,8 @@ class SequencesAPI(APIClient):
             Delete sequences by id or external id::
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
-                >>> c.sequences.delete(id=[1,2,3], external_id="3")
+                >>> client = CogniteClient()
+                >>> client.sequences.delete(id=[1,2,3], external_id="3")
         """
         self._delete_multiple(
             identifiers=IdentifierSequence.load(ids=id, external_ids=external_id),
@@ -561,18 +561,18 @@ class SequencesAPI(APIClient):
             Update a sequence that you have fetched. This will perform a full update of the sequences::
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
-                >>> res = c.sequences.retrieve(id=1)
+                >>> client = CogniteClient()
+                >>> res = client.sequences.retrieve(id=1)
                 >>> res.description = "New description"
-                >>> res = c.sequences.update(res)
+                >>> res = client.sequences.update(res)
 
             Perform a partial update on a sequence, updating the description and adding a new field to metadata::
 
                 >>> from cognite.client import CogniteClient
                 >>> from cognite.client.data_classes import SequenceUpdate
-                >>> c = CogniteClient()
+                >>> client = CogniteClient()
                 >>> my_update = SequenceUpdate(id=1).description.set("New description").metadata.add({"key": "value"})
-                >>> res = c.sequences.update(my_update)
+                >>> res = client.sequences.update(my_update)
 
             **Updating column definitions**
 
@@ -582,53 +582,53 @@ class SequencesAPI(APIClient):
 
                 >>> from cognite.client import CogniteClient
                 >>> from cognite.client.data_classes import SequenceUpdate, SequenceColumn
-                >>> c = CogniteClient()
+                >>> client = CogniteClient()
                 >>>
                 >>> my_update = SequenceUpdate(id=1).columns.add(SequenceColumn(value_type ="String",external_id="user", description ="some description"))
-                >>> res = c.sequences.update(my_update)
+                >>> res = client.sequences.update(my_update)
 
             Add multiple new columns::
 
                 >>> from cognite.client import CogniteClient
                 >>> from cognite.client.data_classes import SequenceUpdate, SequenceColumn
-                >>> c = CogniteClient()
+                >>> client = CogniteClient()
                 >>>
                 >>> column_def = [
                 ...     SequenceColumn(value_type ="String",external_id="user", description ="some description"),
                 ...     SequenceColumn(value_type="Double", external_id="amount")]
                 >>> my_update = SequenceUpdate(id=1).columns.add(column_def)
-                >>> res = c.sequences.update(my_update)
+                >>> res = client.sequences.update(my_update)
 
             Remove a single column::
 
                 >>> from cognite.client import CogniteClient
                 >>> from cognite.client.data_classes import SequenceUpdate
-                >>> c = CogniteClient()
+                >>> client = CogniteClient()
                 >>>
                 >>> my_update = SequenceUpdate(id=1).columns.remove("col_external_id1")
-                >>> res = c.sequences.update(my_update)
+                >>> res = client.sequences.update(my_update)
 
             Remove multiple columns::
 
                 >>> from cognite.client import CogniteClient
                 >>> from cognite.client.data_classes import SequenceUpdate
-                >>> c = CogniteClient()
+                >>> client = CogniteClient()
                 >>>
                 >>> my_update = SequenceUpdate(id=1).columns.remove(["col_external_id1","col_external_id2"])
-                >>> res = c.sequences.update(my_update)
+                >>> res = client.sequences.update(my_update)
 
             Update existing columns::
 
                 >>> from cognite.client import CogniteClient
                 >>> from cognite.client.data_classes import SequenceUpdate, SequenceColumnUpdate
-                >>> c = CogniteClient()
+                >>> client = CogniteClient()
                 >>>
                 >>> column_updates = [
                 ...     SequenceColumnUpdate(external_id="col_external_id_1").external_id.set("new_col_external_id"),
                 ...     SequenceColumnUpdate(external_id="col_external_id_2").description.set("my new description"),
                 ... ]
                 >>> my_update = SequenceUpdate(id=1).columns.modify(column_updates)
-                >>> res = c.sequences.update(my_update)
+                >>> res = client.sequences.update(my_update)
         """
         return self._update_multiple(
             list_cls=SequenceList, resource_cls=Sequence, update_cls=SequenceUpdate, items=item
@@ -668,11 +668,11 @@ class SequencesAPI(APIClient):
 
                 >>> from cognite.client import CogniteClient
                 >>> from cognite.client.data_classes import Sequence
-                >>> c = CogniteClient()
-                >>> existing_sequence = c.sequences.retrieve(id=1)
+                >>> client = CogniteClient()
+                >>> existing_sequence = client.sequences.retrieve(id=1)
                 >>> existing_sequence.description = "New description"
                 >>> new_sequence = Sequence(external_id="new_sequence", description="New sequence")
-                >>> res = c.sequences.upsert([existing_sequence, new_sequence], mode="replace")
+                >>> res = client.sequences.upsert([existing_sequence, new_sequence], mode="replace")
         """
         return self._upsert_multiple(
             item,
@@ -709,8 +709,8 @@ class SequencesAPI(APIClient):
             Search for a sequence::
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
-                >>> res = c.sequences.search(name="some name")
+                >>> client = CogniteClient()
+                >>> res = client.sequences.search(name="some name")
         """
         return self._search(
             list_cls=SequenceList,
@@ -746,10 +746,10 @@ class SequencesAPI(APIClient):
 
                 >>> from cognite.client import CogniteClient
                 >>> from cognite.client.data_classes import filters as flt
-                >>> c = CogniteClient()
+                >>> client = CogniteClient()
                 >>> asset_filter = flt.Equals("asset_id", 123)
                 >>> is_efficiency = flt.Equals(["metadata", "type"], "efficiency")
-                >>> res = c.time_series.filter(filter=flt.And(asset_filter, is_efficiency), sort="created_time")
+                >>> res = client.time_series.filter(filter=flt.And(asset_filter, is_efficiency), sort="created_time")
 
             Note that you can check the API documentation above to see which properties you can filter on
             with which filters.
@@ -760,10 +760,10 @@ class SequencesAPI(APIClient):
                 >>> from cognite.client import CogniteClient
                 >>> from cognite.client.data_classes import filters as flt
                 >>> from cognite.client.data_classes.sequences import SequenceProperty, SortableSequenceProperty
-                >>> c = CogniteClient()
+                >>> client = CogniteClient()
                 >>> asset_filter = flt.Equals(SequenceProperty.asset_id, 123)
                 >>> is_efficiency = flt.Equals(SequenceProperty.metadata_key("type"), "efficiency")
-                >>> res = c.time_series.filter(
+                >>> res = client.time_series.filter(
                 ...     filter=flt.And(asset_filter, is_efficiency),
                 ...     sort=SortableSequenceProperty.created_time)
 
@@ -820,21 +820,21 @@ class SequencesAPI(APIClient):
             List sequences::
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
-                >>> res = c.sequences.list(limit=5)
+                >>> client = CogniteClient()
+                >>> res = client.sequences.list(limit=5)
 
             Iterate over sequences::
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
-                >>> for seq in c.sequences:
+                >>> client = CogniteClient()
+                >>> for seq in client.sequences:
                 ...     seq # do something with the sequence
 
             Iterate over chunks of sequences to reduce memory load::
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
-                >>> for seq_list in c.sequences(chunk_size=2500):
+                >>> client = CogniteClient()
+                >>> for seq_list in client.sequences(chunk_size=2500):
                 ...     seq_list # do something with the sequences
         """
         asset_subtree_ids_processed = process_asset_subtree_ids(asset_subtree_ids, asset_subtree_external_ids)
@@ -887,32 +887,32 @@ class SequencesDataAPI(APIClient):
 
                 >>> from cognite.client import CogniteClient
                 >>> from cognite.client.data_classes import Sequence, SequenceColumn
-                >>> c = CogniteClient()
-                >>> seq = c.sequences.create(Sequence(columns=[SequenceColumn(value_type="String", external_id="col_a"),
+                >>> client = CogniteClient()
+                >>> seq = client.sequences.create(Sequence(columns=[SequenceColumn(value_type="String", external_id="col_a"),
                 ...     SequenceColumn(value_type="Double", external_id ="col_b")]))
                 >>> data = [(1, ['pi',3.14]), (2, ['e',2.72]) ]
-                >>> c.sequences.data.insert(columns=["col_a","col_b"], rows=data, id=1)
+                >>> client.sequences.data.insert(columns=["col_a","col_b"], rows=data, id=1)
 
             They can also be provided as a list of API-style objects with a rowNumber and values field::
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
+                >>> client = CogniteClient()
                 >>> data = [{"rowNumber": 123, "values": ['str',3]}, {"rowNumber": 456, "values": ["bar",42]} ]
-                >>> c.sequences.data.insert(data, id=1, columns=["col_a","col_b"]) # implicit columns are retrieved from metadata
+                >>> client.sequences.data.insert(data, id=1, columns=["col_a","col_b"]) # implicit columns are retrieved from metadata
 
             Or they can be a given as a dictionary with row number as the key, and the value is the data to be inserted at that row::
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
+                >>> client = CogniteClient()
                 >>> data = {123 : ['str',3], 456 : ['bar',42] }
-                >>> c.sequences.data.insert(columns=['stringColumn','intColumn'], rows=data, id=1)
+                >>> client.sequences.data.insert(columns=['stringColumn','intColumn'], rows=data, id=1)
 
             Finally, they can be a SequenceData object retrieved from another request. In this case columns from this object are used as well.
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
-                >>> data = c.sequences.data.retrieve(id=2,start=0,end=10)
-                >>> c.sequences.data.insert(rows=data, id=1,columns=None)
+                >>> client = CogniteClient()
+                >>> data = client.sequences.data.retrieve(id=2,start=0,end=10)
+                >>> client.sequences.data.insert(rows=data, id=1,columns=None)
         """
         columns = handle_renamed_argument(columns, "columns", "column_external_ids", "insert", kwargs, False)
         if isinstance(rows, SequenceRows):
@@ -962,9 +962,9 @@ class SequencesDataAPI(APIClient):
 
                 >>> from cognite.client import CogniteClient
                 >>> import pandas as pd
-                >>> c = CogniteClient()
+                >>> client = CogniteClient()
                 >>> df = pd.DataFrame({'col_a': [1, 2, 3], 'col_b': [4, 5, 6]}, index=[1, 2, 3])
-                >>> c.sequences.data.insert_dataframe(df, id=1)
+                >>> client.sequences.data.insert_dataframe(df, id=1)
         """
         if dropna:
             dataframe = dataframe.dropna()
@@ -987,8 +987,8 @@ class SequencesDataAPI(APIClient):
         Examples:
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
-                >>> c.sequences.data.delete(id=1, rows=[1,2,42])
+                >>> client = CogniteClient()
+                >>> client.sequences.data.delete(id=1, rows=[1,2,42])
         """
         post_obj = Identifier.of_either(id, external_id).as_dict()
         post_obj["rows"] = rows
@@ -1007,8 +1007,8 @@ class SequencesDataAPI(APIClient):
         Examples:
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
-                >>> c.sequences.data.delete_range(id=1, start=0, end=None)
+                >>> client = CogniteClient()
+                >>> client.sequences.data.delete_range(id=1, start=0, end=None)
         """
         sequence = self._cognite_client.sequences.retrieve(external_id=external_id, id=id)
         assert sequence is not None
@@ -1094,8 +1094,8 @@ class SequencesDataAPI(APIClient):
         Examples:
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
-                >>> res = c.sequences.data.retrieve(id=1)
+                >>> client = CogniteClient()
+                >>> res = client.sequences.data.retrieve(id=1)
                 >>> tuples = [(r,v) for r,v in res.items()] # You can use this iterator in for loops and list comprehensions,
                 >>> single_value = res[23] # ... get the values at a single row number,
                 >>> col = res.get_column(external_id='columnExtId') # ... get the array of values for a specific column,
@@ -1153,8 +1153,8 @@ class SequencesDataAPI(APIClient):
             Getting the latest row in a sequence before row number 1000:
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
-                >>> res = c.sequences.data.retrieve_last_row(id=1, before=1000)
+                >>> client = CogniteClient()
+                >>> res = client.sequences.data.retrieve_last_row(id=1, before=1000)
         """
         columns = handle_renamed_argument(columns, "columns", "column_external_ids", "insert", kwargs, False)
         identifier = Identifier.of_either(id, external_id).as_dict()
@@ -1186,8 +1186,8 @@ class SequencesDataAPI(APIClient):
             pandas.DataFrame: pandas.DataFrame
         Examples:
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
-                >>> df = c.sequences.data.retrieve_dataframe(id=1, start=0, end=None)
+                >>> client = CogniteClient()
+                >>> df = client.sequences.data.retrieve_dataframe(id=1, start=0, end=None)
         """
         warnings.warn("This method is deprecated. Use retrieve(...).to_pandas(..) instead.", DeprecationWarning)
         if isinstance(external_id, list) or isinstance(id, list) or (id is not None and external_id is not None):

--- a/cognite/client/_api/synthetic_time_series.py
+++ b/cognite/client/_api/synthetic_time_series.py
@@ -58,19 +58,19 @@ class SyntheticDatapointsAPI(APIClient):
             Request a synthetic time series query with direct syntax
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
-                >>> dps = c.time_series.data.synthetic.query(expressions="TS{id:123} + TS{externalId:'abc'}", start="2w-ago", end="now")
+                >>> client = CogniteClient()
+                >>> dps = client.time_series.data.synthetic.query(expressions="TS{id:123} + TS{externalId:'abc'}", start="2w-ago", end="now")
 
             Use variables to re-use an expression:
 
                 >>> vars = {"A": "my_ts_external_id", "B": client.time_series.retrieve(id=1)}
-                >>> dps = c.time_series.data.synthetic.query(expressions="A+B", start="2w-ago", end="now", variables=vars)
+                >>> dps = client.time_series.data.synthetic.query(expressions="A+B", start="2w-ago", end="now", variables=vars)
 
             Use sympy to build complex expressions:
 
                 >>> from sympy import symbols, cos, sin
                 >>> a = symbols('a')
-                >>> dps = c.time_series.data.synthetic.query([sin(a), cos(a)], start="2w-ago", end="now", variables={"a": "my_ts_external_id"}, aggregate='interpolation', granularity='1m', target_unit='temperature:deg_c')
+                >>> dps = client.time_series.data.synthetic.query([sin(a), cos(a)], start="2w-ago", end="now", variables={"a": "my_ts_external_id"}, aggregate='interpolation', granularity='1m', target_unit='temperature:deg_c')
         """
         if limit is None or limit == -1:
             limit = cast(int, float("inf"))

--- a/cognite/client/_api/templates.py
+++ b/cognite/client/_api/templates.py
@@ -64,7 +64,7 @@ class TemplatesAPI(APIClient):
             Run a GraphQL query:
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
+                >>> client = CogniteClient()
                 >>> query = '''
                 >>>    {
                 >>>        countryQuery {
@@ -82,7 +82,7 @@ class TemplatesAPI(APIClient):
                 >>>        }
                 >>>    }
                 >>>    '''
-                >>> result = c.templates.graphql_query("template-group-ext-id", 1, query)
+                >>> result = client.templates.graphql_query("template-group-ext-id", 1, query)
         """
         TemplatesAPI._deprecation_warning()
         path = "/templategroups/{}/versions/{}/graphql"
@@ -108,10 +108,10 @@ class TemplateGroupsAPI(APIClient):
 
                 >>> from cognite.client import CogniteClient
                 >>> from cognite.client.data_classes import TemplateGroup
-                >>> c = CogniteClient()
+                >>> client = CogniteClient()
                 >>> template_group_1 = TemplateGroup("sdk-test-group", "This is a test group")
                 >>> template_group_2 = TemplateGroup("sdk-test-group-2", "This is another test group")
-                >>> c.templates.groups.create([template_group_1, template_group_2])
+                >>> client.templates.groups.create([template_group_1, template_group_2])
         """
         TemplatesAPI._deprecation_warning()
         return self._create_multiple(
@@ -136,10 +136,10 @@ class TemplateGroupsAPI(APIClient):
 
                 >>> from cognite.client import CogniteClient
                 >>> from cognite.client.data_classes import TemplateGroup
-                >>> c = CogniteClient()
+                >>> client = CogniteClient()
                 >>> template_group_1 = TemplateGroup("sdk-test-group", "This is a test group")
                 >>> template_group_2 = TemplateGroup("sdk-test-group-2", "This is another test group")
-                >>> c.templates.groups.upsert([template_group_1, template_group_2])
+                >>> client.templates.groups.upsert([template_group_1, template_group_2])
         """
         TemplatesAPI._deprecation_warning()
         path = self._RESOURCE_PATH + "/upsert"
@@ -172,8 +172,8 @@ class TemplateGroupsAPI(APIClient):
             Get template groups by external id:
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
-                >>> res = c.templates.groups.retrieve_multiple(external_ids=["abc", "def"])
+                >>> client = CogniteClient()
+                >>> res = client.templates.groups.retrieve_multiple(external_ids=["abc", "def"])
         """
         TemplatesAPI._deprecation_warning()
         identifiers = IdentifierSequence.load(ids=None, external_ids=external_ids)
@@ -201,8 +201,8 @@ class TemplateGroupsAPI(APIClient):
             List template groups:
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
-                >>> template_group_list = c.templates.groups.list(limit=5)
+                >>> client = CogniteClient()
+                >>> template_group_list = client.templates.groups.list(limit=5)
         """
         TemplatesAPI._deprecation_warning()
         filter = {}
@@ -229,8 +229,8 @@ class TemplateGroupsAPI(APIClient):
             Delete template groups by external id:
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
-                >>> c.templates.groups.delete(external_ids=["a", "b"])
+                >>> client = CogniteClient()
+                >>> client.templates.groups.delete(external_ids=["a", "b"])
         """
         TemplatesAPI._deprecation_warning()
         self._delete_multiple(
@@ -264,9 +264,9 @@ class TemplateGroupVersionsAPI(APIClient):
 
                 >>> from cognite.client import CogniteClient
                 >>> from cognite.client.data_classes import TemplateGroup
-                >>> c = CogniteClient()
+                >>> client = CogniteClient()
                 >>> template_group = TemplateGroup("sdk-test-group", "This template group models Covid-19 spread")
-                >>> c.templates.groups.create(template_group)
+                >>> client.templates.groups.create(template_group)
                 >>> schema = '''
                 >>>     type Demographics @template {
                 >>>         "The amount of people"
@@ -281,7 +281,7 @@ class TemplateGroupVersionsAPI(APIClient):
                 >>>         confirmed: TimeSeries,
                 >>>     }'''
                 >>> template_group_version = TemplateGroupVersion(schema)
-                >>> c.templates.versions.upsert(template_group.external_id, template_group_version)
+                >>> client.templates.versions.upsert(template_group.external_id, template_group_version)
         """
         TemplatesAPI._deprecation_warning()
         resource_path = interpolate_and_url_encode(self._RESOURCE_PATH, external_id) + "/upsert"
@@ -311,8 +311,8 @@ class TemplateGroupVersionsAPI(APIClient):
             List template group versions:
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
-                >>> template_group_list = c.templates.versions.list("template-group-ext-id", limit=5)
+                >>> client = CogniteClient()
+                >>> template_group_list = client.templates.versions.list("template-group-ext-id", limit=5)
         """
         TemplatesAPI._deprecation_warning()
         resource_path = interpolate_and_url_encode(self._RESOURCE_PATH, external_id)
@@ -341,8 +341,8 @@ class TemplateGroupVersionsAPI(APIClient):
             Delete template groups by external id:
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
-                >>> c.templates.versions.delete("sdk-test-group", 1)
+                >>> client = CogniteClient()
+                >>> client.templates.versions.delete("sdk-test-group", 1)
         """
         TemplatesAPI._deprecation_warning()
         resource_path = interpolate_and_url_encode(self._RESOURCE_PATH, external_id)
@@ -370,7 +370,7 @@ class TemplateInstancesAPI(APIClient):
 
                 >>> from cognite.client import CogniteClient
                 >>> from cognite.client.data_classes import TemplateInstance
-                >>> c = CogniteClient()
+                >>> client = CogniteClient()
                 >>> template_instance_1 = TemplateInstance(external_id="norway",
                 >>>                               template_name="Country",
                 >>>                               field_resolvers={
@@ -387,7 +387,7 @@ class TemplateInstancesAPI(APIClient):
                 >>>                                   "growthRate": ConstantResolver(value=0.02)
                 >>>                                   }
                 >>>                               )
-                >>> c.templates.instances.create("sdk-test-group", 1, [template_instance_1, template_instance_2])
+                >>> client.templates.instances.create("sdk-test-group", 1, [template_instance_1, template_instance_2])
         """
         TemplatesAPI._deprecation_warning()
         resource_path = interpolate_and_url_encode(self._RESOURCE_PATH, external_id, version)
@@ -418,7 +418,7 @@ class TemplateInstancesAPI(APIClient):
 
             >>> from cognite.client import CogniteClient
             >>> from cognite.client.data_classes import TemplateInstance
-            >>> c = CogniteClient()
+            >>> client = CogniteClient()
             >>> template_instance_1 = TemplateInstance(external_id="norway",
             >>>        template_name="Country",
             >>>        field_resolvers={
@@ -435,7 +435,7 @@ class TemplateInstancesAPI(APIClient):
             >>>           "growthRate": ConstantResolver(0.02)
             >>>           }
             >>>   )
-            >>> c.templates.instances.upsert("sdk-test-group", 1, [template_instance_1, template_instance_2])
+            >>> client.templates.instances.upsert("sdk-test-group", 1, [template_instance_1, template_instance_2])
         """
         TemplatesAPI._deprecation_warning()
         if isinstance(instances, TemplateInstance):
@@ -466,9 +466,9 @@ class TemplateInstancesAPI(APIClient):
 
                 >>> from cognite.client import CogniteClient
                 >>> from cognite.client.data_classes import TemplateInstanceUpdate
-                >>> c = CogniteClient()
+                >>> client = CogniteClient()
                 >>> my_update = TemplateInstanceUpdate(external_id="test").field_resolvers.add({ "name": ConstantResolver("Norway") })
-                >>> res = c.templates.instances.update("sdk-test-group", 1, my_update)
+                >>> res = client.templates.instances.update("sdk-test-group", 1, my_update)
         """
         TemplatesAPI._deprecation_warning()
         resource_path = interpolate_and_url_encode(self._RESOURCE_PATH, external_id, version)
@@ -498,8 +498,8 @@ class TemplateInstancesAPI(APIClient):
             Get template instances by external id:
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
-                >>> res = c.templates.instances.retrieve_multiple(external_id="sdk-test-group", version=1, external_ids=["abc", "def"])
+                >>> client = CogniteClient()
+                >>> res = client.templates.instances.retrieve_multiple(external_id="sdk-test-group", version=1, external_ids=["abc", "def"])
         """
         TemplatesAPI._deprecation_warning()
         resource_path = interpolate_and_url_encode(self._RESOURCE_PATH, external_id, version)
@@ -537,8 +537,8 @@ class TemplateInstancesAPI(APIClient):
             List template instances:
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
-                >>> template_instances_list = c.templates.instances.list("template-group-ext-id", 1, limit=5)
+                >>> client = CogniteClient()
+                >>> template_instances_list = client.templates.instances.list("template-group-ext-id", 1, limit=5)
         """
         TemplatesAPI._deprecation_warning()
         resource_path = interpolate_and_url_encode(self._RESOURCE_PATH, external_id, version)
@@ -571,8 +571,8 @@ class TemplateInstancesAPI(APIClient):
             Delete template groups by external id:
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
-                >>> c.templates.instances.delete("sdk-test-group", 1, external_ids=["a", "b"])
+                >>> client = CogniteClient()
+                >>> client.templates.instances.delete("sdk-test-group", 1, external_ids=["a", "b"])
         """
         TemplatesAPI._deprecation_warning()
         resource_path = interpolate_and_url_encode(self._RESOURCE_PATH, external_id, version)
@@ -603,7 +603,7 @@ class TemplateViewsAPI(APIClient):
 
                 >>> from cognite.client import CogniteClient
                 >>> from cognite.client.data_classes.templates import View, Source
-                >>> c = CogniteClient()
+                >>> client = CogniteClient()
                 >>> view = View(external_id="view",
                 >>>             source=Source(
                 >>>                 type='events',
@@ -618,7 +618,7 @@ class TemplateViewsAPI(APIClient):
                 >>>                 }
                 >>>             )
                 >>>        )
-                >>> c.templates.views.create("sdk-test-group", 1, [view])
+                >>> client.templates.views.create("sdk-test-group", 1, [view])
         """
         TemplatesAPI._deprecation_warning()
         resource_path = interpolate_and_url_encode(self._RESOURCE_PATH, external_id, version)
@@ -642,7 +642,7 @@ class TemplateViewsAPI(APIClient):
 
                 >>> from cognite.client import CogniteClient
                 >>> from cognite.client.data_classes.templates import View
-                >>> c = CogniteClient()
+                >>> client = CogniteClient()
                 >>> view = View(external_id="view",
                 >>>             source=Source(
                 >>>                 type: 'events',
@@ -657,7 +657,7 @@ class TemplateViewsAPI(APIClient):
                 >>>                 }
                 >>>             )
                 >>>        )
-                >>> c.templates.views.upsert("sdk-test-group", 1, [view])
+                >>> client.templates.views.upsert("sdk-test-group", 1, [view])
         """
         TemplatesAPI._deprecation_warning()
         if isinstance(views, View):
@@ -694,8 +694,8 @@ class TemplateViewsAPI(APIClient):
             Resolve view:
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
-                >>> c.templates.views.resolve("template-group-ext-id", 1, "view", { "startTime": 10 }, limit=5)
+                >>> client = CogniteClient()
+                >>> client.templates.views.resolve("template-group-ext-id", 1, "view", { "startTime": 10 }, limit=5)
         """
         TemplatesAPI._deprecation_warning()
         url_path = interpolate_and_url_encode(self._RESOURCE_PATH, external_id, version) + "/resolve"
@@ -724,8 +724,8 @@ class TemplateViewsAPI(APIClient):
             List views:
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
-                >>> c.templates.views.list("template-group-ext-id", 1, limit=5)
+                >>> client = CogniteClient()
+                >>> client.templates.views.list("template-group-ext-id", 1, limit=5)
         """
         TemplatesAPI._deprecation_warning()
         resource_path = interpolate_and_url_encode(self._RESOURCE_PATH, external_id, version)
@@ -750,8 +750,8 @@ class TemplateViewsAPI(APIClient):
             Delete views by external id:
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
-                >>> c.templates.views.delete("sdk-test-group", 1, external_id=["a", "b"])
+                >>> client = CogniteClient()
+                >>> client.templates.views.delete("sdk-test-group", 1, external_id=["a", "b"])
         """
         TemplatesAPI._deprecation_warning()
         resource_path = interpolate_and_url_encode(self._RESOURCE_PATH, external_id, version)

--- a/cognite/client/_api/three_d.py
+++ b/cognite/client/_api/three_d.py
@@ -92,8 +92,8 @@ class ThreeDModelsAPI(APIClient):
             Get 3d model by id::
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
-                >>> res = c.three_d.models.retrieve(id=1)
+                >>> client = CogniteClient()
+                >>> res = client.three_d.models.retrieve(id=1)
         """
         return self._retrieve(cls=ThreeDModel, identifier=InternalId(id))
 
@@ -112,21 +112,21 @@ class ThreeDModelsAPI(APIClient):
             List 3d models::
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
-                >>> three_d_model_list = c.three_d.models.list()
+                >>> client = CogniteClient()
+                >>> three_d_model_list = client.three_d.models.list()
 
             Iterate over 3d models::
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
-                >>> for three_d_model in c.three_d.models:
+                >>> client = CogniteClient()
+                >>> for three_d_model in client.three_d.models:
                 ...     three_d_model # do something with the 3d model
 
             Iterate over chunks of 3d models to reduce memory load::
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
-                >>> for three_d_model in c.three_d.models(chunk_size=50):
+                >>> client = CogniteClient()
+                >>> for three_d_model in client.three_d.models(chunk_size=50):
                 ...     three_d_model # do something with the 3d model
         """
         return self._list(
@@ -156,8 +156,8 @@ class ThreeDModelsAPI(APIClient):
             Create new 3d models::
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
-                >>> res = c.three_d.models.create(name="My Model", data_set_id=1, metadata={"key1": "value1", "key2": "value2"})
+                >>> client = CogniteClient()
+                >>> res = client.three_d.models.create(name="My Model", data_set_id=1, metadata={"key1": "value1", "key2": "value2"})
         """
         assert_type(name, "name", [str, Sequence])
         item_processed: dict[str, Any] | list[dict[str, Any]]
@@ -195,18 +195,18 @@ class ThreeDModelsAPI(APIClient):
             Update 3d model that you have fetched. This will perform a full update of the model::
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
-                >>> three_d_model = c.three_d.models.retrieve(id=1)
+                >>> client = CogniteClient()
+                >>> three_d_model = client.three_d.models.retrieve(id=1)
                 >>> three_d_model.name = "New Name"
-                >>> res = c.three_d.models.update(three_d_model)
+                >>> res = client.three_d.models.update(three_d_model)
 
             Perform a partial update on a 3d model::
 
                 >>> from cognite.client import CogniteClient
                 >>> from cognite.client.data_classes import ThreeDModelUpdate
-                >>> c = CogniteClient()
+                >>> client = CogniteClient()
                 >>> my_update = ThreeDModelUpdate(id=1).name.set("New Name")
-                >>> res = c.three_d.models.update(my_update)
+                >>> res = client.three_d.models.update(my_update)
 
         """
         return self._update_multiple(
@@ -224,8 +224,8 @@ class ThreeDModelsAPI(APIClient):
             Delete 3d model by id::
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
-                >>> res = c.three_d.models.delete(id=1)
+                >>> client = CogniteClient()
+                >>> res = client.three_d.models.delete(id=1)
         """
         self._delete_multiple(identifiers=IdentifierSequence.load(ids=id), wrap_ids=True)
 
@@ -274,8 +274,8 @@ class ThreeDRevisionsAPI(APIClient):
             Retrieve 3d model revision by model id and revision id::
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
-                >>> res = c.three_d.revisions.retrieve(model_id=1, id=1)
+                >>> client = CogniteClient()
+                >>> res = client.three_d.revisions.retrieve(model_id=1, id=1)
         """
         return self._retrieve(
             cls=ThreeDModelRevision,
@@ -316,9 +316,9 @@ class ThreeDRevisionsAPI(APIClient):
 
                 >>> from cognite.client import CogniteClient
                 >>> from cognite.client.data_classes import ThreeDModelRevisionWrite
-                >>> c = CogniteClient()
+                >>> client = CogniteClient()
                 >>> my_revision = ThreeDModelRevisionWrite(file_id=1)
-                >>> res = c.three_d.revisions.create(model_id=1, revision=my_revision)
+                >>> res = client.three_d.revisions.create(model_id=1, revision=my_revision)
         """
         return self._create_multiple(
             list_cls=ThreeDModelRevisionList,
@@ -346,8 +346,8 @@ class ThreeDRevisionsAPI(APIClient):
             List 3d model revisions::
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
-                >>> res = c.three_d.revisions.list(model_id=1, published=True, limit=100)
+                >>> client = CogniteClient()
+                >>> res = client.three_d.revisions.list(model_id=1, published=True, limit=100)
         """
         return self._list(
             list_cls=ThreeDModelRevisionList,
@@ -379,18 +379,18 @@ class ThreeDRevisionsAPI(APIClient):
             Update a revision that you have fetched. This will perform a full update of the revision::
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
-                >>> revision = c.three_d.revisions.retrieve(model_id=1, id=1)
+                >>> client = CogniteClient()
+                >>> revision = client.three_d.revisions.retrieve(model_id=1, id=1)
                 >>> revision.status = "New Status"
-                >>> res = c.three_d.revisions.update(model_id=1, item=revision)
+                >>> res = client.three_d.revisions.update(model_id=1, item=revision)
 
             Perform a partial update on a revision, updating the published property and adding a new field to metadata::
 
                 >>> from cognite.client import CogniteClient
                 >>> from cognite.client.data_classes import ThreeDModelRevisionUpdate
-                >>> c = CogniteClient()
+                >>> client = CogniteClient()
                 >>> my_update = ThreeDModelRevisionUpdate(id=1).published.set(False).metadata.add({"key": "value"})
-                >>> res = c.three_d.revisions.update(model_id=1, item=my_update)
+                >>> res = client.three_d.revisions.update(model_id=1, item=my_update)
         """
         return self._update_multiple(
             list_cls=ThreeDModelRevisionList,
@@ -412,8 +412,8 @@ class ThreeDRevisionsAPI(APIClient):
             Delete 3d model revision by id::
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
-                >>> res = c.three_d.revisions.delete(model_id=1, id=1)
+                >>> client = CogniteClient()
+                >>> res = client.three_d.revisions.delete(model_id=1, id=1)
         """
         self._delete_multiple(
             resource_path=interpolate_and_url_encode(self._RESOURCE_PATH, model_id),
@@ -434,8 +434,8 @@ class ThreeDRevisionsAPI(APIClient):
             Update revision thumbnail::
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
-                >>> res = c.three_d.revisions.update_thumbnail(model_id=1, revision_id=1, file_id=1)
+                >>> client = CogniteClient()
+                >>> res = client.three_d.revisions.update_thumbnail(model_id=1, revision_id=1, file_id=1)
         """
         resource_path = interpolate_and_url_encode(self._RESOURCE_PATH + "/{}/thumbnail", model_id, revision_id)
         body = {"fileId": file_id}
@@ -473,8 +473,8 @@ class ThreeDRevisionsAPI(APIClient):
             List nodes from the hierarchy in the 3d model::
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
-                >>> res = c.three_d.revisions.list_nodes(model_id=1, revision_id=1, limit=10)
+                >>> client = CogniteClient()
+                >>> res = client.three_d.revisions.list_nodes(model_id=1, revision_id=1, limit=10)
         """
         resource_path = interpolate_and_url_encode(self._RESOURCE_PATH + "/{}/nodes", model_id, revision_id)
         return self._list(
@@ -513,8 +513,8 @@ class ThreeDRevisionsAPI(APIClient):
             Filter nodes from the hierarchy in the 3d model that have one of the values "AB76", "AB77" or "AB78" for property PDMS/Area AND that also have one of the values "PIPE", "BEND" or "PIPESUP" for the property PDMS/Type.
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
-                >>> res = c.three_d.revisions.filter_nodes(model_id=1, revision_id=1, properties={ "PDMS": { "Area": ["AB76", "AB77", "AB78"], "Type": ["PIPE", "BEND", "PIPESUP"] } }, limit=10)
+                >>> client = CogniteClient()
+                >>> res = client.three_d.revisions.filter_nodes(model_id=1, revision_id=1, properties={ "PDMS": { "Area": ["AB76", "AB77", "AB78"], "Type": ["PIPE", "BEND", "PIPESUP"] } }, limit=10)
         """
         resource_path = interpolate_and_url_encode(self._RESOURCE_PATH + "/{}/nodes", model_id, revision_id)
         return self._list(
@@ -546,8 +546,8 @@ class ThreeDRevisionsAPI(APIClient):
             Get a list of ancestor nodes of a given node::
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
-                >>> res = c.three_d.revisions.list_ancestor_nodes(model_id=1, revision_id=1, node_id=5, limit=10)
+                >>> client = CogniteClient()
+                >>> res = client.three_d.revisions.list_ancestor_nodes(model_id=1, revision_id=1, node_id=5, limit=10)
         """
         resource_path = interpolate_and_url_encode(self._RESOURCE_PATH + "/{}/nodes", model_id, revision_id)
         return self._list(
@@ -577,8 +577,8 @@ class ThreeDFilesAPI(APIClient):
             Retrieve the contents of a 3d file by id::
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
-                >>> res = c.three_d.files.retrieve(1)
+                >>> client = CogniteClient()
+                >>> res = client.three_d.files.retrieve(1)
         """
         path = interpolate_and_url_encode(self._RESOURCE_PATH + "/{}", id)
         return self._get(path).content
@@ -614,14 +614,14 @@ class ThreeDAssetMappingAPI(APIClient):
             List 3d node asset mappings:
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
-                >>> res = c.three_d.asset_mappings.list(model_id=1, revision_id=1)
+                >>> client = CogniteClient()
+                >>> res = client.three_d.asset_mappings.list(model_id=1, revision_id=1)
 
             List 3d node asset mappings for assets whose bounding box intersects with a given bounding box:
 
                 >>> from cognite.client.data_classes import BoundingBox3D
                 >>> bbox = BoundingBox3D(min=[0.0, 0.0, 0.0], max=[1.0, 1.0, 1.0])
-                >>> res = c.three_d.asset_mappings.list(
+                >>> res = client.three_d.asset_mappings.list(
                 ...     model_id=1, revision_id=1, intersects_bounding_box=bbox)
         """
         path = interpolate_and_url_encode(self._RESOURCE_PATH, model_id, revision_id)
@@ -678,8 +678,8 @@ class ThreeDAssetMappingAPI(APIClient):
                 >>> from cognite.client import CogniteClient
                 >>> from cognite.client.data_classes import ThreeDAssetMappingWrite
                 >>> my_mapping = ThreeDAssetMappingWrite(node_id=1, asset_id=1)
-                >>> c = CogniteClient()
-                >>> res = c.three_d.asset_mappings.create(model_id=1, revision_id=1, asset_mapping=my_mapping)
+                >>> client = CogniteClient()
+                >>> res = client.three_d.asset_mappings.create(model_id=1, revision_id=1, asset_mapping=my_mapping)
         """
         path = interpolate_and_url_encode(self._RESOURCE_PATH, model_id, revision_id)
         return self._create_multiple(
@@ -705,9 +705,9 @@ class ThreeDAssetMappingAPI(APIClient):
             Delete 3d node asset mapping::
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
-                >>> mapping_to_delete = c.three_d.asset_mappings.list(model_id=1, revision_id=1)[0]
-                >>> res = c.three_d.asset_mappings.delete(model_id=1, revision_id=1, asset_mapping=mapping_to_delete)
+                >>> client = CogniteClient()
+                >>> mapping_to_delete = client.three_d.asset_mappings.list(model_id=1, revision_id=1)[0]
+                >>> res = client.three_d.asset_mappings.delete(model_id=1, revision_id=1, asset_mapping=mapping_to_delete)
         """
         path = interpolate_and_url_encode(self._RESOURCE_PATH, model_id, revision_id)
         assert_type(asset_mapping, "asset_mapping", [Sequence, ThreeDAssetMapping])

--- a/cognite/client/_api/time_series.py
+++ b/cognite/client/_api/time_series.py
@@ -171,14 +171,14 @@ class TimeSeriesAPI(APIClient):
             Get time series by id::
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
-                >>> res = c.time_series.retrieve(id=1)
+                >>> client = CogniteClient()
+                >>> res = client.time_series.retrieve(id=1)
 
             Get time series by external id::
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
-                >>> res = c.time_series.retrieve(external_id="1")
+                >>> client = CogniteClient()
+                >>> res = client.time_series.retrieve(external_id="1")
         """
         identifiers = IdentifierSequence.load(ids=id, external_ids=external_id).as_singleton()
 
@@ -209,14 +209,14 @@ class TimeSeriesAPI(APIClient):
             Get time series by id::
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
-                >>> res = c.time_series.retrieve_multiple(ids=[1, 2, 3])
+                >>> client = CogniteClient()
+                >>> res = client.time_series.retrieve_multiple(ids=[1, 2, 3])
 
             Get time series by external id::
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
-                >>> res = c.time_series.retrieve_multiple(external_ids=["abc", "def"])
+                >>> client = CogniteClient()
+                >>> res = client.time_series.retrieve_multiple(external_ids=["abc", "def"])
         """
         identifiers = IdentifierSequence.load(ids=ids, external_ids=external_ids)
         return self._retrieve_multiple(
@@ -240,8 +240,8 @@ class TimeSeriesAPI(APIClient):
             List time series::
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
-                >>> res = c.time_series.aggregate(filter={"unit": "kpa"})
+                >>> client = CogniteClient()
+                >>> res = client.time_series.aggregate(filter={"unit": "kpa"})
         """
         warnings.warn(
             "This method will be deprecated in the next major release. Use aggregate_count instead.", DeprecationWarning
@@ -267,17 +267,17 @@ class TimeSeriesAPI(APIClient):
         Count the number of time series in your CDF project:
 
             >>> from cognite.client import CogniteClient
-            >>> c = CogniteClient()
-            >>> count = c.time_series.aggregate_count()
+            >>> client = CogniteClient()
+            >>> count = client.time_series.aggregate_count()
 
         Count the number of numeric time series in your CDF project:
 
             >>> from cognite.client import CogniteClient
             >>> from cognite.client.data_classes import filters
             >>> from cognite.client.data_classes.time_series import TimeSeriesProperty
-            >>> c = CogniteClient()
+            >>> client = CogniteClient()
             >>> is_numeric = filters.Equals(TimeSeriesProperty.is_string, False)
-            >>> count = c.time_series.aggregate_count(advanced_filter=is_numeric)
+            >>> count = client.time_series.aggregate_count(advanced_filter=is_numeric)
 
         """
         self._validate_filter(advanced_filter)
@@ -310,8 +310,8 @@ class TimeSeriesAPI(APIClient):
 
             >>> from cognite.client import CogniteClient
             >>> from cognite.client.data_classes.time_series import TimeSeriesProperty
-            >>> c = CogniteClient()
-            >>> unit_count = c.time_series.aggregate_cardinality_values(TimeSeriesProperty.unit)
+            >>> client = CogniteClient()
+            >>> unit_count = client.time_series.aggregate_cardinality_values(TimeSeriesProperty.unit)
 
         Count the number of timezones (metadata key) for time series with the word "critical" in the description
         in your CDF project, but exclude timezones from america:
@@ -319,10 +319,10 @@ class TimeSeriesAPI(APIClient):
             >>> from cognite.client import CogniteClient
             >>> from cognite.client.data_classes import filters, aggregations as aggs
             >>> from cognite.client.data_classes.time_series import TimeSeriesProperty
-            >>> c = CogniteClient()
+            >>> client = CogniteClient()
             >>> not_america = aggs.Not(aggs.Prefix("america"))
             >>> is_critical = filters.Search(TimeSeriesProperty.description, "critical")
-            >>> timezone_count = c.time_series.aggregate_cardinality_values(
+            >>> timezone_count = client.time_series.aggregate_cardinality_values(
             ...     TimeSeriesProperty.metadata_key("timezone"),
             ...     advanced_filter=is_critical,
             ...     aggregate_filter=not_america)
@@ -360,8 +360,8 @@ class TimeSeriesAPI(APIClient):
 
                 >>> from cognite.client import CogniteClient
                 >>> from cognite.client.data_classes.time_series import TimeSeriesProperty
-                >>> c = CogniteClient()
-                >>> key_count = c.time_series.aggregate_cardinality_properties(TimeSeriesProperty.metadata)
+                >>> client = CogniteClient()
+                >>> key_count = client.time_series.aggregate_cardinality_properties(TimeSeriesProperty.metadata)
         """
         self._validate_filter(advanced_filter)
         return self._advanced_aggregate(
@@ -396,8 +396,8 @@ class TimeSeriesAPI(APIClient):
 
                 >>> from cognite.client import CogniteClient
                 >>> from cognite.client.data_classes.time_series import TimeSeriesProperty
-                >>> c = CogniteClient()
-                >>> result = c.time_series.aggregate_unique_values(TimeSeriesProperty.metadata_key("timezone"))
+                >>> client = CogniteClient()
+                >>> result = client.time_series.aggregate_unique_values(TimeSeriesProperty.metadata_key("timezone"))
                 >>> print(result.unique)
 
             Get the different units with count used for time series created after 2020-01-01 in your CDF project:
@@ -407,9 +407,9 @@ class TimeSeriesAPI(APIClient):
                 >>> from cognite.client.data_classes.time_series import TimeSeriesProperty
                 >>> from cognite.client.utils import timestamp_to_ms
                 >>> from datetime import datetime
-                >>> c = CogniteClient()
+                >>> client = CogniteClient()
                 >>> created_after_2020 = filters.Range(TimeSeriesProperty.created_time, gte=timestamp_to_ms(datetime(2020, 1, 1)))
-                >>> result = c.time_series.aggregate_unique_values(TimeSeriesProperty.unit, advanced_filter=created_after_2020)
+                >>> result = client.time_series.aggregate_unique_values(TimeSeriesProperty.unit, advanced_filter=created_after_2020)
                 >>> print(result.unique)
 
             Get the different units with count for time series updated after 2020-01-01 in your CDF project, but exclude all units that
@@ -418,10 +418,10 @@ class TimeSeriesAPI(APIClient):
                 >>> from cognite.client import CogniteClient
                 >>> from cognite.client.data_classes.time_series import TimeSeriesProperty
                 >>> from cognite.client.data_classes import aggregations as aggs, filters
-                >>> c = CogniteClient()
+                >>> client = CogniteClient()
                 >>> not_test = aggs.Not(aggs.Prefix("test"))
                 >>> created_after_2020 = filters.Range(TimeSeriesProperty.last_updated_time, gte=timestamp_to_ms(datetime(2020, 1, 1)))
-                >>> result = c.time_series.aggregate_unique_values(TimeSeriesProperty.unit, advanced_filter=created_after_2020, aggregate_filter=not_test)
+                >>> result = client.time_series.aggregate_unique_values(TimeSeriesProperty.unit, advanced_filter=created_after_2020, aggregate_filter=not_test)
                 >>> print(result.unique)
         """
         self._validate_filter(advanced_filter)
@@ -457,8 +457,8 @@ class TimeSeriesAPI(APIClient):
 
                 >>> from cognite.client import CogniteClient
                 >>> from cognite.client.data_classes.time_series import TimeSeriesProperty
-                >>> c = CogniteClient()
-                >>> result = c.time_series.aggregate_unique_values(TimeSeriesProperty.metadata)
+                >>> client = CogniteClient()
+                >>> result = client.time_series.aggregate_unique_values(TimeSeriesProperty.metadata)
         """
         self._validate_filter(advanced_filter)
         return self._advanced_aggregate(
@@ -494,8 +494,8 @@ class TimeSeriesAPI(APIClient):
 
                 >>> from cognite.client import CogniteClient
                 >>> from cognite.client.data_classes import TimeSeriesWrite
-                >>> c = CogniteClient()
-                >>> ts = c.time_series.create(TimeSeriesWrite(name="my_ts", data_set_id=123, external_id="foo"))
+                >>> client = CogniteClient()
+                >>> ts = client.time_series.create(TimeSeriesWrite(name="my_ts", data_set_id=123, external_id="foo"))
         """
         return self._create_multiple(
             list_cls=TimeSeriesList,
@@ -522,8 +522,8 @@ class TimeSeriesAPI(APIClient):
             Delete time series by id or external id::
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
-                >>> c.time_series.delete(id=[1,2,3], external_id="3")
+                >>> client = CogniteClient()
+                >>> client.time_series.delete(id=[1,2,3], external_id="3")
         """
         self._delete_multiple(
             identifiers=IdentifierSequence.load(ids=id, external_ids=external_id),
@@ -559,18 +559,18 @@ class TimeSeriesAPI(APIClient):
             Update a time series that you have fetched. This will perform a full update of the time series::
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
-                >>> res = c.time_series.retrieve(id=1)
+                >>> client = CogniteClient()
+                >>> res = client.time_series.retrieve(id=1)
                 >>> res.description = "New description"
-                >>> res = c.time_series.update(res)
+                >>> res = client.time_series.update(res)
 
             Perform a partial update on a time series, updating the description and adding a new field to metadata::
 
                 >>> from cognite.client import CogniteClient
                 >>> from cognite.client.data_classes import TimeSeriesUpdate
-                >>> c = CogniteClient()
+                >>> client = CogniteClient()
                 >>> my_update = TimeSeriesUpdate(id=1).description.set("New description").metadata.add({"key": "value"})
-                >>> res = c.time_series.update(my_update)
+                >>> res = client.time_series.update(my_update)
         """
 
         return self._update_multiple(
@@ -614,11 +614,11 @@ class TimeSeriesAPI(APIClient):
 
                 >>> from cognite.client import CogniteClient
                 >>> from cognite.client.data_classes import TimeSeries
-                >>> c = CogniteClient()
-                >>> existing_time_series = c.time_series.retrieve(id=1)
+                >>> client = CogniteClient()
+                >>> existing_time_series = client.time_series.retrieve(id=1)
                 >>> existing_time_series.description = "New description"
                 >>> new_time_series = TimeSeries(external_id="new_timeSeries", description="New timeSeries")
-                >>> res = c.time_series.upsert([existing_time_series, new_time_series], mode="replace")
+                >>> res = client.time_series.upsert([existing_time_series, new_time_series], mode="replace")
         """
 
         return self._upsert_multiple(
@@ -656,14 +656,14 @@ class TimeSeriesAPI(APIClient):
             Search for a time series::
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
-                >>> res = c.time_series.search(name="some name")
+                >>> client = CogniteClient()
+                >>> res = client.time_series.search(name="some name")
 
             Search for all time series connected to asset with id 123::
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
-                >>> res = c.time_series.search(filter={"asset_ids":[123]})
+                >>> client = CogniteClient()
+                >>> res = client.time_series.search(filter={"asset_ids":[123]})
         """
 
         return self._search(
@@ -699,9 +699,9 @@ class TimeSeriesAPI(APIClient):
 
                 >>> from cognite.client import CogniteClient
                 >>> from cognite.client.data_classes.filters import Equals
-                >>> c = CogniteClient()
+                >>> client = CogniteClient()
                 >>> is_numeric = Equals("is_string", False)
-                >>> res = c.time_series.filter(filter=is_numeric, sort="external_id")
+                >>> res = client.time_series.filter(filter=is_numeric, sort="external_id")
 
             Note that you can check the API documentation above to see which properties you can filter on
             with which filters.
@@ -712,9 +712,9 @@ class TimeSeriesAPI(APIClient):
                 >>> from cognite.client import CogniteClient
                 >>> from cognite.client.data_classes.filters import Equals
                 >>> from cognite.client.data_classes.time_series import TimeSeriesProperty, SortableTimeSeriesProperty
-                >>> c = CogniteClient()
+                >>> client = CogniteClient()
                 >>> is_numeric = Equals(TimeSeriesProperty.is_string, False)
-                >>> res = c.time_series.filter(filter=is_numeric, sort=SortableTimeSeriesProperty.external_id)
+                >>> res = client.time_series.filter(filter=is_numeric, sort=SortableTimeSeriesProperty.external_id)
         """
         self._validate_filter(filter)
 
@@ -781,21 +781,21 @@ class TimeSeriesAPI(APIClient):
             List time series::
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
-                >>> res = c.time_series.list(limit=5)
+                >>> client = CogniteClient()
+                >>> res = client.time_series.list(limit=5)
 
             Iterate over time series::
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
-                >>> for ts in c.time_series:
+                >>> client = CogniteClient()
+                >>> for ts in client.time_series:
                 ...     ts # do something with the time series
 
             Iterate over chunks of time series to reduce memory load::
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
-                >>> for ts_list in c.time_series(chunk_size=2500):
+                >>> client = CogniteClient()
+                >>> for ts_list in client.time_series(chunk_size=2500):
                 ...     ts_list # do something with the time series
         """
         asset_subtree_ids_processed = process_asset_subtree_ids(asset_subtree_ids, asset_subtree_external_ids)

--- a/cognite/client/_api/transformations/__init__.py
+++ b/cognite/client/_api/transformations/__init__.py
@@ -71,7 +71,7 @@ class TransformationsAPI(APIClient):
                 >>> from cognite.client import CogniteClient
                 >>> from cognite.client.data_classes import TransformationWrite, TransformationDestination
                 >>> from cognite.client.data_classes.transformations.common import ViewInfo, EdgeType, DataModelInfo
-                >>> c = CogniteClient()
+                >>> client = CogniteClient()
                 >>> transformations = [
                 >>>     TransformationWrite(
                 >>>         external_id="transformation1",
@@ -121,7 +121,7 @@ class TransformationsAPI(APIClient):
                 >>>          destination=TransformationDestination.instances(data_model,"InstanceSpace")
                 >>>      ),
                 >>> ]
-                >>> res = c.transformations.create(transformations)
+                >>> res = client.transformations.create(transformations)
 
         """
         if isinstance(transformation, Sequence):
@@ -166,8 +166,8 @@ class TransformationsAPI(APIClient):
             Delete transformations by id or external id::
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
-                >>> c.transformations.delete(id=[1,2,3], external_id="function3")
+                >>> client = CogniteClient()
+                >>> client.transformations.delete(id=[1,2,3], external_id="function3")
         """
         self._delete_multiple(
             identifiers=IdentifierSequence.load(ids=id, external_ids=external_id),
@@ -216,8 +216,8 @@ class TransformationsAPI(APIClient):
             List transformations::
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
-                >>> transformations_list = c.transformations.list()
+                >>> client = CogniteClient()
+                >>> transformations_list = client.transformations.list()
         """
         ds_ids: list[dict[str, Any]] | None = None
         if data_set_ids and data_set_external_ids:
@@ -264,14 +264,14 @@ class TransformationsAPI(APIClient):
             Get transformation by id:
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
-                >>> res = c.transformations.retrieve(id=1)
+                >>> client = CogniteClient()
+                >>> res = client.transformations.retrieve(id=1)
 
             Get transformation by external id:
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
-                >>> res = c.transformations.retrieve(external_id="1")
+                >>> client = CogniteClient()
+                >>> res = client.transformations.retrieve(external_id="1")
         """
         identifiers = IdentifierSequence.load(ids=id, external_ids=external_id).as_singleton()
         return self._retrieve_multiple(
@@ -301,8 +301,8 @@ class TransformationsAPI(APIClient):
             Get multiple transformations:
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
-                >>> res = c.transformations.retrieve_multiple(ids=[1,2,3], external_ids=['transform-1','transform-2'])
+                >>> client = CogniteClient()
+                >>> res = client.transformations.retrieve_multiple(ids=[1,2,3], external_ids=['transform-1','transform-2'])
         """
         identifiers = IdentifierSequence.load(ids=ids, external_ids=external_ids)
         return self._retrieve_multiple(
@@ -340,23 +340,23 @@ class TransformationsAPI(APIClient):
             Update a transformation that you have fetched. This will perform a full update of the transformation::
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
-                >>> transformation = c.transformations.retrieve(id=1)
+                >>> client = CogniteClient()
+                >>> transformation = client.transformations.retrieve(id=1)
                 >>> transformation.query = "SELECT * FROM _cdf.assets"
-                >>> res = c.transformations.update(transformation)
+                >>> res = client.transformations.update(transformation)
 
             Perform a partial update on a transformation, updating the query and making it private::
 
                 >>> from cognite.client.data_classes import TransformationUpdate
-                >>> my_update = TransformationUpdate(id=1).query.set("SELECT * FROM _cdf.assets").is_public.set(False)
-                >>> res = c.transformations.update(my_update)
+                >>> my_update = TransformationUpdate(id=1).query.set("SELECT * FROM _cdf.assets").is_publiclient.set(False)
+                >>> res = client.transformations.update(my_update)
 
             Update the session used for reading (source) and writing (destination) when authenticating for all
             transformations in a given data set:
 
                 >>> from cognite.client.data_classes import NonceCredentials
-                >>> to_update = c.transformations.list(data_set_external_ids=["foo"])
-                >>> new_session = c.iam.sessions.create()
+                >>> to_update = client.transformations.list(data_set_external_ids=["foo"])
+                >>> new_session = client.iam.sessions.create()
                 >>> new_nonce = NonceCredentials(
                 ...     session_id=new_session.id,
                 ...     nonce=new_session.nonce,
@@ -365,7 +365,7 @@ class TransformationsAPI(APIClient):
                 >>> for tr in to_update:
                 ...     tr.source_nonce = new_nonce
                 ...     tr.destination_nonce = new_nonce
-                >>> res = c.transformations.update(to_update)
+                >>> res = client.transformations.update(to_update)
         """
         if isinstance(item, Sequence):
             item = list(item)
@@ -412,16 +412,16 @@ class TransformationsAPI(APIClient):
             Run transformation to completion by id:
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
+                >>> client = CogniteClient()
                 >>>
-                >>> res = c.transformations.run(transformation_id = 1)
+                >>> res = client.transformations.run(transformation_id = 1)
 
             Start running transformation by id:
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
+                >>> client = CogniteClient()
                 >>>
-                >>> res = c.transformations.run(transformation_id = 1, wait = False)
+                >>> res = client.transformations.run(transformation_id = 1, wait = False)
         """
         IdentifierSequence.load(transformation_id, transformation_external_id).assert_singleton()
 
@@ -458,10 +458,10 @@ class TransformationsAPI(APIClient):
                 >>> import asyncio
                 >>> from cognite.client import CogniteClient
                 >>>
-                >>> c = CogniteClient()
+                >>> client = CogniteClient()
                 >>>
                 >>> async def run_transformation():
-                >>>     res = await c.transformations.run_async(id = 1)
+                >>>     res = await client.transformations.run_async(id = 1)
                 >>>
                 >>> loop = asyncio.get_event_loop()
                 >>> loop.run_until_complete(run_transformation())
@@ -486,9 +486,9 @@ class TransformationsAPI(APIClient):
 
                 >>> from cognite.client import CogniteClient
                 >>> from cognite.client.data_classes import TransformationJobStatus
-                >>> c = CogniteClient()
+                >>> client = CogniteClient()
                 >>>
-                >>> res = c.transformations.run(id = 1, timeout = 60.0)
+                >>> res = client.transformations.run(id = 1, timeout = 60.0)
                 >>> if res.status == TransformationJobStatus.RUNNING:
                 >>>     res.cancel()
         """
@@ -523,16 +523,16 @@ class TransformationsAPI(APIClient):
             Preview transformation results as schema and list of rows:
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
+                >>> client = CogniteClient()
                 >>>
-                >>> query_result = c.transformations.preview(query="select * from _cdf.assets")
+                >>> query_result = client.transformations.preview(query="select * from _cdf.assets")
 
             Preview transformation results as pandas dataframe:
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
+                >>> client = CogniteClient()
                 >>>
-                >>> df = c.transformations.preview(query="select * from _cdf.assets").to_pandas()
+                >>> df = client.transformations.preview(query="select * from _cdf.assets").to_pandas()
         """
         request_body = {
             "query": query,

--- a/cognite/client/_api/transformations/__init__.py
+++ b/cognite/client/_api/transformations/__init__.py
@@ -360,7 +360,7 @@ class TransformationsAPI(APIClient):
                 >>> new_nonce = NonceCredentials(
                 ...     session_id=new_session.id,
                 ...     nonce=new_session.nonce,
-                ...     cdf_project_name=c.config.project
+                ...     cdf_project_name=client.config.project
                 ... )
                 >>> for tr in to_update:
                 ...     tr.source_nonce = new_nonce

--- a/cognite/client/_api/transformations/jobs.py
+++ b/cognite/client/_api/transformations/jobs.py
@@ -39,14 +39,14 @@ class TransformationJobsAPI(APIClient):
             List transformation jobs::
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
-                >>> transformation_jobs_list = c.transformations.jobs.list()
+                >>> client = CogniteClient()
+                >>> transformation_jobs_list = client.transformations.jobs.list()
 
             List transformation jobs of a single transformation::
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
-                >>> transformation_jobs_list = c.transformations.jobs.list(transformation_id=1)
+                >>> client = CogniteClient()
+                >>> transformation_jobs_list = client.transformations.jobs.list(transformation_id=1)
         """
 
         filter = TransformationJobFilter(
@@ -71,8 +71,8 @@ class TransformationJobsAPI(APIClient):
             Get transformation job by id:
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
-                >>> res = c.transformations.jobs.retrieve(id=1)
+                >>> client = CogniteClient()
+                >>> res = client.transformations.jobs.retrieve(id=1)
         """
         identifiers = IdentifierSequence.load(ids=id, external_ids=None).as_singleton()
         return self._retrieve_multiple(
@@ -93,8 +93,8 @@ class TransformationJobsAPI(APIClient):
             Get metrics by transformation job id:
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
-                >>> res = c.transformations.jobs.list_metrics(id=1)
+                >>> client = CogniteClient()
+                >>> res = client.transformations.jobs.list_metrics(id=1)
         """
         url_path = interpolate_and_url_encode(self._RESOURCE_PATH + "/{}/metrics", str(id))
 
@@ -121,8 +121,8 @@ class TransformationJobsAPI(APIClient):
             Get jobs by id::
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
-                >>> res = c.transformations.jobs.retrieve_multiple(ids=[1, 2, 3])
+                >>> client = CogniteClient()
+                >>> res = client.transformations.jobs.retrieve_multiple(ids=[1, 2, 3])
         """
         identifiers = IdentifierSequence.load(ids=ids, external_ids=None)
         return self._retrieve_multiple(

--- a/cognite/client/_api/transformations/notifications.py
+++ b/cognite/client/_api/transformations/notifications.py
@@ -34,9 +34,9 @@ class TransformationNotificationsAPI(APIClient):
 
                 >>> from cognite.client import CogniteClient
                 >>> from cognite.client.data_classes import TransformationNotification
-                >>> c = CogniteClient()
+                >>> client = CogniteClient()
                 >>> notifications = [TransformationNotification(transformation_id = 1, destination="my@email.com"), TransformationNotification(transformation_external_id="transformation2", destination="other@email.com"))]
-                >>> res = c.transformations.notifications.create(notifications)
+                >>> res = client.transformations.notifications.create(notifications)
         """
         assert_type(notification, "notification", [TransformationNotificationCore, Sequence])
         return self._create_multiple(
@@ -69,14 +69,14 @@ class TransformationNotificationsAPI(APIClient):
             List all notifications::
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
-                >>> notifications_list = c.transformations.notifications.list()
+                >>> client = CogniteClient()
+                >>> notifications_list = client.transformations.notifications.list()
 
             List all notifications by transformation id::
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
-                >>> notifications_list = c.transformations.notifications.list(transformation_id = 1)
+                >>> client = CogniteClient()
+                >>> notifications_list = client.transformations.notifications.list(transformation_id = 1)
         """
         filter = TransformationNotificationFilter(
             transformation_id=transformation_id,
@@ -103,7 +103,7 @@ class TransformationNotificationsAPI(APIClient):
             Delete schedules by id or external id::
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
-                >>> c.transformations.notifications.delete(id=[1,2,3])
+                >>> client = CogniteClient()
+                >>> client.transformations.notifications.delete(id=[1,2,3])
         """
         self._delete_multiple(identifiers=IdentifierSequence.load(ids=id), wrap_ids=True)

--- a/cognite/client/_api/transformations/schedules.py
+++ b/cognite/client/_api/transformations/schedules.py
@@ -61,9 +61,9 @@ class TransformationSchedulesAPI(APIClient):
 
                 >>> from cognite.client import CogniteClient
                 >>> from cognite.client.data_classes import TransformationScheduleWrite
-                >>> c = CogniteClient()
+                >>> client = CogniteClient()
                 >>> schedules = [TransformationScheduleWrite(id = 1, interval = "0 * * * *"), TransformationScheduleWrite(external_id="transformation2", interval = "5 * * * *"))]
-                >>> res = c.transformations.schedules.create(schedules)
+                >>> res = client.transformations.schedules.create(schedules)
         """
         assert_type(schedule, "schedule", [TransformationScheduleCore, Sequence])
 
@@ -89,14 +89,14 @@ class TransformationSchedulesAPI(APIClient):
             Get transformation schedule by transformation id:
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
-                >>> res = c.transformations.schedules.retrieve(id=1)
+                >>> client = CogniteClient()
+                >>> res = client.transformations.schedules.retrieve(id=1)
 
             Get transformation schedule by transformation external id:
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
-                >>> res = c.transformations.schedules.retrieve(external_id="1")
+                >>> client = CogniteClient()
+                >>> res = client.transformations.schedules.retrieve(external_id="1")
         """
         identifiers = IdentifierSequence.load(ids=id, external_ids=external_id).as_singleton()
         return self._retrieve_multiple(
@@ -124,14 +124,14 @@ class TransformationSchedulesAPI(APIClient):
             Get transformation schedules by transformation ids:
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
-                >>> res = c.transformations.schedules.retrieve_multiple(ids=[1, 2, 3])
+                >>> client = CogniteClient()
+                >>> res = client.transformations.schedules.retrieve_multiple(ids=[1, 2, 3])
 
             Get transformation schedules by transformation external ids:
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
-                >>> res = c.transformations.schedules.retrieve_multiple(external_ids=["t1", "t2"])
+                >>> client = CogniteClient()
+                >>> res = client.transformations.schedules.retrieve_multiple(external_ids=["t1", "t2"])
         """
         identifiers = IdentifierSequence.load(ids=ids, external_ids=external_ids)
         return self._retrieve_multiple(
@@ -156,8 +156,8 @@ class TransformationSchedulesAPI(APIClient):
             List schedules::
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
-                >>> schedules_list = c.transformations.schedules.list()
+                >>> client = CogniteClient()
+                >>> schedules_list = client.transformations.schedules.list()
         """
         filter = TransformationFilter(include_public=include_public).dump(camel_case=True)
 
@@ -187,8 +187,8 @@ class TransformationSchedulesAPI(APIClient):
             Delete schedules by id or external id::
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
-                >>> c.transformations.schedules.delete(id=[1,2,3], external_id="3")
+                >>> client = CogniteClient()
+                >>> client.transformations.schedules.delete(id=[1,2,3], external_id="3")
         """
         self._delete_multiple(
             identifiers=IdentifierSequence.load(ids=id, external_ids=external_id),
@@ -228,18 +228,18 @@ class TransformationSchedulesAPI(APIClient):
             Update a transformation schedule that you have fetched. This will perform a full update of the schedule::
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
-                >>> transformation_schedule = c.transformations.schedules.retrieve(id=1)
+                >>> client = CogniteClient()
+                >>> transformation_schedule = client.transformations.schedules.retrieve(id=1)
                 >>> transformation_schedule.is_paused = True
-                >>> res = c.transformations.schedules.update(transformation_schedule)
+                >>> res = client.transformations.schedules.update(transformation_schedule)
 
             Perform a partial update on a transformation schedule, updating the interval and unpausing it::
 
                 >>> from cognite.client import CogniteClient
                 >>> from cognite.client.data_classes import TransformationScheduleUpdate
-                >>> c = CogniteClient()
+                >>> client = CogniteClient()
                 >>> my_update = TransformationScheduleUpdate(id=1).interval.set("0 * * * *").is_paused.set(False)
-                >>> res = c.transformations.schedules.update(my_update)
+                >>> res = client.transformations.schedules.update(my_update)
         """
         return self._update_multiple(
             list_cls=TransformationScheduleList,

--- a/cognite/client/_api/transformations/schema.py
+++ b/cognite/client/_api/transformations/schema.py
@@ -30,8 +30,8 @@ class TransformationSchemaAPI(APIClient):
 
                 >>> from cognite.client import CogniteClient
                 >>> from cognite.client.data_classes import TransformationDestination
-                >>> c = CogniteClient()
-                >>> columns = c.transformations.schema.retrieve(destination = TransformationDestination.assets())
+                >>> client = CogniteClient()
+                >>> columns = client.transformations.schema.retrieve(destination = TransformationDestination.assets())
         """
 
         url_path = interpolate_and_url_encode(self._RESOURCE_PATH + "/{}", str(destination.type))

--- a/cognite/client/_api/units.py
+++ b/cognite/client/_api/units.py
@@ -53,14 +53,14 @@ class UnitAPI(APIClient):
             Retrive unit 'temperature:deg_c'::
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
-                >>> res = c.units.retrieve('temperature:deg_c')
+                >>> client = CogniteClient()
+                >>> res = client.units.retrieve('temperature:deg_c')
 
             Retrive units 'temperature:deg_c' and 'pressure:bar'::
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
-                >>> res = c.units.retrieve(['temperature:deg_c', 'pressure:bar'])
+                >>> client = CogniteClient()
+                >>> res = client.units.retrieve(['temperature:deg_c', 'pressure:bar'])
 
         """
         identifier = IdentifierSequence.load(external_ids=external_id)
@@ -82,8 +82,8 @@ class UnitAPI(APIClient):
             List all supported unit in CDF::
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
-                >>> res = c.units.list()
+                >>> client = CogniteClient()
+                >>> res = client.units.list()
         """
         return self._list(method="GET", list_cls=UnitList, resource_cls=Unit)
 
@@ -102,8 +102,8 @@ class UnitSystemAPI(APIClient):
             List all supported unit systems in CDF::
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
-                >>> res = c.units.systems.list()
+                >>> client = CogniteClient()
+                >>> res = client.units.systems.list()
 
         """
         return self._list(method="GET", list_cls=UnitSystemList, resource_cls=UnitSystem)

--- a/cognite/client/_api/user_profiles.py
+++ b/cognite/client/_api/user_profiles.py
@@ -38,8 +38,8 @@ class UserProfilesAPI(APIClient):
             Get your own user profile:
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
-                >>> res = c.iam.user_profiles.me()
+                >>> client = CogniteClient()
+                >>> res = client.iam.user_profiles.me()
         """
         return UserProfile.load(self._get(self._RESOURCE_PATH + "/me").json())
 
@@ -70,12 +70,12 @@ class UserProfilesAPI(APIClient):
             Get a single user profile:
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
-                >>> res = c.iam.user_profiles.retrieve("foo")
+                >>> client = CogniteClient()
+                >>> res = client.iam.user_profiles.retrieve("foo")
 
             Get multiple user profiles:
 
-                >>> res = c.iam.user_profiles.retrieve(["bar", "baz"])
+                >>> res = client.iam.user_profiles.retrieve(["bar", "baz"])
         """
         identifiers = UserIdentifierSequence.load(user_identifier)
         profiles = self._retrieve_multiple(
@@ -105,8 +105,8 @@ class UserProfilesAPI(APIClient):
             Search for users with first (or second...) name starting with "Alex":
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
-                >>> res = c.iam.user_profiles.search(name="Alex")
+                >>> client = CogniteClient()
+                >>> res = client.iam.user_profiles.search(name="Alex")
         """
         return self._search(
             list_cls=UserProfileList,
@@ -131,8 +131,8 @@ class UserProfilesAPI(APIClient):
             List all user profiles:
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
-                >>> res = c.iam.user_profiles.list(limit=None)
+                >>> client = CogniteClient()
+                >>> res = client.iam.user_profiles.list(limit=None)
         """
         return self._list(
             "GET",

--- a/cognite/client/_api/vision.py
+++ b/cognite/client/_api/vision.py
@@ -81,8 +81,8 @@ class VisionAPI(APIClient):
 
                 >>> from cognite.client import CogniteClient
                 >>> from cognite.client.data_classes.contextualization import VisionFeature
-                >>> c = CogniteClient()
-                >>> extract_job = c.vision.extract(features=VisionFeature.ASSET_TAG_DETECTION, file_ids=[1])
+                >>> client = CogniteClient()
+                >>> extract_job = client.vision.extract(features=VisionFeature.ASSET_TAG_DETECTION, file_ids=[1])
                 >>> extract_job.wait_for_completion()
                 >>> for item in extract_job.items:
                 ...     predictions = item.predictions
@@ -129,8 +129,8 @@ class VisionAPI(APIClient):
             Retrieve a vision extract job by ID::
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
-                >>> extract_job = c.vision.get_extract_job(job_id=1)
+                >>> client = CogniteClient()
+                >>> extract_job = client.vision.get_extract_job(job_id=1)
                 >>> extract_job.wait_for_completion()
                 >>> for item in extract_job.items:
                 ...     predictions = item.predictions

--- a/cognite/client/_api/workflows.py
+++ b/cognite/client/_api/workflows.py
@@ -78,22 +78,22 @@ class WorkflowTaskAPI(BetaWorkflowAPIClient):
             Update task with UUID '000560bc-9080-4286-b242-a27bb4819253' to status 'completed':
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
-                >>> res = c.workflows.tasks.update("000560bc-9080-4286-b242-a27bb4819253", "completed")
+                >>> client = CogniteClient()
+                >>> res = client.workflows.tasks.update("000560bc-9080-4286-b242-a27bb4819253", "completed")
 
             Update task with UUID '000560bc-9080-4286-b242-a27bb4819253' to status 'failed' with output '{"a": 1, "b": 2}':
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
-                >>> res = c.workflows.tasks.update("000560bc-9080-4286-b242-a27bb4819253", "failed", output={"a": 1, "b": 2})
+                >>> client = CogniteClient()
+                >>> res = client.workflows.tasks.update("000560bc-9080-4286-b242-a27bb4819253", "failed", output={"a": 1, "b": 2})
 
             Trigger workflow, retrieve detailed task execution and update status of the second task (assumed to be async) to 'completed':
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
-                >>> res = c.workflows.executions.trigger("my workflow", "1")
-                >>> res = c.workflows.executions.retrieve_detailed(res.id)
-                >>> res = c.workflows.tasks.update(res.tasks[1].id, "completed")
+                >>> client = CogniteClient()
+                >>> res = client.workflows.executions.trigger("my workflow", "1")
+                >>> res = client.workflows.executions.retrieve_detailed(res.id)
+                >>> res = client.workflows.tasks.update(res.tasks[1].id, "completed")
 
         """
         self._warning.warn()
@@ -125,15 +125,15 @@ class WorkflowExecutionAPI(BetaWorkflowAPIClient):
             Retrieve workflow execution with UUID '000560bc-9080-4286-b242-a27bb4819253':
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
-                >>> res = c.workflows.executions.retrieve_detailed("000560bc-9080-4286-b242-a27bb4819253")
+                >>> client = CogniteClient()
+                >>> res = client.workflows.executions.retrieve_detailed("000560bc-9080-4286-b242-a27bb4819253")
 
             List workflow executions and retrieve detailed information for the first one:
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
-                >>> res = c.workflows.executions.list()
-                >>> res = c.workflows.executions.retrieve_detailed(res[0].id)
+                >>> client = CogniteClient()
+                >>> res = client.workflows.executions.list()
+                >>> res = client.workflows.executions.retrieve_detailed(res[0].id)
 
         """
         self._warning.warn()
@@ -181,19 +181,19 @@ class WorkflowExecutionAPI(BetaWorkflowAPIClient):
             Trigger a workflow execution for the workflow "foo", version 1:
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
-                >>> res = c.workflows.executions.trigger("foo", "1")
+                >>> client = CogniteClient()
+                >>> res = client.workflows.executions.trigger("foo", "1")
 
             Trigger a workflow execution with input data:
 
-                >>> res = c.workflows.executions.trigger("foo", "1", input={"a": 1, "b": 2})
+                >>> res = client.workflows.executions.trigger("foo", "1", input={"a": 1, "b": 2})
 
             Trigger a workflow execution using a specific set of client credentials (i.e. not your current credentials):
 
                 >>> import os
                 >>> from cognite.client.data_classes import ClientCredentials
                 >>> credentials = ClientCredentials("my-client-id", os.environ["MY_CLIENT_SECRET"])
-                >>> res = c.workflows.executions.trigger("foo", "1", client_credentials=credentials)
+                >>> res = client.workflows.executions.trigger("foo", "1", client_credentials=credentials)
         """
         self._warning.warn()
         nonce = create_session_and_return_nonce(
@@ -232,15 +232,15 @@ class WorkflowExecutionAPI(BetaWorkflowAPIClient):
             Get all workflow executions for workflows 'my_workflow' version '1':
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
-                >>> res = c.workflows.executions.list(("my_workflow", "1"))
+                >>> client = CogniteClient()
+                >>> res = client.workflows.executions.list(("my_workflow", "1"))
 
             Get all workflow executions for workflows after last 24 hours:
 
                 >>> from cognite.client import CogniteClient
                 >>> from datetime import datetime, timedelta
-                >>> c = CogniteClient()
-                >>> res = c.workflows.executions.list(created_time_start=int((datetime.now() - timedelta(days=1)).timestamp() * 1000))
+                >>> client = CogniteClient()
+                >>> res = client.workflows.executions.list(created_time_start=int((datetime.now() - timedelta(days=1)).timestamp() * 1000))
 
         """
         self._warning.warn()
@@ -281,9 +281,9 @@ class WorkflowExecutionAPI(BetaWorkflowAPIClient):
 
                 >>> from cognite.client import CogniteClient
                 >>> from cognite.client.data_classes import CancelExecution
-                >>> c = CogniteClient()
-                >>> res = c.workflows.executions.trigger("foo", "1")
-                >>> c.workflows.executions.cancel([CancelExecution(res.id, "test cancelation")])
+                >>> client = CogniteClient()
+                >>> res = client.workflows.executions.trigger("foo", "1")
+                >>> client.workflows.executions.cancel([CancelExecution(res.id, "test cancelation")])
         """
         self._warning.warn()
         response = self._post(
@@ -321,7 +321,7 @@ class WorkflowVersionAPI(BetaWorkflowAPIClient):
 
                 >>> from cognite.client import CogniteClient
                 >>> from cognite.client.data_classes import WorkflowVersionUpsert, WorkflowDefinitionUpsert, WorkflowTask, FunctionTaskParameters
-                >>> c = CogniteClient()
+                >>> client = CogniteClient()
                 >>> new_version = WorkflowVersionUpsert(
                 ...    workflow_external_id="my_workflow",
                 ...    version="1",
@@ -338,7 +338,7 @@ class WorkflowVersionAPI(BetaWorkflowAPIClient):
                 ...        description="This workflow has one step",
                 ...    ),
                 ... )
-                >>> res = c.workflows.versions.upsert(new_version)
+                >>> res = client.workflows.versions.upsert(new_version)
         """
         self._warning.warn()
         if mode != "replace":
@@ -367,15 +367,15 @@ class WorkflowVersionAPI(BetaWorkflowAPIClient):
             Delete workflow version "1" of workflow "my workflow" specified by using a tuple:
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
-                >>> c.workflows.versions.delete(("my workflow", "1"))
+                >>> client = CogniteClient()
+                >>> client.workflows.versions.delete(("my workflow", "1"))
 
             Delete workflow version "1" of workflow "my workflow" and workflow version "2" of workflow "my workflow 2" using the WorkflowVersionId class:
 
                 >>> from cognite.client import CogniteClient
                 >>> from cognite.client.data_classes import WorkflowVersionId
-                >>> c = CogniteClient()
-                >>> c.workflows.versions.delete([WorkflowVersionId("my workflow", "1"), WorkflowVersionId("my workflow 2", "2")])
+                >>> client = CogniteClient()
+                >>> client.workflows.versions.delete([WorkflowVersionId("my workflow", "1"), WorkflowVersionId("my workflow 2", "2")])
 
         """
         self._warning.warn()
@@ -401,8 +401,8 @@ class WorkflowVersionAPI(BetaWorkflowAPIClient):
             Retrieve workflow version 1 of workflow my workflow:
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
-                >>> res = c.workflows.versions.retrieve("my workflow", "1")
+                >>> client = CogniteClient()
+                >>> res = client.workflows.versions.retrieve("my workflow", "1")
         """
         self._warning.warn()
         try:
@@ -435,21 +435,21 @@ class WorkflowVersionAPI(BetaWorkflowAPIClient):
             Get all workflow version for workflows 'my_workflow' and 'my_workflow_2':
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
-                >>> res = c.workflows.versions.list(["my_workflow", "my_workflow_2"])
+                >>> client = CogniteClient()
+                >>> res = client.workflows.versions.list(["my_workflow", "my_workflow_2"])
 
             Get all workflow versions for workflows 'my_workflow' and 'my_workflow_2' using the WorkflowVersionId class:
 
                 >>> from cognite.client import CogniteClient
                 >>> from cognite.client.data_classes import WorkflowVersionId
-                >>> c = CogniteClient()
-                >>> res = c.workflows.versions.list([WorkflowVersionId("my_workflow"), WorkflowVersionId("my_workflow_2")])
+                >>> client = CogniteClient()
+                >>> res = client.workflows.versions.list([WorkflowVersionId("my_workflow"), WorkflowVersionId("my_workflow_2")])
 
             Get all workflow versions for workflows 'my_workflow' version '1' and 'my_workflow_2' version '2' using tuples:
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
-                >>> res = c.workflows.versions.list([("my_workflow", "1"), ("my_workflow_2", "2")])
+                >>> client = CogniteClient()
+                >>> res = client.workflows.versions.list([("my_workflow", "1"), ("my_workflow_2", "2")])
 
         """
         self._warning.warn()
@@ -500,8 +500,8 @@ class WorkflowAPI(BetaWorkflowAPIClient):
 
                 >>> from cognite.client import CogniteClient
                 >>> from cognite.client.data_classes import WorkflowUpsert
-                >>> c = CogniteClient()
-                >>> res = c.workflows.upsert(WorkflowUpsert(external_id="my workflow", description="my workflow description"))
+                >>> client = CogniteClient()
+                >>> res = client.workflows.upsert(WorkflowUpsert(external_id="my workflow", description="my workflow description"))
         """
         self._warning.warn()
         if mode != "replace":
@@ -527,8 +527,8 @@ class WorkflowAPI(BetaWorkflowAPIClient):
             Retrieve workflow my workflow:
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
-                >>> res = c.workflows.retrieve("my workflow")
+                >>> client = CogniteClient()
+                >>> res = client.workflows.retrieve("my workflow")
         """
         self._warning.warn()
         try:
@@ -551,8 +551,8 @@ class WorkflowAPI(BetaWorkflowAPIClient):
             Delete workflow my workflow:
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
-                >>> c.workflows.delete("my workflow")
+                >>> client = CogniteClient()
+                >>> client.workflows.delete("my workflow")
         """
         self._warning.warn()
         self._delete_multiple(
@@ -574,8 +574,8 @@ class WorkflowAPI(BetaWorkflowAPIClient):
             List all workflows:
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
-                >>> res = c.workflows.list()
+                >>> client = CogniteClient()
+                >>> res = client.workflows.list()
         """
         self._warning.warn()
 

--- a/cognite/client/_version.py
+++ b/cognite/client/_version.py
@@ -1,4 +1,4 @@
 from __future__ import annotations
 
-__version__ = "7.20.1"
+__version__ = "7.20.2"
 __api_subversion__ = "V20220125"

--- a/cognite/client/_version.py
+++ b/cognite/client/_version.py
@@ -1,4 +1,4 @@
 from __future__ import annotations
 
-__version__ = "7.20.2"
+__version__ = "7.20.1"
 __api_subversion__ = "V20220125"

--- a/cognite/client/data_classes/geospatial.py
+++ b/cognite/client/data_classes/geospatial.py
@@ -359,8 +359,8 @@ class FeatureListCore(WriteableCogniteResourceList[FeatureWrite, T_Feature], Ext
 
                 >>> from cognite.client.data_classes.geospatial import PropertyAndSearchSpec
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
-                >>> features = c.geospatial.search_features(...)
+                >>> client = CogniteClient()
+                >>> features = client.geospatial.search_features(...)
                 >>> gdf = features.to_geopandas(
                 ...     geometry="position",
                 ...     camel_case=False
@@ -398,13 +398,13 @@ class FeatureListCore(WriteableCogniteResourceList[FeatureWrite, T_Feature], Ext
             Create features from a geopandas dataframe:
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
+                >>> client = CogniteClient()
                 >>> my_feature_type = ... # some feature type with 'position' and 'temperature' properties
                 >>> my_geodataframe = ...  # some geodataframe with 'center_xy', 'temp' and 'id' columns
                 >>> feature_list = FeatureList.from_geopandas(feature_type=my_feature_type, geodataframe=my_geodataframe,
                 >>>     external_id_column="id", data_set_id_column="dataSetId",
                 >>>     property_column_mapping={'position': 'center_xy', 'temperature': 'temp'})
-                >>> created_features = c.geospatial.create_features(my_feature_type.external_id, feature_list)
+                >>> created_features = client.geospatial.create_features(my_feature_type.external_id, feature_list)
 
         """
         features = []

--- a/cognite/client/data_classes/transformations/jobs.py
+++ b/cognite/client/data_classes/transformations/jobs.py
@@ -146,21 +146,21 @@ class TransformationJob(CogniteResource):
             run transformations 1 and 2 in parallel, and run 3 once they finish successfully:
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
+                >>> client = CogniteClient()
                 >>>
-                >>> job1 = c.transformations.run(id = 1, wait = False)
-                >>> job2 = c.transformations.run(id = 2, wait = False)
+                >>> job1 = client.transformations.run(id = 1, wait = False)
+                >>> job2 = client.transformations.run(id = 2, wait = False)
                 >>> job1.wait()
                 >>> job2.wait()
                 >>> if TransformationJobStatus.FAILED not in [job1.status, job2.status]:
-                >>>     c.transformations.run(id = 3, wait = False)
+                >>>     client.transformations.run(id = 3, wait = False)
 
             wait transformation for 5 minutes and do something if still running:
 
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
+                >>> client = CogniteClient()
                 >>>
-                >>> job = c.transformations.run(id = 1, wait = False)
+                >>> job = client.transformations.run(id = 1, wait = False)
                 >>> job.wait(timeout = 5.0*60)
                 >>> if job.status == TransformationJobStatus.FAILED:
                 >>>     # do something if job failed
@@ -200,15 +200,15 @@ class TransformationJob(CogniteResource):
 
                 >>> from asyncio import ensure_future
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
+                >>> client = CogniteClient()
                 >>>
                 >>> async def run_successive_transformations():
-                >>>     job1 = c.transformations.run(id = 1, wait = False)
-                >>>     job2 = c.transformations.run(id = 2, wait = False)
+                >>>     job1 = client.transformations.run(id = 1, wait = False)
+                >>>     job2 = client.transformations.run(id = 2, wait = False)
                 >>>     await job1.wait_async()
                 >>>     await job2.wait_async()
                 >>>     if TransformationJobStatus.FAILED not in [job1.status, job2.status]:
-                >>>         c.transformations.run(id = 3, wait = False)
+                >>>         client.transformations.run(id = 3, wait = False)
                 >>>
                 >>> ensure_future(run_successive_transformations())
 
@@ -216,10 +216,10 @@ class TransformationJob(CogniteResource):
 
                 >>> from asyncio import ensure_future
                 >>> from cognite.client import CogniteClient
-                >>> c = CogniteClient()
+                >>> client = CogniteClient()
                 >>>
                 >>> async def run_successive_transformations():
-                >>>     job = c.transformations.run(id = 1, wait = False)
+                >>>     job = client.transformations.run(id = 1, wait = False)
                 >>>     await job.wait_async(timeout = 5.0*60)
                 >>>     if job.status == TransformationJobStatus.FAILED:
                 >>>         # do something if job failed

--- a/cognite/client/exceptions.py
+++ b/cognite/client/exceptions.py
@@ -144,10 +144,10 @@ class CogniteAPIError(CogniteMultiException):
             from cognite.client import CogniteClient
             from cognite.client.exceptions import CogniteAPIError
 
-            c = CogniteClient()
+            client = CogniteClient()
 
             try:
-                c.iam.token.inspect()
+                client.iam.token.inspect()
             except CogniteAPIError as e:
                 if e.code == 401:
                     print("You are not authorized")

--- a/cognite/client/testing.py
+++ b/cognite/client/testing.py
@@ -182,7 +182,7 @@ def monkeypatch_cognite_client() -> Iterator[CogniteClientMock]:
             >>> from cognite.client.testing import monkeypatch_cognite_client
             >>>
             >>> with monkeypatch_cognite_client():
-            >>>     c = CogniteClient()
+            >>>     client = CogniteClient()
             >>>     client.time_series.create(TimeSeries(external_id="blabla"))
 
         This example shows how to set the return value of a given method::
@@ -195,7 +195,7 @@ def monkeypatch_cognite_client() -> Iterator[CogniteClientMock]:
             >>>     c_mock.iam.token.inspect.return_value = TokenInspection(
             >>>         subject="subject", projects=[], capabilities=[]
             >>>     )
-            >>>     c = CogniteClient()
+            >>>     client = CogniteClient()
             >>>     res = client.iam.token.inspect()
             >>>     assert "subject" == res.subject
 
@@ -207,7 +207,7 @@ def monkeypatch_cognite_client() -> Iterator[CogniteClientMock]:
             >>>
             >>> with monkeypatch_cognite_client() as c_mock:
             >>>     c_mock.iam.token.inspect.side_effect = CogniteAPIError(message="Something went wrong", code=400)
-            >>>     c = CogniteClient()
+            >>>     client = CogniteClient()
             >>>     try:
             >>>         res = client.iam.token.inspect()
             >>>     except CogniteAPIError as e:

--- a/cognite/client/testing.py
+++ b/cognite/client/testing.py
@@ -183,7 +183,7 @@ def monkeypatch_cognite_client() -> Iterator[CogniteClientMock]:
             >>>
             >>> with monkeypatch_cognite_client():
             >>>     c = CogniteClient()
-            >>>     c.time_series.create(TimeSeries(external_id="blabla"))
+            >>>     client.time_series.create(TimeSeries(external_id="blabla"))
 
         This example shows how to set the return value of a given method::
 
@@ -196,7 +196,7 @@ def monkeypatch_cognite_client() -> Iterator[CogniteClientMock]:
             >>>         subject="subject", projects=[], capabilities=[]
             >>>     )
             >>>     c = CogniteClient()
-            >>>     res = c.iam.token.inspect()
+            >>>     res = client.iam.token.inspect()
             >>>     assert "subject" == res.subject
 
         Here you can see how to have a given method raise an exception::
@@ -209,7 +209,7 @@ def monkeypatch_cognite_client() -> Iterator[CogniteClientMock]:
             >>>     c_mock.iam.token.inspect.side_effect = CogniteAPIError(message="Something went wrong", code=400)
             >>>     c = CogniteClient()
             >>>     try:
-            >>>         res = c.iam.token.inspect()
+            >>>         res = client.iam.token.inspect()
             >>>     except CogniteAPIError as e:
             >>>         assert 400 == e.code
             >>>         assert "Something went wrong" == e.message

--- a/docs/source/contextualization.rst
+++ b/docs/source/contextualization.rst
@@ -58,8 +58,8 @@ Start an asynchronous job to extract information from image files stored in CDF:
     from cognite.client import CogniteClient
     from cognite.client.data_classes.contextualization import VisionFeature
 
-    c = CogniteClient()
-    extract_job = c.vision.extract(
+    client = CogniteClient()
+    extract_job = client.vision.extract(
         features=[VisionFeature.ASSET_TAG_DETECTION, VisionFeature.PEOPLE_DETECTION],
         file_ids=[1, 2],
     )
@@ -90,7 +90,7 @@ Tweaking the parameters of a feature extractor:
 
     from cognite.client.data_classes.contextualization import FeatureParameters, TextDetectionParameters
 
-    extract_job = c.vision.extract(
+    extract_job = client.vision.extract(
         features=VisionFeature.TEXT_DETECTION,
         file_ids=[1, 2],
         parameters=FeatureParameters(text_detection_parameters=TextDetectionParameters(threshold=0.9))

--- a/docs/source/data_modeling.rst
+++ b/docs/source/data_modeling.rst
@@ -148,7 +148,7 @@ Example on syncing instances to local sqlite
     )
     from cognite.client.data_classes.filters import Equals
 
-    c = CogniteClient()
+    client = CogniteClient()
 
 
     def sqlite_connection(db_name: str) -> sqlite3.Connection:
@@ -220,7 +220,7 @@ Example on syncing instances to local sqlite
                 connection.commit()
             print(f"Wrote {len(inserts)} nodes and deleted {len(deletes)} nodes")
 
-        return c.data_modeling.instances.subscribe(query, _sync_batch_to_sqlite)
+        return client.data_modeling.instances.subscribe(query, _sync_batch_to_sqlite)
 
 
     if __name__ == "__main__":

--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -41,7 +41,7 @@ Use one of the credential providers such as OAuthClientCredentials to authentica
     )
 
     global_config.default_client_config = cnf
-    c = CogniteClient()
+    client = CogniteClient()
 
 Examples for all OAuth credential providers can be found in the :ref:`credential_providers:Credential Providers` section.
 
@@ -61,7 +61,7 @@ You can also make your own credential provider:
       project="my-project",
       credentials=Token(token_provider)
     )
-    c = CogniteClient(cnf)
+    client = CogniteClient(cnf)
 
 Discover time series
 --------------------
@@ -73,8 +73,8 @@ the following code will return the first 25 time series resources.
 
     from cognite.client import CogniteClient
 
-    c = CogniteClient()
-    ts_list = c.time_series.list()
+    client = CogniteClient()
+    ts_list = client.time_series.list()
 
 List available spaces in your Data Modeling project
 ---------------------------------------------------
@@ -84,5 +84,5 @@ In the following example, we list all spaces in the project.
 
     from cognite.client import CogniteClient
 
-    c = CogniteClient()
-    spaces = c.data_modeling.spaces.list()
+    client = CogniteClient()
+    spaces = client.data_modeling.spaces.list()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "cognite-sdk"
 
-version = "7.20.2"
+version = "7.20.1"
 description = "Cognite Python SDK"
 readme = "README.md"
 documentation = "https://cognite-sdk-python.readthedocs-hosted.com"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "cognite-sdk"
 
-version = "7.20.1"
+version = "7.20.2"
 description = "Cognite Python SDK"
 readme = "README.md"
 documentation = "https://cognite-sdk-python.readthedocs-hosted.com"

--- a/scripts/generate_code_snippets.py
+++ b/scripts/generate_code_snippets.py
@@ -25,7 +25,7 @@ parser = DocTestParser()
 apis = collect_apis(client, {})
 
 snippets = {"language": "Python", "label": "Python SDK", "operations": defaultdict(str)}
-filter_out = ["from cognite.client import CogniteClient", "c = CogniteClient()", "client = CogniteClient()", ""]
+filter_out = ["from cognite.client import CogniteClient", "client = CogniteClient()", ""]
 
 duplicate_operations = {
     "listAssets": "getAssets",
@@ -47,11 +47,10 @@ for api_name, api in apis:
             for ex in [*parsed_lines, "<end>"]:
                 if isinstance(ex, Example):
                     if ex.source.strip() not in filter_out:
-                        current_snippet += re.sub(r"(= |in |^)c\.", "\\1client.", ex.source.rstrip()) + "\n"
-                elif ex != "":
-                    if current_snippet:
-                        endpoint_snippets.append(current_snippet)
-                        current_snippet = ""
+                        current_snippet += ex.source.rstrip() + "\n"
+                elif ex != "" and current_snippet:
+                    endpoint_snippets.append(current_snippet)
+                    current_snippet = ""
 
             code = "\n".join(endpoint_snippets)
             snippets["operations"][openapi_ident] += code

--- a/tests/tests_unit/test_base.py
+++ b/tests/tests_unit/test_base.py
@@ -381,10 +381,10 @@ class TestCogniteResource:
         pd.testing.assert_frame_equal(expected_df, actual_df, check_like=True)
 
     def test_resource_client_correct(self):
-        c = CogniteClient(ClientConfig(client_name="bla", project="bla", credentials=Token("bla")))
+        client = CogniteClient(ClientConfig(client_name="bla", project="bla", credentials=Token("bla")))
         with pytest.raises(CogniteMissingClientError):
             MyResource(1)._cognite_client
-        assert MyResource(1, cognite_client=c)._cognite_client == c
+        assert MyResource(1, cognite_client=client)._cognite_client == client
 
     def test_use_method_which_requires_cognite_client__client_not_set(self):
         mr = MyResource()
@@ -610,10 +610,10 @@ class TestCogniteResourceList:
             MyResourceList([1, 2, 3])
 
     def test_resource_list_client_correct(self):
-        c = CogniteClient(ClientConfig(client_name="bla", project="bla", credentials=Token("bla")))
+        client = CogniteClient(ClientConfig(client_name="bla", project="bla", credentials=Token("bla")))
         with pytest.raises(CogniteMissingClientError):
             MyResource(1)._cognite_client
-        assert MyResource(1, cognite_client=c)._cognite_client == c
+        assert MyResource(1, cognite_client=client)._cognite_client == client
 
     def test_use_method_which_requires_cognite_client__client_not_set(self):
         mr = MyResourceList([])
@@ -791,10 +791,10 @@ class TestCogniteResponse:
         assert MyResponse(1) != MyResponse()
 
     def test_response_client_correct(self):
-        c = CogniteClient(ClientConfig(client_name="bla", project="bla", credentials=Token("bla")))
+        client = CogniteClient(ClientConfig(client_name="bla", project="bla", credentials=Token("bla")))
         with pytest.raises(CogniteMissingClientError):
             MyResource(1)._cognite_client
-        assert MyResource(1, cognite_client=c)._cognite_client == c
+        assert MyResource(1, cognite_client=client)._cognite_client == client
 
     def test_response_no_cogclient_ref(self):
         # CogniteResponse does not have a reference to the cognite client:

--- a/tests/tests_unit/test_cognite_client.py
+++ b/tests/tests_unit/test_cognite_client.py
@@ -62,13 +62,13 @@ class TestCogniteClient:
             CogniteClient(ClientConfig(client_name="", project=None, credentials=Token("bla")))
 
     def test_project_is_correct(self, client_config_w_token_factory):
-        c = CogniteClient(client_config_w_token_factory)
-        assert c.config.project == "test-project"
+        client = CogniteClient(client_config_w_token_factory)
+        assert client.config.project == "test-project"
 
     def test_default_client_config_set(self, client_config_w_token_factory) -> None:
         global_config.default_client_config = client_config_w_token_factory
-        c = CogniteClient()
-        assert c.config == client_config_w_token_factory
+        client = CogniteClient()
+        assert client.config == client_config_w_token_factory
         global_config.default_client_config = None
 
     def test_default_client_config_not_set(self) -> None:
@@ -83,33 +83,33 @@ class TestCogniteClient:
         log.propagate = False
 
     def test_api_version_present_in_header(self, rsps, client_config_w_token_factory, mock_token_inspect):
-        c = CogniteClient(client_config_w_token_factory)
-        c.iam.token.inspect()
-        assert rsps.calls[0].request.headers["cdf-version"] == c.config.api_subversion
+        client = CogniteClient(client_config_w_token_factory)
+        client.iam.token.inspect()
+        assert rsps.calls[0].request.headers["cdf-version"] == client.config.api_subversion
 
     def test_beta_header_for_beta_client(self, rsps, client_config_w_token_factory, mock_token_inspect):
         from cognite.client.beta import CogniteClient as BetaClient
 
-        c = BetaClient(client_config_w_token_factory)
-        c.iam.token.inspect()
+        client = BetaClient(client_config_w_token_factory)
+        client.iam.token.inspect()
         assert rsps.calls[0].request.headers["cdf-version"] == "beta"
 
     def test_verify_ssl_enabled_by_default(self, rsps, client_config_w_token_factory, mock_token_inspect):
-        c = CogniteClient(client_config_w_token_factory)
-        c.iam.token.inspect()
+        client = CogniteClient(client_config_w_token_factory)
+        client.iam.token.inspect()
 
         assert rsps.calls[0][0].req_kwargs["verify"] is True
-        assert c._api_client._http_client_with_retry.session.verify is True
-        assert c._api_client._http_client.session.verify is True
+        assert client._api_client._http_client_with_retry.session.verify is True
+        assert client._api_client._http_client.session.verify is True
 
 
 class TestInstantiateWithClient:
     @pytest.mark.parametrize("cls", [Asset, Event, FileMetadata, TimeSeries])
     def test_instantiate_resources_with_cognite_client(self, cls, client_config_w_token_factory):
-        c = CogniteClient(client_config_w_token_factory)
-        assert cls(cognite_client=c)._cognite_client == c
+        client = CogniteClient(client_config_w_token_factory)
+        assert cls(cognite_client=client)._cognite_client == client
 
     @pytest.mark.parametrize("cls", [AssetList, Event, FileMetadataList, TimeSeriesList])
     def test_instantiate_resource_lists_with_cognite_client(self, cls, client_config_w_token_factory):
-        c = CogniteClient(client_config_w_token_factory)
-        assert cls([], cognite_client=c)._cognite_client == c
+        client = CogniteClient(client_config_w_token_factory)
+        assert cls([], cognite_client=client)._cognite_client == client


### PR DESCRIPTION
## Description
In the Python SDK documentation, we usually have `c = CogniteClient()` as the example to initiate the SDK client. However, shortening this from `client` to `c` has some consequences. One is that it's often challenging to read code with such variable names, in addition to AI being worse at code generation with non descriptive variable names.

In the AI team we work on teaching LLMs how to write code with Python SDK and rely heavily on the SDK documentation where we'd like to use `client = ` instead of `c = ` to get a stronger signal on that variable for the LLM. Human users will likely also benefit from this.

## Checklist:
- [x] Tests added/updated.
- [x] Documentation updated. Documentation is generated from docstrings - these must be updated according to your change.
  If a new method has been added it should be referenced in [cognite.rst](https://github.com/cognitedata/cognite-sdk-python/blob/master/docs/source/cognite.rst) in order to generate docs based on its docstring.
- [x] Changelog updated in [CHANGELOG.md](https://github.com/cognitedata/cognite-sdk-python/blob/master/CHANGELOG.md).
- [x] Version bumped. If triggering a new release is desired, bump the version number in [_version.py](https://github.com/cognitedata/cognite-sdk-python/blob/master/cognite/client/_version.py) and [pyproject.toml](https://github.com/cognitedata/cognite-sdk-python/blob/master/pyproject.toml) per [semantic versioning](https://semver.org/).
