### PR TITLE
Fix-devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,7 +3,7 @@
   "name": "Dev Container for Cognite Python SDK",
 
   // Python base image reference: https://github.com/devcontainers/images/tree/main/src/python
-  "image": "mcr.microsoft.com/devcontainers/python:3.12-bullseye",
+  "image": "mcr.microsoft.com/devcontainers/python:3.8-bullseye",
 
   // Features to add to the dev container. More info: https://containers.dev/features
   "features": {

--- a/renovate.json
+++ b/renovate.json
@@ -9,6 +9,10 @@
       "enabled": false,
       "matchManagers": ["poetry"],
       "matchPackagePatterns": ["*"]
+    },
+    {
+      "enabled": false,
+      "matchPackageNames": ["mcr.microsoft.com/devcontainers/python"]
     }
   ],
   "vulnerabilityAlerts": {


### PR DESCRIPTION
## Description
This sets the Python image for devcontainer to a 3.8 version, to be aligned with current setup in cognite-sdk-python.

Also disables automated RenoveBot updated for the devcontainer image, to avoid dependency uppdates from RenovateBot to again use a "too new" version.

## Checklist:
- [ ] Tests added/updated.
- [ ] Documentation updated. Documentation is generated from docstrings - these must be updated according to your change.
  If a new method has been added it should be referenced in [cognite.rst](https://github.com/cognitedata/cognite-sdk-python/blob/master/docs/source/cognite.rst) in order to generate docs based on its docstring.
- [ ] Changelog updated in [CHANGELOG.md](https://github.com/cognitedata/cognite-sdk-python/blob/master/CHANGELOG.md).
- [ ] Version bumped. If triggering a new release is desired, bump the version number in [_version.py](https://github.com/cognitedata/cognite-sdk-python/blob/master/cognite/client/_version.py) and [pyproject.toml](https://github.com/cognitedata/cognite-sdk-python/blob/master/pyproject.toml) per [semantic versioning](https://semver.org/).
