### PR TITLE
Fix no-limit `raw.rows.list` for Pyodide users

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ Changes are grouped as follows
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
+## [7.24.2] - 2024-02-25
+### Fixed
+- [Pyodide/WASM only] The list method for raw rows now works for non-finite queries (got broken in `7.24.1`).
+
 ## [7.24.1] - 2024-02-25
 ### Fixed
 - [Pyodide/WASM only] The iteration method for raw rows now yields rows _while running_ (instead of waiting for tasks to finish first).

--- a/cognite/client/_api/raw.py
+++ b/cognite/client/_api/raw.py
@@ -748,7 +748,9 @@ class RawRowsAPI(APIClient):
                 ...     row_list  # do something with the rows
         """
         chunk_size = None
-        if partitions is None:
+        if _RUNNING_IN_BROWSER:
+            chunk_size = 10_000
+        elif partitions is None:
             if is_unlimited(limit):
                 # Before 'partitions' was introduced, existing logic was that 'limit=None' meant 'partitions=max_workers'.
                 partitions = self._config.max_workers

--- a/cognite/client/_version.py
+++ b/cognite/client/_version.py
@@ -1,4 +1,4 @@
 from __future__ import annotations
 
-__version__ = "7.24.1"
+__version__ = "7.24.2"
 __api_subversion__ = "20230101"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "cognite-sdk"
 
-version = "7.24.1"
+version = "7.24.2"
 description = "Cognite Python SDK"
 readme = "README.md"
 documentation = "https://cognite-sdk-python.readthedocs-hosted.com"


### PR DESCRIPTION
## [7.24.2] - 2024-02-25
### Fixed
- [Pyodide/WASM only] The list method for raw rows now works for non-finite queries (got broken in `7.24.1`).