### PR TITLE
Data Workflows: Fix transformation task output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ Changes are grouped as follows
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
+## [7.21.1] - 2024-02-20
+### Fixed
+- Data Workflows: mark parameter `jobId` as optional in `TransformationTaskOutput`, as it may not be populated in case of a failure.
+
 ## [7.21.0] - 2024-02-10
 ### Added
 - Parameter `sort` to `client.documents.list.

--- a/cognite/client/_version.py
+++ b/cognite/client/_version.py
@@ -1,4 +1,4 @@
 from __future__ import annotations
 
-__version__ = "7.21.0"
+__version__ = "7.21.1"
 __api_subversion__ = "20230101"

--- a/cognite/client/data_classes/workflows.py
+++ b/cognite/client/data_classes/workflows.py
@@ -527,18 +527,18 @@ class TransformationTaskOutput(WorkflowTaskOutput):
     The transformation output is used to specify the output of a transformation task.
 
     Args:
-        job_id (int): The job id of the transformation job.
+        job_id (int | None): The job id of the transformation job.
     """
 
     task_type: ClassVar[str] = "transformation"
 
-    def __init__(self, job_id: int) -> None:
+    def __init__(self, job_id: int | None) -> None:
         self.job_id = job_id
 
     @classmethod
     def load(cls, data: dict[str, Any]) -> TransformationTaskOutput:
         output = data["output"]
-        return cls(output["jobId"])
+        return cls(output.get("jobId"))
 
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         return {("jobId" if camel_case else "job_id"): self.job_id}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "cognite-sdk"
 
-version = "7.21.0"
+version = "7.21.1"
 description = "Cognite Python SDK"
 readme = "README.md"
 documentation = "https://cognite-sdk-python.readthedocs-hosted.com"


### PR DESCRIPTION
## Description
`jobId` may not be available in case of a Transformations task in a `scheduled` state or in case of Transformation call failure

## Checklist:
- [x] Tests added/updated.
- [x] Documentation updated. Documentation is generated from docstrings - these must be updated according to your change.
  If a new method has been added it should be referenced in [cognite.rst](https://github.com/cognitedata/cognite-sdk-python/blob/master/docs/source/cognite.rst) in order to generate docs based on its docstring.
- [x] Changelog updated in [CHANGELOG.md](https://github.com/cognitedata/cognite-sdk-python/blob/master/CHANGELOG.md).
- [x] Version bumped. If triggering a new release is desired, bump the version number in [_version.py](https://github.com/cognitedata/cognite-sdk-python/blob/master/cognite/client/_version.py) and [pyproject.toml](https://github.com/cognitedata/cognite-sdk-python/blob/master/pyproject.toml) per [semantic versioning](https://semver.org/).
