### PR TITLE
Add missing properties to `DatapointSubscriptionProperty`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,17 +17,20 @@ Changes are grouped as follows
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
+## [7.32.2] - 2024-03-26
+### Added
+- Missing filterable properties `unit_external_id` and `unit_quantity` to `DatapointSubscriptionProperty`.
+  Note: was renamed from `DatapointSubscriptionFilterProperties`, which is now a deprecated alias.
+
 ## [7.32.1] - 2024-03-25
 ### Fixed
-- Fix type hints for functions data classes Function/FunctionSchedule/FunctionCall 
-
+- Fix type hints for functions data classes Function/FunctionSchedule/FunctionCall
 
 ## [7.32.0] - 2024-03-25
 ### Changed
 - Type hint for `id`, `last_updated_time`, and `create_time` attributes are no longer `Optional` on
-subclasses of `CogniteResource`. This is to reflect that these attributes are always set when the 
-object is returned by the SDK.
-
+  subclasses of `CogniteResource`. This is to reflect that these attributes are always set when the
+  object is returned by the SDK.
 
 ## [7.31.0] - 2024-03-24
 ### Added
@@ -35,7 +38,7 @@ object is returned by the SDK.
 - The parameter `limit` to the method `client.iam.session.list`.
 
 ### Fixed
-- The method `client.iam.session.revoke` is now overloaded correctly and returns a `Session` for single id 
+- The method `client.iam.session.revoke` is now overloaded correctly and returns a `Session` for single id
   and a `SessionList` for multiple ids.
 
 ## [7.30.1] - 2024-03-23

--- a/cognite/client/_api/datapoints_subscriptions.py
+++ b/cognite/client/_api/datapoints_subscriptions.py
@@ -53,9 +53,9 @@ class DatapointsSubscriptionAPI(APIClient):
                 >>> from cognite.client import CogniteClient
                 >>> from cognite.client.data_classes import DataPointSubscriptionWrite
                 >>> from cognite.client.data_classes import filters as flt
-                >>> from cognite.client.data_classes.datapoints_subscriptions import DatapointSubscriptionFilterProperties
+                >>> from cognite.client.data_classes.datapoints_subscriptions import DatapointSubscriptionProperty
                 >>> client = CogniteClient()
-                >>> prop = DatapointSubscriptionFilterProperties.is_string
+                >>> prop = DatapointSubscriptionProperty.is_string
                 >>> numeric_timeseries = flt.Equals(prop, False)
                 >>> sub = DataPointSubscriptionWrite(
                 ...     "mySubscription",

--- a/cognite/client/_version.py
+++ b/cognite/client/_version.py
@@ -1,4 +1,4 @@
 from __future__ import annotations
 
-__version__ = "7.32.1"
+__version__ = "7.32.2"
 __api_subversion__ = "20230101"

--- a/cognite/client/data_classes/datapoints_subscriptions.py
+++ b/cognite/client/data_classes/datapoints_subscriptions.py
@@ -420,16 +420,13 @@ class TimeSeriesIDList(CogniteResourceList[TimeSeriesID], IdTransformerMixin):
     _RESOURCE = TimeSeriesID
 
 
-def _metadata(key: str) -> list[str]:
-    return ["metadata", key]
-
-
-class DatapointSubscriptionFilterProperties(EnumProperty):
+class DatapointSubscriptionProperty(EnumProperty):
     description = auto()
     external_id = auto()
-    metadata = _metadata
     name = auto()  # type: ignore [assignment]
     unit = auto()
+    unit_external_id = auto()
+    unit_quantity = auto()
     asset_id = auto()
     asset_root_id = auto()
     created_time = auto()
@@ -438,3 +435,13 @@ class DatapointSubscriptionFilterProperties(EnumProperty):
     last_updated_time = auto()
     is_step = auto()
     is_string = auto()
+
+    @staticmethod
+    def metadata_key(key: str) -> list[str]:
+        return ["metadata", key]
+
+    metadata = metadata_key  # TODO: Remove in major version 8
+
+
+# TODO: Remove in major version 8:
+DatapointSubscriptionFilterProperties = DatapointSubscriptionProperty

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "cognite-sdk"
 
-version = "7.32.1"
+version = "7.32.2"
 description = "Cognite Python SDK"
 readme = "README.md"
 documentation = "https://cognite-sdk-python.readthedocs-hosted.com"

--- a/tests/tests_integration/test_api/test_datapoint_subscriptions.py
+++ b/tests/tests_integration/test_api/test_datapoint_subscriptions.py
@@ -13,7 +13,7 @@ from cognite.client import CogniteClient
 from cognite.client.data_classes import TimeSeries, filters
 from cognite.client.data_classes.datapoints_subscriptions import (
     DatapointSubscription,
-    DatapointSubscriptionFilterProperties,
+    DatapointSubscriptionProperty,
     DataPointSubscriptionUpdate,
     DataPointSubscriptionWrite,
 )
@@ -134,7 +134,7 @@ class TestDatapointSubscriptions:
 
     def test_update_filter_defined_subscription(self, cognite_client: CogniteClient):
         f = filters
-        p = DatapointSubscriptionFilterProperties
+        p = DatapointSubscriptionProperty
         numerical_timeseries = f.And(f.Equals(p.is_string, False))
 
         new_subscription = DataPointSubscriptionWrite(
@@ -295,7 +295,7 @@ class TestDatapointSubscriptions:
         self, cognite_client: CogniteClient, time_series_external_ids: list[str]
     ):
         f = filters
-        p = DatapointSubscriptionFilterProperties
+        p = DatapointSubscriptionProperty
         numerical_timeseries = f.And(
             f.Equals(p.is_string, False), f.Prefix(p.external_id, "PYSDK DataPoint Subscription Test")
         )


### PR DESCRIPTION
## [7.30.1] - 2024-03-21
### Added
- Missing filterable properties `unit_external_id` and `unit_quantity` to `DatapointSubscriptionProperty`.
  Note: was renamed from `DatapointSubscriptionFilterProperties`, which is now a deprecated alias.
