### PR TITLE
[CDF-21402] Breaking change: data workflows cancel endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ Changes are grouped as follows
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
+## [7.42.0] - 2024-05-03
+### Changed
+- Breaking change: the `workflows.executions.cancel` method now only allows cancelling one execution at a time to reflect its non-atomic operation.
+
 ## [7.41.0] - 2024-04-30
 ### Added
 - Support for Status Codes in the DatapointsAPI and DatapointSubscriptionsAPI reaches General Availability (GA).

--- a/cognite/client/_api/workflows.py
+++ b/cognite/client/_api/workflows.py
@@ -266,7 +266,7 @@ class WorkflowExecutionAPI(BetaWorkflowAPIClient):
 
         Args:
             id (str): The server-generated id of the workflow execution.
-            reason (str | None): The reason for the cancellation, this will be put within the executions' `reasonForIncompletion` field
+            reason (str | None): The reason for the cancellation, this will be put within the executions' `reasonForIncompletion` field. It is defaulted to 'cancelled' if not provided.
 
         Tip:
             Cancelling a workflow will immediately cancel the `in_progress` tasks, but not their spawned work in
@@ -290,7 +290,9 @@ class WorkflowExecutionAPI(BetaWorkflowAPIClient):
             url_path=f"{self._RESOURCE_PATH}/{id}/cancel",
             json={
                 "reason": reason,
-            },
+            }
+            if reason
+            else {},
         )
 
         return WorkflowExecution._load(response.json())

--- a/cognite/client/_api/workflows.py
+++ b/cognite/client/_api/workflows.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from abc import ABC
-from typing import TYPE_CHECKING, Any, Literal, MutableSequence, Sequence, Tuple, Union
+from typing import TYPE_CHECKING, Any, Literal, MutableSequence, Tuple, Union
 from urllib.parse import quote
 
 from typing_extensions import TypeAlias
@@ -9,7 +9,6 @@ from typing_extensions import TypeAlias
 from cognite.client._api_client import APIClient
 from cognite.client._constants import DEFAULT_LIMIT_READ
 from cognite.client.data_classes.workflows import (
-    CancelExecution,
     Workflow,
     WorkflowExecution,
     WorkflowExecutionDetailed,
@@ -262,18 +261,19 @@ class WorkflowExecutionAPI(BetaWorkflowAPIClient):
             limit=limit,
         )
 
-    def cancel(self, executions: Sequence[CancelExecution]) -> Sequence[WorkflowExecution]:
+    def cancel(self, id: str, reason: str | None) -> WorkflowExecution:
         """`cancel a workflow execution. <https://api-docs.cognite.com/20230101-beta/tag/Workflow-executions/operation/WorkflowExecutionCancellation>`_
 
         Args:
-            executions (Sequence[CancelExecution]): List of executions to cancel.
+            id (str): The server-generated id of the workflow execution.
+            reason (str | None): The reason for the cancellation, this will be put within the executions' `reasonForIncompletion` field
 
         Tip:
-            Cancelling a workflow only prevents it from starting new tasks, tasks already running on
-            other services (transformations and functions) will keep running there.
+            Cancelling a workflow will immediately cancel the `in_progress` tasks, but not their spawned work in
+            other services (like transformations and functions).
 
         Returns:
-            Sequence[WorkflowExecution]: The canceled workflow executions.
+            WorkflowExecution: The canceled workflow execution.
 
         Examples:
 
@@ -283,15 +283,17 @@ class WorkflowExecutionAPI(BetaWorkflowAPIClient):
                 >>> from cognite.client.data_classes import CancelExecution
                 >>> client = CogniteClient()
                 >>> res = client.workflows.executions.trigger("foo", "1")
-                >>> client.workflows.executions.cancel([CancelExecution(res.id, "test cancelation")])
+                >>> client.workflows.executions.cancel(id="foo", reason="test cancelation")
         """
         self._warning.warn()
         response = self._post(
-            url_path=f"{self._RESOURCE_PATH}/cancel",
-            json={"items": [execution.dump(camel_case=True) for execution in executions]},
+            url_path=f"{self._RESOURCE_PATH}/{id}/cancel",
+            json={
+                "reason": reason,
+            },
         )
 
-        return [WorkflowExecution._load(execution) for execution in response.json()["items"]]
+        return WorkflowExecution._load(response.json())
 
     def retry(self, id: str, client_credentials: ClientCredentials | None = None) -> WorkflowExecution:
         """`Retry a workflow execution. <https://api-docs.cognite.com/20230101-beta/tag/Workflow-executions/operation/WorkflowExecutionRetryn>`_
@@ -310,7 +312,7 @@ class WorkflowExecutionAPI(BetaWorkflowAPIClient):
                 >>> from cognite.client.data_classes import CancelExecution
                 >>> client = CogniteClient()
                 >>> res = client.workflows.executions.trigger("foo", "1")
-                >>> client.workflows.executions.cancel([CancelExecution(res.id, "test cancellation")])
+                >>> client.workflows.executions.cancel(id=res.id, reason="test cancellation")
                 >>> client.workflows.executions.retry(res.id)
         """
         self._warning.warn()

--- a/cognite/client/_api/workflows.py
+++ b/cognite/client/_api/workflows.py
@@ -268,7 +268,7 @@ class WorkflowExecutionAPI(BetaWorkflowAPIClient):
             id (str): The server-generated id of the workflow execution.
             reason (str | None): The reason for the cancellation, this will be put within the executions' `reasonForIncompletion` field. It is defaulted to 'cancelled' if not provided.
 
-        Tip:
+        Note:
             Cancelling a workflow will immediately cancel the `in_progress` tasks, but not their spawned work in
             other services (like transformations and functions).
 

--- a/cognite/client/_api/workflows.py
+++ b/cognite/client/_api/workflows.py
@@ -266,7 +266,7 @@ class WorkflowExecutionAPI(BetaWorkflowAPIClient):
 
         Args:
             id (str): The server-generated id of the workflow execution.
-            reason (str | None): The reason for the cancellation, this will be put within the executions' `reasonForIncompletion` field. It is defaulted to 'cancelled' if not provided.
+            reason (str | None): The reason for the cancellation, this will be put within the execution's `reasonForIncompletion` field. It is defaulted to 'cancelled' if not provided.
 
         Note:
             Cancelling a workflow will immediately cancel the `in_progress` tasks, but not their spawned work in

--- a/cognite/client/_version.py
+++ b/cognite/client/_version.py
@@ -1,4 +1,4 @@
 from __future__ import annotations
 
-__version__ = "7.41.0"
+__version__ = "7.42.0"
 __api_subversion__ = "20230101"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "cognite-sdk"
 
-version = "7.41.0"
+version = "7.42.0"
 description = "Cognite Python SDK"
 readme = "README.md"
 documentation = "https://cognite-sdk-python.readthedocs-hosted.com"

--- a/tests/tests_integration/test_api/test_data_workflows.py
+++ b/tests/tests_integration/test_api/test_data_workflows.py
@@ -7,7 +7,6 @@ import pytest
 from cognite.client import CogniteClient
 from cognite.client.data_classes import Function
 from cognite.client.data_classes.workflows import (
-    CancelExecution,
     CDFTaskParameters,
     FunctionTaskParameters,
     SubworkflowTaskParameters,
@@ -421,11 +420,9 @@ class TestWorkflowExecutions:
             add_multiply_workflow.version,
         )
 
-        cancelled_workflow_executions = cognite_client.workflows.executions.cancel(
-            [CancelExecution(id=workflow_execution.id, reason="test")]
+        cancelled_workflow_execution = cognite_client.workflows.executions.cancel(
+            id=workflow_execution.id, reason="test"
         )
-        assert len(cancelled_workflow_executions) == 1
-        cancelled_workflow_execution = cancelled_workflow_executions[0]
         assert cancelled_workflow_execution.status == "terminated"
         assert cancelled_workflow_execution.reason_for_incompletion == "test"
 


### PR DESCRIPTION
## Description
https://cognitedata.atlassian.net/browse/CDF-21399

## Checklist:
- [x] Tests added/updated.
- [x] Documentation updated. Documentation is generated from docstrings - these must be updated according to your change.
  If a new method has been added it should be referenced in [cognite.rst](https://github.com/cognitedata/cognite-sdk-python/blob/master/docs/source/cognite.rst) in order to generate docs based on its docstring.
- [x] Changelog updated in [CHANGELOG.md](https://github.com/cognitedata/cognite-sdk-python/blob/master/CHANGELOG.md).
- [x] Version bumped. If triggering a new release is desired, bump the version number in [_version.py](https://github.com/cognitedata/cognite-sdk-python/blob/master/cognite/client/_version.py) and [pyproject.toml](https://github.com/cognitedata/cognite-sdk-python/blob/master/pyproject.toml) per [semantic versioning](https://semver.org/).
