### PR TITLE
bugfix: always convert 'expires_in' to float

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ Changes are grouped as follows
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
+## [7.43.3] - 2024-05-15
+### Fixed
+- Identity providers that return `expires_in` as a string no longer causes `TypeError` when authenticating.
+
 ## [7.43.2] - 2024-05-10
 ### Fixed
 - In containers, `PropertyType` `Text` required parameter `collation` is now optional when `load()`ing, matching the API spec.

--- a/cognite/client/_version.py
+++ b/cognite/client/_version.py
@@ -1,4 +1,4 @@
 from __future__ import annotations
 
-__version__ = "7.43.2"
+__version__ = "7.43.3"
 __api_subversion__ = "20230101"

--- a/cognite/client/credentials.py
+++ b/cognite/client/credentials.py
@@ -220,7 +220,7 @@ class OAuthDeviceCode(_OAuthCredentialProviderWithTokenRefresh, _WithMsalSeriali
             credentials = self.__app.acquire_token_by_device_flow(flow=device_flow)
 
         self._verify_credentials(credentials)
-        return credentials["access_token"], time.time() + credentials["expires_in"]
+        return credentials["access_token"], time.time() + float(credentials["expires_in"])
 
 
 class OAuthInteractive(_OAuthCredentialProviderWithTokenRefresh, _WithMsalSerializableTokenCache):
@@ -300,7 +300,7 @@ class OAuthInteractive(_OAuthCredentialProviderWithTokenRefresh, _WithMsalSerial
             credentials = self.__app.acquire_token_interactive(scopes=self.__scopes, port=self.__redirect_port)
 
         self._verify_credentials(credentials)
-        return credentials["access_token"], time.time() + credentials["expires_in"]
+        return credentials["access_token"], time.time() + float(credentials["expires_in"])
 
     @classmethod
     def default_for_azure_ad(
@@ -436,7 +436,7 @@ class OAuthClientCredentials(_OAuthCredentialProviderWithTokenRefresh):
                 **self.__token_custom_args,
             )
             # Azure gives 'expires_at' directly, but it's not a part of the RFC:
-            return credentials["access_token"], time.time() + credentials["expires_in"]
+            return credentials["access_token"], time.time() + float(credentials["expires_in"])
 
         except OAuth2Error as oauth_err:
             raise CogniteAuthError(
@@ -552,4 +552,4 @@ class OAuthClientCertificate(_OAuthCredentialProviderWithTokenRefresh):
         credentials = self.__app.acquire_token_for_client(scopes=self.__scopes)
 
         self._verify_credentials(credentials)
-        return credentials["access_token"], time.time() + credentials["expires_in"]
+        return credentials["access_token"], time.time() + float(credentials["expires_in"])

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "cognite-sdk"
 
-version = "7.43.2"
+version = "7.43.3"
 description = "Cognite Python SDK"
 readme = "README.md"
 documentation = "https://cognite-sdk-python.readthedocs-hosted.com"

--- a/tests/tests_unit/test_credential_providers.py
+++ b/tests/tests_unit/test_credential_providers.py
@@ -32,9 +32,10 @@ class TestOauthClientCredentials:
 
     @patch("cognite.client.credentials.BackendApplicationClient")
     @patch("cognite.client.credentials.OAuth2Session")
-    def test_access_token_generated(self, mock_oauth_session, mock_backend_client):
+    @pytest.mark.parametrize("expires_in", (1000, "1001"))  # some IDPs return as string
+    def test_access_token_generated(self, mock_oauth_session, mock_backend_client, expires_in):
         mock_backend_client().return_value = Mock()
-        mock_oauth_session().fetch_token.return_value = {"access_token": "azure_token", "expires_in": 1000}
+        mock_oauth_session().fetch_token.return_value = {"access_token": "azure_token", "expires_in": expires_in}
         creds = OAuthClientCredentials(**self.DEFAULT_PROVIDER_ARGS)
         creds._refresh_access_token()
         assert "Authorization", "Bearer azure_token" == creds.authorization_header()


### PR DESCRIPTION
## [7.43.3] - 2024-05-15
### Fixed
- Identity providers that return `expires_in` as a string no longer cause `TypeError` when authenticating.