### PR TITLE
Fix dtype conversion on `DatapointsArray`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,11 @@ Changes are grouped as follows
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
+## [7.32.4] - 2024-03-28
+### Fixed
+- Several methods for `DatapointsArray` that previously failed for string datapoints due to bad handling
+  of numpy `dtype`-to-native conversion.
+
 ## [7.32.3] - 2024-03-27
 ### Removed
 - Support for `protobuf==3.*` was dropped.

--- a/cognite/client/_version.py
+++ b/cognite/client/_version.py
@@ -1,4 +1,4 @@
 from __future__ import annotations
 
-__version__ = "7.32.3"
+__version__ = "7.32.4"
 __api_subversion__ = "20230101"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "cognite-sdk"
 
-version = "7.32.3"
+version = "7.32.4"
 description = "Cognite Python SDK"
 readme = "README.md"
 documentation = "https://cognite-sdk-python.readthedocs-hosted.com"


### PR DESCRIPTION
## [7.32.4] - 2024-03-28
### Fixed
- Several methods for `DatapointsArray` that previously failed for string datapoints due to bad handling
  of numpy `dtype`-to-native conversion.