### PR TITLE
fix linter errors due to `WriteableCogniteResourceList` inheritance

### DIFF
--- a/cognite/client/data_classes/_base.py
+++ b/cognite/client/data_classes/_base.py
@@ -398,7 +398,9 @@ class CogniteResourceList(UserList, Generic[T_CogniteResource], _WithClientMixin
 T_CogniteResourceList = TypeVar("T_CogniteResourceList", bound=CogniteResourceList)
 
 
-class WriteableCogniteResourceList(CogniteResourceList, Generic[T_WriteClass, T_WritableCogniteResource]):
+class WriteableCogniteResourceList(
+    CogniteResourceList[T_WritableCogniteResource], Generic[T_WriteClass, T_WritableCogniteResource]
+):
     @abstractmethod
     def as_write(self) -> CogniteResourceList[T_WriteClass]:
         raise NotImplementedError()

--- a/tests/tests_integration/test_api/test_extraction_pipelines.py
+++ b/tests/tests_integration/test_api/test_extraction_pipelines.py
@@ -8,7 +8,7 @@ from cognite.client.data_classes.extractionpipelines import ExtractionPipelineCo
 from cognite.client.exceptions import CogniteNotFoundError
 from cognite.client.utils import datetime_to_ms
 from cognite.client.utils._text import random_string
-from cognite.client.utils._time import YearAligner
+from cognite.client.utils._time import DayAligner
 
 
 @pytest.fixture(scope="function")
@@ -40,7 +40,7 @@ def new_extpipe(cognite_client: CogniteClient):
 @pytest.fixture(scope="function")
 def populated_runs(cognite_client: CogniteClient, new_extpipe: ExtractionPipeline) -> ExtractionPipelineRunList:
     now = datetime_to_ms(dt_now := datetime.now(timezone.utc))
-    a_year_ago = datetime_to_ms(YearAligner.add_units(dt_now, -1))
+    long_time_ago = datetime_to_ms(DayAligner.add_units(dt_now, -300))
     runs = [
         ExtractionPipelineRun(
             extpipe_external_id=new_extpipe.external_id, status="failure", message="lorem ipsum", created_time=now
@@ -49,7 +49,7 @@ def populated_runs(cognite_client: CogniteClient, new_extpipe: ExtractionPipelin
             extpipe_external_id=new_extpipe.external_id,
             status="success",
             message="dolor sit amet",
-            created_time=a_year_ago,
+            created_time=long_time_ago,
         ),
     ]
     created = []


### PR DESCRIPTION
## Description
As reported by https://github.com/cognitedata/cognite-sdk-python/issues/1648

Mypy doesn't seem to care about this change (it infers correctly with/without).