### PR TITLE
test: Added CI for pyodide

### DIFF
--- a/.github/workflows/verify-jupyter.yml
+++ b/.github/workflows/verify-jupyter.yml
@@ -21,7 +21,7 @@ jobs:
         run: npm install pyodide@0.25.0
       - name: Install cognite-sdk in pyodide environment
         run: |
-          whl_file=$(find dist -type f -name "*.whl")
+          whl_file=$(find dist -name "*.whl" | sed 's|^dist/||') # Find the built wheel file, remove dist/ prefix
           echo "Found built wheel file: $whl_file"
           SDK_FILE_PATH=$whl_file \
           PACKAGES="[\"pyodide-http\", \"http://localhost:3000/dist/$whl_file\"]" \

--- a/.github/workflows/verify-jupyter.yml
+++ b/.github/workflows/verify-jupyter.yml
@@ -17,6 +17,9 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: "20"
+      - name: Use 20.9
+        # https://github.com/microsoft/playwright/issues/29253
+        run: nvm use v20.9
       - name: Install dependencies
         run: npm install pyodide@0.25.0
       - name: Install cognite-sdk in pyodide environment

--- a/.github/workflows/verify-jupyter.yml
+++ b/.github/workflows/verify-jupyter.yml
@@ -21,6 +21,6 @@ jobs:
         run: npm install pyodide@0.25.0
       - name: Install cognite-sdk in pyodide environment
         run: |
-          echo 'SDK_FILE_PATH="cognite_sdk-7.49.0-py3-none-any.whl"' >> $GITHUB_ENV
-          echo 'PACKAGES="[\"pyodide-http\", \"http://localhost:3000/dist/cognite_sdk-7.49.0-py3-none-any.whl\"]' >> $GITHUB_ENV
+          SDK_FILE_PATH=cognite_sdk-7.49.0-py3-none-any.whl \
+          PACKAGES="[\"pyodide-http\", \"http://localhost:3000/dist/cognite_sdk-7.49.0-py3-none-any.whl\"]" \
           node scripts/test-pyodide.js

--- a/.github/workflows/verify-jupyter.yml
+++ b/.github/workflows/verify-jupyter.yml
@@ -18,7 +18,7 @@ jobs:
         with:
           node-version: "20"
       - name: Install dependencies
-        run: npm install pyodide@0.25.0 # JupyterLite currently using pyodide 0.25.1
+        run: npm install pyodide@0.25.1 # JupyterLite currently using pyodide 0.25.0
       - name: Install cognite-sdk in pyodide environment
         run: |
           whl_file=$(find dist -name "*.whl" | sed 's|^dist/||') # Find the built wheel file, remove dist/ prefix

--- a/.github/workflows/verify-jupyter.yml
+++ b/.github/workflows/verify-jupyter.yml
@@ -6,16 +6,13 @@ on:
     branches: [master]
 
 jobs:
-  build_package:
+  build_and_test_pyodide:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup
       - name: Build package
         run: poetry build
-  install_jupyter:
-    runs-on: ubuntu-latest
-    steps:
       - name: Set up Node.js
         uses: actions/setup-node@v3
         with:

--- a/.github/workflows/verify-jupyter.yml
+++ b/.github/workflows/verify-jupyter.yml
@@ -6,7 +6,7 @@ on:
     branches: [master]
 
 jobs:
-  build_and_test_pyodide:
+  build_and_test_jupyter_pyodide:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -21,6 +21,8 @@ jobs:
         run: npm install pyodide@0.25.0
       - name: Install cognite-sdk in pyodide environment
         run: |
-          SDK_FILE_PATH=cognite_sdk-7.49.0-py3-none-any.whl \
-          PACKAGES="[\"pyodide-http\", \"http://localhost:3000/dist/cognite_sdk-7.49.0-py3-none-any.whl\"]" \
+          whl_file=$(find . -type f -name "dist/*.whl" -print -quit)
+          echo "Found built wheel file: $whl_file"
+          SDK_FILE_PATH=$whl_file \
+          PACKAGES="[\"pyodide-http\", \"http://localhost:3000/dist/$whl_file\"]" \
           node scripts/test-pyodide.js

--- a/.github/workflows/verify-jupyter.yml
+++ b/.github/workflows/verify-jupyter.yml
@@ -1,0 +1,29 @@
+---
+name: build
+
+on:
+  pull_request:
+    branches: [master]
+
+jobs:
+  build_package:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/setup
+      - name: Build package
+        run: poetry build
+  install_jupyter:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: "20"
+      - name: Install dependencies
+        run: npm install pyodide==0.25.0
+      - name: Install cognite-sdk in pyodide environment
+        run: |
+          echo "SDK_FILE_PATH=cognite_sdk-7.49.0-py3-none-any.whl" >> $GITHUB_ENV
+          echo 'PACKAGES=["pyodide-http", "http://localhost:3000/dist/cognite_sdk-7.49.0-py3-none-any.whl"]' >> $GITHUB_ENV
+          node scripts/test-pyodide.js

--- a/.github/workflows/verify-jupyter.yml
+++ b/.github/workflows/verify-jupyter.yml
@@ -21,7 +21,7 @@ jobs:
         with:
           node-version: "20"
       - name: Install dependencies
-        run: npm install pyodide==0.25.0
+        run: npm install pyodide@0.25.0
       - name: Install cognite-sdk in pyodide environment
         run: |
           echo "SDK_FILE_PATH=cognite_sdk-7.49.0-py3-none-any.whl" >> $GITHUB_ENV

--- a/.github/workflows/verify-jupyter.yml
+++ b/.github/workflows/verify-jupyter.yml
@@ -16,11 +16,11 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: "20.9"
+          node-version: "20"
       - name: Install dependencies
         run: npm install pyodide@0.25.0
       - name: Install cognite-sdk in pyodide environment
         run: |
-          echo "SDK_FILE_PATH=cognite_sdk-7.49.0-py3-none-any.whl" >> $GITHUB_ENV
-          echo 'PACKAGES=["pyodide-http", "http://localhost:3000/dist/cognite_sdk-7.49.0-py3-none-any.whl"]' >> $GITHUB_ENV
+          echo 'SDK_FILE_PATH="cognite_sdk-7.49.0-py3-none-any.whl"' >> $GITHUB_ENV
+          echo 'PACKAGES="[\"pyodide-http\", \"http://localhost:3000/dist/cognite_sdk-7.49.0-py3-none-any.whl\"]' >> $GITHUB_ENV
           node scripts/test-pyodide.js

--- a/.github/workflows/verify-jupyter.yml
+++ b/.github/workflows/verify-jupyter.yml
@@ -16,10 +16,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: "20"
-      - name: Use 20.9
-        # https://github.com/microsoft/playwright/issues/29253
-        run: nvm use v20.9
+          node-version: "20.9"
       - name: Install dependencies
         run: npm install pyodide@0.25.0
       - name: Install cognite-sdk in pyodide environment

--- a/.github/workflows/verify-jupyter.yml
+++ b/.github/workflows/verify-jupyter.yml
@@ -21,7 +21,7 @@ jobs:
         run: npm install pyodide@0.25.0
       - name: Install cognite-sdk in pyodide environment
         run: |
-          whl_file=$(find . -type f -name "dist/*.whl" -print -quit)
+          whl_file=$(find dist -type f -name "*.whl")
           echo "Found built wheel file: $whl_file"
           SDK_FILE_PATH=$whl_file \
           PACKAGES="[\"pyodide-http\", \"http://localhost:3000/dist/$whl_file\"]" \

--- a/.github/workflows/verify-jupyter.yml
+++ b/.github/workflows/verify-jupyter.yml
@@ -18,7 +18,7 @@ jobs:
         with:
           node-version: "20"
       - name: Install dependencies
-        run: npm install pyodide@0.25.0
+        run: npm install pyodide@0.25.0 # JupyterLite currently using pyodide 0.25.1
       - name: Install cognite-sdk in pyodide environment
         run: |
           whl_file=$(find dist -name "*.whl" | sed 's|^dist/||') # Find the built wheel file, remove dist/ prefix

--- a/.github/workflows/verify-streamlit.yml
+++ b/.github/workflows/verify-streamlit.yml
@@ -2,27 +2,27 @@
 name: build
 
 on:
-    pull_request:
+  pull_request:
     branches: [master]
 
 jobs:
-    build_and_test_jupyter_pyodide:
+  build_and_test_streamlit_pyodide:
     runs-on: ubuntu-latest
     steps:
-        - uses: actions/checkout@v4
-        - uses: ./.github/actions/setup
-        - name: Build package
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/setup
+      - name: Build package
         run: poetry build
-        - name: Set up Node.js
+      - name: Set up Node.js
         uses: actions/setup-node@v3
         with:
-            node-version: "20"
-        - name: Install dependencies
+          node-version: "20"
+      - name: Install dependencies
         run: npm install pyodide@0.25.1 # stlite currently using pyodide 0.25.1
-        - name: Install cognite-sdk in pyodide environment
+      - name: Install cognite-sdk in pyodide environment
         run: |
-            whl_file=$(find dist -name "*.whl" | sed 's|^dist/||') # Find the built wheel file, remove dist/ prefix
-            echo "Found built wheel file: $whl_file"
-            SDK_FILE_PATH=$whl_file \
-            PACKAGES="[\"pyodide-http\", \"http://localhost:3000/dist/$whl_file\"]" \
-            node scripts/test-pyodide.js
+          whl_file=$(find dist -name "*.whl" | sed 's|^dist/||') # Find the built wheel file, remove dist/ prefix
+          echo "Found built wheel file: $whl_file"
+          SDK_FILE_PATH=$whl_file \
+          PACKAGES="[\"pyodide-http\", \"http://localhost:3000/dist/$whl_file\"]" \
+          node scripts/test-pyodide.js

--- a/.github/workflows/verify-streamlit.yml
+++ b/.github/workflows/verify-streamlit.yml
@@ -1,0 +1,28 @@
+---
+name: build
+
+on:
+    pull_request:
+    branches: [master]
+
+jobs:
+    build_and_test_jupyter_pyodide:
+    runs-on: ubuntu-latest
+    steps:
+        - uses: actions/checkout@v4
+        - uses: ./.github/actions/setup
+        - name: Build package
+        run: poetry build
+        - name: Set up Node.js
+        uses: actions/setup-node@v3
+        with:
+            node-version: "20"
+        - name: Install dependencies
+        run: npm install pyodide@0.25.1 # stlite currently using pyodide 0.25.1
+        - name: Install cognite-sdk in pyodide environment
+        run: |
+            whl_file=$(find dist -name "*.whl" | sed 's|^dist/||') # Find the built wheel file, remove dist/ prefix
+            echo "Found built wheel file: $whl_file"
+            SDK_FILE_PATH=$whl_file \
+            PACKAGES="[\"pyodide-http\", \"http://localhost:3000/dist/$whl_file\"]" \
+            node scripts/test-pyodide.js

--- a/scripts/test-pyodide.js
+++ b/scripts/test-pyodide.js
@@ -1,0 +1,52 @@
+const { loadPyodide } = require("pyodide");
+
+const http = require('http');
+const fs = require('fs');
+const path = require('path');
+
+const PORT = 3000;
+
+// The Cognite Python SDK wheel filename will be sent in as environment variable
+const wheelFilePath = path.join(__dirname, process.env.SDK_FILE_PATH);
+
+// Create an HTTP server to serve the wheel file
+const server = http.createServer((req, res) => {
+  fs.readFile(wheelFilePath, (err, data) => {
+    if (err) {
+      // Handle file read errors
+      res.writeHead(500, { 'Content-Type': 'text/plain' });
+      res.end('500 - Internal Server Error');
+    } else {
+      // Serve the file content
+      res.writeHead(200, { 'Content-Type': 'application/octet-stream' });
+      res.end(data);
+    }
+  });
+});
+
+// Start the server and listen on the defined port. Then try to install the SDK in Python
+server.listen(PORT, () => {
+  console.log(`Server is running at http://localhost:${PORT}. Now trying to install sdk.`);
+  
+  async function test_cognite_sdk() {
+    let pyodide = await loadPyodide();
+    await pyodide.loadPackage("micropip");
+    const micropip = pyodide.pyimport("micropip");
+    // Read packages to install from environment variable as JSON
+
+    const packages = JSON.parse(process.env.PACKAGES);
+    for (const pkg of packages) {
+      await micropip.install(pkg);
+    }
+    // await micropip.install("pyodide-http");
+    // await micropip.install('http://localhost:3000/cognite_sdk-7.49.0-py3-none-any.whl');
+    await pyodide.runPythonAsync("from cognite.client import CogniteClient");
+    
+    return pyodide.runPythonAsync("1+1");
+  }
+
+  test_cognite_sdk().then((result) => {
+    console.log("Python says that 1+1 =", result);
+    server.close();
+  });
+});

--- a/scripts/test-pyodide.js
+++ b/scripts/test-pyodide.js
@@ -45,7 +45,7 @@ server.listen(PORT, () => {
     }
     await pyodide.runPythonAsync("from cognite.client import CogniteClient");
     
-    return pyodide.runPythonAsync("Python SDK successfully installed and imported!");
+    return pyodide.runPythonAsync('print("Python SDK successfully installed and imported!"');
   }
 
   test_cognite_sdk().then((result) => {

--- a/scripts/test-pyodide.js
+++ b/scripts/test-pyodide.js
@@ -45,7 +45,7 @@ server.listen(PORT, () => {
     }
     await pyodide.runPythonAsync("from cognite.client import CogniteClient");
     
-    return pyodide.runPythonAsync('print("Python SDK successfully installed and imported!"');
+    return pyodide.runPythonAsync('print("Python SDK successfully installed and imported!")');
   }
 
   test_cognite_sdk().then((result) => {

--- a/scripts/test-pyodide.js
+++ b/scripts/test-pyodide.js
@@ -45,7 +45,7 @@ server.listen(PORT, () => {
     }
     await pyodide.runPythonAsync("from cognite.client import CogniteClient");
     
-    return pyodide.runPythonAsync('print("Python SDK successfully installed and imported!")');
+    return pyodide.runPythonAsync('"Python SDK successfully installed and imported!"');
   }
 
   test_cognite_sdk().then((result) => {

--- a/scripts/test-pyodide.js
+++ b/scripts/test-pyodide.js
@@ -7,7 +7,7 @@ const path = require('path');
 const PORT = 3000;
 
 // The Cognite Python SDK wheel filename will be sent in as environment variable
-const wheelFilePath = path.join(__dirname, process.env.SDK_FILE_PATH);
+const wheelFilePath = path.join(__dirname, '..', 'dist', process.env.SDK_FILE_PATH);
 
 // Create an HTTP server to serve the wheel file
 const server = http.createServer((req, res) => {
@@ -38,8 +38,6 @@ server.listen(PORT, () => {
     for (const pkg of packages) {
       await micropip.install(pkg);
     }
-    // await micropip.install("pyodide-http");
-    // await micropip.install('http://localhost:3000/cognite_sdk-7.49.0-py3-none-any.whl');
     await pyodide.runPythonAsync("from cognite.client import CogniteClient");
     
     return pyodide.runPythonAsync("1+1");

--- a/scripts/test-pyodide.js
+++ b/scripts/test-pyodide.js
@@ -1,3 +1,8 @@
+// Description: This script is used to test the Python SDK installation in a Pyodide environment.
+// We are using JupyterLite and stlite, both pyodide based Python runtimes. To ensure that the SDK works
+// in these runtimes, we need to test the installation of the SDK in a Pyodide environment.
+// This script will start an HTTP server to serve the SDK wheel file and then try to install the SDK in Python.
+// If the installation is successful, it will run a simple Python script to test the SDK.
 const { loadPyodide } = require("pyodide");
 
 const http = require('http');
@@ -40,11 +45,11 @@ server.listen(PORT, () => {
     }
     await pyodide.runPythonAsync("from cognite.client import CogniteClient");
     
-    return pyodide.runPythonAsync("1+1");
+    return pyodide.runPythonAsync("Python SDK successfully installed and imported!");
   }
 
   test_cognite_sdk().then((result) => {
-    console.log("Python says that 1+1 =", result);
+    console.log("Response from Python =", result);
     server.close();
   });
 });


### PR DESCRIPTION
## Description
Closes https://github.com/cognitedata/cog-ai/issues/2336

The Python SDK is heavily used in our Jupyter notebook and Streamlit environment which is Pyodide based. To ensure compatibility, I have added a CI step that verifies that the SDK can be installed and imported in Pyodide.

The test is implemented as a nodejs script triggered by GitHub workflows, one for Jupyter and one for Streamlit.

## Checklist:
- [x] Tests added/updated.
- [ ] Documentation updated. Documentation is generated from docstrings - these must be updated according to your change.
  If a new method has been added it should be referenced in [cognite.rst](https://github.com/cognitedata/cognite-sdk-python/blob/master/docs/source/cognite.rst) in order to generate docs based on its docstring.
- [ ] Changelog updated in [CHANGELOG.md](https://github.com/cognitedata/cognite-sdk-python/blob/master/CHANGELOG.md).
- [ ] Version bumped. If triggering a new release is desired, bump the version number in [_version.py](https://github.com/cognitedata/cognite-sdk-python/blob/master/cognite/client/_version.py) and [pyproject.toml](https://github.com/cognitedata/cognite-sdk-python/blob/master/pyproject.toml) per [semantic versioning](https://semver.org/).
