### PR TITLE
dont pass json twice to requests

### DIFF
--- a/cognite/client/_api_client.py
+++ b/cognite/client/_api_client.py
@@ -194,7 +194,7 @@ class APIClient:
         **kwargs: Any,
     ) -> Response:
         is_retryable, full_url = self._resolve_url(method, url_path)
-        json_payload = kwargs.get("json")
+        json_payload = kwargs.pop("json", None)
         headers = self._configure_headers(
             accept,
             additional_headers=self._config.headers.copy(),
@@ -202,7 +202,7 @@ class APIClient:
         )
         headers.update(kwargs.get("headers") or {})
 
-        if json_payload:
+        if json_payload is not None:
             try:
                 data = _json.dumps(json_payload, allow_nan=False)
             except ValueError as e:


### PR DESCRIPTION
JSON is passed both as `"json"` and `"data"` to requests (`data` may be compressed)

Example:
```
kwargs:
-k='json', v={'items': [{'start': 734168890000, 'end': 762187567726, 'limit': 100000, 'externalId': 'benchmark:9-...
-k='timeout', v=1000
-k='data', v=b"\x1f\x8b\x08\x00\xbe\x80Pf\x02\xff5\x8eA\x0e\xc2 \x10E\xaf\xd2\x8c[\x89P\x15ho\xd0\x03\xb82.PF\x9d...
-k='allow_redirects', v=False
```

Edit:
The requests docs says "Note, the json parameter is ignored if either data or files is passed." so I guess that is why this has worked as expected all along.