### PR TITLE
remove `InAssetSubtree` from time series filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ Changes are grouped as follows
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
+## [7.40.2] - 2024-04-30
+### Fixed
+- `InAssetSubtree` is no longer (mistakenly) accepted as a time series filter.
+
 ## [7.40.1] - 2024-04-30
 ### Fixed
 - Deleting multiple Datapoint Subscriptions now work as expected.

--- a/cognite/client/_api/assets.py
+++ b/cognite/client/_api/assets.py
@@ -51,7 +51,7 @@ from cognite.client.data_classes.assets import (
     AssetWrite,
     SortableAssetProperty,
 )
-from cognite.client.data_classes.filters import Filter, _validate_filter
+from cognite.client.data_classes.filters import _BASIC_FILTERS, Filter, _validate_filter
 from cognite.client.exceptions import CogniteAPIError
 from cognite.client.utils._auxiliary import split_into_chunks, split_into_n_parts
 from cognite.client.utils._concurrency import ConcurrencySettings, classify_error, execute_tasks
@@ -81,21 +81,7 @@ SortSpec: TypeAlias = Union[
     Tuple[str, Literal["asc", "desc"], Literal["auto", "first", "last"]],
 ]
 
-_FILTERS_SUPPORTED: frozenset[type[Filter]] = frozenset(
-    {
-        filters.And,
-        filters.Or,
-        filters.Not,
-        filters.In,
-        filters.Equals,
-        filters.Exists,
-        filters.Range,
-        filters.Prefix,
-        filters.ContainsAny,
-        filters.ContainsAll,
-        filters.Search,
-    }
-)
+_FILTERS_SUPPORTED: frozenset[type[Filter]] = _BASIC_FILTERS | {filters.Search}
 
 
 class AssetsAPI(APIClient):

--- a/cognite/client/_api/data_modeling/instances.py
+++ b/cognite/client/_api/data_modeling/instances.py
@@ -64,7 +64,7 @@ from cognite.client.data_classes.data_modeling.query import (
     SourceSelector,
 )
 from cognite.client.data_classes.data_modeling.views import View
-from cognite.client.data_classes.filters import Filter, _validate_filter
+from cognite.client.data_classes.filters import _BASIC_FILTERS, Filter, _validate_filter
 from cognite.client.utils._auxiliary import load_yaml_or_json
 from cognite.client.utils._concurrency import ConcurrencySettings
 from cognite.client.utils._identifier import DataModelingIdentifierSequence
@@ -75,23 +75,8 @@ from cognite.client.utils.useful_types import SequenceNotStr
 if TYPE_CHECKING:
     from cognite.client import CogniteClient
 
-_DATA_MODELING_SUPPORTED_FILTERS: frozenset[type[Filter]] = frozenset(
-    {
-        filters.And,
-        filters.Or,
-        filters.Not,
-        filters.In,
-        filters.Equals,
-        filters.Exists,
-        filters.Range,
-        filters.Prefix,
-        filters.ContainsAny,
-        filters.ContainsAll,
-        filters.Nested,
-        filters.HasData,
-        filters.MatchAll,
-        filters.Overlaps,
-    }
+_FILTERS_SUPPORTED: frozenset[type[Filter]] = _BASIC_FILTERS.union(
+    {filters.Nested, filters.HasData, filters.MatchAll, filters.Overlaps}
 )
 
 logger = logging.getLogger(__name__)
@@ -1197,7 +1182,7 @@ class InstancesAPI(APIClient):
         )
 
     def _validate_filter(self, filter: Filter | dict[str, Any] | None) -> None:
-        _validate_filter(filter, _DATA_MODELING_SUPPORTED_FILTERS, type(self).__name__)
+        _validate_filter(filter, _FILTERS_SUPPORTED, type(self).__name__)
 
     @staticmethod
     def _merge_space_into_filter(

--- a/cognite/client/_api/documents.py
+++ b/cognite/client/_api/documents.py
@@ -18,29 +18,13 @@ from cognite.client.data_classes.documents import (
     SourceFileProperty,
     TemporaryLink,
 )
-from cognite.client.data_classes.filters import Filter, _validate_filter
+from cognite.client.data_classes.filters import _BASIC_FILTERS, Filter, _validate_filter
 
 if TYPE_CHECKING:
     from cognite.client import ClientConfig, CogniteClient
 
-_DOCUMENTS_SUPPORTED_FILTERS: frozenset[type[Filter]] = frozenset(
-    {
-        filters.And,
-        filters.Or,
-        filters.Not,
-        filters.In,
-        filters.Equals,
-        filters.Exists,
-        filters.Range,
-        filters.Prefix,
-        filters.ContainsAny,
-        filters.ContainsAll,
-        filters.GeoJSONIntersects,
-        filters.GeoJSONDisjoint,
-        filters.GeoJSONWithin,
-        filters.InAssetSubtree,
-        filters.Search,
-    }
+_FILTERS_SUPPORTED: frozenset[type[Filter]] = _BASIC_FILTERS.union(
+    {filters.InAssetSubtree, filters.Search, filters.GeoJSONIntersects, filters.GeoJSONDisjoint, filters.GeoJSONWithin}
 )
 
 
@@ -701,4 +685,4 @@ class DocumentsAPI(APIClient):
         )
 
     def _validate_filter(self, filter: Filter | dict[str, Any] | None) -> None:
-        _validate_filter(filter, _DOCUMENTS_SUPPORTED_FILTERS, type(self).__name__)
+        _validate_filter(filter, _FILTERS_SUPPORTED, type(self).__name__)

--- a/cognite/client/_api/events.py
+++ b/cognite/client/_api/events.py
@@ -19,7 +19,7 @@ from cognite.client.data_classes import (
 )
 from cognite.client.data_classes.aggregations import AggregationFilter, UniqueResultList
 from cognite.client.data_classes.events import EventPropertyLike, EventSort, EventWrite, SortableEventProperty
-from cognite.client.data_classes.filters import Filter, _validate_filter
+from cognite.client.data_classes.filters import _BASIC_FILTERS, Filter, _validate_filter
 from cognite.client.utils._identifier import IdentifierSequence
 from cognite.client.utils._validation import prepare_filter_sort, process_asset_subtree_ids, process_data_set_ids
 from cognite.client.utils.useful_types import SequenceNotStr
@@ -32,21 +32,7 @@ SortSpec: TypeAlias = Union[
     Tuple[str, Literal["asc", "desc"], Literal["auto", "first", "last"]],
 ]
 
-_FILTERS_SUPPORTED: frozenset[type[Filter]] = frozenset(
-    {
-        filters.And,
-        filters.Or,
-        filters.Not,
-        filters.In,
-        filters.Equals,
-        filters.Exists,
-        filters.Range,
-        filters.Prefix,
-        filters.ContainsAny,
-        filters.ContainsAll,
-        filters.Search,
-    }
-)
+_FILTERS_SUPPORTED: frozenset[type[Filter]] = _BASIC_FILTERS | {filters.Search}
 
 
 class EventsAPI(APIClient):

--- a/cognite/client/_api/sequences.py
+++ b/cognite/client/_api/sequences.py
@@ -19,7 +19,7 @@ from cognite.client.data_classes import (
     filters,
 )
 from cognite.client.data_classes.aggregations import AggregationFilter, CountAggregate, UniqueResultList
-from cognite.client.data_classes.filters import Filter, _validate_filter
+from cognite.client.data_classes.filters import _BASIC_FILTERS, Filter, _validate_filter
 from cognite.client.data_classes.sequences import (
     SequenceCore,
     SequenceProperty,
@@ -53,21 +53,7 @@ SortSpec: TypeAlias = Union[
     Tuple[str, Literal["asc", "desc"], Literal["auto", "first", "last"]],
 ]
 
-_FILTERS_SUPPORTED: frozenset[type[Filter]] = frozenset(
-    {
-        filters.And,
-        filters.Or,
-        filters.Not,
-        filters.In,
-        filters.Equals,
-        filters.Exists,
-        filters.Range,
-        filters.Prefix,
-        filters.ContainsAny,
-        filters.ContainsAll,
-        filters.Search,
-    }
-)
+_FILTERS_SUPPORTED: frozenset[type[Filter]] = _BASIC_FILTERS | {filters.Search}
 
 
 class SequencesAPI(APIClient):

--- a/cognite/client/_api/time_series.py
+++ b/cognite/client/_api/time_series.py
@@ -17,7 +17,7 @@ from cognite.client.data_classes import (
     filters,
 )
 from cognite.client.data_classes.aggregations import AggregationFilter, CountAggregate, UniqueResultList
-from cognite.client.data_classes.filters import Filter, _validate_filter
+from cognite.client.data_classes.filters import _BASIC_FILTERS, Filter, _validate_filter
 from cognite.client.data_classes.time_series import (
     SortableTimeSeriesProperty,
     TimeSeriesProperty,
@@ -40,21 +40,7 @@ SortSpec: TypeAlias = Union[
     Tuple[str, Literal["asc", "desc"], Literal["auto", "first", "last"]],
 ]
 
-_FILTERS_SUPPORTED: frozenset[type[Filter]] = frozenset(
-    {
-        filters.And,
-        filters.Or,
-        filters.Not,
-        filters.In,
-        filters.Equals,
-        filters.Exists,
-        filters.Range,
-        filters.Prefix,
-        filters.ContainsAny,
-        filters.ContainsAll,
-        filters.Search,
-    }
-)
+_FILTERS_SUPPORTED: frozenset[type[Filter]] = _BASIC_FILTERS | {filters.Search}
 
 
 class TimeSeriesAPI(APIClient):

--- a/cognite/client/_api/time_series.py
+++ b/cognite/client/_api/time_series.py
@@ -52,7 +52,6 @@ _FILTERS_SUPPORTED: frozenset[type[Filter]] = frozenset(
         filters.Prefix,
         filters.ContainsAny,
         filters.ContainsAll,
-        filters.InAssetSubtree,
         filters.Search,
     }
 )

--- a/cognite/client/_version.py
+++ b/cognite/client/_version.py
@@ -1,4 +1,4 @@
 from __future__ import annotations
 
-__version__ = "7.40.1"
+__version__ = "7.40.2"
 __api_subversion__ = "20230101"

--- a/cognite/client/data_classes/datapoints_subscriptions.py
+++ b/cognite/client/data_classes/datapoints_subscriptions.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING, Any
 
 from typing_extensions import Self, TypeAlias
 
-from cognite.client.data_classes import Datapoints, filters
+from cognite.client.data_classes import Datapoints
 from cognite.client.data_classes._base import (
     CogniteListUpdate,
     CognitePrimitiveUpdate,
@@ -21,6 +21,7 @@ from cognite.client.data_classes._base import (
     WriteableCogniteResource,
     WriteableCogniteResourceList,
 )
+from cognite.client.data_classes.filters import _BASIC_FILTERS as _FILTERS_SUPPORTED
 from cognite.client.data_classes.filters import Filter, _validate_filter
 from cognite.client.utils import _json
 from cognite.client.utils._auxiliary import exactly_one_is_not_none
@@ -29,21 +30,6 @@ if TYPE_CHECKING:
     from cognite.client import CogniteClient
 
 ExternalId: TypeAlias = str
-
-_DATAPOINT_SUBSCRIPTION_SUPPORTED_FILTERS: frozenset[type[Filter]] = frozenset(
-    {
-        filters.And,
-        filters.Or,
-        filters.Not,
-        filters.In,
-        filters.Equals,
-        filters.Exists,
-        filters.Range,
-        filters.Prefix,
-        filters.ContainsAny,
-        filters.ContainsAll,
-    }
-)
 
 
 class DatapointSubscriptionCore(WriteableCogniteResource["DataPointSubscriptionWrite"], ABC):
@@ -157,7 +143,7 @@ class DataPointSubscriptionWrite(DatapointSubscriptionCore):
     ) -> None:
         if not exactly_one_is_not_none(time_series_ids, filter):
             raise ValueError("Exactly one of time_series_ids and filter must be given")
-        _validate_filter(filter, _DATAPOINT_SUBSCRIPTION_SUPPORTED_FILTERS, "DataPointSubscriptions")
+        _validate_filter(filter, _FILTERS_SUPPORTED, "DataPointSubscriptions")
         super().__init__(external_id, partition_count, filter, name, description, data_set_id)
         self.time_series_ids = time_series_ids
 

--- a/cognite/client/data_classes/filters.py
+++ b/cognite/client/data_classes/filters.py
@@ -782,6 +782,11 @@ class Search(FilterWithPropertyAndValue):
     _filter_name = "search"
 
 
+_BASIC_FILTERS: frozenset[type[Filter]] = frozenset(
+    {And, Or, Not, In, Equals, Exists, Range, Prefix, ContainsAny, ContainsAll}
+)
+
+
 # ######################################################### #
 # Custom filters below (custom meaning 'no API equivalent') #
 # ######################################################### #

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "cognite-sdk"
 
-version = "7.40.1"
+version = "7.40.2"
 description = "Cognite Python SDK"
 readme = "README.md"
 documentation = "https://cognite-sdk-python.readthedocs-hosted.com"


### PR DESCRIPTION
1. remove `InAssetSubtree` from time series filters
2. unify the name of `_FILTERS_SUPPORTED` variable
3. simplify by removing filters in common (`_BASIC_FILTERS`)