### PR TITLE
[CDF-21657] Add status filter to workflow executions list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ Changes are grouped as follows
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
-## [7.49.0] - 2024-06-04
+## [7.49.0] - 2024-06-05
 ### Added
 - `WorkfowExecutionAPI.list` now allows filtering by execution status.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ Changes are grouped as follows
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
+## [7.47.0] - 2024-06-03
+### Added
+- `WorkfowExecutionAPI.list` now allows filtering by execution status.
+
 ## [7.46.1] - 2024-05-31
 ### Fixed
 - Pyodide issue related to missing tzdata package.

--- a/cognite/client/_api/workflows.py
+++ b/cognite/client/_api/workflows.py
@@ -212,6 +212,7 @@ class WorkflowExecutionAPI(BetaWorkflowAPIClient):
         workflow_version_ids: WorkflowVersionIdentifier | MutableSequence[WorkflowVersionIdentifier] | None = None,
         created_time_start: int | None = None,
         created_time_end: int | None = None,
+        status: Literal["completed", "failed", "running", "terminated", "timed_out"] | None = None,
         limit: int = DEFAULT_LIMIT_READ,
     ) -> WorkflowExecutionList:
         """`List workflow executions in the project. <https://api-docs.cognite.com/20230101-beta/tag/Workflow-executions/operation/ListWorkflowExecutions>`_
@@ -220,9 +221,9 @@ class WorkflowExecutionAPI(BetaWorkflowAPIClient):
             workflow_version_ids (WorkflowVersionIdentifier | MutableSequence[WorkflowVersionIdentifier] | None): Workflow version id or list of workflow version ids to filter on.
             created_time_start (int | None): Filter out executions that was created before this time. Time is in milliseconds since epoch.
             created_time_end (int | None): Filter out executions that was created after this time. Time is in milliseconds since epoch.
+            status (Literal["completed", "failed", "running", "terminated", "timed_out"] | None): Fetch only executions with this status.
             limit (int): Maximum number of results to return. Defaults to 25. Set to -1, float("inf") or None
                         to return all items.
-
         Returns:
             WorkflowExecutionList: The requested workflow executions.
 
@@ -252,6 +253,8 @@ class WorkflowExecutionAPI(BetaWorkflowAPIClient):
             filter_["createdTimeStart"] = created_time_start
         if created_time_end is not None:
             filter_["createdTimeEnd"] = created_time_end
+        if status is not None:
+            filter_["status"] = status.upper()
 
         return self._list(
             method="POST",

--- a/cognite/client/_api/workflows.py
+++ b/cognite/client/_api/workflows.py
@@ -15,8 +15,8 @@ from cognite.client.data_classes.workflows import (
     WorkflowExecutionList,
     WorkflowIds,
     WorkflowList,
-    WorkflowTaskExecution,
     WorkflowStatus,
+    WorkflowTaskExecution,
     WorkflowUpsert,
     WorkflowVersion,
     WorkflowVersionId,
@@ -213,7 +213,7 @@ class WorkflowExecutionAPI(BetaWorkflowAPIClient):
         workflow_version_ids: WorkflowVersionIdentifier | MutableSequence[WorkflowVersionIdentifier] | None = None,
         created_time_start: int | None = None,
         created_time_end: int | None = None,
-        statuses:  WorkflowStatus | MutableSequence[WorkflowStatus] | None = None,
+        statuses: WorkflowStatus | MutableSequence[WorkflowStatus] | None = None,
         limit: int = DEFAULT_LIMIT_READ,
     ) -> WorkflowExecutionList:
         """`List workflow executions in the project. <https://api-docs.cognite.com/20230101-beta/tag/Workflow-executions/operation/ListWorkflowExecutions>`_
@@ -255,7 +255,10 @@ class WorkflowExecutionAPI(BetaWorkflowAPIClient):
         if created_time_end is not None:
             filter_["createdTimeEnd"] = created_time_end
         if statuses is not None:
-            filter_["status"] = [status.upper() for status in statuses]
+            if isinstance(statuses, str):
+                filter_["status"] = [statuses.upper()]
+            else:  # Assume it is a sequence
+                filter_["status"] = [status.upper() for status in statuses]
 
         return self._list(
             method="POST",

--- a/cognite/client/_api/workflows.py
+++ b/cognite/client/_api/workflows.py
@@ -16,6 +16,7 @@ from cognite.client.data_classes.workflows import (
     WorkflowIds,
     WorkflowList,
     WorkflowTaskExecution,
+    WorkflowStatus,
     WorkflowUpsert,
     WorkflowVersion,
     WorkflowVersionId,
@@ -212,7 +213,7 @@ class WorkflowExecutionAPI(BetaWorkflowAPIClient):
         workflow_version_ids: WorkflowVersionIdentifier | MutableSequence[WorkflowVersionIdentifier] | None = None,
         created_time_start: int | None = None,
         created_time_end: int | None = None,
-        statuses: list[Literal["completed", "failed", "running", "terminated", "timed_out"]] | None = None,
+        statuses:  WorkflowStatus | MutableSequence[WorkflowStatus] | None = None,
         limit: int = DEFAULT_LIMIT_READ,
     ) -> WorkflowExecutionList:
         """`List workflow executions in the project. <https://api-docs.cognite.com/20230101-beta/tag/Workflow-executions/operation/ListWorkflowExecutions>`_
@@ -221,7 +222,7 @@ class WorkflowExecutionAPI(BetaWorkflowAPIClient):
             workflow_version_ids (WorkflowVersionIdentifier | MutableSequence[WorkflowVersionIdentifier] | None): Workflow version id or list of workflow version ids to filter on.
             created_time_start (int | None): Filter out executions that was created before this time. Time is in milliseconds since epoch.
             created_time_end (int | None): Filter out executions that was created after this time. Time is in milliseconds since epoch.
-            statuses (list[Literal["completed", "failed", "running", "terminated", "timed_out"]] | None): Fetch only executions with these statuses.
+            statuses (WorkflowStatus | MutableSequence[WorkflowStatus] | None): Workflow status or list of workflow statuses to filter on.
             limit (int): Maximum number of results to return. Defaults to 25. Set to -1, float("inf") or None
                         to return all items.
         Returns:

--- a/cognite/client/_api/workflows.py
+++ b/cognite/client/_api/workflows.py
@@ -212,7 +212,7 @@ class WorkflowExecutionAPI(BetaWorkflowAPIClient):
         workflow_version_ids: WorkflowVersionIdentifier | MutableSequence[WorkflowVersionIdentifier] | None = None,
         created_time_start: int | None = None,
         created_time_end: int | None = None,
-        status: Literal["completed", "failed", "running", "terminated", "timed_out"] | None = None,
+        statuses: list[Literal["completed", "failed", "running", "terminated", "timed_out"]] | None = None,
         limit: int = DEFAULT_LIMIT_READ,
     ) -> WorkflowExecutionList:
         """`List workflow executions in the project. <https://api-docs.cognite.com/20230101-beta/tag/Workflow-executions/operation/ListWorkflowExecutions>`_
@@ -221,7 +221,7 @@ class WorkflowExecutionAPI(BetaWorkflowAPIClient):
             workflow_version_ids (WorkflowVersionIdentifier | MutableSequence[WorkflowVersionIdentifier] | None): Workflow version id or list of workflow version ids to filter on.
             created_time_start (int | None): Filter out executions that was created before this time. Time is in milliseconds since epoch.
             created_time_end (int | None): Filter out executions that was created after this time. Time is in milliseconds since epoch.
-            status (Literal["completed", "failed", "running", "terminated", "timed_out"] | None): Fetch only executions with this status.
+            statuses (list[Literal["completed", "failed", "running", "terminated", "timed_out"]] | None): Fetch only executions with these statuses.
             limit (int): Maximum number of results to return. Defaults to 25. Set to -1, float("inf") or None
                         to return all items.
         Returns:
@@ -253,8 +253,8 @@ class WorkflowExecutionAPI(BetaWorkflowAPIClient):
             filter_["createdTimeStart"] = created_time_start
         if created_time_end is not None:
             filter_["createdTimeEnd"] = created_time_end
-        if status is not None:
-            filter_["status"] = status.upper()
+        if statuses is not None:
+            filter_["status"] = [status.upper() for status in statuses]
 
         return self._list(
             method="POST",

--- a/cognite/client/_api/workflows.py
+++ b/cognite/client/_api/workflows.py
@@ -233,10 +233,10 @@ class WorkflowExecutionAPI(APIClient):
         if created_time_end is not None:
             filter_["createdTimeEnd"] = created_time_end
         if statuses is not None:
-            if isinstance(statuses, str):
-                filter_["status"] = [statuses.upper()]
-            else:  # Assume it is a sequence
+            if isinstance(statuses, MutableSequence):
                 filter_["status"] = [status.upper() for status in statuses]
+            else:  # Assume it is a stringy type
+                filter_["status"] = [statuses.upper()]
 
         return self._list(
             method="POST",

--- a/cognite/client/_version.py
+++ b/cognite/client/_version.py
@@ -1,4 +1,4 @@
 from __future__ import annotations
 
-__version__ = "7.46.1"
+__version__ = "7.47.0"
 __api_subversion__ = "20230101"

--- a/cognite/client/data_classes/workflows.py
+++ b/cognite/client/data_classes/workflows.py
@@ -1016,7 +1016,7 @@ class WorkflowExecutionDetailed(WorkflowExecution):
         id (str): The server generated id of the workflow execution.
         workflow_external_id (str): The external ID of the workflow.
         workflow_definition (WorkflowDefinition): The workflow definition of the workflow.
-        status (Literal["running", "completed", "failed", "timed_out", "terminated", "paused"]): The status of the workflow execution.
+        status (WorkflowStatus): The status of the workflow execution.
         executed_tasks (list[WorkflowTaskExecution]): The executed tasks of the workflow execution.
         created_time (int): The time when the workflow execution was created. Unix timestamp in milliseconds.
         version (str | None): The version of the workflow. Defaults to None.
@@ -1032,7 +1032,7 @@ class WorkflowExecutionDetailed(WorkflowExecution):
         id: str,
         workflow_external_id: str,
         workflow_definition: WorkflowDefinition,
-        status: Literal["running", "completed", "failed", "timed_out", "terminated", "paused"],
+        status: WorkflowStatus,
         executed_tasks: list[WorkflowTaskExecution],
         created_time: int,
         version: str | None = None,
@@ -1057,7 +1057,7 @@ class WorkflowExecutionDetailed(WorkflowExecution):
             workflow_external_id=resource["workflowExternalId"],
             version=resource.get("version"),
             status=cast(
-                Literal["running", "completed", "failed", "timed_out", "terminated", "paused"],
+                WorkflowStatus,
                 to_snake_case(resource["status"]),
             ),
             created_time=resource["createdTime"],

--- a/cognite/client/data_classes/workflows.py
+++ b/cognite/client/data_classes/workflows.py
@@ -21,7 +21,7 @@ from cognite.client.utils._text import to_snake_case
 if TYPE_CHECKING:
     from cognite.client import CogniteClient
 
-WorkflowStatus: TypeAlias = Literal[
+TaskStatus: TypeAlias = Literal[
     "in_progress",
     "cancelled",
     "failed",
@@ -32,6 +32,13 @@ WorkflowStatus: TypeAlias = Literal[
     "skipped",
 ]
 
+WorkflowStatus: TypeAlias = Literal[
+    "completed",
+    "failed",
+    "running",
+    "terminated",
+    "timed_out"
+]
 
 class WorkflowCore(WriteableCogniteResource["WorkflowUpsert"], ABC):
     def __init__(self, external_id: str, description: str | None) -> None:
@@ -630,7 +637,7 @@ class WorkflowTaskExecution(CogniteObject):
         self,
         id: str,
         external_id: str,
-        status: WorkflowStatus,
+        status: TaskStatus,
         input: WorkflowTaskParameters,
         output: WorkflowTaskOutput,
         version: str | None = None,
@@ -657,7 +664,7 @@ class WorkflowTaskExecution(CogniteObject):
         return cls(
             id=resource["id"],
             external_id=resource["externalId"],
-            status=cast(WorkflowStatus, to_snake_case(resource["status"])),
+            status=cast(TaskStatus, to_snake_case(resource["status"])),
             input=WorkflowTaskParameters.load_parameters(resource),
             output=WorkflowTaskOutput.load_output(resource),
             version=resource.get("version"),
@@ -953,7 +960,7 @@ class WorkflowExecution(CogniteResource):
         self,
         id: str,
         workflow_external_id: str,
-        status: Literal["running", "completed", "failed", "timed_out", "terminated", "paused"],
+        status: WorkflowStatus,
         created_time: int,
         version: str | None = None,
         start_time: int | None = None,
@@ -984,7 +991,7 @@ class WorkflowExecution(CogniteResource):
             workflow_external_id=resource["workflowExternalId"],
             version=resource.get("version"),
             status=cast(
-                Literal["running", "completed", "failed", "timed_out", "terminated", "paused"],
+                WorkflowStatus,
                 to_snake_case(resource["status"]),
             ),
             created_time=resource["createdTime"],

--- a/cognite/client/data_classes/workflows.py
+++ b/cognite/client/data_classes/workflows.py
@@ -32,13 +32,8 @@ TaskStatus: TypeAlias = Literal[
     "skipped",
 ]
 
-WorkflowStatus: TypeAlias = Literal[
-    "completed",
-    "failed",
-    "running",
-    "terminated",
-    "timed_out"
-]
+WorkflowStatus: TypeAlias = Literal["completed", "failed", "running", "terminated", "timed_out"]
+
 
 class WorkflowCore(WriteableCogniteResource["WorkflowUpsert"], ABC):
     def __init__(self, external_id: str, description: str | None) -> None:
@@ -624,7 +619,7 @@ class WorkflowTaskExecution(CogniteObject):
     Args:
         id (str): The server generated id of the task execution.
         external_id (str): The external ID provided by the client. Must be unique for the resource type.
-        status (WorkflowStatus): The status of the task execution.
+        status (TaskStatus): The status of the task execution.
         input (WorkflowTaskParameters): The input parameters of the task execution.
         output (WorkflowTaskOutput): The output of the task execution.
         version (str | None): The version of the task execution. Defaults to None.
@@ -947,7 +942,7 @@ class WorkflowExecution(CogniteResource):
     Args:
         id (str): The server generated id of the workflow execution.
         workflow_external_id (str): The external ID of the workflow.
-        status (Literal["running", "completed", "failed", "timed_out", "terminated", "paused"]): The status of the workflow execution.
+        status (WorkflowStatus): The status of the workflow execution.
         created_time (int): The time when the workflow execution was created. Unix timestamp in milliseconds.
         version (str | None): The version of the workflow. Defaults to None.
         start_time (int | None): The start time of the workflow execution. Unix timestamp in milliseconds. Defaults to None.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "cognite-sdk"
 
-version = "7.46.1"
+version = "7.47.0"
 description = "Cognite Python SDK"
 readme = "README.md"
 documentation = "https://cognite-sdk-python.readthedocs-hosted.com"

--- a/tests/tests_integration/test_api/test_data_workflows.py
+++ b/tests/tests_integration/test_api/test_data_workflows.py
@@ -375,13 +375,13 @@ class TestWorkflowExecutions:
 
         # the new execution should not be completed yet, but running
         listed_completed = cognite_client.workflows.executions.list(
-            workflow_version_ids=add_multiply_workflow.as_id(), status=["completed"], limit=3
+            workflow_version_ids=add_multiply_workflow.as_id(), statuses=["completed"], limit=3
         )
         listed_running = cognite_client.workflows.executions.list(
-            workflow_version_ids=add_multiply_workflow.as_id(), status=["running"], limit=3
+            workflow_version_ids=add_multiply_workflow.as_id(), statuses=["running"], limit=3
         )
-        assert filter(lambda x: x.id == result.id, listed_completed) == []
-        assert len(filter(lambda x: x.id == result.id, listed_running)) == 1
+        assert not any(x.id == result.id for x in listed_completed)
+        assert sum(1 for x in listed_running if x.id == result.id) == 1
 
     def test_retrieve_workflow_execution_detailed(
         self,

--- a/tests/tests_integration/test_api/test_data_workflows.py
+++ b/tests/tests_integration/test_api/test_data_workflows.py
@@ -375,13 +375,13 @@ class TestWorkflowExecutions:
 
         # the new execution should not be completed yet, but running
         listed_completed = cognite_client.workflows.executions.list(
-            workflow_version_ids=add_multiply_workflow.as_id(), status="completed", limit=3
+            workflow_version_ids=add_multiply_workflow.as_id(), status=["completed"], limit=3
         )
-        listed_failed = cognite_client.workflows.executions.list(
-            workflow_version_ids=add_multiply_workflow.as_id(), status="running", limit=3
+        listed_running = cognite_client.workflows.executions.list(
+            workflow_version_ids=add_multiply_workflow.as_id(), status=["running"], limit=3
         )
         assert filter(lambda x: x.id == result.id, listed_completed) == []
-        assert len(filter(lambda x: x.id == result.id, listed_failed)) == 1
+        assert len(filter(lambda x: x.id == result.id, listed_running)) == 1
 
     def test_retrieve_workflow_execution_detailed(
         self,

--- a/tests/tests_integration/test_api/test_data_workflows.py
+++ b/tests/tests_integration/test_api/test_data_workflows.py
@@ -360,6 +360,29 @@ class TestWorkflowExecutions:
         assert len(listed) == len(workflow_execution_list)
         assert all(w.as_workflow_id() in workflow_ids for w in listed)
 
+    def test_list_workflow_executions_by_status(
+        self,
+        cognite_client: CogniteClient,
+        workflow_execution_list: WorkflowExecutionList,
+        add_multiply_workflow: WorkflowVersion,
+    ) -> None:
+        # start a fresh execution
+        result = cognite_client.workflows.executions.trigger(
+            add_multiply_workflow.workflow_external_id,
+            add_multiply_workflow.version,
+            {"a": 5, "b": "a"},
+        )
+
+        # the new execution should not be completed yet, but running
+        listed_completed = cognite_client.workflows.executions.list(
+            workflow_version_ids=add_multiply_workflow.as_id(), status="completed", limit=3
+        )
+        listed_failed = cognite_client.workflows.executions.list(
+            workflow_version_ids=add_multiply_workflow.as_id(), status="running", limit=3
+        )
+        assert filter(lambda x: x.id == result.id, listed_completed) == []
+        assert len(filter(lambda x: x.id == result.id, listed_failed)) == 1
+
     def test_retrieve_workflow_execution_detailed(
         self,
         cognite_client: CogniteClient,

--- a/tests/tests_integration/test_api/test_data_workflows.py
+++ b/tests/tests_integration/test_api/test_data_workflows.py
@@ -385,7 +385,7 @@ class TestWorkflowExecutions:
 
         # the new execution should not be completed yet, but running
         listed_completed = cognite_client.workflows.executions.list(
-            workflow_version_ids=add_multiply_workflow.as_id(), statuses=["completed"], limit=3
+            workflow_version_ids=add_multiply_workflow.as_id(), statuses="completed", limit=3
         )
         listed_running = cognite_client.workflows.executions.list(
             workflow_version_ids=add_multiply_workflow.as_id(), statuses=["running"], limit=3


### PR DESCRIPTION
## Description
Allows filtering data workflow executions by status

## Checklist:
- [x] Documentation updated. Documentation is generated from docstrings - these must be updated according to your change.
  If a new method has been added it should be referenced in [cognite.rst](https://github.com/cognitedata/cognite-sdk-python/blob/master/docs/source/cognite.rst) in order to generate docs based on its docstring.
- [x] Changelog updated in [CHANGELOG.md](https://github.com/cognitedata/cognite-sdk-python/blob/master/CHANGELOG.md).
- [x] Version bumped. If triggering a new release is desired, bump the version number in [_version.py](https://github.com/cognitedata/cognite-sdk-python/blob/master/cognite/client/_version.py) and [pyproject.toml](https://github.com/cognitedata/cognite-sdk-python/blob/master/pyproject.toml) per [semantic versioning](https://semver.org/).
