### PR TITLE
Add `dropna` option to `RawRowsAPI.insert_dataframe`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,11 @@ Changes are grouped as follows
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
-## [7.45.0] - 2024-05-28
+## [7.46.0] - 2024-05-31
+### Added
+- `RawRowsAPI.insert_dataframe` now has a new `dropna` setting (defaulting to True, as this would otherwise raise later).
+
+## [7.45.0] - 2024-05-31
 ### Added
 - DatapointsAPI now support `timezone` and new calendar-based granularities like `month`, `quarter` and `year`.
   These API features are in beta, and the SDK implementation in alpha, meaning breaking changes can

--- a/cognite/client/_api/raw.py
+++ b/cognite/client/_api/raw.py
@@ -4,7 +4,7 @@ import math
 import random
 import threading
 import time
-from collections import deque
+from collections import defaultdict, deque
 from typing import TYPE_CHECKING, Any, Iterator, Sequence, cast, overload
 
 from cognite.client._api_client import APIClient
@@ -12,6 +12,7 @@ from cognite.client._constants import _RUNNING_IN_BROWSER, DEFAULT_LIMIT_READ
 from cognite.client.data_classes import Database, DatabaseList, Row, RowList, RowWrite, Table, TableList
 from cognite.client.data_classes.raw import RowCore
 from cognite.client.utils._auxiliary import (
+    find_duplicates,
     interpolate_and_url_encode,
     is_finite,
     is_unlimited,
@@ -523,7 +524,12 @@ class RawRowsAPI(APIClient):
         )
 
     def insert_dataframe(
-        self, db_name: str, table_name: str, dataframe: pd.DataFrame, ensure_parent: bool = False
+        self,
+        db_name: str,
+        table_name: str,
+        dataframe: pd.DataFrame,
+        ensure_parent: bool = False,
+        dropna: bool = True,
     ) -> None:
         """`Insert pandas dataframe into a table <https://developer.cognite.com/api#tag/Raw/operation/postRows>`_
 
@@ -534,22 +540,41 @@ class RawRowsAPI(APIClient):
             table_name (str): Name of the table.
             dataframe (pd.DataFrame): The dataframe to insert. Index will be used as row keys.
             ensure_parent (bool): Create database/table if they don't already exist.
+            dropna (bool): Remove NaNs before insert, done individually per column. Default: True
 
         Examples:
 
-            Insert new rows into a table::
+            Insert new rows into a table:
 
                 >>> import pandas as pd
                 >>> from cognite.client import CogniteClient
                 >>>
                 >>> client = CogniteClient()
-                >>> df = pd.DataFrame(data={"a": 1, "b": 2}, index=["r1", "r2", "r3"])
-                >>> res = client.raw.rows.insert_dataframe("db1", "table1", df)
+                >>> df = pd.DataFrame(
+                ...     {"col-a": [1, 3, None], "col-b": [2, -1, 9]},
+                ...     index=["r1", "r2", "r3"])
+                >>> res = client.raw.rows.insert_dataframe(
+                ...     "db1", "table1", df, dropna=True)
         """
         if not dataframe.index.is_unique:
             raise ValueError("Dataframe index is not unique (used for the row keys)")
-        rows = dataframe.to_dict(orient="index")
+        elif not dataframe.columns.is_unique:
+            raise ValueError(f"Dataframe columns are not unique: {sorted(find_duplicates(dataframe.columns))}")
+
+        if not dropna:
+            rows = dataframe.to_dict(orient="index")
+        else:
+            rows = self._df_to_rows_skip_nans(dataframe)
         self.insert(db_name=db_name, table_name=table_name, row=rows, ensure_parent=ensure_parent)
+
+    @staticmethod
+    def _df_to_rows_skip_nans(df: pd.DataFrame) -> dict[str, dict[str, Any]]:
+        rows: defaultdict[str, dict[str, Any]] = defaultdict(dict)
+        for column_id, col in df.items():
+            col = col.dropna()
+            for idx, val in col.items():
+                rows[idx][column_id] = val
+        return dict(rows)
 
     def _process_row_input(self, row: Sequence[Row] | Sequence[RowWrite] | Row | RowWrite | dict) -> list[list[dict]]:
         assert_type(row, "row", [Sequence, dict, RowCore])

--- a/cognite/client/_version.py
+++ b/cognite/client/_version.py
@@ -1,4 +1,4 @@
 from __future__ import annotations
 
-__version__ = "7.45.0"
+__version__ = "7.46.0"
 __api_subversion__ = "20230101"

--- a/poetry.lock
+++ b/poetry.lock
@@ -2675,11 +2675,11 @@ functions = ["pip"]
 geo = ["geopandas", "geopandas", "shapely"]
 numpy = ["numpy", "numpy", "numpy"]
 pandas = ["pandas", "pandas"]
-pyodide = ["pyodide-http"]
+pyodide = ["pyodide-http", "tzdata"]
 sympy = ["sympy"]
 yaml = ["PyYAML"]
 
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8"
-content-hash = "d1af07445f013565e6cdd2b6513b9fc0a1d4df6109f9933a47f3d423f2b10412"
+content-hash = "108bba6708b5f23e380af2ae0f07a11993a57334384ac8e56068df03cd4e8614"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "cognite-sdk"
 
-version = "7.45.0"
+version = "7.46.0"
 description = "Cognite Python SDK"
 readme = "README.md"
 documentation = "https://cognite-sdk-python.readthedocs-hosted.com"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,8 +31,8 @@ protobuf = ">=4"
 pip = ">=20.0.0"  # make optional once poetry doesn't auto-remove it on "simple install"
 typing_extensions = ">= 4"
 backports-zoneinfo = { version = ">=0.2.1",  python = "<3.9" }
-# Windows does not have a ANSI database and need tzdata
-tzdata = { version = ">=2024.1", markers = "platform_system == 'Windows'" }
+# Windows does not have a ANSI database and need tzdata... pyodide also needs it:
+tzdata = { version = ">=2024.1", markers = "platform_system == 'Windows' or platform_system == 'Emscripten'" }
 numpy = [
     { version = ">=1.20, <1.25", python = "~3.8", optional = true },
     { version = "^1.25", python = ">=3.9, <3.12", optional = true },
@@ -59,7 +59,7 @@ geo = ["geopandas", "shapely"]
 sympy = ["sympy"]
 functions = ["pip"]
 yaml = ["PyYAML"]
-pyodide = ["pyodide-http"]  # keep pyodide related dependencies outside of 'all'
+pyodide = ["pyodide-http", "tzdata"]  # keep pyodide related dependencies outside of 'all'
 all = ["numpy", "pandas", "geopandas", "shapely", "sympy", "pip", "PyYAML"]
 
 [tool.poetry.group.dev.dependencies]

--- a/tests/tests_integration/test_api/test_raw.py
+++ b/tests/tests_integration/test_api/test_raw.py
@@ -126,7 +126,7 @@ class TestRawRowsAPI:
         data = {"a": {"r1": 1, "r2": 1, "r3": 1}, "b": {"r1": None, "r2": None, "r3": None}}
 
         df = pd.DataFrame.from_dict(data)
-        cognite_client.raw.rows.insert_dataframe(db.name, table.name, df)
+        cognite_client.raw.rows.insert_dataframe(db.name, table.name, df, dropna=False)
         retrieved_df = cognite_client.raw.rows.retrieve_dataframe(db.name, table.name)
 
         pd.testing.assert_frame_equal(df.sort_index(), retrieved_df.sort_index())

--- a/tests/tests_integration/test_api/test_raw.py
+++ b/tests/tests_integration/test_api/test_raw.py
@@ -126,7 +126,7 @@ class TestRawRowsAPI:
         data = {"a": {"r1": 1, "r2": 1, "r3": 1}, "b": {"r1": None, "r2": None, "r3": None}}
 
         df = pd.DataFrame.from_dict(data)
-        cognite_client.raw.rows.insert_dataframe(db.name, table.name, df, dropna=False)
+        cognite_client.raw.rows.insert_dataframe(db.name, table.name, df)
         retrieved_df = cognite_client.raw.rows.retrieve_dataframe(db.name, table.name)
 
         pd.testing.assert_frame_equal(df.sort_index(), retrieved_df.sort_index())

--- a/tests/tests_unit/test_api/test_raw.py
+++ b/tests/tests_unit/test_api/test_raw.py
@@ -357,11 +357,12 @@ def test_df_to_rows_skip_nans():
             "f": [None, None, None],
         }
     )
+    df.at[1, "f"] = math.nan  # object column, should keep None's, but this should be removed
     res = RawRowsAPI._df_to_rows_skip_nans(df)
     expected = {
-        0: {"a": 1.0, "b": 1.0, "c": 10, "d": math.inf, "e": 100.0},
+        0: {"a": 1.0, "b": 1.0, "c": 10, "d": math.inf, "e": 100.0, "f": None},
         1: {"b": 2.0, "c": 20, "d": 20.0, "e": 200.0},
-        2: {"a": 3.0, "c": 30, "d": 30.0},
+        2: {"a": 3.0, "c": 30, "d": 30.0, "f": None},
     }
     assert res == expected
 

--- a/tests/tests_unit/test_api/test_raw.py
+++ b/tests/tests_unit/test_api/test_raw.py
@@ -342,6 +342,7 @@ def test_insert_dataframe_raises_on_duplicated_cols(cognite_client):
         cognite_client.raw.rows.insert_dataframe("db", "tbl", df)
 
 
+@pytest.mark.dsl
 def test_df_to_rows_skip_nans():
     import numpy as np
     import pandas as pd

--- a/tests/tests_unit/test_api/test_raw.py
+++ b/tests/tests_unit/test_api/test_raw.py
@@ -1,8 +1,9 @@
+import math
 import re
 
 import pytest
 
-from cognite.client._api.raw import Database, DatabaseList, Row, RowList, Table, TableList
+from cognite.client._api.raw import Database, DatabaseList, RawRowsAPI, Row, RowList, Table, TableList
 from cognite.client.exceptions import CogniteAPIError
 from tests.utils import jsgz_load
 
@@ -320,6 +321,48 @@ def test_raw_row__direct_column_access():
     row.columns = None
     with pytest.raises(RuntimeError, match="^columns not set on Row instance$"):
         del row["wrong-key"]
+
+
+@pytest.mark.dsl
+def test_insert_dataframe_raises_on_duplicated_cols(cognite_client):
+    import pandas as pd
+
+    df = pd.DataFrame(
+        {
+            "a": [1, 2, 3],
+            "b": [1, 2, 3],
+            "c": [10, 20, 30],
+            "d": [10, 20, 30],
+            "e": [100, 200, 300],
+            "f": [100, 200, 300],
+        }
+    )
+    df.columns = ["a", "b", "a", "c", "a", "b"]
+    with pytest.raises(ValueError, match=r"^Dataframe columns are not unique: \['a', 'b'\]$"):
+        cognite_client.raw.rows.insert_dataframe("db", "tbl", df)
+
+
+def test_df_to_rows_skip_nans():
+    import numpy as np
+    import pandas as pd
+
+    df = pd.DataFrame(
+        {
+            "a": [1, None, 3],
+            "b": [1, 2, None],
+            "c": [10, 20, 30],
+            "d": [math.inf, 20, 30],
+            "e": [100, 200, np.nan],
+            "f": [None, None, None],
+        }
+    )
+    res = RawRowsAPI._df_to_rows_skip_nans(df)
+    expected = {
+        0: {"a": 1.0, "b": 1.0, "c": 10, "d": math.inf, "e": 100.0},
+        1: {"b": 2.0, "c": 20, "d": 20.0, "e": 200.0},
+        2: {"a": 3.0, "c": 30, "d": 30.0},
+    }
+    assert res == expected
 
 
 @pytest.mark.dsl


### PR DESCRIPTION
## [7.44.2] - 2024-05-30
### Added
- `RawRowsAPI.insert_dataframe` now has a new `dropna` setting (defaulting to True, as this would otherwise raise later).

## Checklist:
- [x] Tests added/updated.
- [x] Documentation updated. Documentation is generated from docstrings - these must be updated according to your change.
  If a new method has been added it should be referenced in [cognite.rst](https://github.com/cognitedata/cognite-sdk-python/blob/master/docs/source/cognite.rst) in order to generate docs based on its docstring.
- [x] Changelog updated in [CHANGELOG.md](https://github.com/cognitedata/cognite-sdk-python/blob/master/CHANGELOG.md).
- [x] Version bumped. If triggering a new release is desired, bump the version number in [_version.py](https://github.com/cognitedata/cognite-sdk-python/blob/master/cognite/client/_version.py) and [pyproject.toml](https://github.com/cognitedata/cognite-sdk-python/blob/master/pyproject.toml) per [semantic versioning](https://semver.org/).
