### PR TITLE
Add `_repr_html_` to `Properties` class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,19 +17,23 @@ Changes are grouped as follows
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
-## [7.29.0] - 2024-03-19
+## [7.30.0] - 2024-03-20
+### Added
+- `Properties` class, as used on e.g. `Node` and `Edge`, now renders in Jupyter Notebooks (`_repr_html_` added).
+
+## [7.29.0] - 2024-03-20
 ### Added
 - Direct access to the columns/data stored on raw rows have been added (alongside a `.get` method). Example usage:
   `row["my_col"]` (short-cut for: `row.columns["my_col"]`).
 
 ## [7.28.2] - 2024-03-14
 ### Fixed
- - Retrieving more than 100 containers, views, data models, or spaces would raise a
+- Retrieving more than 100 containers, views, data models, or spaces would raise a
    `CogniteAPIError`. This is now fixed.
 
 ## [7.28.1] - 2024-03-13
 ### Fixed
- - Fixed issue causing multipart file upload to fail when mime-type was set.
+- Fixed issue causing multipart file upload to fail when mime-type was set.
 
 ## [7.28.0] - 2024-03-13
 ### Added
@@ -532,7 +536,7 @@ with no easy way to add a prefix. Also, it no longer expands metadata by default
 - Classes `Geometry`, `AssetAggregate`, `AggregateResultItem`, `EndTimeFilter`, `Label`, `LabelFilter`, `ExtractionPipelineContact`,
   `TimestampRange`, `AggregateResult`, `GeometryFilter`, `GeoLocation`, `RevisionCameraProperties`, `BoundingBox3D` are no longer
   `dict` but classes with attributes matching the API.
-- Calling `client.iam.token.inspect()` now gives an object `TokenInspection` with attribute `cababilities` of type `ProjectCapabilityList`
+- Calling `client.iam.token.inspect()` now gives an object `TokenInspection` with attribute `capabilities` of type `ProjectCapabilityList`
   instead of `list[dict]`
 - In data class `Transformation` the attribute `schedule`, `running_job`, and `last_running_job`, `external_id` and `id`
   are set to the `Transformation` `id` and `external_id` if not set. If they are set to a different value, a `ValueError` is raised

--- a/cognite/client/_version.py
+++ b/cognite/client/_version.py
@@ -1,4 +1,4 @@
 from __future__ import annotations
 
-__version__ = "7.29.0"
+__version__ = "7.30.0"
 __api_subversion__ = "20230101"

--- a/cognite/client/data_classes/data_modeling/instances.py
+++ b/cognite/client/data_classes/data_modeling/instances.py
@@ -258,6 +258,19 @@ class Properties(MutableMapping[ViewIdentifier, MutableMapping[PropertyIdentifie
         view_id = ViewId.load(view)
         self.data[view_id] = properties
 
+    def _repr_html_(self) -> str:
+        pd = local_import("pandas")
+        index_names = "space", "view", "version"
+        if not self:
+            df = pd.DataFrame(index=pd.MultiIndex(levels=([], [], []), codes=([], [], []), names=index_names))
+        else:
+            df = pd.DataFrame.from_dict(
+                {view_id.as_tuple(): props for view_id, props in self.data.items()},
+                orient="index",
+            )
+            df.index.names = index_names
+        return df._repr_html_()
+
 
 class Instance(WritableInstanceCore[T_CogniteResource], ABC):
     """A node or edge. This is the read version of the instance.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "cognite-sdk"
 
-version = "7.29.0"
+version = "7.30.0"
 description = "Cognite Python SDK"
 readme = "README.md"
 documentation = "https://cognite-sdk-python.readthedocs-hosted.com"


### PR DESCRIPTION
As requested here: https://github.com/cognitedata/cognite-sdk-python/pull/1624#pullrequestreview-1897448951

## [7.30.0] - 2024-03-20
### Added
- `Properties` class, as used on e.g. `Node` and `Edge`, now renders in Jupyter Notebooks (`_repr_html_` added).