### PR TITLE
Robustify data model tests

### DIFF
--- a/tests/tests_integration/test_api/test_data_modeling/test_data_models.py
+++ b/tests/tests_integration/test_api/test_data_modeling/test_data_models.py
@@ -29,11 +29,7 @@ def cdf_data_models(
     movie_model: DataModel[View],
     empty_model: DataModel[ViewId],
 ) -> DataModelList[ViewId]:
-    # The movie model and empty fixture are used to ensure that
-    # there are at least two data models in the test environment.
-    data_models = cognite_client.data_modeling.data_models.list(limit=-1)
-    assert len(data_models) >= 2, "Please add at least two data models to the test environment"
-    return data_models
+    return DataModelList[ViewId]([movie_model, empty_model])
 
 
 class TestDataModelsAPI:


### PR DESCRIPTION
## Description
Problem: The fixture `cdf_data_models` uses a `.list(limit=-1)` call. When the tests run in parallel the tests such as `test_apply_retrieve_and_delete` create temporarily data models which are retrieved by the `.list(limit=-1)` call. When this fixture is used in testing later, the temporary model is no longer there and thus the test fails.

https://github.com/cognitedata/cognite-sdk-python/actions/runs/8188053206/job/22389846913

Solution: Avoid the `.list(limit=-1)` and instead just use two permanent models for the `cdf_data_models` fixture.


## Checklist:
- [ ] Tests added/updated.
- [ ] Documentation updated. Documentation is generated from docstrings - these must be updated according to your change.
  If a new method has been added it should be referenced in [cognite.rst](https://github.com/cognitedata/cognite-sdk-python/blob/master/docs/source/cognite.rst) in order to generate docs based on its docstring.
- [ ] Changelog updated in [CHANGELOG.md](https://github.com/cognitedata/cognite-sdk-python/blob/master/CHANGELOG.md).
- [ ] Version bumped. If triggering a new release is desired, bump the version number in [_version.py](https://github.com/cognitedata/cognite-sdk-python/blob/master/cognite/client/_version.py) and [pyproject.toml](https://github.com/cognitedata/cognite-sdk-python/blob/master/pyproject.toml) per [semantic versioning](https://semver.org/).
