### PR TITLE
Add quick column access to `Row`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,11 @@ Changes are grouped as follows
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
+## [7.29.0] - 2024-03-19
+### Added
+- Direct access to the columns/data stored on raw rows have been added (alongside a `.get` method). Example usage:
+  `row["my_col"]` (short-cut for: `row.columns["my_col"]`).
+
 ## [7.28.2] - 2024-03-14
 ### Fixed
  - Retrieving more than 100 containers, views, data models, or spaces would raise a
@@ -249,7 +254,7 @@ Changes are grouped as follows
 
 ## [7.13.2] - 2024-01-11
 ### Fixed
-- When calling `ExtractinoPipeline.load` not having a `schedule` would raise a `KeyError` even though it is optional. This is now fixed.
+- When calling `ExtractionPipeline.load` not having a `schedule` would raise a `KeyError` even though it is optional. This is now fixed.
 
 ## [7.13.1] - 2024-01-10
 ### Improved

--- a/cognite/client/_api/raw.py
+++ b/cognite/client/_api/raw.py
@@ -617,11 +617,17 @@ class RawRowsAPI(APIClient):
 
         Examples:
 
-            Retrieve a row with key 'k1' from table 't1' in database 'db1'::
+            Retrieve a row with key 'k1' from table 't1' in database 'db1':
 
                 >>> from cognite.client import CogniteClient
                 >>> client = CogniteClient()
                 >>> row = client.raw.rows.retrieve("db1", "t1", "k1")
+
+            You may access the data directly on the row (like a dict), or use '.get' when keys can be missing:
+
+                >>> val1 = row["col1"]
+                >>> val2 = row.get("col2")
+
         """
         return self._retrieve(
             cls=Row,
@@ -737,7 +743,7 @@ class RawRowsAPI(APIClient):
 
                 >>> for row in client.raw.rows("db1", "t1", columns=["col1","col2"]):
                 ...     val1 = row["col1"]  # You may access the data directly
-                ...     val2 = row.get("col2")  # ...or use .get when keys can be missing
+                ...     val2 = row.get("col2")  # ...or use '.get' when keys can be missing
 
             Iterate through all rows, one chunk at a time, to reduce memory load (no concurrency used):
 

--- a/cognite/client/_api/raw.py
+++ b/cognite/client/_api/raw.py
@@ -736,12 +736,13 @@ class RawRowsAPI(APIClient):
             Iterate through all rows one-by-one to reduce memory load (no concurrency used):
 
                 >>> for row in client.raw.rows("db1", "t1", columns=["col1","col2"]):
-                ...     row  # do something with the row
+                ...     val1 = row["col1"]  # You may access the data directly
+                ...     val2 = row.get("col2")  # ...or use .get when keys can be missing
 
             Iterate through all rows, one chunk at a time, to reduce memory load (no concurrency used):
 
                 >>> for row_list in client.raw.rows("db1", "t1", chunk_size=2500):
-                ...     row_list  # do something with the rows
+                ...     row_list  # Do something with the rows
 
             Iterate through a massive table to reduce memory load while using concurrency for high throughput.
             Note: ``partitions`` must be specified for concurrency to be used (this is different from ``list()``
@@ -752,7 +753,7 @@ class RawRowsAPI(APIClient):
                 ...     db_name="db1", table_name="t1", partitions=5, chunk_size=5000, limit=1_000_000
                 ... )
                 >>> for row_list in rows_iterator:
-                ...     row_list  # do something with the rows
+                ...     row_list  # Do something with the rows
         """
         chunk_size = None
         if _RUNNING_IN_BROWSER:

--- a/cognite/client/_version.py
+++ b/cognite/client/_version.py
@@ -1,4 +1,4 @@
 from __future__ import annotations
 
-__version__ = "7.28.2"
+__version__ = "7.29.0"
 __api_subversion__ = "20230101"

--- a/cognite/client/data_classes/data_modeling/instances.py
+++ b/cognite/client/data_classes/data_modeling/instances.py
@@ -333,6 +333,12 @@ class Instance(WritableInstanceCore[T_CogniteResource], ABC):
         except TypeError:
             self.__raise_if_non_singular_source(attr)
 
+    def __contains__(self, attr: str) -> bool:
+        try:
+            return attr in self._prop_lookup
+        except TypeError:
+            self.__raise_if_non_singular_source(attr)
+
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         dumped = super().dump(camel_case)
         if "properties" in dumped:

--- a/cognite/client/data_classes/raw.py
+++ b/cognite/client/data_classes/raw.py
@@ -76,13 +76,13 @@ class Row(RowCore):
         return (self.columns or {})[attr]
 
     def __setitem__(self, attr: str, value: Any) -> None:
-        if self.columns:
+        if self.columns is not None:
             self.columns[attr] = value
         else:
             raise RuntimeError("columns not set on Row instance")
 
     def __delitem__(self, attr: str) -> None:
-        if self.columns:
+        if self.columns is not None:
             del self.columns[attr]
         else:
             raise RuntimeError("columns not set on Row instance")

--- a/cognite/client/data_classes/raw.py
+++ b/cognite/client/data_classes/raw.py
@@ -69,6 +69,27 @@ class Row(RowCore):
         self.last_updated_time = last_updated_time
         self._cognite_client = cast("CogniteClient", cognite_client)
 
+    def get(self, attr: str, default: Any = None) -> Any:
+        return (self.columns or {}).get(attr, default)
+
+    def __getitem__(self, attr: str) -> Any:
+        return (self.columns or {})[attr]
+
+    def __setitem__(self, attr: str, value: Any) -> None:
+        if self.columns:
+            self.columns[attr] = value
+        else:
+            raise RuntimeError("columns not set on Row instance")
+
+    def __delitem__(self, attr: str) -> None:
+        if self.columns:
+            del self.columns[attr]
+        else:
+            raise RuntimeError("columns not set on Row instance")
+
+    def __contains__(self, attr: str) -> bool:
+        return self.columns is not None and attr in self.columns
+
     def as_write(self) -> RowWrite:
         """Returns this Row as a RowWrite"""
         if self.key is None or self.columns is None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "cognite-sdk"
 
-version = "7.28.2"
+version = "7.29.0"
 description = "Cognite Python SDK"
 readme = "README.md"
 documentation = "https://cognite-sdk-python.readthedocs-hosted.com"

--- a/tests/tests_unit/test_api/test_raw.py
+++ b/tests/tests_unit/test_api/test_raw.py
@@ -291,6 +291,28 @@ class TestRawRows:
             cognite_client.raw.rows(db_name="db1", table_name="table1", columns="a,b")
 
 
+def test_raw_row__direct_column_access():
+    # Verify additional methods: 'get', '__getitem__', '__setitem__', '__delitem__' and '__contains__'
+    key = "itsamee"
+    row = Row(key="foo", columns={"bar": 42, key: "mario"})
+    assert row[key] == row.columns[key] == row.get(key) == "mario"
+
+    row[key] = "luigi?"
+    assert row[key] == row.columns[key] == row.get(key) == "luigi?"
+
+    del row[key]
+    assert key not in row
+    assert key not in row.columns
+    assert row.get(key) is None
+
+    row.columns[key] = "wario?"
+    assert row[key] == row.columns[key] == "wario?"
+
+    del row.columns[key]
+    assert key not in row
+    assert key not in row.columns
+
+
 @pytest.mark.dsl
 class TestPandasIntegration:
     def test_dbs_to_pandas(self):

--- a/tests/tests_unit/test_api/test_raw.py
+++ b/tests/tests_unit/test_api/test_raw.py
@@ -312,6 +312,15 @@ def test_raw_row__direct_column_access():
     assert key not in row
     assert key not in row.columns
 
+    del row["bar"]
+    assert row.columns == {}
+    with pytest.raises(KeyError, match="^'wrong-key'$"):
+        del row["wrong-key"]
+
+    row.columns = None
+    with pytest.raises(RuntimeError, match="^columns not set on Row instance$"):
+        del row["wrong-key"]
+
 
 @pytest.mark.dsl
 class TestPandasIntegration:

--- a/tests/tests_unit/test_data_classes/test_data_models/test_instances.py
+++ b/tests/tests_unit/test_data_classes/test_data_models/test_instances.py
@@ -189,7 +189,9 @@ def test_instances__quick_property_access_single_source(
         del inst["space"]
     # ...but __setitem__ should work, Python mantra is "we are adults". Either way, the API will block all
     # reserved ones, and we don't want to keep a duplicate list up-to-date:
+    assert "space" not in inst
     inst["space"] = "more-space"
+    assert "space" in inst  # ensre __contains__ reflects change
     assert inst.space == "craft"  # ...ensure attribute not affected
 
     # Any property should work fine with all access/set/delete:
@@ -225,6 +227,8 @@ def test_instances__quick_property_access_no_source(
         inst["space"] = "more-space"
     with pytest.raises(RuntimeError):
         del inst["space"]
+    with pytest.raises(RuntimeError):
+        "space" in inst
 
     # ...same applies to properties. We have none so everything should fail:
     with pytest.raises(RuntimeError):


### PR DESCRIPTION
## [7.29.0] - 2024-03-19
### Added
- Direct access to the columns/data stored on raw rows have been added (alongside a `.get` method). Example usage:
  `row["my_col"]` (short-cut for: `row.columns["my_col"]`).

Also added missing dunder method contains to `Instance`.

## Checklist:
- [x] Tests added/updated.
