### PR TITLE
add `partitions` to `RawRowsAPI.list` and `__call__`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,14 +17,16 @@ Changes are grouped as follows
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
-## [7.24.0] - 2024-02-24
+## [7.24.0] - 2024-02-25
 ### Added
 - New parameter for `client.raw.rows(...)`: `partitions`. This enables greater throughput thorough concurrent reads when using
   the generator method (while still keeping a low memory impact). For backwards compatibility, the default is _no concurrency_.
-- New parameter for `client.raw.rows.list(...)`: `partitions`. This method has always used `partitions=max_workers` under the hood
-  for non-finite calls, but now this can be overridden easily.
+  When specified, can be used together with a finite limit, as opposed to most (if not all) other resources/APIs.
+- New parameter for `client.raw.rows.list(...)`: `partitions`. For backwards compatibility, the default is _no concurrency_ when
+  a finite `limit` is given, and _"max" concurrency_ (`partitions=max_workers`) otherwise. Partitions can be used with finite limits.
+  With this change it is easy to set an appropriate level of concurrency without messing with the global client configuration.
 ### Changed
-- Default configuration setting of `max_workers` has been changed from 10 to 5 (now matches the documentation).
+- Default configuration setting of `max_workers` has been changed from 10 to 5 (to match the documentation).
 
 ## [7.23.1] - 2024-02-23
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,8 +23,10 @@ Changes are grouped as follows
 
 ## [7.23.0] - 2024-02-23
 ### Added
-- New method for `RawRowsAPI`: `iterate_rows()`. It combines the high-throughput speed of concurrent reads with the low memory
-  impact of a generator.
+- New parameter for `client.raw.rows(...)`: `partitions`. This enables greater throughput thorough concurrent reads when using
+  the generator method (while still keeping a low memory impact). For backwards compatibility, the default is _no concurrency_.
+- New parameter for `client.raw.rows.list(...)`: `partitions`. This method has always used `partitions=max_workers` under the hood
+  for non-finite calls, but now this can be overridden easily.
 
 ## [7.23.0] - 2024-02-23
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,8 +38,7 @@ Changes are grouped as follows
 ### Added
 - Data point subscriptions reaches General Availability (GA).
   - Use the new [Data point subscriptions](https://developer.cognite.com/dev/concepts/data_point_subscriptions/)
-    feature to configure a subscription to listen to changes in one or more
-    time series (in ingestion order).
+    feature to configure a subscription to listen to changes in one or more time series (in ingestion order).
     The feature is intended to be used where data points consumers need to keep up to date with
     changes to one or more time series without the need to read the entire time series again.
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,11 +17,7 @@ Changes are grouped as follows
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
-## [7.23.1] - 2024-02-23
-### Fixed
-- Add missing `partition` scope to `seismicAcl`.
-
-## [7.23.0] - 2024-02-23
+## [7.24.0] - 2024-02-24
 ### Added
 - New parameter for `client.raw.rows(...)`: `partitions`. This enables greater throughput thorough concurrent reads when using
   the generator method (while still keeping a low memory impact). For backwards compatibility, the default is _no concurrency_.
@@ -29,6 +25,10 @@ Changes are grouped as follows
   for non-finite calls, but now this can be overridden easily.
 ### Changed
 - Default configuration setting of `max_workers` has been changed from 10 to 5 (now matches the documentation).
+
+## [7.23.1] - 2024-02-23
+### Fixed
+- Add missing `partition` scope to `seismicAcl`.
 
 ## [7.23.0] - 2024-02-23
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,11 @@ Changes are grouped as follows
 
 ## [7.23.0] - 2024-02-23
 ### Added
+- New method for `RawRowsAPI`: `iterate_rows()`. It combines the high-throughput speed of concurrent reads with the low memory
+  impact of a generator.
+
+## [7.23.0] - 2024-02-23
+### Added
 - Make properties on instances (`Node`, `Edge`) easier to work with, by implementing support for direct indexing (and a `.get` method).
   If the instances have properties from no source or multiple sources, an error is raised instead. Example usage: `instance["my_prop"]`
   (short-cut for: `instance.properties[ViewId("space", "ext.id", "version")]["my_prop"]`)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@ Changes are grouped as follows
   the generator method (while still keeping a low memory impact). For backwards compatibility, the default is _no concurrency_.
 - New parameter for `client.raw.rows.list(...)`: `partitions`. This method has always used `partitions=max_workers` under the hood
   for non-finite calls, but now this can be overridden easily.
+### Changed
+- Default configuration setting of `max_workers` has been changed from 10 to 5 (now matches the documentation).
 
 ## [7.23.0] - 2024-02-23
 ### Added

--- a/cognite/client/_api/raw.py
+++ b/cognite/client/_api/raw.py
@@ -454,8 +454,8 @@ class RawRowsAPI(APIClient):
             You may also insert a dictionary directly:
 
                 >>> rows = {
-                ...     {"key-1": {"col1": 1, "col2": 2}},
-                ...     {"key-2": {"col1": 3, "col2": 4, "col3": "high five"}},
+                ...     "key-1": {"col1": 1, "col2": 2},
+                ...     "key-2": {"col1": 3, "col2": 4, "col3": "high five"},
                 ... }
                 >>> client.raw.rows.insert("db1", "table1", rows)
         """
@@ -691,8 +691,8 @@ class RawRowsAPI(APIClient):
                 >>> for row_list in client.raw.rows(db_name="db1", table_name="t1", chunk_size=2500):
                 ...     row_list  # do something with the rows
 
-            Iterate through a massive table, using concurrency, to reduce memory load. Note: 'partitions' must be specified.
-            You can either pass a number, or simply use the default 'max_workers' already set in your configuration:
+            Iterate through a massive table, using concurrency, to reduce memory load. Note: ``partitions`` must be specified.
+            You can either pass a number, or simply use the default ``max_workers`` already set in your configuration:
 
                 >>> from cognite.client import global_config
                 >>> rows_iterator = client.raw.rows(

--- a/cognite/client/_api/raw.py
+++ b/cognite/client/_api/raw.py
@@ -345,7 +345,7 @@ class RawRowsAPI(APIClient):
         Args:
             db_name (str): Name of the database
             table_name (str): Name of the table to iterate over rows for
-            chunk_size (int | None): Number of rows to return in each chunk (may be lower). Defaults to yielding one row a time.
+            chunk_size (int | None): Number of rows to return in each chunk (may be lower). Defaults to yielding one row at a time.
                 Note: When used together with 'partitions' the default is 10000 (matching the API limit) and there's an implicit minimum of 1000 rows.
             limit (int | None): Maximum number of rows to return. Can be used with partitions. Defaults to returning all items.
             min_last_updated_time (int | None): Rows must have been last updated after this time (exclusive). ms since epoch.
@@ -705,7 +705,7 @@ class RawRowsAPI(APIClient):
             columns (list[str] | None): List of column keys. Set to `None` for retrieving all, use [] to retrieve only row keys.
             limit (int | None): The number of rows to retrieve. Can be used with partitions. Defaults to 25. Set to -1, float("inf") or None to return all items.
             partitions (int | None): Retrieve rows in parallel using this number of workers. Can be used together with a (large) finite limit.
-                When partitions is not passed, it defaults to 1, i.e. no concurrency for a finite limit and `global_config.max_workers` for an unlimited query
+                When partitions is not passed, it defaults to 1, i.e. no concurrency for a finite limit and ``global_config.max_workers`` for an unlimited query
                 (will be capped at this value). To prevent unexpected problems and maximize read throughput, check out
                 `concurrency limits in the API documentation. <https://developer.cognite.com/api#tag/Raw/#section/Request-and-concurrency-limits>`_
 
@@ -720,7 +720,7 @@ class RawRowsAPI(APIClient):
                 >>> client = CogniteClient()
                 >>> row_list = client.raw.rows.list("db1", "tbl1", limit=5)
 
-            Read an entire table efficiently by using concurrency (default behaviour when limit=None):
+            Read an entire table efficiently by using concurrency (default behavior when ``limit=None``):
 
                 >>> row_list = client.raw.rows.list("db1", "tbl1", limit=None)
 
@@ -729,14 +729,14 @@ class RawRowsAPI(APIClient):
                 >>> for row in client.raw.rows("db1", "t1", columns=["col1","col2"]):
                 ...     row  # do something with the row
 
-            Iterate through all rows, one chunk at the time, to reduce memory load (no concurrency used):
+            Iterate through all rows, one chunk at a time, to reduce memory load (no concurrency used):
 
                 >>> for row_list in client.raw.rows("db1", "t1", chunk_size=2500):
                 ...     row_list  # do something with the rows
 
             Iterate through a massive table to reduce memory load while using concurrency for high throughput.
-            Note: ``partitions`` must be specified for concurrency to be used (this is different from `list()`
-            to keep backwards compatibility). Supplying a finite ``limit`` does not affect concurrency settings
+            Note: ``partitions`` must be specified for concurrency to be used (this is different from ``list()``
+            to keep backward compatibility). Supplying a finite ``limit`` does not affect concurrency settings
             (except for very small values).
 
                 >>> rows_iterator = client.raw.rows(

--- a/cognite/client/_api/raw.py
+++ b/cognite/client/_api/raw.py
@@ -10,6 +10,7 @@ from cognite.client.data_classes import Database, DatabaseList, Row, RowList, Ro
 from cognite.client.data_classes.raw import RowCore
 from cognite.client.utils._auxiliary import (
     interpolate_and_url_encode,
+    is_finite,
     is_unlimited,
     split_into_chunks,
     unpack_items_in_payload,
@@ -355,7 +356,7 @@ class RawRowsAPI(APIClient):
         Returns:
             Iterator[Row] | Iterator[RowList]: An iterator yielding the requested rows (or row) in chunks.
         """
-        if partitions is None or not is_unlimited(limit):
+        if partitions is None or is_finite(limit):
             return self._list_generator(
                 list_cls=RowList,
                 resource_cls=Row,

--- a/cognite/client/_api/raw.py
+++ b/cognite/client/_api/raw.py
@@ -355,7 +355,7 @@ class RawRowsAPI(APIClient):
         Returns:
             Iterator[Row] | Iterator[RowList]: An iterator yielding the requested rows (or row) in chunks.
         """
-        if partitions is None:
+        if partitions is None or not is_unlimited(limit):
             return self._list_generator(
                 list_cls=RowList,
                 resource_cls=Row,

--- a/cognite/client/_api/raw.py
+++ b/cognite/client/_api/raw.py
@@ -374,7 +374,7 @@ class RawRowsAPI(APIClient):
         columns: list[str] | None = None,
         partitions: int | None = None,
     ) -> Iterator[RowList]:
-        """Iterate over rows concurrently.
+        """Iterate over all rows using parallel reads.
 
         Fetches rows as they are iterated over, so you keep a limited number of rows in memory. This function is different from
         ``client.raw.rows(...)`` in that it supports concurrent reads (higher throughput). Try to use a ``chunk_size`` that is a multiple
@@ -392,6 +392,16 @@ class RawRowsAPI(APIClient):
 
         Yields:
             RowList: The requested rows in chunks.
+
+        Examples:
+
+            Iterate through all rows of a large table, while keeping a limited set of rows in memory,
+            using defaults for 'chunk_size' and 'partitions':
+
+                >>> from cognite.client import CogniteClient
+                >>> client = CogniteClient()
+                >>> for rows in client.raw.rows.iterate_rows("db1", "tbl1"):
+                ...     pass  # do something with the rows
         """
         partitions = self._config.max_workers if partitions is None else min(partitions, self._config.max_workers)
         pool = ConcurrencySettings.get_executor(max_workers=partitions)

--- a/cognite/client/_version.py
+++ b/cognite/client/_version.py
@@ -1,4 +1,4 @@
 from __future__ import annotations
 
-__version__ = "7.23.1"
+__version__ = "7.24.0"
 __api_subversion__ = "20230101"

--- a/cognite/client/config.py
+++ b/cognite/client/config.py
@@ -101,12 +101,10 @@ class ClientConfig:
 
     @property
     def max_workers(self) -> int:
-        # TODO: Remove max_workers from ClientConfig in next major version
         return global_config.max_workers
 
     @max_workers.setter
     def max_workers(self, value: int) -> None:
-        # TODO: Remove max_workers from ClientConfig in next major version
         global_config.max_workers = value
         warnings.warn(
             "Passing (or setting) max_workers to ClientConfig is deprecated. Please use global_config.max_workers instead",

--- a/cognite/client/config.py
+++ b/cognite/client/config.py
@@ -41,7 +41,7 @@ class GlobalConfig:
         self.max_connection_pool_size: int = 50
         self.disable_ssl: bool = False
         self.proxies: dict[str, str] | None = {}
-        self.max_workers: int = 10
+        self.max_workers: int = 5
 
 
 global_config = GlobalConfig()

--- a/cognite/client/config.py
+++ b/cognite/client/config.py
@@ -84,11 +84,7 @@ class ClientConfig:
         self.base_url = (base_url or "https://api.cognitedata.com").rstrip("/")
         if max_workers is not None:
             # TODO: Remove max_workers from ClientConfig in next major version
-            warnings.warn(
-                "Passing max_workers to ClientConfig is deprecated. Please use global_config.max_workers instead",
-                DeprecationWarning,
-            )
-        self.max_workers = max_workers if max_workers is not None else global_config.max_workers
+            self.max_workers = max_workers  # Will trigger a deprecation warning
         self.headers = headers or {}
         self.timeout = timeout or 30
         self.file_transfer_timeout = file_transfer_timeout or 600
@@ -102,6 +98,20 @@ class ClientConfig:
 
                 _check_client_has_newest_major_version()
         self._validate_config()
+
+    @property
+    def max_workers(self) -> int:
+        # TODO: Remove max_workers from ClientConfig in next major version
+        return global_config.max_workers
+
+    @max_workers.setter
+    def max_workers(self, value: int) -> None:
+        # TODO: Remove max_workers from ClientConfig in next major version
+        global_config.max_workers = value
+        warnings.warn(
+            "Passing (or setting) max_workers to ClientConfig is deprecated. Please use global_config.max_workers instead",
+            DeprecationWarning,
+        )
 
     @property
     def debug(self) -> bool:
@@ -125,7 +135,7 @@ class ClientConfig:
             raise ValueError(f"Invalid value for ClientConfig.base_url: <{self.base_url}>")
 
     def __str__(self) -> str:
-        return pprint.pformat(self.__dict__, indent=4)
+        return pprint.pformat({"max_workers": self.max_workers, **self.__dict__}, indent=4)
 
     def _repr_html_(self) -> str:
         return str(self)

--- a/cognite/client/data_classes/capabilities.py
+++ b/cognite/client/data_classes/capabilities.py
@@ -789,7 +789,7 @@ class SecurityCategoriesAcl(Capability):
 class SeismicAcl(Capability):
     _capability_name = "seismicAcl"
     actions: Sequence[Action]
-    scope: AllScope
+    scope: AllScope | PartitionScope
 
     class Action(Capability.Action):
         Read = "READ"

--- a/cognite/client/utils/_auxiliary.py
+++ b/cognite/client/utils/_auxiliary.py
@@ -38,6 +38,10 @@ def no_op(x: T) -> T:
     return x
 
 
+def is_finite(limit: Any) -> bool:
+    return isinstance(limit, int) and limit >= 0
+
+
 def is_unlimited(limit: float | int | None) -> bool:
     return limit in {None, -1, math.inf}
 

--- a/cognite/client/utils/_auxiliary.py
+++ b/cognite/client/utils/_auxiliary.py
@@ -17,6 +17,8 @@ from typing import (
 )
 from urllib.parse import quote
 
+from typing_extensions import TypeGuard
+
 from cognite.client.utils import _json
 from cognite.client.utils._text import (
     convert_all_keys_to_camel_case,
@@ -38,7 +40,7 @@ def no_op(x: T) -> T:
     return x
 
 
-def is_finite(limit: Any) -> bool:
+def is_finite(limit: Any) -> TypeGuard[int]:
     return isinstance(limit, int) and limit >= 0
 
 

--- a/cognite/client/utils/_concurrency.py
+++ b/cognite/client/utils/_concurrency.py
@@ -145,8 +145,9 @@ class SyncFuture(TaskFuture[T_Result]):
             self._result = self._task()
         return self._result
 
-    def done(self) -> bool:
-        return self._has_run
+    def done(self) -> Literal[True]:
+        self.result()
+        return True
 
 
 class MainThreadExecutor(TaskExecutor):

--- a/cognite/client/utils/_concurrency.py
+++ b/cognite/client/utils/_concurrency.py
@@ -130,24 +130,47 @@ class TaskFuture(Protocol[T_Result]):
     def done(self) -> bool:
         ...
 
+    def cancel(self) -> bool:
+        ...
+
+    def cancelled(self) -> bool:
+        ...
+
 
 class SyncFuture(TaskFuture[T_Result]):
+    """Best effort to follow: https://docs.python.org/3/library/concurrent.futures.html#future-objects
+
+    ...except: We don't care about storing any possible exception; if anything happens, they will immediately
+    be raised for the user anyway"""
+
     def __init__(self, fn: Callable[..., T_Result], *args: Any, **kwargs: Any) -> None:
         self._task = functools.partial(fn, *args, **kwargs)
         self._result: T_Result
         self._has_run: bool = False
+        self._cancelled: bool = False
 
     def result(self) -> T_Result:
-        # We don't care about storing any possible exception; if anything happens, they will
-        # immediately be raised for the user anyway:
+        if self._cancelled:
+            raise CancelledError
         if not self._has_run:
             self._has_run = True
             self._result = self._task()
         return self._result
 
     def done(self) -> Literal[True]:
+        if self._cancelled or self._has_run:
+            return True
         self.result()
         return True
+
+    def cancel(self) -> bool:
+        if self._has_run:
+            return False
+        self._cancelled = True
+        return True
+
+    def cancelled(self) -> bool:
+        return self._cancelled
 
 
 class MainThreadExecutor(TaskExecutor):

--- a/docs/source/data_ingestion.rst
+++ b/docs/source/data_ingestion.rst
@@ -43,6 +43,10 @@ List rows in a table
 ~~~~~~~~~~~~~~~~~~~~
 .. automethod:: cognite.client._api.raw.RawRowsAPI.list
 
+Iterate through rows in a table
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+.. automethod:: cognite.client._api.raw.RawRowsAPI.iterate_rows
+
 Insert rows into a table
 ~~~~~~~~~~~~~~~~~~~~~~~~
 .. automethod:: cognite.client._api.raw.RawRowsAPI.insert

--- a/docs/source/data_ingestion.rst
+++ b/docs/source/data_ingestion.rst
@@ -43,10 +43,6 @@ List rows in a table
 ~~~~~~~~~~~~~~~~~~~~
 .. automethod:: cognite.client._api.raw.RawRowsAPI.list
 
-Iterate through rows in a table
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-.. automethod:: cognite.client._api.raw.RawRowsAPI.iterate_rows
-
 Insert rows into a table
 ~~~~~~~~~~~~~~~~~~~~~~~~
 .. automethod:: cognite.client._api.raw.RawRowsAPI.insert

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "cognite-sdk"
 
-version = "7.23.1"
+version = "7.24.0"
 description = "Cognite Python SDK"
 readme = "README.md"
 documentation = "https://cognite-sdk-python.readthedocs-hosted.com"

--- a/tests/tests_integration/test_api/test_raw.py
+++ b/tests/tests_integration/test_api/test_raw.py
@@ -1,3 +1,5 @@
+import random
+
 import pytest
 
 from cognite.client import CogniteClient
@@ -22,7 +24,7 @@ class TestRawDatabasesAPI:
         assert len(dbs) > 0
 
     def test_create_and_delete_database(self, new_database_with_table):
-        pass
+        assert True
 
 
 class TestRawTablesAPI:
@@ -55,19 +57,26 @@ class TestRawRowsAPI:
         assert 2000 == len(rows)
         assert 10 == len(rows[0].columns.keys())
 
-    def test_list_rows_w_parallel_cursors(self, cognite_client):
+    def test_rows_with_parallel_cursors(self, cognite_client):
         randstr = random_string(32)
-        num_rows = 30000
+        num_rows = random.randint(15000, 30000)
         rows_to_insert = [Row(key=str(i), columns={"a": 1}) for i in range(num_rows)]
-        cognite_client.raw.rows.insert(randstr, randstr, row=rows_to_insert, ensure_parent=True)
+        try:
+            cognite_client.raw.rows.insert(randstr, randstr, row=rows_to_insert, ensure_parent=True)
 
-        rows = cognite_client.raw.rows.list(db_name=randstr, table_name=randstr, limit=num_rows)
-        rows_par = cognite_client.raw.rows.list(db_name=randstr, table_name=randstr, limit=-1)
+            rows = cognite_client.raw.rows.list(randstr, randstr, limit=num_rows)
+            rows_par = cognite_client.raw.rows.list(randstr, randstr, limit=None, partitions=2)
+            rows_iter = list(cognite_client.raw.rows(randstr, randstr, limit=None, partitions=3, chunk_size=5000))
 
-        assert num_rows == len(rows) == len(rows_par)
-        assert 1 == len(rows[0].columns.keys()) == len(rows_par[0].columns.keys())
+            assert num_rows == len(rows) == len(rows_par)
+            assert 1 == len(rows[0].columns) == len(rows_par[0].columns) == len(rows_iter[0][0].columns)
 
-        assert {row.key for row in rows} == {row.key for row in rows_par}
+            keys = {row.key for row in rows}
+            keys_par = {row.key for row in rows_par}
+            keys_iter = {row.key for row_list in rows_iter for row in row_list}
+            assert keys == keys_par == keys_iter
+        finally:
+            cognite_client.raw.databases.delete(randstr, recursive=True)
 
     def test_list_rows_cols(self, cognite_client):
         rows_list = cognite_client.raw.rows.list(


### PR DESCRIPTION
## Description
## [7.24.0] - 2024-02-25
### Added
- New parameter for `client.raw.rows(...)`: `partitions`. This enables greater throughput thorough concurrent reads when using
  the generator method (while still keeping a low memory impact). For backwards compatibility, the default is _no concurrency_.
  When specified, can be used together with a finite limit, as opposed to most (if not all) other resources/APIs.
- New parameter for `client.raw.rows.list(...)`: `partitions`. For backwards compatibility, the default is _no concurrency_ when
  a finite `limit` is given, and _"max" concurrency_ (`partitions=max_workers`) otherwise. Partitions can be used with finite limits.
  With this change it is easy to set an appropriate level of concurrency without messing with the global client configuration.
### Changed
- Default configuration setting of `max_workers` has been changed from 10 to 5 (to match the documentation).

## Checklist:
- [x] Tests added/updated.
- [x] Documentation updated. Documentation is generated from docstrings - these must be updated according to your change.
  If a new method has been added it should be referenced in [cognite.rst](https://github.com/cognitedata/cognite-sdk-python/blob/master/docs/source/cognite.rst) in order to generate docs based on its docstring.
- [x] Changelog updated in [CHANGELOG.md](https://github.com/cognitedata/cognite-sdk-python/blob/master/CHANGELOG.md).
- [x] Version bumped. If triggering a new release is desired, bump the version number in [_version.py](https://github.com/cognitedata/cognite-sdk-python/blob/master/cognite/client/_version.py) and [pyproject.toml](https://github.com/cognitedata/cognite-sdk-python/blob/master/pyproject.toml) per [semantic versioning](https://semver.org/).
