### PR TITLE
Change ClientCredentials to use 'expire_in' (not 'expire_at')

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,11 @@ Changes are grouped as follows
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
+## [7.26.1] - 2024-03-05
+### Fixed
+- The `CredentialProvider` class for client credentials, `OAuthClientCredentials`, was switched from using the non-standard
+  field `expires_at` to `expires_in` that's part of the OAuth 2.0 standard (RFC 6749).
+
 ## [7.26.0] - 2024-02-29
 ### Added
 - In data modeling, added support for setting floats with units in containers. In addition, added support for retrieving,

--- a/cognite/client/_version.py
+++ b/cognite/client/_version.py
@@ -1,4 +1,4 @@
 from __future__ import annotations
 
-__version__ = "7.26.0"
+__version__ = "7.26.1"
 __api_subversion__ = "20230101"

--- a/cognite/client/credentials.py
+++ b/cognite/client/credentials.py
@@ -83,13 +83,11 @@ class _OAuthCredentialProviderWithTokenRefresh(CredentialProvider):
 
     @abstractmethod
     def _refresh_access_token(self) -> tuple[str, float]:
-        """This method should return the access_token and expiry time"""
+        """This method should return the access_token and time until expiration (expire_in)"""
         raise NotImplementedError
 
     def __should_refresh_token(self, token: str | None, expires_at: float | None) -> bool:
-        no_token = token is None
-        token_is_expired = expires_at is None or time.time() > expires_at - self.token_expiry_leeway_seconds
-        return no_token or token_is_expired
+        return token is None or expires_at is None or expires_at > time.time() + self.token_expiry_leeway_seconds
 
     @staticmethod
     def _verify_credentials(credentials: dict[str, Any]) -> None:
@@ -109,7 +107,10 @@ class _OAuthCredentialProviderWithTokenRefresh(CredentialProvider):
         # TODO: Consider instead having a background thread periodically refresh the token to avoid this blocking.
         with self.__token_refresh_lock:
             if self.__should_refresh_token(self.__access_token, self.__access_token_expires_at):
-                self.__access_token, self.__access_token_expires_at = self._refresh_access_token()
+                self.__access_token, time_until_expiry = self._refresh_access_token()
+                # Azure gives 'expires_at' directly, but but it's not a part of the RFC:
+                self.__access_token_expires_at = time.time() + time_until_expiry
+
         return "Authorization", f"Bearer {self.__access_token}"
 
 
@@ -222,7 +223,7 @@ class OAuthDeviceCode(_OAuthCredentialProviderWithTokenRefresh, _WithMsalSeriali
             credentials = self.__app.acquire_token_by_device_flow(flow=device_flow)
 
         self._verify_credentials(credentials)
-        return credentials["access_token"], time.time() + credentials["expires_in"]
+        return credentials["access_token"], credentials["expires_in"]
 
 
 class OAuthInteractive(_OAuthCredentialProviderWithTokenRefresh, _WithMsalSerializableTokenCache):
@@ -302,7 +303,7 @@ class OAuthInteractive(_OAuthCredentialProviderWithTokenRefresh, _WithMsalSerial
             credentials = self.__app.acquire_token_interactive(scopes=self.__scopes, port=self.__redirect_port)
 
         self._verify_credentials(credentials)
-        return credentials["access_token"], time.time() + credentials["expires_in"]
+        return credentials["access_token"], credentials["expires_in"]
 
     @classmethod
     def default_for_azure_ad(
@@ -437,7 +438,8 @@ class OAuthClientCredentials(_OAuthCredentialProviderWithTokenRefresh):
                 client_secret=self.__client_secret,
                 **self.__token_custom_args,
             )
-            return token_result["access_token"], token_result["expires_at"]
+            return token_result["access_token"], token_result["expires_in"]
+
         except OAuth2Error as oauth_err:
             raise CogniteAuthError(
                 f"Error generating access token: {oauth_err.error}, {oauth_err.status_code}, {oauth_err.description}"
@@ -552,4 +554,4 @@ class OAuthClientCertificate(_OAuthCredentialProviderWithTokenRefresh):
         credentials = self.__app.acquire_token_for_client(scopes=self.__scopes)
 
         self._verify_credentials(credentials)
-        return credentials["access_token"], time.time() + credentials["expires_in"]
+        return credentials["access_token"], credentials["expires_in"]

--- a/cognite/client/credentials.py
+++ b/cognite/client/credentials.py
@@ -108,7 +108,7 @@ class _OAuthCredentialProviderWithTokenRefresh(CredentialProvider):
         with self.__token_refresh_lock:
             if self.__should_refresh_token(self.__access_token, self.__access_token_expires_at):
                 self.__access_token, time_until_expiry = self._refresh_access_token()
-                # Azure gives 'expires_at' directly, but but it's not a part of the RFC:
+                # Azure gives 'expires_at' directly, but it's not a part of the RFC:
                 self.__access_token_expires_at = time.time() + time_until_expiry
 
         return "Authorization", f"Bearer {self.__access_token}"

--- a/cognite/client/credentials.py
+++ b/cognite/client/credentials.py
@@ -15,7 +15,7 @@ from requests_oauthlib import OAuth2Session
 
 from cognite.client.exceptions import CogniteAuthError
 
-_TOKEN_EXPIRY_LEEWAY_SECONDS_DEFAULT = 15  # Do not change without also updating all the docstrings using it
+_TOKEN_EXPIRY_LEEWAY_SECONDS_DEFAULT = 30  # Do not change without also updating all the docstrings using it
 
 
 class CredentialProvider(Protocol):
@@ -153,7 +153,7 @@ class OAuthDeviceCode(_OAuthCredentialProviderWithTokenRefresh, _WithMsalSeriali
         client_id (str): Your application's client id.
         scopes (list[str]): A list of scopes.
         token_cache_path (Path | None): Location to store token cache, defaults to os temp directory/cognitetokencache.{client_id}.bin.
-        token_expiry_leeway_seconds (int): The token is refreshed at the earliest when this number of seconds is left before expiry. Default: 15 sec
+        token_expiry_leeway_seconds (int): The token is refreshed at the earliest when this number of seconds is left before expiry. Default: 30 sec
 
     Examples:
 
@@ -234,7 +234,7 @@ class OAuthInteractive(_OAuthCredentialProviderWithTokenRefresh, _WithMsalSerial
         scopes (list[str]): A list of scopes.
         redirect_port (int): Redirect port defaults to 53000.
         token_cache_path (Path | None): Location to store token cache, defaults to os temp directory/cognitetokencache.{client_id}.bin.
-        token_expiry_leeway_seconds (int): The token is refreshed at the earliest when this number of seconds is left before expiry. Default: 15 sec
+        token_expiry_leeway_seconds (int): The token is refreshed at the earliest when this number of seconds is left before expiry. Default: 30 sec
 
     Examples:
 
@@ -323,7 +323,7 @@ class OAuthInteractive(_OAuthCredentialProviderWithTokenRefresh, _WithMsalSerial
             tenant_id (str): The Azure tenant id
             client_id (str): Your application's client id.
             cdf_cluster (str): The CDF cluster where the CDF project is located.
-            token_expiry_leeway_seconds (int): The token is refreshed at the earliest when this number of seconds is left before expiry. Default: 15 sec
+            token_expiry_leeway_seconds (int): The token is refreshed at the earliest when this number of seconds is left before expiry. Default: 30 sec
             **token_custom_args (Any): Optional additional arguments to pass as query parameters to the token fetch request.
 
         Returns:
@@ -346,7 +346,7 @@ class OAuthClientCredentials(_OAuthCredentialProviderWithTokenRefresh):
         client_id (str): Your application's client id.
         client_secret (str): Your application's client secret
         scopes (list[str]): A list of scopes.
-        token_expiry_leeway_seconds (int): The token is refreshed at the earliest when this number of seconds is left before expiry. Default: 15 sec
+        token_expiry_leeway_seconds (int): The token is refreshed at the earliest when this number of seconds is left before expiry. Default: 30 sec
         **token_custom_args (Any): Optional additional arguments to pass as query parameters to the token fetch request.
 
     Examples:
@@ -466,7 +466,7 @@ class OAuthClientCredentials(_OAuthCredentialProviderWithTokenRefresh):
             client_id (str): Your application's client id.
             client_secret (str): Your application's client secret.
             cdf_cluster (str): The CDF cluster where the CDF project is located.
-            token_expiry_leeway_seconds (int): The token is refreshed at the earliest when this number of seconds is left before expiry. Default: 15 sec
+            token_expiry_leeway_seconds (int): The token is refreshed at the earliest when this number of seconds is left before expiry. Default: 30 sec
             **token_custom_args (Any): Optional additional arguments to pass as query parameters to the token fetch request.
 
         Returns:
@@ -491,7 +491,7 @@ class OAuthClientCertificate(_OAuthCredentialProviderWithTokenRefresh):
         cert_thumbprint (str): Your certificate's thumbprint. You get it when you upload your certificate to Azure AD.
         certificate (str): Your private certificate, typically read from a .pem file
         scopes (list[str]): A list of scopes.
-        token_expiry_leeway_seconds (int): The token is refreshed at the earliest when this number of seconds is left before expiry. Default: 15 sec
+        token_expiry_leeway_seconds (int): The token is refreshed at the earliest when this number of seconds is left before expiry. Default: 30 sec
 
     Examples:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "cognite-sdk"
 
-version = "7.26.0"
+version = "7.26.1"
 description = "Cognite Python SDK"
 readme = "README.md"
 documentation = "https://cognite-sdk-python.readthedocs-hosted.com"

--- a/tests/tests_unit/test_api/test_functions.py
+++ b/tests/tests_unit/test_api/test_functions.py
@@ -1,7 +1,6 @@
 import io
 import operator as op
 import os
-from datetime import datetime
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 from zipfile import ZipFile
@@ -323,7 +322,7 @@ def cognite_client_with_client_credentials_flow(rsps):
         rsps.POST,
         "https://bla",
         status=200,
-        json={"access_token": "abc", "expires_at": datetime.now().timestamp() + 1000},
+        json={"access_token": "abc", "expires_in": 1000},
     )
     return CogniteClient(
         ClientConfig(

--- a/tests/tests_unit/test_credential_providers.py
+++ b/tests/tests_unit/test_credential_providers.py
@@ -1,4 +1,3 @@
-import datetime
 from typing import ClassVar
 from unittest.mock import Mock, patch
 
@@ -35,10 +34,7 @@ class TestOauthClientCredentials:
     @patch("cognite.client.credentials.OAuth2Session")
     def test_access_token_generated(self, mock_oauth_session, mock_backend_client):
         mock_backend_client().return_value = Mock()
-        mock_oauth_session().fetch_token.return_value = {
-            "access_token": "azure_token",
-            "expires_at": datetime.datetime.now().timestamp() + 1000,
-        }
+        mock_oauth_session().fetch_token.return_value = {"access_token": "azure_token", "expires_in": 1000}
         creds = OAuthClientCredentials(**self.DEFAULT_PROVIDER_ARGS)
         creds._refresh_access_token()
         assert "Authorization", "Bearer azure_token" == creds.authorization_header()
@@ -60,8 +56,8 @@ class TestOauthClientCredentials:
     def test_access_token_expired(self, mock_oauth_session, mock_backend_client):
         mock_backend_client().return_value = Mock()
         mock_oauth_session().fetch_token.side_effect = [
-            {"access_token": "azure_token_expired", "expires_at": datetime.datetime.now().timestamp() - 1000},
-            {"access_token": "azure_token_refreshed", "expires_at": datetime.datetime.now().timestamp() + 1000},
+            {"access_token": "azure_token_expired", "expires_in": -1000},
+            {"access_token": "azure_token_refreshed", "expires_in": 1000},
         ]
         creds = OAuthClientCredentials(**self.DEFAULT_PROVIDER_ARGS)
         assert "Authorization", "Bearer azure_token_expired" == creds.authorization_header()


### PR DESCRIPTION
## Description
Solves #1602 

## Checklist:
- [x] Tests added/updated.
- [ ] Documentation updated. Documentation is generated from docstrings - these must be updated according to your change.
  If a new method has been added it should be referenced in [cognite.rst](https://github.com/cognitedata/cognite-sdk-python/blob/master/docs/source/cognite.rst) in order to generate docs based on its docstring.
- [x] Changelog updated in [CHANGELOG.md](https://github.com/cognitedata/cognite-sdk-python/blob/master/CHANGELOG.md).
- [x] Version bumped. If triggering a new release is desired, bump the version number in [_version.py](https://github.com/cognitedata/cognite-sdk-python/blob/master/cognite/client/_version.py) and [pyproject.toml](https://github.com/cognitedata/cognite-sdk-python/blob/master/pyproject.toml) per [semantic versioning](https://semver.org/).
