### PR TITLE
[Bug] Notebook repr of SequenceRowsList

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,12 @@ Changes are grouped as follows
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
+## [7.30.1] - 2024-03-23
+### Fixed
+- When calling `client.sequences.data.retrieve` in a Jupyter Notebook the returning `SequenceRowsList` would raise
+  an `AttributeError: 'dict' object has no attribute '_repr_html_'`, i.e., the HTML representation of `SequenceRowsList`
+  was failing. This is now fixed.
+
 ## [7.30.0] - 2024-03-20
 ### Added
 - `Properties` class, as used on e.g. `Node` and `Edge`, now renders in Jupyter Notebooks (`_repr_html_` added).

--- a/cognite/client/_api/datapoints_subscriptions.py
+++ b/cognite/client/_api/datapoints_subscriptions.py
@@ -50,7 +50,6 @@ class DatapointsSubscriptionAPI(APIClient):
                 >>> created = client.time_series.subscriptions.create(sub)
 
             Create a filter defined subscription for all numeric time series:
-
                 >>> from cognite.client import CogniteClient
                 >>> from cognite.client.data_classes import DataPointSubscriptionWrite
                 >>> from cognite.client.data_classes import filters as flt

--- a/cognite/client/_version.py
+++ b/cognite/client/_version.py
@@ -1,4 +1,4 @@
 from __future__ import annotations
 
-__version__ = "7.30.0"
+__version__ = "7.30.1"
 __api_subversion__ = "20230101"

--- a/cognite/client/data_classes/sequences.py
+++ b/cognite/client/data_classes/sequences.py
@@ -897,6 +897,9 @@ class SequenceRowsList(CogniteResourceList[SequenceRows]):
 
         raise ValueError(f"Invalid key value '{key}', should be one of ['id', 'external_id']")
 
+    def _repr_html_(self) -> str:
+        return self.to_pandas(key="external_id", concat=True).to_html()
+
 
 SequenceDataList = SequenceRowsList
 

--- a/cognite/client/data_classes/sequences.py
+++ b/cognite/client/data_classes/sequences.py
@@ -898,7 +898,7 @@ class SequenceRowsList(CogniteResourceList[SequenceRows]):
         raise ValueError(f"Invalid key value '{key}', should be one of ['id', 'external_id']")
 
     def _repr_html_(self) -> str:
-        return self.to_pandas(key="external_id", concat=True).to_html()
+        return self.to_pandas(key="external_id", concat=True)._repr_html_()
 
 
 SequenceDataList = SequenceRowsList

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "cognite-sdk"
 
-version = "7.30.0"
+version = "7.30.1"
 description = "Cognite Python SDK"
 readme = "README.md"
 documentation = "https://cognite-sdk-python.readthedocs-hosted.com"

--- a/tests/tests_unit/test_data_classes/test_sequences.py
+++ b/tests/tests_unit/test_data_classes/test_sequences.py
@@ -1,0 +1,21 @@
+import pytest
+
+from cognite.client.data_classes import SequenceColumn, SequenceColumnList, SequenceRow, SequenceRows, SequenceRowsList
+
+
+class TestSequenceRowsList:
+    @pytest.mark.dsl
+    def test_sequence_notebook_repr_html(self):
+        sequence_rows_list = SequenceRowsList(
+            [
+                SequenceRows(
+                    rows=[SequenceRow(row_number=0, values=[1, 2, 3])],
+                    columns=SequenceColumnList([SequenceColumn(col) for col in ["co1", "col2", "col3"]]),
+                    external_id="external_id",
+                )
+            ]
+        )
+
+        html_repr = sequence_rows_list._repr_html_()
+
+        assert isinstance(html_repr, str)


### PR DESCRIPTION
## Description
**Problem**: `SequencesRowList` have a custom implementation of the `.to_pandas()` method with default arguments that 
returns a `dict` instead of `pd.Dataframe`. This causes the default `_repr_html` method to fail.

**Fix**: Add custom implementation of `_repr_html` for the `SequenceRowsList` class.

## Checklist:
- [x] Tests added/updated.
- [ ] Documentation updated. Documentation is generated from docstrings - these must be updated according to your change.
  If a new method has been added it should be referenced in [cognite.rst](https://github.com/cognitedata/cognite-sdk-python/blob/master/docs/source/cognite.rst) in order to generate docs based on its docstring.
- [x] Changelog updated in [CHANGELOG.md](https://github.com/cognitedata/cognite-sdk-python/blob/master/CHANGELOG.md).
- [x] Version bumped. If triggering a new release is desired, bump the version number in [_version.py](https://github.com/cognitedata/cognite-sdk-python/blob/master/cognite/client/_version.py) and [pyproject.toml](https://github.com/cognitedata/cognite-sdk-python/blob/master/pyproject.toml) per [semantic versioning](https://semver.org/).
