### PR TITLE
Add support for Groups internally managed by CogIdP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,13 +17,17 @@ Changes are grouped as follows
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
-## [7.38.3] - 2024-04-23
-### Improved
-- The classes `WorkflowUpsert`, `Filter`, `DatapointsArray`, `Query`, `Node`, `Edge`, `Container`, `Document`,
-  `Transformation` which are used for parsing API responses were not handling adding new parameters in 
-  the API correctly. This is now fixed.
+## [7.39.0] - 2024-04-25
+### Added
+- Support for internally managed groups (inside CDF, as opposed to the external identity provider).
 
-## [7.38.2] - 2024-04-23
+## [7.38.3] - 2024-04-25
+### Improved
+- The classes `WorkflowUpsert`, `Filter`, `Query`, `Node`, `Edge`, `Container`, `Document`, and
+  `Transformation` which are used for parsing API responses were not handling adding new parameters in
+  the API correctly. These are now future-proofed.
+
+## [7.38.2] - 2024-04-24
 ### Added
 - Added new parameter `function_external_id` to `FunctionScheduleAPI.create` as a convenience to the user. Note
   that schedules must be attached to a Function by (internal) ID, so a lookup is first done on behalf of the user.

--- a/cognite/client/_api/iam.py
+++ b/cognite/client/_api/iam.py
@@ -285,11 +285,11 @@ class GroupsAPI(APIClient):
 
                 >>> from cognite.client import CogniteClient
                 >>> client = CogniteClient()
-                >>> res = client.iam.groups.list()
+                >>> my_groups = client.iam.groups.list()
 
             List all groups:
 
-                >>> res = client.iam.groups.list(all=True)
+                >>> all_groups = client.iam.groups.list(all=True)
         """
         res = self._get(self._RESOURCE_PATH, params={"all": all})
         # Dev.note: We don't use public load method here (it is final) and we need to pass a magic keyword arg. to

--- a/cognite/client/_api/iam.py
+++ b/cognite/client/_api/iam.py
@@ -312,7 +312,7 @@ class GroupsAPI(APIClient):
 
         Example:
 
-            Create an group without any members:
+            Create a group without any members:
 
                 >>> from cognite.client import CogniteClient
                 >>> from cognite.client.data_classes import GroupWrite

--- a/cognite/client/_api/iam.py
+++ b/cognite/client/_api/iam.py
@@ -312,7 +312,7 @@ class GroupsAPI(APIClient):
 
         Example:
 
-            Create group:
+            Create an group without any members:
 
                 >>> from cognite.client import CogniteClient
                 >>> from cognite.client.data_classes import GroupWrite
@@ -323,6 +323,33 @@ class GroupsAPI(APIClient):
                 ...     EventsAcl([EventsAcl.Action.Write], EventsAcl.Scope.DataSet([123, 456]))]
                 >>> my_group = GroupWrite(name="My Group", capabilities=my_capabilities)
                 >>> res = client.iam.groups.create(my_group)
+
+            Create a group whose members are managed externally (by your company's identity provider (IdP)).
+            This is done by using the ``source_id`` field. If this is the same ID as a group in the IdP,
+            a user in that group will implicitly be a part of this group as well.
+
+                >>> grp = GroupWrite(
+                ...     name="Externally managed group",
+                ...     capabilities=my_capabilities
+                ...     source_id="b7c9a5a4...")
+                >>> res = client.iam.groups.create(grp)
+
+            Create a group whose members are managed internally by Cognite. This group may grant access through
+            listing specific users or include them all. This is done by passing the ``members`` field, either a
+            list of strings with the unique user identifiers or as the constant ``ALL_USER_ACCOUNTS``. To find the
+            user identifiers, you may use the UserProfilesAPI: ``client.iam.user_profiles.list()``.
+
+                >>> from cognite.client.data_classes import ALL_USER_ACCOUNTS
+                >>> all_group = GroupWrite(
+                ...     name="Everyone is welcome!",
+                ...     capabilities=my_capabilities
+                ...     members=ALL_USER_ACCOUNTS,
+                ... )
+                >>> user_list_group = GroupWrite(
+                ...     name="Specfic users only",
+                ...     capabilities=my_capabilities
+                ...     members=["XRsSD1k3mTIKG", "M0SxY6bM9Jl"])
+                >>> res = client.iam.groups.create([user_list_group, all_group])
 
             Capabilities are often defined in configuration files, like YAML or JSON. You may convert capabilities
             from a dict-representation directly into ACLs (access-control list) by using ``Capability.load``.

--- a/cognite/client/_api/iam.py
+++ b/cognite/client/_api/iam.py
@@ -330,7 +330,7 @@ class GroupsAPI(APIClient):
 
                 >>> grp = GroupWrite(
                 ...     name="Externally managed group",
-                ...     capabilities=my_capabilities
+                ...     capabilities=my_capabilities,
                 ...     source_id="b7c9a5a4...")
                 >>> res = client.iam.groups.create(grp)
 
@@ -342,12 +342,12 @@ class GroupsAPI(APIClient):
                 >>> from cognite.client.data_classes import ALL_USER_ACCOUNTS
                 >>> all_group = GroupWrite(
                 ...     name="Everyone is welcome!",
-                ...     capabilities=my_capabilities
+                ...     capabilities=my_capabilities,
                 ...     members=ALL_USER_ACCOUNTS,
                 ... )
                 >>> user_list_group = GroupWrite(
                 ...     name="Specfic users only",
-                ...     capabilities=my_capabilities
+                ...     capabilities=my_capabilities,
                 ...     members=["XRsSD1k3mTIKG", "M0SxY6bM9Jl"])
                 >>> res = client.iam.groups.create([user_list_group, all_group])
 

--- a/cognite/client/_version.py
+++ b/cognite/client/_version.py
@@ -1,4 +1,4 @@
 from __future__ import annotations
 
-__version__ = "7.38.3"
+__version__ = "7.39.0"
 __api_subversion__ = "20230101"

--- a/cognite/client/data_classes/__init__.py
+++ b/cognite/client/data_classes/__init__.py
@@ -134,6 +134,7 @@ from cognite.client.data_classes.geospatial import (
     FeatureWriteList,
 )
 from cognite.client.data_classes.iam import (
+    ALL_USER_ACCOUNTS,
     ClientCredentials,
     CreatedSession,
     Group,
@@ -382,6 +383,7 @@ __all__ = [
     "DocumentHighlight",
     "DocumentHighlightList",
     "ClientCredentials",
+    "ALL_USER_ACCOUNTS",
     "CreatedSession",
     "Group",
     "GroupWrite",

--- a/cognite/client/data_classes/iam.py
+++ b/cognite/client/data_classes/iam.py
@@ -23,14 +23,18 @@ if TYPE_CHECKING:
     from cognite.client import CogniteClient
 
 
+ALL_USER_ACCOUNTS = "allUserAccounts"
+
+
 class GroupCore(WriteableCogniteResource["GroupWrite"], ABC):
     """No description.
 
     Args:
         name (str): Name of the group
         source_id (str | None): ID of the group in the source. If this is the same ID as a group in the IDP, a service account in that group will implicitly be a part of this group as well.
-        capabilities (list[Capability] | None): List of capabilities (acls) this group should grant its users.
+        capabilities (list[Capability] | None): List of capabilities (acls) this group should grant its users. Can not be used together with 'members'.
         metadata (dict[str, Any] | None): Custom, immutable application specific metadata. String key -> String value. Limits: Key are at most 32 bytes. Values are at most 512 bytes. Up to 16 key-value pairs. Total size is at most 4096.
+        members (Literal['allUserAccounts'] | list[str] | None): Specifies which users are members of the group. Can not be used together with 'source_id'.
     """
 
     def __init__(
@@ -39,6 +43,7 @@ class GroupCore(WriteableCogniteResource["GroupWrite"], ABC):
         source_id: str | None = None,
         capabilities: list[Capability] | None = None,
         metadata: dict[str, Any] | None = None,
+        members: Literal["allUserAccounts"] | list[str] | None = None,
     ) -> None:
         self.name = name
         self.source_id = source_id
@@ -46,6 +51,7 @@ class GroupCore(WriteableCogniteResource["GroupWrite"], ABC):
         if isinstance(self.capabilities, Capability):
             self.capabilities = [capabilities]
         self.metadata = metadata
+        self.members = members
 
     @classmethod
     def _load(cls, resource: dict, cognite_client: CogniteClient | None = None) -> Self:
@@ -54,6 +60,7 @@ class GroupCore(WriteableCogniteResource["GroupWrite"], ABC):
             source_id=resource.get("sourceId"),
             capabilities=[Capability.load(c, allow_unknown=False) for c in resource.get("capabilities", [])] or None,
             metadata=resource.get("metadata"),
+            members=resource.get("members"),
         )
 
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
@@ -64,16 +71,20 @@ class GroupCore(WriteableCogniteResource["GroupWrite"], ABC):
 
 
 class Group(GroupCore):
-    """No description.
+    """Groups are used to give principals the capabilities to access CDF resources. One principal
+    can be a member in multiple groups and one group can have multiple members.
+
+    Groups can either be managed through the external identity provider for the project or managed by CDF.
 
     Args:
         name (str): Name of the group
         source_id (str | None): ID of the group in the source. If this is the same ID as a group in the IDP, a service account in that group will implicitly be a part of this group as well.
-        capabilities (list[Capability] | None): List of capabilities (acls) this group should grant its users.
+        capabilities (list[Capability] | None): List of capabilities (acls) this group should grant its users. Can not be used together with 'members'.
         id (int | None): No description.
         is_deleted (bool | None): No description.
         deleted_time (int | None): No description.
         metadata (dict[str, Any] | None): Custom, immutable application specific metadata. String key -> String value. Limits: Key are at most 32 bytes. Values are at most 512 bytes. Up to 16 key-value pairs. Total size is at most 4096.
+        members (Literal['allUserAccounts'] | list[str] | None): Specifies which users are members of the group. Can not be used together with 'source_id'.
         cognite_client (CogniteClient | None): No description.
     """
 
@@ -86,6 +97,7 @@ class Group(GroupCore):
         is_deleted: bool | None = None,
         deleted_time: int | None = None,
         metadata: dict[str, Any] | None = None,
+        members: Literal["allUserAccounts"] | list[str] | None = None,
         cognite_client: CogniteClient | None = None,
     ) -> None:
         super().__init__(
@@ -93,6 +105,7 @@ class Group(GroupCore):
             source_id=source_id,
             capabilities=capabilities,
             metadata=metadata,
+            members=members,
         )
         # id is required when using the class to read, but doesn't make sense passing in when
         # creating a new object. So in order to make the typing correct here
@@ -110,7 +123,21 @@ class Group(GroupCore):
             source_id=self.source_id,
             capabilities=self.capabilities,
             metadata=self.metadata,
+            members=self.members,
         )
+
+    @property
+    def is_externally_managed(self) -> bool:
+        # Note: `source_id` may be returned as the empty string, hence the 'truthy' test
+        if self.source_id and self.members is not None:
+            raise ValueError("Managed status is unknown")
+        return self.source_id is not None
+
+    @property
+    def is_managed_in_cdf(self) -> bool:
+        if self.source_id and self.members is not None:
+            raise ValueError("Managed status is unknown")
+        return self.members is not None
 
     @classmethod
     def _load(cls, resource: dict, cognite_client: CogniteClient | None = None, allow_unknown: bool = False) -> Group:
@@ -122,6 +149,7 @@ class Group(GroupCore):
             is_deleted=resource.get("isDeleted"),
             deleted_time=resource.get("deletedTime"),
             metadata=resource.get("metadata"),
+            members=resource.get("members"),
             cognite_client=cognite_client,
         )
 
@@ -144,13 +172,17 @@ class Group(GroupCore):
 
 
 class GroupWrite(GroupCore):
-    """No description.
+    """Groups are used to give principals the capabilities to access CDF resources. One principal
+    can be a member in multiple groups and one group can have multiple members.
+
+    Groups can either be managed through the external identity provider for the project or managed by CDF.
 
     Args:
         name (str): Name of the group
         source_id (str | None): ID of the group in the source. If this is the same ID as a group in the IDP, a service account in that group will implicitly be a part of this group as well.
-        capabilities (list[Capability] | None): List of capabilities (acls) this group should grant its users.
+        capabilities (list[Capability] | None): List of capabilities (acls) this group should grant its users. Can not be used together with 'members'.
         metadata (dict[str, Any] | None): Custom, immutable application specific metadata. String key -> String value. Limits: Key are at most 32 bytes. Values are at most 512 bytes. Up to 16 key-value pairs. Total size is at most 4096.
+        members (Literal['allUserAccounts'] | list[str] | None): Specifies which users are members of the group. Can not be used together with 'source_id'.
     """
 
     def __init__(
@@ -159,12 +191,14 @@ class GroupWrite(GroupCore):
         source_id: str | None = None,
         capabilities: list[Capability] | None = None,
         metadata: dict[str, Any] | None = None,
+        members: Literal["allUserAccounts"] | list[str] | None = None,
     ) -> None:
         super().__init__(
             name=name,
             source_id=source_id,
             capabilities=capabilities,
             metadata=metadata,
+            members=members,
         )
 
     def as_write(self) -> GroupWrite:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "cognite-sdk"
 
-version = "7.38.3"
+version = "7.39.0"
 description = "Cognite Python SDK"
 readme = "README.md"
 documentation = "https://cognite-sdk-python.readthedocs-hosted.com"

--- a/tests/tests_integration/test_api/test_iam.py
+++ b/tests/tests_integration/test_api/test_iam.py
@@ -38,7 +38,7 @@ class TestGroupsAPI:
             )
             assert "bla" == group.name
             assert metadata == group.metadata
-            assert group.source_id or "" == source_id
+            assert group.source_id == (source_id or "")
             assert group.members == members
         finally:
             if group:

--- a/tests/tests_integration/test_api/test_iam.py
+++ b/tests/tests_integration/test_api/test_iam.py
@@ -22,7 +22,8 @@ class TestGroupsAPI:
         loaded = GroupList.load(group_list.dump(camel_case=True))
         assert group_list.dump() == loaded.dump()
 
-    def test_create(self, cognite_client):
+    @pytest.mark.parametrize("source_id, members", (("abc-123", None), (None, ["user1", "user2"])))
+    def test_create(self, cognite_client, source_id, members):
         metadata = {"haha": "blabla"}
         group: Group | None = None
         try:
@@ -31,10 +32,14 @@ class TestGroupsAPI:
                     name="bla",
                     capabilities=[EventsAcl([EventsAcl.Action.Read], EventsAcl.Scope.All())],
                     metadata=metadata,
+                    source_id=source_id,
+                    members=members,
                 )
             )
             assert "bla" == group.name
             assert metadata == group.metadata
+            assert group.source_id or "" == source_id
+            assert group.members == members
         finally:
             if group:
                 cognite_client.iam.groups.delete(group.id)

--- a/tests/tests_unit/test_data_classes/test_groups.py
+++ b/tests/tests_unit/test_data_classes/test_groups.py
@@ -8,6 +8,34 @@ from cognite.client.data_classes import Group, GroupList
 from cognite.client.data_classes.capabilities import DataModelInstancesAcl
 
 
+@pytest.fixture
+def group_with_members():
+    return {
+        "id": 168183,
+        "isDeleted": False,
+        "deletedTime": -1,
+        "sourceId": "",
+        "name": "internal list of users",
+        "capabilities": [{"assetsAcl": {"actions": ["READ"], "scope": {"all": {}}}}],
+        "metadata": {},
+        "members": ["H6bM9ldQjDg", "XRO3mTIK0Lo"],
+    }
+
+
+@pytest.fixture
+def group_with_all_members():
+    return {
+        "name": "internal all user",
+        "sourceId": "",
+        "capabilities": [{"assetsAcl": {"actions": ["READ"], "scope": {"all": {}}}}],
+        "metadata": {},
+        "members": "allUserAccounts",
+        "id": 4961547,
+        "isDeleted": False,
+        "deletedTime": -1,
+    }
+
+
 def raw_groups():
     yield {
         "name": "entitymatching",
@@ -48,6 +76,12 @@ class TestGroups:
     def test_load_dump_unknown_group(self, raw: dict[str, Any]) -> None:
         group = Group.load(raw)
         assert group.dump(camel_case=True) == raw
+
+    def test_load_dump__cdf_managed_groups(self, group_with_members, group_with_all_members) -> None:
+        for raw in (group_with_members, group_with_all_members):
+            group = Group.load(raw)
+            assert group.dump(camel_case=True) == raw
+            assert group.is_managed_in_cdf
 
     @pytest.mark.dsl
     def test_to_pandas__deleted_time(self):


### PR DESCRIPTION
## [7.38.0] - 2024-04-19
### Added
- Support for groups managed internally in CDF.

## Checklist:
- [x] Tests added/updated.
- [x] Documentation updated. Documentation is generated from docstrings - these must be updated according to your change.
  If a new method has been added it should be referenced in [cognite.rst](https://github.com/cognitedata/cognite-sdk-python/blob/master/docs/source/cognite.rst) in order to generate docs based on its docstring.
- [x] Changelog updated in [CHANGELOG.md](https://github.com/cognitedata/cognite-sdk-python/blob/master/CHANGELOG.md).
- [x] Version bumped. If triggering a new release is desired, bump the version number in [_version.py](https://github.com/cognitedata/cognite-sdk-python/blob/master/cognite/client/_version.py) and [pyproject.toml](https://github.com/cognitedata/cognite-sdk-python/blob/master/pyproject.toml) per [semantic versioning](https://semver.org/).
