### PR TITLE
Add a flag to `to_pandas()` to convert np.nan to None in object columns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ Changes are grouped as follows
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
+## [7.37.4] - 2024-04-22
+### Added
+- Added `convert_nan_to_none` parameter to `CogniteResourceList.to_pandas` method. If set to `True` all columns of dtype object (e.g. metadata, lables, string columns etc.) will now consistently use `None` in place of missing values (instead of `numpy.nan` or other).
+
 ## [7.37.3] - 2024-04-18
 ### Improved
 - Minor quality of life change for comparing capabilities involving `DataModelInstancesAcl.WRITE_PROPERTIES`; any

--- a/cognite/client/_version.py
+++ b/cognite/client/_version.py
@@ -1,4 +1,4 @@
 from __future__ import annotations
 
-__version__ = "7.37.3"
+__version__ = "7.37.4"
 __api_subversion__ = "20230101"

--- a/cognite/client/data_classes/_base.py
+++ b/cognite/client/data_classes/_base.py
@@ -36,6 +36,7 @@ from cognite.client.utils._pandas_helpers import (
     convert_nullable_int_cols,
     convert_timestamp_columns_to_datetime,
     notebook_display_with_fallback,
+    convert_nan_to_none_for_object_cols,
 )
 from cognite.client.utils._text import convert_all_keys_to_camel_case, to_camel_case
 from cognite.client.utils._time import TIME_ATTRIBUTES, convert_and_isoformat_time_attrs
@@ -342,6 +343,7 @@ class CogniteResourceList(UserList, Generic[T_CogniteResource], _WithClientMixin
         expand_metadata: bool = False,
         metadata_prefix: str = "metadata.",
         convert_timestamps: bool = True,
+        convert_nan_to_none: bool = False, # switch to True in next major realase?
     ) -> pandas.DataFrame:
         """Convert the instance into a pandas DataFrame. Note that if the metadata column is expanded and there are
         keys in the metadata that already exist in the DataFrame, then an error will be raised by pd.join.
@@ -358,6 +360,9 @@ class CogniteResourceList(UserList, Generic[T_CogniteResource], _WithClientMixin
         pd = local_import("pandas")
         df = pd.DataFrame(self.dump(camel_case=camel_case))
         df = convert_nullable_int_cols(df)
+
+        if convert_nan_to_none:
+            convert_nan_to_none_for_object_cols(df)
 
         if convert_timestamps:
             df = convert_timestamp_columns_to_datetime(df)

--- a/cognite/client/data_classes/_base.py
+++ b/cognite/client/data_classes/_base.py
@@ -353,7 +353,7 @@ class CogniteResourceList(UserList, Generic[T_CogniteResource], _WithClientMixin
             expand_metadata (bool): Expand the metadata column into separate columns.
             metadata_prefix (str): Prefix to use for metadata columns.
             convert_timestamps (bool): Convert known columns storing CDF timestamps (milliseconds since epoch) to datetime. Does not affect custom data like metadata.
-            convert_nan_to_none (bool): Convert any missing value type (such as NaN) to None for each column with object dtype.
+            convert_nan_to_none (bool): Convert any missing value type (such as NaN) to None for each column with object dtype (e.g. metadata).
 
         Returns:
             pandas.DataFrame: The Cognite resource as a dataframe.

--- a/cognite/client/data_classes/_base.py
+++ b/cognite/client/data_classes/_base.py
@@ -33,10 +33,10 @@ from cognite.client.utils._auxiliary import fast_dict_load, load_yaml_or_json
 from cognite.client.utils._identifier import IdentifierSequence
 from cognite.client.utils._importing import local_import
 from cognite.client.utils._pandas_helpers import (
+    convert_nan_to_none_for_object_cols,
     convert_nullable_int_cols,
     convert_timestamp_columns_to_datetime,
     notebook_display_with_fallback,
-    convert_nan_to_none_for_object_cols,
 )
 from cognite.client.utils._text import convert_all_keys_to_camel_case, to_camel_case
 from cognite.client.utils._time import TIME_ATTRIBUTES, convert_and_isoformat_time_attrs
@@ -343,7 +343,7 @@ class CogniteResourceList(UserList, Generic[T_CogniteResource], _WithClientMixin
         expand_metadata: bool = False,
         metadata_prefix: str = "metadata.",
         convert_timestamps: bool = True,
-        convert_nan_to_none: bool = False, # switch to True in next major realase?
+        convert_nan_to_none: bool = False,  # switch to True in next major realase?
     ) -> pandas.DataFrame:
         """Convert the instance into a pandas DataFrame. Note that if the metadata column is expanded and there are
         keys in the metadata that already exist in the DataFrame, then an error will be raised by pd.join.
@@ -353,6 +353,7 @@ class CogniteResourceList(UserList, Generic[T_CogniteResource], _WithClientMixin
             expand_metadata (bool): Expand the metadata column into separate columns.
             metadata_prefix (str): Prefix to use for metadata columns.
             convert_timestamps (bool): Convert known columns storing CDF timestamps (milliseconds since epoch) to datetime. Does not affect custom data like metadata.
+            convert_nan_to_none (bool): No description.
 
         Returns:
             pandas.DataFrame: The Cognite resource as a dataframe.

--- a/cognite/client/data_classes/_base.py
+++ b/cognite/client/data_classes/_base.py
@@ -353,7 +353,7 @@ class CogniteResourceList(UserList, Generic[T_CogniteResource], _WithClientMixin
             expand_metadata (bool): Expand the metadata column into separate columns.
             metadata_prefix (str): Prefix to use for metadata columns.
             convert_timestamps (bool): Convert known columns storing CDF timestamps (milliseconds since epoch) to datetime. Does not affect custom data like metadata.
-            convert_nan_to_none (bool): No description.
+            convert_nan_to_none (bool): Convert any missing value type (such as NaN) to None for each column with object dtype.
 
         Returns:
             pandas.DataFrame: The Cognite resource as a dataframe.

--- a/cognite/client/data_classes/iam.py
+++ b/cognite/client/data_classes/iam.py
@@ -201,8 +201,9 @@ class GroupList(WriteableCogniteResourceList[GroupWrite, Group], NameTransformer
         expand_metadata: bool = False,
         metadata_prefix: str = "metadata.",
         convert_timestamps: bool = True,
+        convert_nan_to_none: bool = False,
     ) -> pd.DataFrame:
-        df = super().to_pandas(camel_case, expand_metadata, metadata_prefix, convert_timestamps)
+        df = super().to_pandas(camel_case, expand_metadata, metadata_prefix, convert_timestamps, convert_nan_to_none)
 
         # The API uses -1 to represent "no deleted time". It looks weird if deleted = False,
         # but deleted_time = 1969-12-31 23:59:59.999:

--- a/cognite/client/utils/_pandas_helpers.py
+++ b/cognite/client/utils/_pandas_helpers.py
@@ -98,3 +98,12 @@ def concat_dataframes_with_nullable_int_cols(dfs: Sequence[pd.DataFrame]) -> pd.
     else:
         df.isetitem(int_cols, df.iloc[:, int_cols].astype("Int64"))  # They actually fixed it :D
     return df
+
+
+def convert_nan_to_none_for_object_cols(df: pd.DataFrame) -> None:
+    """
+    Convert np.nan (or other NA values) to None for columns with object dtype.
+    """
+    for col_name, d_type in df.dtypes.items():
+        if "object" == str(d_type):
+            df[col_name].mask(df[col_name].isna(), None, inplace=True)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "cognite-sdk"
 
-version = "7.37.3"
+version = "7.37.4"
 description = "Cognite Python SDK"
 readme = "README.md"
 documentation = "https://cognite-sdk-python.readthedocs-hosted.com"

--- a/tests/tests_unit/test_base.py
+++ b/tests/tests_unit/test_base.py
@@ -540,12 +540,12 @@ class TestCogniteResourceList:
 
         mime_type_expected = ["text/plain", "text/plain", None]
         metadata_expected = [{"catchphrase": "ni!"}, None, None]
-        lables_expected = [None, None, [{"external_id": "interesting"}]]
+        labels_expected = [None, None, [{"external_id": "interesting"}]]
 
         # frame_equal ignores missing value type differences, so converting to list
         assert list(df_converted["mime_type"]) == mime_type_expected
         assert list(df_converted["metadata"]) == metadata_expected
-        assert list(df_converted["labels"]) == lables_expected
+        assert list(df_converted["labels"]) == labels_expected
 
     def test_load(self):
         resource_list = MyResourceList.load([{"varA": 1, "varB": 2}, {"varA": 2, "varB": 3}, {"varA": 3}])

--- a/tests/tests_unit/test_base.py
+++ b/tests/tests_unit/test_base.py
@@ -497,6 +497,7 @@ class TestCogniteResourceList:
         actual_df = event_list.to_pandas(expand_metadata=True)
         pd.testing.assert_frame_equal(expected_df, actual_df)
 
+    @pytest.mark.dsl
     def test_to_pandas_nan(self):
         resources = FileMetadataList(
             [


### PR DESCRIPTION
## Description
It can be surprising to find NaN values in an object column. And it's not consistent when pandas creates NaN or None.

`to_pandas()` method is creating a dataframe from a list of dicts created by the `dump()` method on the CogniteResource. Depending on the specific resource implementations some field keys like `labels` are not included if there are no labels attached. In this case pandas assigns `np.nan` value in the label column for this row. But if the empty field was dumped with `{"labels": None}` then pandas would use `None` value. The behaviour is inconsistent and could lead to bugs, considering that lables is a list of dicts and the user would need to write python code of arbitrary complexity to process the values in the column. A surprising property of `np.nan` is that it's truthy, unlike `None`.

To address the problems of having `nan` I'm suggesting to convert nans to None in the `to_pandas()` method.

Proposed implementation provided.

## Checklist:
- [ ] Tests added/updated.
- [ ] Documentation updated. Documentation is generated from docstrings - these must be updated according to your change.
  If a new method has been added it should be referenced in [cognite.rst](https://github.com/cognitedata/cognite-sdk-python/blob/master/docs/source/cognite.rst) in order to generate docs based on its docstring.
- [ ] Changelog updated in [CHANGELOG.md](https://github.com/cognitedata/cognite-sdk-python/blob/master/CHANGELOG.md).
- [ ] Version bumped. If triggering a new release is desired, bump the version number in [_version.py](https://github.com/cognitedata/cognite-sdk-python/blob/master/cognite/client/_version.py) and [pyproject.toml](https://github.com/cognitedata/cognite-sdk-python/blob/master/pyproject.toml) per [semantic versioning](https://semver.org/).
