### PR TITLE
Add support for `partitions` param in FilesAPI.list()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ Changes are grouped as follows
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
+## [7.38.1] - 2024-04-23
+### Added
+- Added missing `partitions` parameter to `list()` and `__call__()` methods for `FilesAPI`.
+
 ## [7.38.0] - 2024-04-22
 ### Added
 - Support for `workflows.executions.retry`

--- a/cognite/client/_api/files.py
+++ b/cognite/client/_api/files.py
@@ -67,6 +67,7 @@ class FilesAPI(APIClient):
         directory_prefix: str | None = None,
         uploaded: bool | None = None,
         limit: int | None = None,
+        partitions: int | None = None,
     ) -> Iterator[FileMetadata] | Iterator[FileMetadataList]:
         """Iterate over files
 
@@ -95,6 +96,7 @@ class FilesAPI(APIClient):
             directory_prefix (str | None): Filter by this (case-sensitive) prefix for the directory provided by the client.
             uploaded (bool | None): Whether or not the actual file is uploaded. This field is returned only by the API, it has no effect in a post body.
             limit (int | None): Maximum number of files to return. Defaults to return all items.
+            partitions (int | None): Retrieve resources in parallel using this number of workers (values up to 10 allowed), limit must be set to `None` (or `-1`).
 
         Returns:
             Iterator[FileMetadata] | Iterator[FileMetadataList]: yields FileMetadata one by one if chunk_size is not specified, else FileMetadataList objects.
@@ -129,6 +131,7 @@ class FilesAPI(APIClient):
             chunk_size=chunk_size,
             filter=filter,
             limit=limit,
+            partitions=partitions,
         )
 
     def __iter__(self) -> Iterator[FileMetadata]:
@@ -1021,6 +1024,7 @@ class FilesAPI(APIClient):
         directory_prefix: str | None = None,
         uploaded: bool | None = None,
         limit: int | None = DEFAULT_LIMIT_READ,
+        partitions: int | None = None,
     ) -> FileMetadataList:
         """`List files <https://developer.cognite.com/api#tag/Files/operation/advancedListFiles>`_
 
@@ -1046,6 +1050,7 @@ class FilesAPI(APIClient):
             directory_prefix (str | None): Filter by this (case-sensitive) prefix for the directory provided by the client.
             uploaded (bool | None): Whether or not the actual file is uploaded. This field is returned only by the API, it has no effect in a post body.
             limit (int | None): Max number of files to return. Defaults to 25. Set to -1, float("inf") or None to return all items.
+            partitions (int | None): Retrieve resources in parallel using this number of workers (values up to 10 allowed), limit must be set to `None` (or `-1`).
 
         Returns:
             FileMetadataList: The requested files.
@@ -1113,5 +1118,10 @@ class FilesAPI(APIClient):
         ).dump(camel_case=True)
 
         return self._list(
-            list_cls=FileMetadataList, resource_cls=FileMetadata, method="POST", limit=limit, filter=filter
+            list_cls=FileMetadataList,
+            resource_cls=FileMetadata,
+            method="POST",
+            limit=limit,
+            filter=filter,
+            partitions=partitions,
         )

--- a/cognite/client/_version.py
+++ b/cognite/client/_version.py
@@ -1,4 +1,4 @@
 from __future__ import annotations
 
-__version__ = "7.38.0"
+__version__ = "7.38.1"
 __api_subversion__ = "20230101"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "cognite-sdk"
 
-version = "7.38.0"
+version = "7.38.1"
 description = "Cognite Python SDK"
 readme = "README.md"
 documentation = "https://cognite-sdk-python.readthedocs-hosted.com"

--- a/tests/tests_unit/test_api/test_signatures.py
+++ b/tests/tests_unit/test_api/test_signatures.py
@@ -36,7 +36,11 @@ class TestListAndIterSignatures:
             (
                 files.FilesAPI,
                 files.FileMetadataFilter,
-                ["data_set_external_ids", "asset_subtree_external_ids", "partitions",],
+                [
+                    "data_set_external_ids",
+                    "asset_subtree_external_ids",
+                    "partitions",
+                ],
             ),
             (
                 sequences.SequencesAPI,

--- a/tests/tests_unit/test_api/test_signatures.py
+++ b/tests/tests_unit/test_api/test_signatures.py
@@ -36,7 +36,7 @@ class TestListAndIterSignatures:
             (
                 files.FilesAPI,
                 files.FileMetadataFilter,
-                ["data_set_external_ids", "asset_subtree_external_ids"],
+                ["data_set_external_ids", "asset_subtree_external_ids", "partitions",],
             ),
             (
                 sequences.SequencesAPI,


### PR DESCRIPTION
## Description
Bumped into missing partitions when had to list a lot of files. The API supports partitions but its support has been overlooked in the SDK. 

## Checklist:
- [x] Tests added/updated.
- [x] Documentation updated. Documentation is generated from docstrings - these must be updated according to your change.
  If a new method has been added it should be referenced in [cognite.rst](https://github.com/cognitedata/cognite-sdk-python/blob/master/docs/source/cognite.rst) in order to generate docs based on its docstring.
- [x] Changelog updated in [CHANGELOG.md](https://github.com/cognitedata/cognite-sdk-python/blob/master/CHANGELOG.md).
- [x] Version bumped. If triggering a new release is desired, bump the version number in [_version.py](https://github.com/cognitedata/cognite-sdk-python/blob/master/cognite/client/_version.py) and [pyproject.toml](https://github.com/cognitedata/cognite-sdk-python/blob/master/pyproject.toml) per [semantic versioning](https://semver.org/).
