### PR TITLE
Fix the problem for multipart uploads on Google by not setting Content-Type header in the individual upload_part calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ Changes are grouped as follows
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
+## [7.27.3] - 2024-03-13
+### Fixed
+ - Fixed issue causing multipart file upload to fail when mime-type was set.
+
 ## [7.27.2] - 2024-03-08
 ### Added
 - Retry 429s on graphql endpoints

--- a/cognite/client/_api/files.py
+++ b/cognite/client/_api/files.py
@@ -699,8 +699,7 @@ class FilesAPI(APIClient):
     def _upload_multipart_part(
         self,
         upload_url: str,
-        content: str | bytes | TextIO | BinaryIO,
-        mime_type: str | None = None,
+        content: str | bytes | TextIO | BinaryIO
     ) -> None:
         """Upload part of a file to an upload URL returned from `multipart_upload_session`.
         Note that if `content` does not somehow expose its length, this method may not work
@@ -709,18 +708,16 @@ class FilesAPI(APIClient):
         Args:
             upload_url (str): URL to upload file chunk to.
             content (str | bytes | TextIO | BinaryIO): The content to upload.
-            mime_type (str | None): Optional mime type for the `Content-Type` header.
         """
         if isinstance(content, str):
             content = content.encode("utf-8")
 
-        headers = {"Content-Type": mime_type}
         upload_response = self._http_client_with_retry.request(
             "PUT",
             upload_url,
             data=content,
             timeout=self._config.file_transfer_timeout,
-            headers=headers,
+            headers=None,
         )
         if not upload_response.ok:
             raise CogniteFileUploadError(

--- a/cognite/client/_api/files.py
+++ b/cognite/client/_api/files.py
@@ -696,11 +696,7 @@ class FilesAPI(APIClient):
             FileMetadata._load(returned_file_metadata), upload_urls, upload_id, self._cognite_client
         )
 
-    def _upload_multipart_part(
-        self,
-        upload_url: str,
-        content: str | bytes | TextIO | BinaryIO
-    ) -> None:
+    def _upload_multipart_part(self, upload_url: str, content: str | bytes | TextIO | BinaryIO) -> None:
         """Upload part of a file to an upload URL returned from `multipart_upload_session`.
         Note that if `content` does not somehow expose its length, this method may not work
         on Azure. See `requests.utils.super_len`.

--- a/cognite/client/_version.py
+++ b/cognite/client/_version.py
@@ -1,4 +1,4 @@
 from __future__ import annotations
 
-__version__ = "7.27.2"
+__version__ = "7.27.3"
 __api_subversion__ = "20230101"

--- a/cognite/client/data_classes/files.py
+++ b/cognite/client/data_classes/files.py
@@ -503,9 +503,7 @@ class FileMultipartUploadSession:
             raise ValueError(f"Index out of range: {part_no}, must be between 0 and {len(self._uploaded_urls)}")
         if self._uploaded_urls[part_no]:
             raise CogniteFileUploadError(message="Attempted to upload an already uploaded part", code=400)
-        self._cognite_client.files._upload_multipart_part(
-            self._upload_urls[part_no], content, self.file_metadata.mime_type
-        )
+        self._cognite_client.files._upload_multipart_part(self._upload_urls[part_no], content)
         self._uploaded_urls[part_no] = True
 
     def __enter__(self) -> FileMultipartUploadSession:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "cognite-sdk"
 
-version = "7.27.2"
+version = "7.27.3"
 description = "Cognite Python SDK"
 readme = "README.md"
 documentation = "https://cognite-sdk-python.readthedocs-hosted.com"

--- a/tests/tests_integration/test_api/test_files.py
+++ b/tests/tests_integration/test_api/test_files.py
@@ -229,6 +229,7 @@ class TestFilesAPI:
 
         with cognite_client.files.multipart_upload_session(
             name="test_multipart.txt",
+            mime_type="text/plain",
             parts=2,
             external_id=external_id,
             overwrite=True,


### PR DESCRIPTION
Setting the content-type for the whole file is handled by initmultipartupload or completemultipartupload.

## Description

In the files API multipart upload support, the Content-Type is set by the files service in the initmultipartupload or completemultipartupload. It is not necessary, and actually causes a problem on at least Google clusters, to set it in the part upload requests for the upload URLs.

## Checklist:
- [ ] Tests added/updated.
- [ ] Documentation updated. Documentation is generated from docstrings - these must be updated according to your change.
  If a new method has been added it should be referenced in [cognite.rst](https://github.com/cognitedata/cognite-sdk-python/blob/master/docs/source/cognite.rst) in order to generate docs based on its docstring.
- [ ] Changelog updated in [CHANGELOG.md](https://github.com/cognitedata/cognite-sdk-python/blob/master/CHANGELOG.md).
- [ ] Version bumped. If triggering a new release is desired, bump the version number in [_version.py](https://github.com/cognitedata/cognite-sdk-python/blob/master/cognite/client/_version.py) and [pyproject.toml](https://github.com/cognitedata/cognite-sdk-python/blob/master/pyproject.toml) per [semantic versioning](https://semver.org/).
