### PR TITLE
Only convert single-element prop refs to camelCase

### DIFF
--- a/cognite/client/data_classes/_base.py
+++ b/cognite/client/data_classes/_base.py
@@ -601,11 +601,6 @@ class CogniteFilter(ABC):
 T_CogniteFilter = TypeVar("T_CogniteFilter", bound=CogniteFilter)
 
 
-class NoCaseConversionPropertyList(list):
-    def as_reference(self) -> list[str]:
-        return list(self)
-
-
 class EnumProperty(Enum):
     @staticmethod
     def _generate_next_value_(name: str, *_: Any) -> str:

--- a/cognite/client/data_classes/assets.py
+++ b/cognite/client/data_classes/assets.py
@@ -41,7 +41,6 @@ from cognite.client.data_classes._base import (
     EnumProperty,
     ExternalIDTransformerMixin,
     IdTransformerMixin,
-    NoCaseConversionPropertyList,
     PropertySpec,
     WriteableCogniteResource,
     WriteableCogniteResourceList,
@@ -1085,7 +1084,7 @@ class AssetProperty(EnumProperty):
 
     @staticmethod
     def metadata_key(key: str) -> list[str]:
-        return NoCaseConversionPropertyList(["metadata", key])
+        return ["metadata", key]
 
 
 AssetPropertyLike: TypeAlias = Union[AssetProperty, str, List[str]]
@@ -1103,7 +1102,7 @@ class SortableAssetProperty(EnumProperty):
 
     @staticmethod
     def metadata_key(key: str) -> list[str]:
-        return NoCaseConversionPropertyList(["metadata", key])
+        return ["metadata", key]
 
 
 SortableAssetPropertyLike: TypeAlias = Union[SortableAssetProperty, str, List[str]]

--- a/cognite/client/data_classes/datapoints_subscriptions.py
+++ b/cognite/client/data_classes/datapoints_subscriptions.py
@@ -17,7 +17,6 @@ from cognite.client.data_classes._base import (
     EnumProperty,
     ExternalIDTransformerMixin,
     IdTransformerMixin,
-    NoCaseConversionPropertyList,
     PropertySpec,
     WriteableCogniteResource,
     WriteableCogniteResourceList,
@@ -422,7 +421,7 @@ class TimeSeriesIDList(CogniteResourceList[TimeSeriesID], IdTransformerMixin):
 
 
 def _metadata(key: str) -> list[str]:
-    return NoCaseConversionPropertyList(["metadata", key])
+    return ["metadata", key]
 
 
 class DatapointSubscriptionFilterProperties(EnumProperty):

--- a/cognite/client/data_classes/documents.py
+++ b/cognite/client/data_classes/documents.py
@@ -14,7 +14,6 @@ from cognite.client.data_classes._base import (
     EnumProperty,
     Geometry,
     IdTransformerMixin,
-    NoCaseConversionPropertyList,
 )
 from cognite.client.data_classes.aggregations import UniqueResult
 from cognite.client.data_classes.labels import Label, LabelDefinition
@@ -370,7 +369,7 @@ class SourceFileProperty(EnumProperty):
 
     @staticmethod
     def metadata_key(key: str) -> list[str]:
-        return NoCaseConversionPropertyList(["sourceFile", "metadata", key])
+        return ["sourceFile", "metadata", key]
 
     def as_reference(self) -> list[str]:
         return ["sourceFile", self.value]

--- a/cognite/client/data_classes/events.py
+++ b/cognite/client/data_classes/events.py
@@ -19,7 +19,6 @@ from cognite.client.data_classes._base import (
     EnumProperty,
     ExternalIDTransformerMixin,
     IdTransformerMixin,
-    NoCaseConversionPropertyList,
     PropertySpec,
     WriteableCogniteResource,
     WriteableCogniteResourceList,
@@ -406,7 +405,7 @@ class EventProperty(EnumProperty):
 
     @staticmethod
     def metadata_key(key: str) -> list[str]:
-        return NoCaseConversionPropertyList(["metadata", key])
+        return ["metadata", key]
 
 
 EventPropertyLike: TypeAlias = Union[EventProperty, str, List[str]]
@@ -427,7 +426,7 @@ class SortableEventProperty(EnumProperty):
 
     @staticmethod
     def metadata_key(key: str) -> list[str]:
-        return NoCaseConversionPropertyList(["metadata", key])
+        return ["metadata", key]
 
 
 SortableEventPropertyLike: TypeAlias = Union[SortableEventProperty, str, List[str]]

--- a/cognite/client/data_classes/filters.py
+++ b/cognite/client/data_classes/filters.py
@@ -61,7 +61,10 @@ def _dump_property(property_: PropertyReference, camel_case: bool) -> list[str] 
     elif isinstance(property_, str):
         return [to_camel_case(property_) if camel_case else property_]
     elif isinstance(property_, (list, tuple)):
-        return type(property_)(map(to_camel_case, property_)) if camel_case else property_
+        if len(property_) == 1:
+            return [to_camel_case(property_[0])] if camel_case else property_
+        else:
+            return property_
     else:
         raise ValueError(f"Invalid property format {property_}")
 

--- a/cognite/client/data_classes/filters.py
+++ b/cognite/client/data_classes/filters.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING, Any, List, Literal, Mapping, NoReturn, Sequenc
 
 from typing_extensions import TypeAlias
 
-from cognite.client.data_classes._base import EnumProperty, Geometry, NoCaseConversionPropertyList
+from cognite.client.data_classes._base import EnumProperty, Geometry
 from cognite.client.data_classes.labels import Label
 from cognite.client.utils._text import to_camel_case
 from cognite.client.utils.useful_types import SequenceNotStr
@@ -56,7 +56,7 @@ def _load_filter_value(value: Any) -> FilterValue | FilterValueList:
 
 
 def _dump_property(property_: PropertyReference, camel_case: bool) -> list[str] | tuple[str, ...]:
-    if isinstance(property_, (EnumProperty, NoCaseConversionPropertyList)):
+    if isinstance(property_, EnumProperty):
         return property_.as_reference()
     elif isinstance(property_, str):
         return [to_camel_case(property_) if camel_case else property_]

--- a/cognite/client/data_classes/sequences.py
+++ b/cognite/client/data_classes/sequences.py
@@ -21,7 +21,6 @@ from cognite.client.data_classes._base import (
     EnumProperty,
     ExternalIDTransformerMixin,
     IdTransformerMixin,
-    NoCaseConversionPropertyList,
     PropertySpec,
     WriteableCogniteResource,
     WriteableCogniteResourceList,
@@ -925,7 +924,7 @@ class SequenceProperty(EnumProperty):
 
     @staticmethod
     def metadata_key(key: str) -> list[str]:
-        return NoCaseConversionPropertyList(["metadata", key])
+        return ["metadata", key]
 
 
 class SortableSequenceProperty(EnumProperty):
@@ -939,7 +938,7 @@ class SortableSequenceProperty(EnumProperty):
 
     @staticmethod
     def metadata_key(key: str) -> list[str]:
-        return NoCaseConversionPropertyList(["metadata", key])
+        return ["metadata", key]
 
 
 SortableSequencePropertyLike: TypeAlias = Union[SortableSequenceProperty, str, List[str]]

--- a/cognite/client/data_classes/time_series.py
+++ b/cognite/client/data_classes/time_series.py
@@ -19,7 +19,6 @@ from cognite.client.data_classes._base import (
     EnumProperty,
     ExternalIDTransformerMixin,
     IdTransformerMixin,
-    NoCaseConversionPropertyList,
     PropertySpec,
     WriteableCogniteResource,
     WriteableCogniteResourceList,
@@ -433,7 +432,7 @@ class TimeSeriesProperty(EnumProperty):
 
     @staticmethod
     def metadata_key(key: str) -> list[str]:
-        return NoCaseConversionPropertyList(["metadata", key])
+        return ["metadata", key]
 
 
 class SortableTimeSeriesProperty(EnumProperty):
@@ -447,7 +446,7 @@ class SortableTimeSeriesProperty(EnumProperty):
 
     @staticmethod
     def metadata_key(key: str) -> list[str]:
-        return NoCaseConversionPropertyList(["metadata", key])
+        return ["metadata", key]
 
 
 SortableTimeSeriesPropertyLike: TypeAlias = Union[SortableTimeSeriesProperty, str, List[str]]

--- a/tests/tests_unit/test_data_classes/test_filters.py
+++ b/tests/tests_unit/test_data_classes/test_filters.py
@@ -1,0 +1,27 @@
+import pytest
+
+from cognite.client.data_classes.filters import Filter, In
+
+
+@pytest.mark.parametrize(
+    "user_filter, expected",
+    [
+        (
+            In(property=["do_not_convert_me", "do_not_convert_me"], values=[1, 2, 3]),
+            {"in": {"property": ["do_not_convert_me", "do_not_convert_me"], "values": [1, 2, 3]}},
+        ),
+        (
+            In(property=["do_not_convert_me", "do_not_convert_me/v1", "do_not_convert_me"], values=[1, 2, 3]),
+            {
+                "in": {
+                    "property": ["do_not_convert_me", "do_not_convert_me/v1", "do_not_convert_me"],
+                    "values": [1, 2, 3],
+                }
+            },
+        ),
+        # Only single-element property references should be converted to camelCase
+        (In(property=["convert_me"], values=[1, 2, 3]), {"in": {"property": ["convertMe"], "values": [1, 2, 3]}}),
+    ],
+)
+def test_filter_property_case_conversion(user_filter: Filter, expected: dict) -> None:
+    assert user_filter.dump(camel_case_property=True) == expected


### PR DESCRIPTION
- Only convert single-element property references to camel_case when dumping filters
- Remove NoCaseConversionPropertyList

## Description
Please describe the change you have made.

## Checklist:
- [ ] Tests added/updated.
- [ ] Documentation updated. Documentation is generated from docstrings - these must be updated according to your change.
  If a new method has been added it should be referenced in [cognite.rst](https://github.com/cognitedata/cognite-sdk-python/blob/master/docs/source/cognite.rst) in order to generate docs based on its docstring.
- [ ] Changelog updated in [CHANGELOG.md](https://github.com/cognitedata/cognite-sdk-python/blob/master/CHANGELOG.md).
- [ ] Version bumped. If triggering a new release is desired, bump the version number in [_version.py](https://github.com/cognitedata/cognite-sdk-python/blob/master/cognite/client/_version.py) and [pyproject.toml](https://github.com/cognitedata/cognite-sdk-python/blob/master/pyproject.toml) per [semantic versioning](https://semver.org/).
