### PR TITLE
Improve Capability.load

### DIFF
--- a/cognite/client/data_classes/capabilities.py
+++ b/cognite/client/data_classes/capabilities.py
@@ -190,7 +190,7 @@ class Capability(ABC):
             try:
                 scopes = Capability.Scope.load(resource[name]["scope"], allow_unknown)
             except Exception as err:
-                raise ValueError(f"Could not instantiate {capability_cls.__name__} due to: {err}") from None
+                raise ValueError(f"Could not instantiate {capability_cls.__name__} due to: {err}")
 
             return cast(
                 Self,

--- a/tests/tests_unit/test_data_classes/test_capabilities.py
+++ b/tests/tests_unit/test_data_classes/test_capabilities.py
@@ -209,8 +209,16 @@ class TestCapabilities:
         assert capability.dump(camel_case=True) == cap_with_extra_key
 
     def test_load_dump_unknown__extra_top_level_keys(self, unknown_cap_with_extra_key) -> None:
-        with pytest.raises(ValueError, match="^Unable to parse capability from API-response"):
+        match = (
+            "^Unable to parse Capability, none of the top-level keys in the input, "
+            r"\['extra-key', 'veryUnknownAcl'\], matched known ACLs"
+        )
+        with pytest.raises(ValueError, match=match):
             Capability.load(unknown_cap_with_extra_key)
+
+        # API responses should never fail to load, even when crazy:
+        loaded = Capability.load(unknown_cap_with_extra_key, allow_unknown=True)
+        assert loaded.dump() == unknown_cap_with_extra_key
 
     @pytest.mark.parametrize(
         "raw", [{"dataproductAcl": {"actions": ["UTILIZE"], "scope": {"components": {"ids": [1, 2, 3]}}}}]
@@ -397,13 +405,21 @@ class TestCogniteClientDoesntRaiseOnUnknownAcls:
         assert expected == [g["capabilities"] for g in groups.dump()]
 
         # Ensure that the capabilities that did -not- raise from groups/list, would raise for a normal user:
-        with pytest.raises(ValueError, match=r"^'READ' is not a valid Capability.Action"):
+        err_match = r"top-level keys in the input, \['funkyAssetsAcl'\], matched known ACLs"
+        with pytest.raises(ValueError, match=err_match):
             GroupList.load(groups.dump(camel_case=True))
 
         # ...and ensure each individual (acl/action/scope) raises:
-        for unknown_acl in unknown_acls_items:
-            with pytest.raises(ValueError, match="is not a valid |^Could not instantiate "):
-                Group.load({"name": "me", "id": 123, "source_id": "huh", "capabilities": [unknown_acl]})
+        u1, u2, u3, u4 = unknown_acls_items
+        group = {"name": "me", "id": 123, "source_id": "huh"}
+        with pytest.raises(ValueError, match=err_match):
+            Group.load({**group, "capabilities": [u1]})  # Unknown capability
+        with pytest.raises(ValueError, match="^'UN-KN-OWN' is not a valid AssetsAcl.Action$"):
+            Group.load({**group, "capabilities": [u2]})  # Unknown action
+        with pytest.raises(ValueError, match="Could not instantiate AssetsAcl due to: AssetsAcl got an unknown scope: UnknownScope"):
+            Group.load({**group, "capabilities": [u3]})  # Unknown scope
+        with pytest.raises(ValueError, match=err_match):
+            Group.load({**group, "capabilities": [u4]})  # Unknown -everything-
 
     def test_token_inspect(self, cognite_client, mock_token_inspect_resp):
         # Mostly a repeat of test_groups_list, ensuring token/inspect won't ever raise

--- a/tests/tests_unit/test_data_classes/test_capabilities.py
+++ b/tests/tests_unit/test_data_classes/test_capabilities.py
@@ -405,20 +405,22 @@ class TestCogniteClientDoesntRaiseOnUnknownAcls:
         assert expected == [g["capabilities"] for g in groups.dump()]
 
         # Ensure that the capabilities that did -not- raise from groups/list, would raise for a normal user:
-        err_match = r"top-level keys in the input, \['funkyAssetsAcl'\], matched known ACLs"
-        with pytest.raises(ValueError, match=err_match):
+        acl_err_match = r"top-level keys in the input, \['funkyAssetsAcl'\], matched known ACLs"
+        action_err_match = "^'UN-KN-OWN' is not a valid AssetsAcl.Action$"
+        scope_err_match = "^Could not instantiate AssetsAcl due to: Unable to parse Scope, 'astronautSpace' is not"
+        with pytest.raises(ValueError, match=acl_err_match):
             GroupList.load(groups.dump(camel_case=True))
 
         # ...and ensure each individual (acl/action/scope) raises:
         u1, u2, u3, u4 = unknown_acls_items
         group = {"name": "me", "id": 123, "source_id": "huh"}
-        with pytest.raises(ValueError, match=err_match):
+        with pytest.raises(ValueError, match=acl_err_match):
             Group.load({**group, "capabilities": [u1]})  # Unknown capability
-        with pytest.raises(ValueError, match="^'UN-KN-OWN' is not a valid AssetsAcl.Action$"):
+        with pytest.raises(ValueError, match=action_err_match):
             Group.load({**group, "capabilities": [u2]})  # Unknown action
-        with pytest.raises(ValueError, match="Could not instantiate AssetsAcl due to: AssetsAcl got an unknown scope: UnknownScope"):
+        with pytest.raises(ValueError, match=scope_err_match):
             Group.load({**group, "capabilities": [u3]})  # Unknown scope
-        with pytest.raises(ValueError, match=err_match):
+        with pytest.raises(ValueError, match=acl_err_match):
             Group.load({**group, "capabilities": [u4]})  # Unknown -everything-
 
     def test_token_inspect(self, cognite_client, mock_token_inspect_resp):


### PR DESCRIPTION
## Description
1. Greatly improve error messages when loading a `Capability` fails (https://cognitedata.atlassian.net/browse/CDF-21155)
2. Change `Scope.load` to also use the `allow_unknown` pattern and future-proof with no expectation of the presence of a single key.

## Example
Before
```
from cognite.client.data_classes.capabilities import Capability

Capability.load(
    {'EventsAcl': {'actions': ['READ', 'WRITE'], 'scope': {'datasetScope': {'ids': [12378]}}}},
    allow_unknown=False,
)
```
Raises -> `ValueError: 'READ' is not a valid Capability.Action`

Now, you get quite the mouthful: (list has been shortened here)
```
ValueError: Unable to parse Capability, none of the top-level keys in the input, ['EventsAcl'],
    matched known ACLs, - or - multiple was found. Pass `allow_unknown=True` to force
    loading it as an unknown capability. List of known ACLs:
    ['analyticsAcl', 'annotationsAcl', ..., 'workflowOrchestrationAcl'].
```


## Checklist:
- [x] Tests added/updated.