### PR TITLE
Fix documentation bug

### DIFF
--- a/cognite/client/_api/data_modeling/spaces.py
+++ b/cognite/client/_api/data_modeling/spaces.py
@@ -81,7 +81,7 @@ class SpacesAPI(APIClient):
 
                 >>> from cognite.client import CogniteClient
                 >>> client = CogniteClient()
-                >>> res = client.data_modeling.spaces.retrieve(space='mySpace')
+                >>> res = client.data_modeling.spaces.retrieve(spaces='mySpace')
 
             Get multiple spaces by id:
 


### PR DESCRIPTION
The parameter name is `spaces`, not `space`.