### PR TITLE
Fix reset dataset for 3d model update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,11 @@ Changes are grouped as follows
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
+## [7.50.0] - 2024-06-11
+
+### Fixed
+- Fixes resetting dataSetId to None in a ThreeDModelUpdate.
+
 ## [7.49.0] - 2024-06-05
 ### Added
 - `WorkfowExecutionAPI.list` now allows filtering by execution status.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ Changes are grouped as follows
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
-## [7.50.0] - 2024-06-11
+## [7.49.1] - 2024-06-11
 
 ### Fixed
 - Fixes resetting dataSetId to None in a ThreeDModelUpdate.

--- a/cognite/client/_version.py
+++ b/cognite/client/_version.py
@@ -1,4 +1,4 @@
 from __future__ import annotations
 
-__version__ = "7.49.0"
+__version__ = "7.49.1"
 __api_subversion__ = "20230101"

--- a/cognite/client/data_classes/three_d.py
+++ b/cognite/client/data_classes/three_d.py
@@ -204,8 +204,8 @@ class ThreeDModelUpdate(CogniteUpdate):
         return ThreeDModelUpdate._ObjectThreeDModelUpdate(self, "metadata")
 
     @property
-    def data_set_id(self) -> _ObjectThreeDModelUpdate:
-        return ThreeDModelUpdate._ObjectThreeDModelUpdate(self, "dataSetId")
+    def data_set_id(self) -> _PrimitiveThreeDModelUpdate:
+        return ThreeDModelUpdate._PrimitiveThreeDModelUpdate(self, "dataSetId")
 
     @classmethod
     def _get_update_properties(cls) -> list[PropertySpec]:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "cognite-sdk"
 
-version = "7.49.0"
+version = "7.49.1"
 description = "Cognite Python SDK"
 readme = "README.md"
 documentation = "https://cognite-sdk-python.readthedocs-hosted.com"

--- a/renovate.json
+++ b/renovate.json
@@ -9,10 +9,6 @@
       "enabled": false,
       "matchManagers": ["poetry"],
       "matchPackagePatterns": ["*"]
-    },
-    {
-      "enabled": false,
-      "matchPackageNames": ["mcr.microsoft.com/devcontainers/python"]
     }
   ],
   "vulnerabilityAlerts": {

--- a/renovate.json
+++ b/renovate.json
@@ -9,6 +9,10 @@
       "enabled": false,
       "matchManagers": ["poetry"],
       "matchPackagePatterns": ["*"]
+    },
+    {
+      "enabled": false,
+      "matchPackageNames": ["mcr.microsoft.com/devcontainers/python"]
     }
   ],
   "vulnerabilityAlerts": {

--- a/tests/tests_unit/test_api/test_3d.py
+++ b/tests/tests_unit/test_api/test_3d.py
@@ -58,6 +58,22 @@ class Test3DModels:
         ][0]
         assert mock_3d_model_response.calls[0].response.json()["items"][0] == res.dump(camel_case=True)
 
+    def test_update_dataset(self, cognite_client, mock_3d_model_response):
+        update = ThreeDModelUpdate(id=1).data_set_id.set(2)
+        res = cognite_client.three_d.models.update(update)
+        assert {"id": 1, "update": {"dataSetId": {"set": 2}}} == jsgz_load(
+            mock_3d_model_response.calls[0].request.body
+        )["items"][0]
+        assert mock_3d_model_response.calls[0].response.json()["items"][0] == res.dump(camel_case=True)
+
+    def test_reset_dataset(self, cognite_client, mock_3d_model_response):
+        update = ThreeDModelUpdate(id=1).data_set_id.set(None)
+        res = cognite_client.three_d.models.update(update)
+        assert {"id": 1, "update": {"dataSetId": {"setNull": True}}} == jsgz_load(
+            mock_3d_model_response.calls[0].request.body
+        )["items"][0]
+        assert mock_3d_model_response.calls[0].response.json()["items"][0] == res.dump(camel_case=True)
+
     def test_update_with_resource_object(self, cognite_client, mock_3d_model_response):
         res = cognite_client.three_d.models.update(ThreeDModel(id=1, name="bla", created_time=123))
         assert {"id": 1, "update": {"name": {"set": "bla"}}} == jsgz_load(mock_3d_model_response.calls[0].request.body)[


### PR DESCRIPTION
## Description

This fixes resetting the dataSetId for 3d model updates.

Previously , trying to use ThreeDModelUpdate with a `data_set_id.set(None)` would lead to a invalid request sent to 3d api.

The dataSetId property is a "primitive" field, not an object, so the fix is to use the correct return type for it, CognitePrimitiveUpdate.

## Checklist:
- [x] Tests added/updated.
- [ ] Documentation updated. Documentation is generated from docstrings - these must be updated according to your change.
  If a new method has been added it should be referenced in [cognite.rst](https://github.com/cognitedata/cognite-sdk-python/blob/master/docs/source/cognite.rst) in order to generate docs based on its docstring.
- [x] Changelog updated in [CHANGELOG.md](https://github.com/cognitedata/cognite-sdk-python/blob/master/CHANGELOG.md).
- [x] Version bumped. If triggering a new release is desired, bump the version number in [_version.py](https://github.com/cognitedata/cognite-sdk-python/blob/master/cognite/client/_version.py) and [pyproject.toml](https://github.com/cognitedata/cognite-sdk-python/blob/master/pyproject.toml) per [semantic versioning](https://semver.org/).
