### PR TITLE
Bugfix: limited dps queries yielding more than limit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,11 @@ Changes are grouped as follows
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
+## [7.41.1] - 2024-05-06
+### Fixed
+- An edge case when a request for datapoints from several hundred time series (with specific finite limits) would return
+  more datapoints than the user-specified limit.
+
 ## [7.41.0] - 2024-04-30
 ### Added
 - Support for Status Codes in the DatapointsAPI and DatapointSubscriptionsAPI reaches General Availability (GA).

--- a/cognite/client/_api/datapoint_tasks.py
+++ b/cognite/client/_api/datapoint_tasks.py
@@ -1060,7 +1060,7 @@ class BaseTaskOrchestrator(ABC):
 class SerialTaskOrchestratorMixin(BaseTaskOrchestrator):
     def get_remaining_limit(self) -> int:
         assert len(self.subtasks) == 1
-        return self.query.limit - self.subtasks[0].n_dps_fetched
+        return self.query.limit - self.n_dps_first_batch - self.subtasks[0].n_dps_fetched
 
     def split_into_subtasks(self, max_workers: int, n_tot_queries: int) -> list[BaseDpsFetchSubtask]:
         # For serial fetching, a single task suffice

--- a/cognite/client/_version.py
+++ b/cognite/client/_version.py
@@ -1,4 +1,4 @@
 from __future__ import annotations
 
-__version__ = "7.41.0"
+__version__ = "7.41.1"
 __api_subversion__ = "20230101"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "cognite-sdk"
 
-version = "7.41.0"
+version = "7.41.1"
 description = "Cognite Python SDK"
 readme = "README.md"
 documentation = "https://cognite-sdk-python.readthedocs-hosted.com"

--- a/tests/tests_integration/test_api/test_datapoints.py
+++ b/tests/tests_integration/test_api/test_datapoints.py
@@ -349,8 +349,19 @@ def timeseries_degree_c_minus40_0_100(cognite_client: CogniteClient) -> TimeSeri
 
 class TestRetrieveRawDatapointsAPI:
     """Note: Since `retrieve` and `retrieve_arrays` endpoints should give identical results,
-    except for the data container types, all tests run both endpoints.
+    except for the data container types, all tests run both endpoints except those targeting a specific bug
     """
+
+    def test_retrieve_chunking_mode_with_limit_ignores_dps_count_in_first_batch(
+        self, cognite_client, all_test_time_series
+    ):
+        # From 6.33.2 to 7.41.0, when fetching in "chunking mode" with a finite limit and with more than
+        # 100 time series per available worker - in some rare cases - the initial batch of datapoints would
+        # not be counted towards the total limit requested.
+        ids = [all_test_time_series[105].id] * 100
+        with set_max_workers(cognite_client, 1), patch(DATAPOINTS_API.format("EagerDpsFetcher")):
+            dps_lst = cognite_client.time_series.data.retrieve(id=ids, limit=1001)
+        assert all(len(dps) == 1001 for dps in dps_lst)
 
     def test_retrieve_eager_mode_raises_single_error_with_all_missing_ts(self, cognite_client, outside_points_ts):
         # From v5 to 6.33.1, when fetching in "eager mode", only the first encountered missing


### PR DESCRIPTION
Oneliner fix of a bug introduced in #1425 .

## [7.41.1] - 2024-05-06
### Fixed
- An edge case when a request for datapoints from several hundred time series (with specific finite limits) would return
  more datapoints than the user-specified limit.

## Checklist:
- [x] Tests added/updated.
- [ ] Documentation updated. Documentation is generated from docstrings - these must be updated according to your change.
  If a new method has been added it should be referenced in [cognite.rst](https://github.com/cognitedata/cognite-sdk-python/blob/master/docs/source/cognite.rst) in order to generate docs based on its docstring.
- [x] Changelog updated in [CHANGELOG.md](https://github.com/cognitedata/cognite-sdk-python/blob/master/CHANGELOG.md).
- [x] Version bumped. If triggering a new release is desired, bump the version number in [_version.py](https://github.com/cognitedata/cognite-sdk-python/blob/master/cognite/client/_version.py) and [pyproject.toml](https://github.com/cognitedata/cognite-sdk-python/blob/master/pyproject.toml) per [semantic versioning](https://semver.org/).
