### PR TITLE
timezone and calendar aggregates -> GA

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,13 @@ Changes are grouped as follows
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
+## [7.50.0] - 2024-06-14
+### Changed
+- DatapointsAPI support for timezones and calendar-based aggregates reaches general availability (GA).
+### Deprecated
+- The function `DatapointsAPI.retrieve_dataframe_in_tz` is deprecated. Use the other retrieve methods instead
+  and pass in `timezone`.
+
 ## [7.49.2] - 2024-06-12
 ### Fixed
 - Converting rows (`RowList` and `RowListWrite`) to a pandas DataFrame no longer silently drops rows that do not have

--- a/cognite/client/_api/datapoints.py
+++ b/cognite/client/_api/datapoints.py
@@ -6,6 +6,7 @@ import heapq
 import itertools
 import math
 import time
+import warnings
 from abc import ABC, abstractmethod
 from collections import defaultdict
 from itertools import chain
@@ -1083,6 +1084,14 @@ class DatapointsAPI(APIClient):
     ) -> pd.DataFrame:
         """Get datapoints directly in a pandas dataframe in the same timezone as ``start`` and ``end``.
 
+        .. admonition:: Deprecation Warning
+
+            This SDK function is deprecated and will be removed in the next major release. Reason: Cognite Data
+            Fusion now has native support for timezone and calendar-based aggregations. Please consider migrating
+            already today: The API also supports fixed offsets, yields more accurate results and have better support
+            for exotic timezones and unusual DST offsets. You can use the normal retrieve methods instead, just
+            pass 'timezone' as a parameter.
+
         This is a convenience method extending the Time Series API capabilities to make timezone-aware datapoints
         fetching easy with daylight saving time (DST) transitions taken care of automatically. It builds on top
         of the methods ``retrieve_arrays`` and ``retrieve_dataframe``.
@@ -1163,6 +1172,15 @@ class DatapointsAPI(APIClient):
                 ...     start=datetime(2020, 1, 1, tzinfo=ZoneInfo("America/New_York")),
                 ...     end=datetime(2022, 12, 31, tzinfo=ZoneInfo("America/New_York")))
         """
+        warnings.warn(
+            (
+                "This SDK function is deprecated and will be removed in the next major release. Reason: Cognite Data "
+                "Fusion now has native support for timezone and calendar-based aggregations. Please consider "
+                "migrating already today: The API yields more accurate results and have better support for exotic "
+                "timezones. You can use the normal retrieve methods instead, just pass 'timezone' as a parameter."
+            ),
+            UserWarning,
+        )
         _, pd = local_import("numpy", "pandas")  # Verify that deps are available or raise CogniteImportError
 
         if not exactly_one_is_not_none(id, external_id):
@@ -1173,7 +1191,6 @@ class DatapointsAPI(APIClient):
                 "Got only one of 'aggregates' and 'granularity'. "
                 "Pass both to get aggregates, or neither to get raw data"
             )
-
         tz = validate_timezone(start, end)
         if aggregates is None and granularity is None:
             # For raw data, we only need to convert the timezone:

--- a/cognite/client/_version.py
+++ b/cognite/client/_version.py
@@ -1,4 +1,4 @@
 from __future__ import annotations
 
-__version__ = "7.49.2"
+__version__ = "7.50.0"
 __api_subversion__ = "20230101"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "cognite-sdk"
 
-version = "7.49.2"
+version = "7.50.0"
 description = "Cognite Python SDK"
 readme = "README.md"
 documentation = "https://cognite-sdk-python.readthedocs-hosted.com"


### PR DESCRIPTION
## [7.50.0] - 2024-06-14
### Changed
- DatapointsAPI support for timezones and calendar-based aggregates reaches general availability (GA).
### Deprecated
- The function `DatapointsAPI.retrieve_dataframe_in_tz` is deprecated. Use the other retrieve methods instead
  and pass in `timezone`.