### PR TITLE
Get rid of Optional on read-required CogniteResource properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,13 @@ Changes are grouped as follows
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
+## [7.32.0] - 2024-03-25
+### Changed
+- Type hint for `id`, `last_updated_time`, and `create_time` attributes are no longer `Optional` on
+subclasses of `CogniteResource`. This is to reflect that these attributes are always set when the 
+object is returned by the SDK.
+
+
 ## [7.31.0] - 2024-03-24
 ### Added
 - Retrieve method for session, `client.iam.session.retrieve`

--- a/cognite/client/_api/files.py
+++ b/cognite/client/_api/files.py
@@ -901,7 +901,7 @@ class FilesAPI(APIClient):
 
         id_to_metadata: dict[str | int, FileMetadata] = {}
         for f in files_metadata:
-            id_to_metadata[cast(int, f.id)] = f
+            id_to_metadata[f.id] = f
             if f.external_id is not None:
                 id_to_metadata[f.external_id] = f
 

--- a/cognite/client/_api/functions.py
+++ b/cognite/client/_api/functions.py
@@ -12,7 +12,7 @@ from multiprocessing import Process, Queue
 from numbers import Number
 from pathlib import Path
 from tempfile import TemporaryDirectory
-from typing import TYPE_CHECKING, Any, Callable, Sequence, cast
+from typing import TYPE_CHECKING, Any, Callable, Sequence
 from zipfile import ZipFile
 
 from cognite.client._api_client import APIClient
@@ -452,7 +452,7 @@ class FunctionsAPI(APIClient):
                     overwrite=overwrite,
                     data_set_id=data_set_id,
                 )
-                return cast(int, file.id)
+                return file.id
         finally:
             os.chdir(current_dir)
 
@@ -491,7 +491,7 @@ class FunctionsAPI(APIClient):
                 overwrite=overwrite,
                 data_set_id=data_set_id,
             )
-            return cast(int, file.id)
+            return file.id
 
     @staticmethod
     def _assert_exactly_one_of_folder_or_file_id_or_function_handle(

--- a/cognite/client/_version.py
+++ b/cognite/client/_version.py
@@ -1,4 +1,4 @@
 from __future__ import annotations
 
-__version__ = "7.31.0"
+__version__ = "7.32.0"
 __api_subversion__ = "20230101"

--- a/cognite/client/data_classes/__init__.py
+++ b/cognite/client/data_classes/__init__.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from cognite.client.data_classes._base import Geometry
+from cognite.client.data_classes._base import Geometry, HasExternalAndInternalId, HasExternalId, HasInternalId, HasName
 from cognite.client.data_classes.aggregations import CountAggregate
 from cognite.client.data_classes.annotations import (
     Annotation,
@@ -561,4 +561,8 @@ __all__ = [
     "WorkflowTask",
     "WorkflowUpsertList",
     "WorkflowVersionUpsertList",
+    "HasName",
+    "HasExternalId",
+    "HasInternalId",
+    "HasExternalAndInternalId",
 ]

--- a/cognite/client/data_classes/_base.py
+++ b/cognite/client/data_classes/_base.py
@@ -22,6 +22,7 @@ from typing import (
     cast,
     final,
     overload,
+    runtime_checkable,
 )
 
 from typing_extensions import Self, TypeAlias
@@ -766,27 +767,31 @@ class CogniteSort:
 T_CogniteSort = TypeVar("T_CogniteSort", bound=CogniteSort)
 
 
+@runtime_checkable
 class HasExternalId(Protocol):
     @property
     def external_id(self) -> str | None: ...
 
 
+@runtime_checkable
 class HasName(Protocol):
     @property
     def name(self) -> str | None: ...
 
 
+@runtime_checkable
 class HasInternalId(Protocol):
     @property
-    def id(self) -> int | None: ...
+    def id(self) -> int: ...
 
 
+@runtime_checkable
 class HasExternalAndInternalId(Protocol):
     @property
     def external_id(self) -> str | None: ...
 
     @property
-    def id(self) -> int | None: ...
+    def id(self) -> int: ...
 
 
 class ExternalIDTransformerMixin(Sequence[HasExternalId], ABC):
@@ -846,37 +851,4 @@ class InternalIdTransformerMixin(Sequence[HasInternalId], ABC):
         return ids
 
 
-class IdTransformerMixin(Sequence[HasExternalAndInternalId], ABC):
-    def as_external_ids(self) -> list[str]:
-        """
-        Returns the external ids of all resources.
-
-        Raises:
-            ValueError: If any resource in the list does not have an external id.
-
-        Returns:
-            list[str]: The external ids of all resources in the list.
-        """
-        external_ids: list[str] = []
-        for x in self:
-            if x.external_id is None:
-                raise ValueError(f"All {type(x).__name__} must have external_id")
-            external_ids.append(x.external_id)
-        return external_ids
-
-    def as_ids(self) -> list[int]:
-        """
-        Returns the ids of all resources.
-
-        Raises:
-            ValueError: If any resource in the list does not have an id.
-
-        Returns:
-            list[int]: The ids of all resources in the list.
-        """
-        ids: list[int] = []
-        for x in self:
-            if x.id is None:
-                raise ValueError(f"All {type(x).__name__} must have id")
-            ids.append(x.id)
-        return ids
+class IdTransformerMixin(ExternalIDTransformerMixin, InternalIdTransformerMixin): ...

--- a/cognite/client/data_classes/annotations.py
+++ b/cognite/client/data_classes/annotations.py
@@ -127,9 +127,14 @@ class Annotation(AnnotationCore):
             annotated_resource_type,
             annotated_resource_id,
         )
-        self.id = id
-        self.created_time = created_time
-        self.last_updated_time = last_updated_time
+        # id/created_time/last_updated_time are required when using the class to read,
+        # but don't make sense passing in when creating a new object. So in order to make the typing
+        # correct here (i.e. int and not Optional[int]), we force the type to be int rather than
+        # Optional[int].
+        # TODO: In the next major version we can make these properties required in the constructor
+        self.id: int = id  # type: ignore
+        self.created_time: int = created_time  # type: ignore
+        self.last_updated_time: int = last_updated_time  # type: ignore
         self._cognite_client = cast("CogniteClient", cognite_client)
 
     @classmethod

--- a/cognite/client/data_classes/assets.py
+++ b/cognite/client/data_classes/assets.py
@@ -203,9 +203,14 @@ class Asset(AssetCore):
             labels=Label._load_list(labels),
             geo_location=geo_location,
         )
-        self.id = id
-        self.created_time = created_time
-        self.last_updated_time = last_updated_time
+        # id/created_time/last_updated_time are required when using the class to read,
+        # but don't make sense passing in when creating a new object. So in order to make the typing
+        # correct here (i.e. int and not Optional[int]), we force the type to be int rather than
+        # Optional[int].
+        # TODO: In the next major version we can make these properties required in the constructor
+        self.id: int = id  # type: ignore
+        self.created_time: int = created_time  # type: ignore
+        self.last_updated_time: int = last_updated_time  # type: ignore
         self.root_id = root_id
         self.aggregates = aggregates
         self._cognite_client = cast("CogniteClient", cognite_client)

--- a/cognite/client/data_classes/contextualization.py
+++ b/cognite/client/data_classes/contextualization.py
@@ -201,9 +201,14 @@ class EntityMatchingModel(CogniteResource):
         external_id: str | None = None,
         cognite_client: CogniteClient | None = None,
     ) -> None:
-        self.id = id
+        # id/created_time are required when using the class to read,
+        # but don't make sense passing in when creating a new object. So in order to make the typing
+        # correct here (i.e. int and not Optional[int]), we force the type to be int rather than
+        # Optional[int].
+        # TODO: In the next major version we can make these properties required in the constructor
+        self.id: int = id  # type: ignore
+        self.created_time: int = created_time  # type: ignore
         self.status = status
-        self.created_time = created_time
         self.start_time = start_time
         self.status_time = status_time
         self.error_message = error_message

--- a/cognite/client/data_classes/data_sets.py
+++ b/cognite/client/data_classes/data_sets.py
@@ -84,9 +84,14 @@ class DataSet(DataSetCore):
             metadata=metadata,
             write_protected=write_protected,
         )
-        self.id = id
-        self.created_time = created_time
-        self.last_updated_time = last_updated_time
+        # id/created_time/last_updated_time are required when using the class to read,
+        # but don't make sense passing in when creating a new object. So in order to make the typing
+        # correct here (i.e. int and not Optional[int]), we force the type to be int rather than
+        # Optional[int].
+        # TODO: In the next major version we can make these properties required in the constructor
+        self.id: int = id  # type: ignore
+        self.created_time: int = created_time  # type: ignore
+        self.last_updated_time: int = last_updated_time  # type: ignore
         self._cognite_client = cast("CogniteClient", cognite_client)
 
     def as_write(self) -> DataSetWrite:

--- a/cognite/client/data_classes/events.py
+++ b/cognite/client/data_classes/events.py
@@ -141,9 +141,14 @@ class Event(EventCore):
             asset_ids=asset_ids,
             source=source,
         )
-        self.id = id
-        self.last_updated_time = last_updated_time
-        self.created_time = created_time
+        # id/created_time/last_updated_time are required when using the class to read,
+        # but don't make sense passing in when creating a new object. So in order to make the typing
+        # correct here (i.e. int and not Optional[int]), we force the type to be int rather than
+        # Optional[int].
+        # TODO: In the next major version we can make these properties required in the constructor
+        self.id: int = id  # type: ignore
+        self.created_time: int = created_time  # type: ignore
+        self.last_updated_time: int = last_updated_time  # type: ignore
         self._cognite_client = cast("CogniteClient", cognite_client)
 
     def as_write(self) -> EventWrite:

--- a/cognite/client/data_classes/extractionpipelines.py
+++ b/cognite/client/data_classes/extractionpipelines.py
@@ -163,13 +163,18 @@ class ExtractionPipeline(ExtractionPipelineCore):
             documentation=documentation,
             created_by=created_by,
         )
-        self.id = id
+        # id/created_time/last_updated_time are required when using the class to read,
+        # but don't make sense passing in when creating a new object. So in order to make the typing
+        # correct here (i.e. int and not Optional[int]), we force the type to be int rather than
+        # Optional[int].
+        # TODO: In the next major version we can make these properties required in the constructor
+        self.id: int = id  # type: ignore
+        self.created_time: int = created_time  # type: ignore
+        self.last_updated_time: int = last_updated_time  # type: ignore
         self.last_success = last_success
         self.last_failure = last_failure
         self.last_message = last_message
         self.last_seen = last_seen
-        self.created_time = created_time
-        self.last_updated_time = last_updated_time
         self._cognite_client = cast("CogniteClient", cognite_client)
 
     def as_write(self) -> ExtractionPipelineWrite:

--- a/cognite/client/data_classes/files.py
+++ b/cognite/client/data_classes/files.py
@@ -164,11 +164,16 @@ class FileMetadata(FileMetadataCore):
             source_modified_time=source_modified_time,
             security_categories=security_categories,
         )
-        self.id = id
+        # id/created_time/last_updated_time are required when using the class to read,
+        # but don't make sense passing in when creating a new object. So in order to make the typing
+        # correct here (i.e. int and not Optional[int]), we force the type to be int rather than
+        # Optional[int].
+        # TODO: In the next major version we can make these properties required in the constructor
+        self.id: int = id  # type: ignore
+        self.created_time: int = created_time  # type: ignore
+        self.last_updated_time: int = last_updated_time  # type: ignore
         self.uploaded = uploaded
         self.uploaded_time = uploaded_time
-        self.created_time = created_time
-        self.last_updated_time = last_updated_time
         self._cognite_client = cast("CogniteClient", cognite_client)
 
     def as_write(self) -> FileMetadataWrite:

--- a/cognite/client/data_classes/functions.py
+++ b/cognite/client/data_classes/functions.py
@@ -133,9 +133,14 @@ class Function(FunctionCore):
             runtime=runtime,
             metadata=metadata,
         )
-        self.id = cast(int, id)
+        # id/created_time are required when using the class to read,
+        # but don't make sense passing in when creating a new object. So in order to make the typing
+        # correct here (i.e. int and not Optional[int]), we force the type to be int rather than
+        # Optional[int].
+        # TODO: In the next major version we can make these properties required in the constructor
+        self.id: int = id  # type: ignore
+        self.created_time: int = created_time  # type: ignore
         self.status = status
-        self.created_time = created_time
         self.runtime_version = runtime_version
         self.error = error
         self._cognite_client = cast("CogniteClient", cognite_client)
@@ -553,7 +558,12 @@ class FunctionCall(CogniteResource):
         function_id: int | None = None,
         cognite_client: CogniteClient | None = None,
     ) -> None:
-        self.id = id
+        # id is required when using the class to read,
+        # but don't make sense passing in when creating a new object. So in order to make the typing
+        # correct here (i.e. int and not Optional[int]), we force the type to be int rather than
+        # Optional[int].
+        # TODO: In the next major version we can make these properties required in the constructor
+        self.id: int = id  # type: ignore
         self.start_time = start_time
         self.end_time = end_time
         self.scheduled_time = scheduled_time

--- a/cognite/client/data_classes/iam.py
+++ b/cognite/client/data_classes/iam.py
@@ -94,7 +94,11 @@ class Group(GroupCore):
             capabilities=capabilities,
             metadata=metadata,
         )
-        self.id = id
+        # id is required when using the class to read, but doesn't make sense passing in when
+        # creating a new object. So in order to make the typing correct here
+        # (i.e. int and not Optional[int]), we force the type to be int rather than Optional[int].
+        # TODO: In the next major version we can make these properties required in the constructor
+        self.id: int = id  # type: ignore
         self.is_deleted = is_deleted
         self.deleted_time = deleted_time
         self._cognite_client = cast("CogniteClient", cognite_client)

--- a/cognite/client/data_classes/sequences.py
+++ b/cognite/client/data_classes/sequences.py
@@ -260,7 +260,15 @@ class Sequence(SequenceCore):
             metadata=metadata,
             data_set_id=data_set_id,
         )
-        self.id = id
+        # id/created_time/last_updated_time are required when using the class to read,
+        # but don't make sense passing in when creating a new object. So in order to make the typing
+        # correct here (i.e. int and not Optional[int]), we force the type to be int rather than
+        # Optional[int].
+        # TODO: In the next major version we can make these properties required in the constructor
+        self.id: int = id  # type: ignore
+        self.created_time: int = created_time  # type: ignore
+        self.last_updated_time: int = last_updated_time  # type: ignore
+
         self.columns: SequenceColumnList | None
         if columns is None or isinstance(columns, SequenceColumnList):
             self.columns = columns
@@ -274,8 +282,6 @@ class Sequence(SequenceCore):
             self.columns = SequenceColumnList._load(columns)
         else:
             raise ValueError(f"columns must be a sequence of SequenceColumn objects not {type(columns)}")
-        self.created_time = created_time
-        self.last_updated_time = last_updated_time
         self._cognite_client = cast("CogniteClient", cognite_client)
 
     @classmethod

--- a/cognite/client/data_classes/templates.py
+++ b/cognite/client/data_classes/templates.py
@@ -360,8 +360,13 @@ class TemplateInstance(TemplateInstanceCore):
         cognite_client: CogniteClient | None = None,
     ) -> None:
         super().__init__(external_id, template_name, field_resolvers, data_set_id)
-        self.created_time = created_time
-        self.last_updated_time = last_updated_time
+        # created_time/last_updated_time are required when using the class to read,
+        # but don't make sense passing in when creating a new object. So in order to make the typing
+        # correct here (i.e. int and not Optional[int]), we force the type to be int rather than
+        # Optional[int].
+        # TODO: In the next major version we can make these properties required in the constructor
+        self.created_time: int = created_time  # type: ignore
+        self.last_updated_time: int = last_updated_time  # type: ignore
         self._cognite_client = cast("CogniteClient", cognite_client)
 
     def as_write(self) -> TemplateInstanceWrite:
@@ -545,11 +550,14 @@ class View(ViewCore):
         last_updated_time: int | None = None,
         cognite_client: CogniteClient | None = None,
     ) -> None:
-        self.external_id = external_id
-        self.source = source
-        self.data_set_id = data_set_id
-        self.created_time = created_time
-        self.last_updated_time = last_updated_time
+        super().__init__(external_id=external_id, source=source, data_set_id=data_set_id)
+        # created_time/last_updated_time are required when using the class to read,
+        # but don't make sense passing in when creating a new object. So in order to make the typing
+        # correct here (i.e. int and not Optional[int]), we force the type to be int rather than
+        # Optional[int].
+        # TODO: In the next major version we can make these properties required in the constructor
+        self.created_time: int = created_time  # type: ignore
+        self.last_updated_time: int = last_updated_time  # type: ignore
         self._cognite_client = cast("CogniteClient", cognite_client)
 
     def as_write(self) -> ViewWrite:

--- a/cognite/client/data_classes/three_d.py
+++ b/cognite/client/data_classes/three_d.py
@@ -101,8 +101,13 @@ class ThreeDModel(ThreeDModelCore):
             data_set_id=data_set_id,
             metadata=metadata,
         )
-        self.id = id
-        self.created_time = created_time
+        # id/created_time are required when using the class to read,
+        # but don't make sense passing in when creating a new object. So in order to make the typing
+        # correct here (i.e. int and not Optional[int]), we force the type to be int rather than
+        # Optional[int].
+        # TODO: In the next major version we can make these properties required in the constructor
+        self.id: int = id  # type: ignore
+        self.created_time: int = created_time  # type: ignore
         self._cognite_client = cast("CogniteClient", cognite_client)
 
     def as_write(self) -> ThreeDModelWrite:
@@ -317,12 +322,17 @@ class ThreeDModelRevision(ThreeDModelRevisionCore):
             camera=camera,
             metadata=metadata,
         )
-        self.id = id
+        # id/created_time are required when using the class to read,
+        # but don't make sense passing in when creating a new object. So in order to make the typing
+        # correct here (i.e. int and not Optional[int]), we force the type to be int rather than
+        # Optional[int].
+        # TODO: In the next major version we can make these properties required in the constructor
+        self.id: int = id  # type: ignore
+        self.created_time: int = created_time  # type: ignore
         self.status = status
         self.thumbnail_threed_file_id = thumbnail_threed_file_id
         self.thumbnail_url = thumbnail_url
         self.asset_mapping_count = asset_mapping_count
-        self.created_time = created_time
         self._cognite_client = cast("CogniteClient", cognite_client)
 
     def as_write(self) -> ThreeDModelRevisionWrite:

--- a/cognite/client/data_classes/time_series.py
+++ b/cognite/client/data_classes/time_series.py
@@ -138,10 +138,14 @@ class TimeSeries(TimeSeriesCore):
             data_set_id=data_set_id,
             legacy_name=legacy_name,
         )
-
-        self.id = id
-        self.created_time = created_time
-        self.last_updated_time = last_updated_time
+        # id/created_time/last_updated_time are required when using the class to read,
+        # but don't make sense passing in when creating a new object. So in order to make the typing
+        # correct here (i.e. int and not Optional[int]), we force the type to be int rather than
+        # Optional[int].
+        # TODO: In the next major version we can make these properties required in the constructor
+        self.id: int = id  # type: ignore
+        self.created_time: int = created_time  # type: ignore
+        self.last_updated_time: int = last_updated_time  # type: ignore
         self._cognite_client = cast("CogniteClient", cognite_client)
 
     def as_write(self) -> TimeSeriesWrite:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "cognite-sdk"
 
-version = "7.31.0"
+version = "7.32.0"
 description = "Cognite Python SDK"
 readme = "README.md"
 documentation = "https://cognite-sdk-python.readthedocs-hosted.com"

--- a/tests/tests_unit/test_base.py
+++ b/tests/tests_unit/test_base.py
@@ -23,6 +23,10 @@ from cognite.client.data_classes._base import (
     CogniteResourceList,
     CogniteResponse,
     CogniteUpdate,
+    HasExternalAndInternalId,
+    HasExternalId,
+    HasInternalId,
+    HasName,
     PropertySpec,
     WriteableCogniteResource,
     WriteableCogniteResourceList,
@@ -785,3 +789,28 @@ class TestCogniteResponse:
         # CogniteResponse does not have a reference to the cognite client:
         with pytest.raises(AttributeError):
             MyResponse(1)._cognite_client
+
+
+class TestHasIdProtocols:
+    class WithIdAndExternalId:
+        def __init__(self):
+            self.id: int = 1
+            self.external_id: str | None = None
+
+    class WithName:
+        def __init__(self):
+            self.name: str = "name"
+
+    def test_has_id_protocols(self) -> None:
+        obj = self.WithIdAndExternalId()
+        assert isinstance(obj, HasInternalId)
+        assert isinstance(obj, HasExternalId)
+        assert isinstance(obj, HasExternalAndInternalId)
+        assert not isinstance(obj, HasName)
+
+    def test_has_name_protocol(self) -> None:
+        obj = self.WithName()
+        assert not isinstance(obj, HasInternalId)
+        assert not isinstance(obj, HasExternalId)
+        assert not isinstance(obj, HasExternalAndInternalId)
+        assert isinstance(obj, HasName)


### PR DESCRIPTION
Currently we allow using subclasses of `CogniteResource` to both read _and_ write resources. e.g. `Asset` is returned from the `list`/`retrieve` methods, but is also accepted in the `create`/`update` methods.

The `id`, `last_updated_time`, and `created_time` attributes are all required when using `CogniteResource` classes to read. But when using them to write, the props are optional - they also don't make sense when using the classes to _write_. So this change just forces the type of those attributes to be non-optional. i.e. `int | None -> int`. That means we no longer need uneccesary asserts, casts, or type ignores in code using these classes. e.g.

```
asset = c.assets.retrieve("someId")

# these variants of dealing with the `Optional` are no longer necessary
assert c.id is not None
asset_id: int = cast(int, asset.id)
asset_id: int = asset.id  # type: ignore
```

With this change, we will break clients with a static type checker which rely on explicitly setting these properties to `None` or some optional variable. So, this will fail a static type checker now:

```
id: Optional[int] = 2

asset = Asset()
asset.id = id
# or
asset.id = None
```

But this doesn't match with any intended usage of the SDK that I'm aware of, so we deem this an acceptable tradeoff. We won't break anyone at runtime.