### PR TITLE
Ensure ACLs never raise errors from API responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,13 @@ Changes are grouped as follows
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
-## [7.24.3] - 2024-02-27
+## [7.24.4] - 2024-02-28
+### Fixed
+- Unknown ACLs, actions or scopes no longer causes `IAMAPI.[groups.list(...), token.inspect()]` to raise.
+### Added
+- New action for `DataModelInstancesAcl` added: `Write_Properties`.
+
+## [7.24.3] - 2024-02-28
 ### Fixed
 - Fix handling of GeometryCollection objects in the Documents API.
 

--- a/cognite/client/_api/iam.py
+++ b/cognite/client/_api/iam.py
@@ -249,11 +249,15 @@ class GroupsAPI(APIClient):
 
         Example:
 
-            List groups::
+            List your own groups:
 
                 >>> from cognite.client import CogniteClient
                 >>> client = CogniteClient()
                 >>> res = client.iam.groups.list()
+
+            List all groups:
+
+                >>> res = client.iam.groups.list(all=True)
         """
         res = self._get(self._RESOURCE_PATH, params={"all": all})
         # Dev.note: We don't use public load method here (it is final) and we need to pass a magic keyword arg. to
@@ -282,9 +286,11 @@ class GroupsAPI(APIClient):
 
                 >>> from cognite.client import CogniteClient
                 >>> from cognite.client.data_classes import GroupWrite
-                >>> from cognite.client.data_classes.capabilities import GroupsAcl
+                >>> from cognite.client.data_classes.capabilities import AssetsAcl, EventsAcl
                 >>> client = CogniteClient()
-                >>> my_capabilities = [GroupsAcl([GroupsAcl.Action.List], GroupsAcl.Scope.All())]
+                >>> my_capabilities = [
+                ...     AssetsAcl([AssetsAcl.Action.List], AssetsAcl.Scope.All()),
+                ...     EventsAcl([EventsAcl.Action.Write], EventsAcl.Scope.DataSet([123, 456]))]
                 >>> my_group = GroupWrite(name="My Group", capabilities=my_capabilities)
                 >>> res = client.iam.groups.create(my_group)
         """

--- a/cognite/client/_api/iam.py
+++ b/cognite/client/_api/iam.py
@@ -289,7 +289,7 @@ class GroupsAPI(APIClient):
                 >>> from cognite.client.data_classes.capabilities import AssetsAcl, EventsAcl
                 >>> client = CogniteClient()
                 >>> my_capabilities = [
-                ...     AssetsAcl([AssetsAcl.Action.List], AssetsAcl.Scope.All()),
+                ...     AssetsAcl([AssetsAcl.Action.Read], AssetsAcl.Scope.All()),
                 ...     EventsAcl([EventsAcl.Action.Write], EventsAcl.Scope.DataSet([123, 456]))]
                 >>> my_group = GroupWrite(name="My Group", capabilities=my_capabilities)
                 >>> res = client.iam.groups.create(my_group)

--- a/cognite/client/_api/iam.py
+++ b/cognite/client/_api/iam.py
@@ -256,7 +256,9 @@ class GroupsAPI(APIClient):
                 >>> res = client.iam.groups.list()
         """
         res = self._get(self._RESOURCE_PATH, params={"all": all})
-        return GroupList.load(res.json()["items"], cognite_client=self._cognite_client)
+        # Dev.note: We don't use public load method here (it is final) and we need to pass a magic keyword arg. to
+        # not raise whenever new Acls/actions/scopes are added to the API. So we specifically allow the 'unknown':
+        return GroupList._load(res.json()["items"], cognite_client=self._cognite_client, allow_unknown=True)
 
     @overload
     def create(self, group: Group | GroupWrite) -> Group:
@@ -403,7 +405,8 @@ class TokenAPI(APIClient):
                 >>> client = CogniteClient()
                 >>> res = client.iam.token.inspect()
         """
-        return TokenInspection.load(self._get("/api/v1/token/inspect").json(), self._cognite_client)
+        # To not raise whenever new Acls/actions/scopes are added to the API, we specifically allow the unknown:
+        return TokenInspection.load(self._get("/api/v1/token/inspect").json(), self._cognite_client, allow_unknown=True)
 
 
 class SessionsAPI(APIClient):

--- a/cognite/client/_version.py
+++ b/cognite/client/_version.py
@@ -1,4 +1,4 @@
 from __future__ import annotations
 
-__version__ = "7.24.3"
+__version__ = "7.24.4"
 __api_subversion__ = "20230101"

--- a/cognite/client/data_classes/_base.py
+++ b/cognite/client/data_classes/_base.py
@@ -146,8 +146,8 @@ class CogniteObject:
         yaml = local_import("yaml")
         return yaml.dump(self.dump(camel_case=True), sort_keys=False)
 
-    @classmethod
     @final
+    @classmethod
     def load(cls, resource: dict | str, cognite_client: CogniteClient | None = None) -> Self:
         """Load a resource from a YAML/JSON string or dict."""
         if isinstance(resource, dict):
@@ -373,8 +373,8 @@ class CogniteResourceList(UserList, Generic[T_CogniteResource], _WithClientMixin
     def _repr_html_(self) -> str:
         return notebook_display_with_fallback(self)
 
-    @classmethod
     @final
+    @classmethod
     def load(cls, resource: Iterable[dict[str, Any]] | str, cognite_client: CogniteClient | None = None) -> Self:
         """Load a resource from a YAML/JSON string or iterable of dict."""
         if isinstance(resource, str):

--- a/cognite/client/data_classes/capabilities.py
+++ b/cognite/client/data_classes/capabilities.py
@@ -293,7 +293,7 @@ class ProjectCapabilityList(CogniteResourceList[ProjectCapability]):
         for proj_cap in self:
             cap = proj_cap.capability
             if isinstance(cap, UnknownAcl):
-                warnings.warn(f"Unknown capability {cap.capability_name} will be ignored in comparison")
+                warnings.warn(f"Unknown capability {cap.capability_name!r} will be ignored in comparison")
                 continue
             if isinstance(cap, LegacyCapability):
                 # Legacy capabilities are no longer in use, so they are safe to skip.

--- a/cognite/client/data_classes/capabilities.py
+++ b/cognite/client/data_classes/capabilities.py
@@ -1039,6 +1039,7 @@ class DataModelInstancesAcl(Capability):
     class Action(Capability.Action):
         Read = "READ"
         Write = "WRITE"
+        Write_Properties = "WRITE_PROPERTIES"
 
     class Scope:
         All = AllScope

--- a/cognite/client/data_classes/capabilities.py
+++ b/cognite/client/data_classes/capabilities.py
@@ -41,7 +41,7 @@ class Capability(ABC):
         try:
             # There are so many things that may fail validation; non-enum passed, not iterable etc.
             # We always want to show the example usage to the user.
-            if not self.allow_unknown:  # type: ignore [attr-defined]
+            if not self.allow_unknown:
                 self._validate()
         except Exception as err:
             raise ValueError(
@@ -158,7 +158,7 @@ class Capability(ABC):
                 capability_cls(
                     actions=[capability_cls.Action.load(act, allow_unknown) for act in resource[name]["actions"]],
                     scope=Capability.Scope.load(resource[name]["scope"]),
-                    allow_unknown=allow_unknown,  # type: ignore [call-arg]
+                    allow_unknown=allow_unknown,
                 ),
             )
         elif not known_acls and len(resource) == 1:

--- a/cognite/client/data_classes/capabilities.py
+++ b/cognite/client/data_classes/capabilities.py
@@ -88,9 +88,8 @@ class Capability(ABC):
                 return cls(action)
             except ValueError:
                 if allow_unknown:
-                    name = action.title()
-                    Action = enum.Enum("Action", {name: action}, type=Capability.Action)  # type: ignore [misc]
-                    return Action[name]  # type: ignore [return-value]
+                    Action = enum.Enum("Action", {action.title(): action}, type=Capability.Action)  # type: ignore [misc]
+                    return Action(action)  # type: ignore [return-value]
                 raise
 
     @dataclass(frozen=True)

--- a/cognite/client/data_classes/iam.py
+++ b/cognite/client/data_classes/iam.py
@@ -289,9 +289,19 @@ class ProjectSpec(CogniteResponse):
         self.url_name = url_name
         self.groups = groups
 
+    @property
+    def project_url_name(self) -> str:
+        return self.url_name
+
     @classmethod
     def load(cls, api_response: dict[str, Any]) -> ProjectSpec:
         return cls(url_name=api_response["projectUrlName"], groups=api_response["groups"])
+
+    def dump(self, camel_case: bool = True) -> dict[str, str | list[int]]:
+        return {
+            "projectUrlName" if camel_case else "project_url_name": self.url_name,
+            "groups": self.groups,
+        }
 
 
 class TokenInspection(CogniteResponse):

--- a/cognite/client/data_classes/iam.py
+++ b/cognite/client/data_classes/iam.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from abc import ABC
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING, Any, Iterable, cast
 
 from typing_extensions import Self
 
@@ -52,7 +52,7 @@ class GroupCore(WriteableCogniteResource["GroupWrite"], ABC):
         return cls(
             name=resource["name"],
             source_id=resource.get("sourceId"),
-            capabilities=[Capability.load(c) for c in resource.get("capabilities", [])] or None,
+            capabilities=[Capability.load(c, allow_unknown=False) for c in resource.get("capabilities", [])] or None,
             metadata=resource.get("metadata"),
         )
 
@@ -109,11 +109,11 @@ class Group(GroupCore):
         )
 
     @classmethod
-    def _load(cls, resource: dict, cognite_client: CogniteClient | None = None) -> Group:
+    def _load(cls, resource: dict, cognite_client: CogniteClient | None = None, allow_unknown: bool = False) -> Group:
         return cls(
             name=resource["name"],
             source_id=resource.get("sourceId"),
-            capabilities=[Capability.load(c) for c in resource.get("capabilities", [])] or None,
+            capabilities=[Capability.load(c, allow_unknown) for c in resource.get("capabilities", [])] or None,
             id=resource.get("id"),
             is_deleted=resource.get("isDeleted"),
             deleted_time=resource.get("deletedTime"),
@@ -174,6 +174,18 @@ class GroupWriteList(CogniteResourceList[GroupWrite], NameTransformerMixin):
 
 class GroupList(WriteableCogniteResourceList[GroupWrite, Group], NameTransformerMixin, InternalIdTransformerMixin):
     _RESOURCE = Group
+
+    @classmethod
+    def _load(
+        cls,
+        resource_list: Iterable[dict[str, Any]],
+        cognite_client: CogniteClient | None = None,
+        allow_unknown: bool = False,
+    ) -> Self:
+        return cls(
+            [cls._RESOURCE._load(res, cognite_client, allow_unknown) for res in resource_list],
+            cognite_client=cognite_client,
+        )
 
     def as_write(self) -> GroupWriteList:
         """Returns a writing version of this group list."""
@@ -297,11 +309,13 @@ class TokenInspection(CogniteResponse):
         self.capabilities = capabilities
 
     @classmethod
-    def load(cls, api_response: dict[str, Any], cognite_client: CogniteClient | None = None) -> TokenInspection:
+    def load(
+        cls, api_response: dict[str, Any], cognite_client: CogniteClient | None = None, allow_unknown: bool = False
+    ) -> TokenInspection:
         return cls(
             subject=api_response["subject"],
             projects=[ProjectSpec.load(p) for p in api_response["projects"]],
-            capabilities=ProjectCapabilityList.load(api_response["capabilities"], cognite_client),
+            capabilities=ProjectCapabilityList._load(api_response["capabilities"], cognite_client, allow_unknown),
         )
 
     def dump(self, camel_case: bool = True) -> dict[str, Any]:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "cognite-sdk"
 
-version = "7.24.3"
+version = "7.24.4"
 description = "Cognite Python SDK"
 readme = "README.md"
 documentation = "https://cognite-sdk-python.readthedocs-hosted.com"

--- a/tests/tests_unit/test_api/test_iam.py
+++ b/tests/tests_unit/test_api/test_iam.py
@@ -149,11 +149,11 @@ class TestTokenAPI:
 
         assert obj.dump(camel_case=False) == {
             "subject": "subject",
-            "projects": [{"url_name": "urlName", "groups": groups}],
+            "projects": [{"project_url_name": "urlName", "groups": groups}],
             "capabilities": capabilities.dump(camel_case=False),
         }
         assert obj.dump(camel_case=True) == {
             "subject": "subject",
-            "projects": [{"urlName": "urlName", "groups": groups}],
+            "projects": [{"projectUrlName": "urlName", "groups": groups}],
             "capabilities": capabilities.dump(camel_case=True),
         }

--- a/tests/tests_unit/test_base.py
+++ b/tests/tests_unit/test_base.py
@@ -199,7 +199,7 @@ class TestCogniteObject:
     def test_writable_as_write(
         self, cognite_writable_cls: type[WriteableCogniteResource], cognite_mock_client_placeholder
     ):
-        instance_generator = FakeCogniteResourceGenerator(seed=54, cognite_client=cognite_mock_client_placeholder)
+        instance_generator = FakeCogniteResourceGenerator(seed=69_1337, cognite_client=cognite_mock_client_placeholder)
         instance = instance_generator.create_instance(cognite_writable_cls)
 
         write_format = instance.as_write()
@@ -218,7 +218,7 @@ class TestCogniteObject:
         self, writable_list: type[WriteableCogniteResourceList], cognite_mock_client_placeholder
     ):
         resource_cls = writable_list._RESOURCE
-        instance_generator = FakeCogniteResourceGenerator(seed=54, cognite_client=cognite_mock_client_placeholder)
+        instance_generator = FakeCogniteResourceGenerator(seed=53, cognite_client=cognite_mock_client_placeholder)
         instance = instance_generator.create_instance(resource_cls)
         # Setting the cognite_client to None as the `as_write` should not fail if the client is not set.
         instance_list = writable_list([instance], cognite_client=None)
@@ -284,7 +284,7 @@ class TestCogniteObject:
     )
     def test_yaml_serialize(self, cognite_object_subclass: type[CogniteObject], cognite_mock_client_placeholder):
         instance = FakeCogniteResourceGenerator(
-            seed=66, cognite_client=cognite_mock_client_placeholder
+            seed=65, cognite_client=cognite_mock_client_placeholder
         ).create_instance(cognite_object_subclass)
 
         dumped = instance.dump(camel_case=True)
@@ -420,7 +420,7 @@ class TestCogniteResource:
     )
     def test_yaml_serialize(self, cognite_resource_subclass: type[CogniteResource], cognite_mock_client_placeholder):
         instance = FakeCogniteResourceGenerator(
-            seed=66, cognite_client=cognite_mock_client_placeholder
+            seed=64, cognite_client=cognite_mock_client_placeholder
         ).create_instance(cognite_resource_subclass)
 
         yaml_serialised = instance.dump_yaml()

--- a/tests/tests_unit/test_data_classes/test_capabilities.py
+++ b/tests/tests_unit/test_data_classes/test_capabilities.py
@@ -135,7 +135,7 @@ def unknown_cap_with_extra_key():
 class TestCapabilities:
     @pytest.mark.parametrize("access_control", list(all_acls()))
     def test_loads_to_known(self, access_control):
-        cap = Capability.load(access_control)
+        cap = Capability.load(access_control, allow_unknown=False)
 
         assert not isinstance(cap, UnknownAcl)
         assert not isinstance(cap.scope, UnknownScope)

--- a/tests/tests_unit/test_data_classes/test_capabilities.py
+++ b/tests/tests_unit/test_data_classes/test_capabilities.py
@@ -32,6 +32,12 @@ def all_acls():
         {"assetsAcl": {"actions": ["READ", "WRITE"], "scope": {"datasetScope": {"ids": ["372"]}}}},
         {"dataModelInstancesAcl": {"actions": ["READ", "WRITE"], "scope": {"all": {}}}},
         {"dataModelInstancesAcl": {"actions": ["READ"], "scope": {"spaceScope": {"externalIds": ["maintain"]}}}},
+        {
+            "dataModelInstancesAcl": {
+                "actions": ["WRITE_PROPERTIES"],
+                "scope": {"spaceIdScope": {"spaceIds": ["tech-space"]}},
+            }
+        },
         {"dataModelsAcl": {"actions": ["READ", "WRITE"], "scope": {"all": {}}}},
         {
             "dataModelsAcl": {


### PR DESCRIPTION
## Description
Ensures all error handling still runs for users instantiating their capabilities, but let's unknown through when they come straight from API responses.

## Checklist:
- [x] Tests added/updated.
- [x] Documentation updated. Documentation is generated from docstrings - these must be updated according to your change.
  If a new method has been added it should be referenced in [cognite.rst](https://github.com/cognitedata/cognite-sdk-python/blob/master/docs/source/cognite.rst) in order to generate docs based on its docstring.
- [ ] Changelog updated in [CHANGELOG.md](https://github.com/cognitedata/cognite-sdk-python/blob/master/CHANGELOG.md).
- [ ] Version bumped. If triggering a new release is desired, bump the version number in [_version.py](https://github.com/cognitedata/cognite-sdk-python/blob/master/cognite/client/_version.py) and [pyproject.toml](https://github.com/cognitedata/cognite-sdk-python/blob/master/pyproject.toml) per [semantic versioning](https://semver.org/).
