### PR TITLE
Bugfix: dropna how-setting for `SequencesDataAPI.insert_dataframe`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,11 @@ Changes are grouped as follows
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
+## [7.32.7] - 2024-04-05
+### Fixed
+- Inserting sequence data using `insert_dataframe` would by default drop all rows that contained at least one missing value.
+  This has now been fixed to only remove rows where all values are missing.
+
 ## [7.32.6] - 2024-04-05
 ### Fixed
 - `AssetsAPI.create_hierarchy` now properly supports `AssetWrite`.

--- a/cognite/client/_api/sequences.py
+++ b/cognite/client/_api/sequences.py
@@ -1031,13 +1031,13 @@ class SequencesDataAPI(APIClient):
             dropna (bool): Whether to drop all NaN rows before inserting.
 
         Examples:
-            Multiply data in the sequence by 2::
+            Insert three rows into columns 'col_a' and 'col_b' of the sequence with id=123:
 
                 >>> from cognite.client import CogniteClient
                 >>> import pandas as pd
                 >>> client = CogniteClient()
                 >>> df = pd.DataFrame({'col_a': [1, 2, 3], 'col_b': [4, 5, 6]}, index=[1, 2, 3])
-                >>> client.sequences.data.insert_dataframe(df, id=1)
+                >>> client.sequences.data.insert_dataframe(df, id=123)
         """
         if dropna:
             dataframe = dataframe.dropna()

--- a/cognite/client/_version.py
+++ b/cognite/client/_version.py
@@ -1,4 +1,4 @@
 from __future__ import annotations
 
-__version__ = "7.32.6"
+__version__ = "7.32.7"
 __api_subversion__ = "20230101"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "cognite-sdk"
 
-version = "7.32.6"
+version = "7.32.7"
 description = "Cognite Python SDK"
 readme = "README.md"
 documentation = "https://cognite-sdk-python.readthedocs-hosted.com"


### PR DESCRIPTION
## [7.32.5] - 2024-04-03
### Fixed
- Inserting sequence data using `insert_dataframe` would by default drop all rows that contained at least one missing value. This has now been fixed to only remove rows where all values are missing.