### PR TITLE
Improve memory usage for raw rows iter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,12 @@ Changes are grouped as follows
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
+## [7.27.1] - 2024-03-08
+### Improved
+- When iterating raw rows concurrently, a max queue size for pending results have been added to keep a stable low
+  bounded memory usage profile (for when the caller's code isn't processing fast enough to keep up). Worth noting
+  that this has no effect on the total retrieval time.
+
 ## [7.27.0] - 2024-03-04
 ### Added
 - Added support for multipart file uploads using the `client.files.multipart_upload_session` method.

--- a/cognite/client/_api/raw.py
+++ b/cognite/client/_api/raw.py
@@ -454,7 +454,6 @@ class RawRowsAPI(APIClient):
         while not all(f.done() for f in futures):
             while results:
                 yield results.popleft()
-            time.sleep(0.001)
         yield from results
 
     def _read_rows_limited(
@@ -473,7 +472,6 @@ class RawRowsAPI(APIClient):
                     quit_early.set()
                     yield part[: limit - n_total]
                     return
-            time.sleep(0.001)
             if all(f.done() for f in futures) and not results:
                 return
 

--- a/cognite/client/_api/raw.py
+++ b/cognite/client/_api/raw.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import math
+import random
 import threading
 import time
 from collections import deque
@@ -355,6 +356,10 @@ class RawRowsAPI(APIClient):
 
         Returns:
             Iterator[Row] | Iterator[RowList]: An iterator yielding the requested row or rows.
+
+        Note:
+            When iterating using partitions > 1, the memory usage is bounded at 2 x partitions x chunk_size. This is implemented
+            by halting retrival speed when the callers code can't keep up.
         """
         if partitions is None or _RUNNING_IN_BROWSER:
             return self._list_generator(
@@ -418,16 +423,24 @@ class RawRowsAPI(APIClient):
             for initial in cursors
         ]
 
-        def exhaust(iterator: Iterator, results: deque[RowList], quit_early: threading.Event) -> None:
+        def exhaust(iterator: Iterator) -> None:
             for res in iterator:
                 results.append(res)
                 if quit_early.is_set():
                     return
+                # User code might be processing slower than the rate of row-fetching, and we want this
+                # iteration-based method to have a upper-bounded memory impact, so we keep a max queue
+                # size of unprocessed row-chunks:
+                while len(results) >= partitions:
+                    # Sleep randomly per thread to avoid sending all new fetch requests at the same time
+                    time.sleep(random.uniform(0, partitions))
+                    if quit_early.is_set():
+                        return
 
         quit_early = threading.Event()
         results: deque[RowList] = deque()  # fifo, not that ordering matters anyway...
         pool = ConcurrencySettings.get_thread_pool_executor_or_raise(max_workers=self._config.max_workers)
-        futures = [pool.submit(exhaust, task, results, quit_early) for task in read_iterators]
+        futures = [pool.submit(exhaust, task) for task in read_iterators]
 
         if finite_limit:
             yield from self._read_rows_limited(futures, results, cast(int, limit), quit_early)
@@ -441,7 +454,7 @@ class RawRowsAPI(APIClient):
         while not all(f.done() for f in futures):
             while results:
                 yield results.popleft()
-            time.sleep(0.5)
+            time.sleep(0.001)
         yield from results
 
     def _read_rows_limited(
@@ -460,7 +473,7 @@ class RawRowsAPI(APIClient):
                     quit_early.set()
                     yield part[: limit - n_total]
                     return
-            time.sleep(0.5)
+            time.sleep(0.001)
             if all(f.done() for f in futures) and not results:
                 return
 

--- a/cognite/client/_version.py
+++ b/cognite/client/_version.py
@@ -1,4 +1,4 @@
 from __future__ import annotations
 
-__version__ = "7.27.0"
+__version__ = "7.27.1"
 __api_subversion__ = "20230101"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "cognite-sdk"
 
-version = "7.27.0"
+version = "7.27.1"
 description = "Cognite Python SDK"
 readme = "README.md"
 documentation = "https://cognite-sdk-python.readthedocs-hosted.com"


### PR DESCRIPTION
## Description
### [7.26.3] - 2024-03-07
#### Improved
- When iterating raw rows concurrently, a max queue size for pending results has been added to keep a stable low
  bounded memory usage profile (for when the caller's code isn't processing fast enough to keep up). Worth noting
  that this has no effect on the total retrieval time.

This has the added benefit that our request to the Raw Rows API gets more spread out in time 🚀 

## Example
#### Fetching 600k rows, in chunks of 10k, with 10 cursors.
Current SDK on `master`

<img width="712" alt="Screenshot 2024-03-06 at 22 37 42" src="https://github.com/cognitedata/cognite-sdk-python/assets/8521241/d49ffd5e-c0e4-4211-bd0b-4b9d129adc17">

----
This PR:

<img width="710" alt="Screenshot 2024-03-06 at 22 37 25" src="https://github.com/cognitedata/cognite-sdk-python/assets/8521241/f8741fc5-1763-420e-a77d-0b9ede57fc15">

Note the remarkably similar fetching times

## Checklist:
- [ ] Tests added/updated.
- [x] Documentation updated. Documentation is generated from docstrings - these must be updated according to your change.
  If a new method has been added it should be referenced in [cognite.rst](https://github.com/cognitedata/cognite-sdk-python/blob/master/docs/source/cognite.rst) in order to generate docs based on its docstring.
- [x] Changelog updated in [CHANGELOG.md](https://github.com/cognitedata/cognite-sdk-python/blob/master/CHANGELOG.md).
- [x] Version bumped. If triggering a new release is desired, bump the version number in [_version.py](https://github.com/cognitedata/cognite-sdk-python/blob/master/cognite/client/_version.py) and [pyproject.toml](https://github.com/cognitedata/cognite-sdk-python/blob/master/pyproject.toml) per [semantic versioning](https://semver.org/).
