### PR TITLE
Fix raw rows to pandas (keep all rows)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,8 +17,12 @@ Changes are grouped as follows
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
-## [7.49.1] - 2024-06-11
+## [7.49.2] - 2024-06-12
+### Fixed
+- Converting rows (`RowList` and `RowListWrite`) to a pandas DataFrame no longer silently drops rows that do not have
+  any columnar data.
 
+## [7.49.1] - 2024-06-11
 ### Fixed
 - Fixes resetting dataSetId to None in a ThreeDModelUpdate.
 

--- a/cognite/client/_version.py
+++ b/cognite/client/_version.py
@@ -1,4 +1,4 @@
 from __future__ import annotations
 
-__version__ = "7.49.1"
+__version__ = "7.49.2"
 __api_subversion__ = "20230101"

--- a/cognite/client/data_classes/raw.py
+++ b/cognite/client/data_classes/raw.py
@@ -105,6 +105,13 @@ class RowWrite(RowCore):
         columns (dict[str, Any]): Row data stored as a JSON object.
     """
 
+    def __init__(
+        self,
+        key: str,
+        columns: dict[str, Any],
+    ) -> None:
+        super().__init__(key, columns)
+
     @classmethod
     def _load(cls, resource: dict[str, Any], cognite_client: CogniteClient | None = None) -> RowWrite:
         return cls(resource["key"], resource["columns"])

--- a/cognite/client/data_classes/raw.py
+++ b/cognite/client/data_classes/raw.py
@@ -130,10 +130,10 @@ class RowListCore(WriteableCogniteResourceList[RowWrite, T_Row], ABC):
             pandas.DataFrame: The pandas DataFrame representing this instance.
         """
         pd = local_import("pandas")
-        if self:
-            index, data = zip(*((row.key, row.columns) for row in self))
-            return pd.DataFrame.from_records(data, index=index)
-        return pd.DataFrame(columns=[], index=[])
+        if not self:
+            return pd.DataFrame(columns=[], index=[])
+        index, data = zip(*((row.key, row.columns) for row in self))
+        return pd.DataFrame.from_records(data, index=index)
 
 
 class RowWriteList(RowListCore[RowWrite]):

--- a/cognite/client/data_classes/raw.py
+++ b/cognite/client/data_classes/raw.py
@@ -130,7 +130,10 @@ class RowListCore(WriteableCogniteResourceList[RowWrite, T_Row], ABC):
             pandas.DataFrame: The pandas DataFrame representing this instance.
         """
         pd = local_import("pandas")
-        return pd.DataFrame.from_dict(OrderedDict((d.key, d.columns) for d in self.data), orient="index")
+        if self:
+            index, data = zip(*((row.key, row.columns) for row in self))
+            return pd.DataFrame.from_records(data, index=index)
+        return pd.DataFrame(columns=[], index=[])
 
 
 class RowWriteList(RowListCore[RowWrite]):

--- a/mypy.ini
+++ b/mypy.ini
@@ -32,9 +32,6 @@ ignore_missing_imports = true
 [mypy-sympy.*]
 ignore_missing_imports = true
 
-[mypy-sortedcontainers.*]
-ignore_missing_imports = true
-
 [mypy-pyodide_http.*]
 ignore_missing_imports = true
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "cognite-sdk"
 
-version = "7.49.1"
+version = "7.49.2"
 description = "Cognite Python SDK"
 readme = "README.md"
 documentation = "https://cognite-sdk-python.readthedocs-hosted.com"

--- a/tests/tests_unit/test_api/test_raw.py
+++ b/tests/tests_unit/test_api/test_raw.py
@@ -414,7 +414,7 @@ class TestPandasIntegration:
 
     @pytest.mark.parametrize("n_rows", (1, 5))
     def test_rows_to_pandas__empty_or_sparse(self, n_rows):
-        # Before version 7.49.1, rows with no column data would be silently dropped when converting to a pandas dataframe,
+        # Before version 7.49.2, rows with no column data would be silently dropped when converting to a pandas dataframe,
         # which was most noticable as len(rows) != len(df).
         import pandas as pd
 

--- a/tests/tests_unit/test_data_classes/test_repr.py
+++ b/tests/tests_unit/test_data_classes/test_repr.py
@@ -18,6 +18,7 @@ from cognite.client.data_classes import (
 
 @pytest.mark.dsl
 class TestRepr:
+    # TODO: We should auto-create these tests for all subclasses impl. _repr_html_:
     def test_repr_html(self):
         for cls in [Asset, Datapoints, Sequence, FileMetadata, Row, Table, ThreeDModel]:
             assert len(cls()._repr_html_()) > 0
@@ -26,5 +27,6 @@ class TestRepr:
         assert len(Datapoint(timestamp=0, value=0)._repr_html_()) > 0
 
     def test_repr_html_list(self):
-        for cls in [AssetList, DatapointsList, RowList, TableList]:
+        for cls in [AssetList, DatapointsList, TableList]:
             assert len(cls([cls._RESOURCE()])._repr_html_()) > 0
+        assert len(RowList([RowList._RESOURCE("row", columns={})])._repr_html_()) > 0


### PR DESCRIPTION
## [7.49.2] - 2024-06-12
### Fixed
- Converting rows (`RowList` and `RowListWrite`) to a pandas DataFrame no longer silently drops rows that do not have
  any columnar data.

## Checklist:
- [x] Tests added/updated.
- [ ] Documentation updated. Documentation is generated from docstrings - these must be updated according to your change.
  If a new method has been added it should be referenced in [cognite.rst](https://github.com/cognitedata/cognite-sdk-python/blob/master/docs/source/cognite.rst) in order to generate docs based on its docstring.
- [x] Changelog updated in [CHANGELOG.md](https://github.com/cognitedata/cognite-sdk-python/blob/master/CHANGELOG.md).
- [x] Version bumped. If triggering a new release is desired, bump the version number in [_version.py](https://github.com/cognitedata/cognite-sdk-python/blob/master/cognite/client/_version.py) and [pyproject.toml](https://github.com/cognitedata/cognite-sdk-python/blob/master/pyproject.toml) per [semantic versioning](https://semver.org/).
