### PR TITLE
Set poll_timeout to 0 in subscription tests

### DIFF
--- a/tests/tests_integration/test_api/test_datapoint_subscriptions.py
+++ b/tests/tests_integration/test_api/test_datapoint_subscriptions.py
@@ -167,7 +167,10 @@ class TestDatapointSubscriptions:
             partition_count=1,
         )
         with create_subscription_with_cleanup(cognite_client, new_subscription):
-            subscription_changes = cognite_client.time_series.subscriptions.iterate_data(new_subscription.external_id)
+            subscription_changes = cognite_client.time_series.subscriptions.iterate_data(
+                new_subscription.external_id,
+                poll_timeout=0,
+            )
             batch = next(subscription_changes)
 
             assert (
@@ -190,7 +193,10 @@ class TestDatapointSubscriptions:
             partition_count=1,
         )
         with create_subscription_with_cleanup(cognite_client, new_subscription):
-            subscription_changes = cognite_client.time_series.subscriptions.iterate_data(new_subscription.external_id)
+            subscription_changes = cognite_client.time_series.subscriptions.iterate_data(
+                new_subscription.external_id,
+                poll_timeout=0,
+            )
             batch = next(subscription_changes)
 
             assert batch.subscription_changes.added[0].external_id == first_ts
@@ -262,7 +268,9 @@ class TestDatapointSubscriptions:
             assert created.created_time
 
             for batch in cognite_client.time_series.subscriptions.iterate_data(
-                new_subscription.external_id, start="now"
+                new_subscription.external_id,
+                start="now",
+                poll_timeout=0,
             ):
                 assert len(batch.updates) == 0
                 assert len(batch.subscription_changes.added) == 0
@@ -274,7 +282,11 @@ class TestDatapointSubscriptions:
         self, cognite_client: CogniteClient, subscription: DatapointSubscription
     ):
         added_last_minute = 0
-        for batch in cognite_client.time_series.subscriptions.iterate_data(subscription.external_id, start="1m-ago"):
+        for batch in cognite_client.time_series.subscriptions.iterate_data(
+            subscription.external_id,
+            start="1m-ago",
+            poll_timeout=0,
+        ):
             added_last_minute += len(batch.subscription_changes.added)
             if not batch.has_next:
                 break
@@ -300,7 +312,10 @@ class TestDatapointSubscriptions:
             assert created.created_time
 
             initial_added_count = 0
-            for batch in cognite_client.time_series.subscriptions.iterate_data(new_subscription.external_id):
+            for batch in cognite_client.time_series.subscriptions.iterate_data(
+                new_subscription.external_id,
+                poll_timeout=0,
+            ):
                 initial_added_count += len(batch.subscription_changes.added)
                 if not batch.has_next:
                     break
@@ -321,7 +336,10 @@ class TestDatapointSubscriptions:
                 time.sleep(10)
 
                 updated_added_count = 0
-                for batch in cognite_client.time_series.subscriptions.iterate_data(new_subscription.external_id):
+                for batch in cognite_client.time_series.subscriptions.iterate_data(
+                    new_subscription.external_id,
+                    poll_timeout=0,
+                ):
                     updated_added_count += len(batch.subscription_changes.added)
                     if not batch.has_next:
                         break


### PR DESCRIPTION
## Description

To speed up the tests. Otherwise, it takes 5 seconds to retrieve an empty result.

## Checklist:
- [x] Tests added/updated.
- [x] Documentation updated. Documentation is generated from docstrings - these must be updated according to your change.
  If a new method has been added it should be referenced in [cognite.rst](https://github.com/cognitedata/cognite-sdk-python/blob/master/docs/source/cognite.rst) in order to generate docs based on its docstring.
- [x] Changelog updated in [CHANGELOG.md](https://github.com/cognitedata/cognite-sdk-python/blob/master/CHANGELOG.md).
- [x] Version bumped. If triggering a new release is desired, bump the version number in [_version.py](https://github.com/cognitedata/cognite-sdk-python/blob/master/cognite/client/_version.py) and [pyproject.toml](https://github.com/cognitedata/cognite-sdk-python/blob/master/pyproject.toml) per [semantic versioning](https://semver.org/).
