### PR TITLE
Fix empty cursor check in DatapointsAPI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,17 +17,22 @@ Changes are grouped as follows
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
+## [7.48.1] - 2024-06-04
+### Fixed
+- A bug introduced in `7.45.0` that would short-circuit raw datapoint queries too early when a lot of time series was
+  requested at the same time, and `include_outside_points=True` was used (empty cursor are to be expected).
+
 ## [7.48.0] - 2024-06-04
 ### Changed
 - Mark Data Workflows SDK implementation as Generally Available.
 
 ## [7.47.0] - 2024-06-04
 ### Added
-- Support for retrieving `Labels`, `client.labels.retrieve`. 
+- Support for retrieving `Labels`, `client.labels.retrieve`.
 
 ## [7.46.2] - 2024-06-03
 ### Added
-- Added option for silencing `FeaturePreviewWarnings` in the `cognite.client.global_config`. 
+- Added option for silencing `FeaturePreviewWarnings` in the `cognite.client.global_config`.
 
 ## [7.46.1] - 2024-05-31
 ### Fixed

--- a/cognite/client/_api/datapoint_tasks.py
+++ b/cognite/client/_api/datapoint_tasks.py
@@ -749,8 +749,10 @@ class BaseTaskOrchestrator(ABC):
         self._unpack_and_store(FIRST_IDX, dps)
 
         # Are we done after first batch?
-        if not self.first_cursor or len(dps) < first_limit:
+        if len(dps) < first_limit:
             self._is_done = True
+        elif not self.first_cursor and not self.query.include_outside_points:
+            self._is_done = True  # no cursor when including outside...
         elif not self.query.use_cursors and self.first_start == self.query.end:
             self._is_done = True
         elif self.query.limit is not None and len(dps) <= self.query.limit <= first_limit:  # TODO: len == limit??

--- a/cognite/client/_version.py
+++ b/cognite/client/_version.py
@@ -1,4 +1,4 @@
 from __future__ import annotations
 
-__version__ = "7.48.0"
+__version__ = "7.48.1"
 __api_subversion__ = "20230101"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "cognite-sdk"
 
-version = "7.48.0"
+version = "7.48.1"
 description = "Cognite Python SDK"
 readme = "README.md"
 documentation = "https://cognite-sdk-python.readthedocs-hosted.com"

--- a/tests/tests_integration/test_api/test_datapoints.py
+++ b/tests/tests_integration/test_api/test_datapoints.py
@@ -401,7 +401,7 @@ class TestRetrieveRawDatapointsAPI:
         assert all(len(dps) == 1001 for dps in dps_lst)
 
     def test_retrieve_chunking_mode_outside_points_stopped_after_no_cursor(self, cognite_client, weekly_dps_ts):
-        # From 7.45.0 to 7.47.0, when fetching in "chunking mode" with include_outside_points=True,
+        # From 7.45.0 to 7.48.0, when fetching in "chunking mode" with include_outside_points=True,
         # due to an added is-nextCursor-empty check, the queries would short-circuit after the first batch.
         ts_ids, tx_xids = weekly_dps_ts
         with set_max_workers(cognite_client, 1):

--- a/tests/tests_integration/test_api/test_datapoints.py
+++ b/tests/tests_integration/test_api/test_datapoints.py
@@ -403,18 +403,18 @@ class TestRetrieveRawDatapointsAPI:
     def test_retrieve_chunking_mode_outside_points_stopped_after_no_cursor(self, cognite_client, weekly_dps_ts):
         # From 7.45.0 to 7.48.0, when fetching in "chunking mode" with include_outside_points=True,
         # due to an added is-nextCursor-empty check, the queries would short-circuit after the first batch.
-        ts_ids, tx_xids = weekly_dps_ts
+        ts_ids, ts_xids = weekly_dps_ts
         with set_max_workers(cognite_client, 1):
             dps_lst = cognite_client.time_series.data.retrieve(
                 id=ts_ids.as_ids(),
-                external_id=tx_xids.as_external_ids(),
+                external_id=ts_xids.as_external_ids(),
                 start=ts_to_ms("1951"),
                 end=ts_to_ms("1999"),
                 include_outside_points=True,
             )
             df = dps_lst.to_pandas()
 
-            validate_raw_datapoints_lst(ts_ids + tx_xids, dps_lst)
+            validate_raw_datapoints_lst(ts_ids + ts_xids, dps_lst)
             assert df.shape == (2506, 101)
             assert df.notna().any(axis=None)
 


### PR DESCRIPTION
## [7.47.1] - 2024-06-04
### Fixed
- A bug introduced in `7.45.0` that would short-circuit raw datapoint queries too early when a lot of time series was
  requested at the same time, and `include_outside_points=True` was used (empty cursor are to be expected).