### PR TITLE
Add seismic partition scope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ Changes are grouped as follows
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
+## [7.23.1] - 2024-02-23
+### Fixed
+- Add missing `partition` scope to `seismicAcl`.
+
 ## [7.23.0] - 2024-02-23
 ### Added
 - Make properties on instances (`Node`, `Edge`) easier to work with, by implementing support for direct indexing (and a `.get` method).

--- a/cognite/client/_version.py
+++ b/cognite/client/_version.py
@@ -1,4 +1,4 @@
 from __future__ import annotations
 
-__version__ = "7.23.0"
+__version__ = "7.23.1"
 __api_subversion__ = "20230101"

--- a/cognite/client/data_classes/capabilities.py
+++ b/cognite/client/data_classes/capabilities.py
@@ -390,6 +390,18 @@ class SpaceIDScope(Capability.Scope):
 
 
 @dataclass(frozen=True)
+class PartitionScope(Capability.Scope):
+    _scope_name = "partition"
+    partition_ids: list[int]
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "partition_ids", [int(i) for i in self.partition_ids])
+
+    def as_tuples(self) -> set[tuple]:
+        return {(self._scope_name, i) for i in self.partition_ids}
+
+
+@dataclass(frozen=True)
 class LegacySpaceScope(Capability.Scope):
     _scope_name = "spaceScope"
     external_ids: list[str]
@@ -777,7 +789,7 @@ class SecurityCategoriesAcl(Capability):
 class SeismicAcl(Capability):
     _capability_name = "seismicAcl"
     actions: Sequence[Action]
-    scope: AllScope = field(default_factory=AllScope)
+    scope: AllScope
 
     class Action(Capability.Action):
         Read = "READ"
@@ -785,6 +797,7 @@ class SeismicAcl(Capability):
 
     class Scope:
         All = AllScope
+        Partition = PartitionScope
 
 
 @dataclass

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "cognite-sdk"
 
-version = "7.23.0"
+version = "7.23.1"
 description = "Cognite Python SDK"
 readme = "README.md"
 documentation = "https://cognite-sdk-python.readthedocs-hosted.com"

--- a/tests/tests_unit/test_data_classes/test_capabilities.py
+++ b/tests/tests_unit/test_data_classes/test_capabilities.py
@@ -96,6 +96,7 @@ def all_acls():
             }
         },
         {"seismicAcl": {"actions": ["READ", "WRITE"], "scope": {"all": {}}}},
+        {"seismicAcl": {"actions": ["WRITE"], "scope": {"partition": {"partitionIds": ["123", 456]}}}},
         {"sequencesAcl": {"actions": ["READ"], "scope": {"all": {}}}},
         {"sequencesAcl": {"actions": ["WRITE"], "scope": {"datasetScope": {"ids": ["2332579", "372"]}}}},
         {"sessionsAcl": {"actions": ["LIST", "CREATE", "DELETE"], "scope": {"all": {}}}},


### PR DESCRIPTION
## [7.23.1] - 2024-02-23
### Fixed
- Add missing `partition` scope to `seismicAcl`.

## Checklist:
- [x] Tests added/updated.
- [ ] Documentation updated. Documentation is generated from docstrings - these must be updated according to your change.
  If a new method has been added it should be referenced in [cognite.rst](https://github.com/cognitedata/cognite-sdk-python/blob/master/docs/source/cognite.rst) in order to generate docs based on its docstring.
- [x] Changelog updated in [CHANGELOG.md](https://github.com/cognitedata/cognite-sdk-python/blob/master/CHANGELOG.md).
- [x] Version bumped. If triggering a new release is desired, bump the version number in [_version.py](https://github.com/cognitedata/cognite-sdk-python/blob/master/cognite/client/_version.py) and [pyproject.toml](https://github.com/cognitedata/cognite-sdk-python/blob/master/pyproject.toml) per [semantic versioning](https://semver.org/).
