### PR TITLE
Support Custom Property Types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ Changes are grouped as follows
 - Introduced support for custom dataclasses as Node and Edge properties. This allows you to automtically serialize and 
   deserialize custom dataclasses when working with the Data Modeling API. For example, you parse the
   properties of nodes by doing the following 
-  `client.data_modeling.instances.retrieve(node_id).nodes.property_as_type(MyCustomDataClass)`.
+  `client.data_modeling.instances.retrieve(node_id, sources=MyCustomDataClass._source).nodes.property_as_type(MyCustomDataClass)`.
 
 ## [7.50.0] - 2024-06-14
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,13 @@ Changes are grouped as follows
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
+## [7.51.0] - 2024-06-14
+### Added
+- Introduced support for custom dataclasses as Node and Edge properties. This allows you to automtically serialize and 
+  deserialize custom dataclasses when working with the Data Modeling API. For example, you parse the
+  properties of nodes by doing the following 
+  `client.data_modeling.instances.retrieve(node_id).nodes.property_as_type(MyCustomDataClass)`.
+
 ## [7.50.0] - 2024-06-14
 ### Changed
 - DatapointsAPI support for timezones and calendar-based aggregates reaches general availability (GA).

--- a/cognite/client/_api/data_modeling/instances.py
+++ b/cognite/client/_api/data_modeling/instances.py
@@ -42,6 +42,7 @@ from cognite.client.data_classes.data_modeling.ids import (
 from cognite.client.data_classes.data_modeling.instances import (
     Edge,
     EdgeApply,
+    EdgeApplyBase,
     EdgeApplyResult,
     EdgeApplyResultList,
     EdgeList,
@@ -52,6 +53,7 @@ from cognite.client.data_classes.data_modeling.instances import (
     InstancesResult,
     Node,
     NodeApply,
+    NodeApplyBase,
     NodeApplyResult,
     NodeApplyResultList,
     NodeList,
@@ -536,8 +538,8 @@ class InstancesAPI(APIClient):
 
     def apply(
         self,
-        nodes: NodeApply | Sequence[NodeApply] | None = None,
-        edges: EdgeApply | Sequence[EdgeApply] | None = None,
+        nodes: NodeApplyBase | Sequence[NodeApplyBase] | None = None,
+        edges: EdgeApplyBase | Sequence[EdgeApplyBase] | None = None,
         auto_create_start_nodes: bool = False,
         auto_create_end_nodes: bool = False,
         auto_create_direct_relations: bool = True,
@@ -547,8 +549,8 @@ class InstancesAPI(APIClient):
         """`Add or update (upsert) instances. <https://developer.cognite.com/api#tag/Instances/operation/applyNodeAndEdges>`_
 
         Args:
-            nodes (NodeApply | Sequence[NodeApply] | None): Nodes to apply
-            edges (EdgeApply | Sequence[EdgeApply] | None): Edges to apply
+            nodes (NodeApplyBase | Sequence[NodeApplyBase] | None): Nodes to apply
+            edges (EdgeApplyBase | Sequence[EdgeApplyBase] | None): Edges to apply
             auto_create_start_nodes (bool): Whether to create missing start nodes for edges when ingesting. By default, the start node of an edge must exist before it can be ingested.
             auto_create_end_nodes (bool): Whether to create missing end nodes for edges when ingesting. By default, the end node of an edge must exist before it can be ingested.
             auto_create_direct_relations (bool): Whether to create missing direct relation targets when ingesting.

--- a/cognite/client/_version.py
+++ b/cognite/client/_version.py
@@ -1,4 +1,4 @@
 from __future__ import annotations
 
-__version__ = "7.50.0"
+__version__ = "7.51.0"
 __api_subversion__ = "20230101"

--- a/cognite/client/data_classes/data_modeling/core.py
+++ b/cognite/client/data_classes/data_modeling/core.py
@@ -1,8 +1,7 @@
 from __future__ import annotations
 
-import warnings
 from abc import ABC
-from typing import TYPE_CHECKING, Any, Generic, Literal
+from typing import TYPE_CHECKING, Any, Literal
 
 from typing_extensions import Self
 
@@ -10,18 +9,12 @@ from cognite.client.data_classes._base import (
     CogniteObject,
     CogniteResource,
     T_CogniteResource,
-    T_WritableCogniteResource,
-    T_WriteClass,
     WriteableCogniteResource,
-    WriteableCogniteResourceList,
     basic_instance_dump,
 )
 from cognite.client.utils import _json
-from cognite.client.utils._importing import local_import
 
 if TYPE_CHECKING:
-    import pandas as pd
-
     from cognite.client import CogniteClient
 
 
@@ -75,54 +68,6 @@ class DataModelingSchemaResource(WritableDataModelingResource[T_CogniteResource]
         self.external_id = external_id
         self.name = name
         self.description = description
-
-
-class DataModelingInstancesList(WriteableCogniteResourceList, Generic[T_WriteClass, T_WritableCogniteResource], ABC):
-    def to_pandas(  # type: ignore [override]
-        self,
-        camel_case: bool = False,
-        convert_timestamps: bool = True,
-        expand_properties: bool = False,
-        remove_property_prefix: bool = True,
-        **kwargs: Any,
-    ) -> pd.DataFrame:
-        """Convert the instance into a pandas DataFrame. Note that if the properties column is expanded and there are
-        keys in the metadata that already exist in the DataFrame, then an error will be raised by pandas during joining.
-
-        Args:
-            camel_case (bool): Convert column names to camel case (e.g. `externalId` instead of `external_id`). Does not apply to properties.
-            convert_timestamps (bool): Convert known columns storing CDF timestamps (milliseconds since epoch) to datetime. Does not affect properties.
-            expand_properties (bool): Expand the properties into separate columns. Note: Will change default to True in the next major version.
-            remove_property_prefix (bool): Remove view ID prefix from columns names of expanded properties. Requires data to be from a single view.
-            **kwargs (Any): For backwards compatability.
-
-        Returns:
-            pd.DataFrame: The Cognite resource as a dataframe.
-        """
-        kwargs.pop("expand_metadata", None), kwargs.pop("metadata_prefix", None)
-        if kwargs:
-            raise TypeError(f"Unsupported keyword arguments: {kwargs}")
-        if not expand_properties:
-            warnings.warn(
-                "Keyword argument 'expand_properties' will change default from False to True in the next major version.",
-                DeprecationWarning,
-            )
-        df = super().to_pandas(camel_case=camel_case, expand_metadata=False, convert_timestamps=convert_timestamps)
-        if not expand_properties or "properties" not in df.columns:
-            return df
-
-        prop_df = local_import("pandas").json_normalize(df.pop("properties"), max_level=2)
-        if remove_property_prefix and not prop_df.empty:
-            # We only do/allow this if we have a single source:
-            view_id, *extra = set(vid for item in self for vid in item.properties)
-            if not extra:
-                prop_df.columns = prop_df.columns.str.removeprefix("{}.{}/{}.".format(*view_id.as_tuple()))
-            else:
-                warnings.warn(
-                    "Can't remove view ID prefix from expanded property columns as source was not unique",
-                    RuntimeWarning,
-                )
-        return df.join(prop_df)
 
 
 class DataModelingSort(CogniteObject):

--- a/cognite/client/data_classes/data_modeling/instances.py
+++ b/cognite/client/data_classes/data_modeling/instances.py
@@ -587,6 +587,13 @@ class NodeApplyBase(InstanceApply["NodeApplyBase", T_NodeOrEdgeData]):
             output["type"] = self.type.dump(camel_case)
         return output
 
+    @classmethod
+    def _load(cls, resource: dict, cognite_client: CogniteClient | None = None) -> Self:
+        raise NotImplementedError(
+            "You cannot load a NodeApplyBase instance directly. "
+            "Use NodeApply.load(data).as_property(YOUR_TYPE) instead."
+        )
+
     def as_id(self) -> NodeId:
         return NodeId(space=self.space, external_id=self.external_id)
 
@@ -805,6 +812,13 @@ class EdgeApplyBase(InstanceApply["EdgeApplyBase", T_NodeOrEdgeData]):
         if self.end_node:
             output["endNode" if camel_case else "end_node"] = self.end_node.dump(camel_case)
         return output
+
+    @classmethod
+    def _load(cls, resource: dict, cognite_client: CogniteClient | None = None) -> Self:
+        raise NotImplementedError(
+            "You cannot load a EdgeApplyBase instance directly. "
+            "Use EdgeApply.load(data).as_property(YOUR_TYPE) instead."
+        )
 
     def as_write(self) -> Self:
         """Returns this EdgeApply instance"""

--- a/cognite/client/data_classes/data_modeling/instances.py
+++ b/cognite/client/data_classes/data_modeling/instances.py
@@ -611,7 +611,7 @@ class NodeApplyBase(InstanceApply["NodeApplyBase", T_NodeOrEdgeData]):
     def _load(cls, resource: dict, cognite_client: CogniteClient | None = None) -> Self:
         raise NotImplementedError(
             "You cannot load a NodeApplyBase instance directly. "
-            "Use NodeApply.load(data).as_property(YOUR_TYPE) instead."
+            "Use NodeApply.load(data).property_as_type(YOUR_TYPE) instead."
         )
 
     def as_id(self) -> NodeId:
@@ -736,7 +736,7 @@ class NodeBase(Instance[NodeApply, T_Property]):
     @classmethod
     def _load(cls, resource: dict, cognite_client: CogniteClient | None = None) -> Self:
         raise NotImplementedError(
-            "You cannot load a NodeBase instance directly. Use Node.load(data).as_property(YOUR_TYPE) instead."
+            "You cannot load a NodeBase instance directly. Use Node.load(data).property_as_type(YOUR_TYPE) instead."
         )
 
 
@@ -890,7 +890,7 @@ class EdgeApplyBase(InstanceApply["EdgeApplyBase", T_NodeOrEdgeData]):
     def _load(cls, resource: dict, cognite_client: CogniteClient | None = None) -> Self:
         raise NotImplementedError(
             "You cannot load a EdgeApplyBase instance directly. "
-            "Use EdgeApply.load(data).as_property(YOUR_TYPE) instead."
+            "Use EdgeApply.load(data).property_as_type(YOUR_TYPE) instead."
         )
 
     def as_write(self) -> Self:
@@ -1030,7 +1030,7 @@ class EdgeBase(Instance[EdgeApply, T_Property]):
     @classmethod
     def _load(cls, resource: dict, cognite_client: CogniteClient | None = None) -> Self:
         raise NotImplementedError(
-            "You cannot load a EdgeBase instance directly. Use Edge.load(data).as_property(YOUR_TYPE) instead."
+            "You cannot load a EdgeBase instance directly. Use Edge.load(data).property_as_type(YOUR_TYPE) instead."
         )
 
 

--- a/cognite/client/data_classes/data_modeling/instances.py
+++ b/cognite/client/data_classes/data_modeling/instances.py
@@ -139,11 +139,11 @@ class NodeOrEdgeData(CogniteObject):
 class PropertyLike(CogniteObject, ABC):
     """This is a base class for all custom data classes that represent the data values of a node or edge."""
 
-    source: ClassVar[ViewId]
+    _source: ClassVar[ViewId]
 
     def as_node_or_edge_data(self) -> list[NodeOrEdgeData]:
         """Convert the custom data class to a list of NodeOrEdgeData."""
-        return [NodeOrEdgeData(source=self.source, properties=asdict(self))]
+        return [NodeOrEdgeData(source=self._source, properties=asdict(self))]
 
     @classmethod
     def from_node_or_edge_data(cls, data: list[NodeOrEdgeData] | None) -> Self | None:
@@ -151,22 +151,22 @@ class PropertyLike(CogniteObject, ABC):
         if data is None:
             return None
         for node_or_edge_data in data:
-            if node_or_edge_data.source == cls.source:
+            if node_or_edge_data.source == cls._source:
                 return cls(**node_or_edge_data.properties)
         else:
-            raise TypeError(f"NodeOrEdgeData with source {cls.source} not found in data")
+            raise TypeError(f"NodeOrEdgeData with source {cls._source} not found in data")
 
     def as_properties(self) -> Properties:
-        return Properties({self.source: asdict(self)})
+        return Properties({self._source: asdict(self)})
 
     @classmethod
     def from_properties(cls, properties: Properties | None) -> Self | None:
         if properties is None:
             return None
         for view_id, props in properties.items():
-            if view_id == cls.source:
+            if view_id == cls._source:
                 return cls(**props)
-        raise TypeError(f"Properties with source {cls.source} not found in data")
+        raise TypeError(f"Properties with source {cls._source} not found in data")
 
 
 T_PropertyLike = TypeVar("T_PropertyLike", bound=PropertyLike)

--- a/cognite/client/data_classes/data_modeling/instances.py
+++ b/cognite/client/data_classes/data_modeling/instances.py
@@ -650,7 +650,7 @@ class NodeApply(NodeApplyBase[List[NodeOrEdgeData]]):
             type=DirectRelationReference.load(resource["type"]) if "type" in resource else None,
         )
 
-    def as_property(self, property_type: type[T_PropertyLike]) -> NodeApplyBase[T_PropertyLike]:
+    def property_as_type(self, property_type: type[T_PropertyLike]) -> NodeApplyBase[T_PropertyLike]:
         """Convert the sources to a property type."""
         return NodeApplyBase[T_PropertyLike](
             space=self.space,
@@ -772,7 +772,7 @@ class Node(NodeBase[Properties]):
             type=DirectRelationReference.load(resource["type"]) if "type" in resource else None,
         )
 
-    def as_property(self, property_type: type[T_PropertyLike]) -> NodeBase[T_PropertyLike]:
+    def property_as_type(self, property_type: type[T_PropertyLike]) -> NodeBase[T_PropertyLike]:
         return NodeBase(
             space=self.space,
             external_id=self.external_id,
@@ -926,7 +926,7 @@ class EdgeApply(EdgeApplyBase[List[NodeOrEdgeData]]):
             end_node=DirectRelationReference.load(resource["endNode"]),
         )
 
-    def as_property(self, property_type: type[T_PropertyLike]) -> EdgeApplyBase[T_PropertyLike]:
+    def property_as_type(self, property_type: type[T_PropertyLike]) -> EdgeApplyBase[T_PropertyLike]:
         """Convert the sources to a property type."""
         return EdgeApplyBase[T_PropertyLike](
             space=self.space,
@@ -1077,7 +1077,7 @@ class Edge(EdgeBase[Properties]):
             properties=Properties.load(resource["properties"]) if "properties" in resource else None,
         )
 
-    def as_property(self, property_type: type[T_PropertyLike]) -> EdgeBase[T_PropertyLike]:
+    def property_as_type(self, property_type: type[T_PropertyLike]) -> EdgeBase[T_PropertyLike]:
         return EdgeBase(
             space=self.space,
             external_id=self.external_id,

--- a/cognite/client/data_classes/data_modeling/instances.py
+++ b/cognite/client/data_classes/data_modeling/instances.py
@@ -730,6 +730,12 @@ class NodeBase(Instance[NodeApply, T_Property]):
             output["type"] = self.type.dump(camel_case)
         return output
 
+    @classmethod
+    def _load(cls, resource: dict, cognite_client: CogniteClient | None = None) -> Self:
+        raise NotImplementedError(
+            "You cannot load a NodeBase instance directly. Use Node.load(data).as_property(YOUR_TYPE) instead."
+        )
+
 
 @final
 class Node(NodeBase[Properties]):
@@ -1017,6 +1023,12 @@ class EdgeBase(Instance[EdgeApply, T_Property]):
         if self.end_node:
             output["endNode" if camel_case else "end_node"] = self.end_node.dump(camel_case)
         return output
+
+    @classmethod
+    def _load(cls, resource: dict, cognite_client: CogniteClient | None = None) -> Self:
+        raise NotImplementedError(
+            "You cannot load a EdgeBase instance directly. Use Edge.load(data).as_property(YOUR_TYPE) instead."
+        )
 
 
 @final

--- a/cognite/client/data_classes/data_modeling/instances.py
+++ b/cognite/client/data_classes/data_modeling/instances.py
@@ -118,7 +118,7 @@ class NodeOrEdgeData(CogniteObject):
     def dump(self, camel_case: bool = True) -> dict:
         properties: dict[str, Any] = {}
         for key, value in self.properties.items():
-            if isinstance(value, Iterable):
+            if isinstance(value, Iterable) and not isinstance(value, (str, dict)):
                 properties[key] = [self._serialize_value(v, camel_case) for v in value]
             else:
                 properties[key] = self._serialize_value(value, camel_case)
@@ -171,7 +171,7 @@ class PropertyLike(CogniteObject, ABC):
             if field.name not in properties:
                 continue
             value = properties[field.name]
-            if isinstance(value, Iterable):
+            if isinstance(value, Iterable) and not isinstance(value, (str, dict)):
                 args[field.name] = [cls._deserialize_value(v, str(field.type)) for v in value]
             else:
                 args[field.name] = cls._deserialize_value(value, str(field.type))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "cognite-sdk"
 
-version = "7.50.0"
+version = "7.51.0"
 description = "Cognite Python SDK"
 readme = "README.md"
 documentation = "https://cognite-sdk-python.readthedocs-hosted.com"

--- a/tests/tests_integration/test_api/test_data_modeling/conftest.py
+++ b/tests/tests_integration/test_api/test_data_modeling/conftest.py
@@ -24,7 +24,11 @@ from cognite.client.data_classes.data_modeling import (
     ViewList,
 )
 from cognite.client.data_classes.data_modeling.ids import DataModelId, ViewId
-from cognite.client.data_classes.data_modeling.instances import EdgeApplyList, InstancesResult, NodeApplyList
+from cognite.client.data_classes.data_modeling.instances import (
+    EdgeApplyList,
+    InstancesResult,
+    NodeApplyList,
+)
 
 RESOURCES = Path(__file__).parent / "resources"
 

--- a/tests/tests_integration/test_api/test_data_modeling/conftest.py
+++ b/tests/tests_integration/test_api/test_data_modeling/conftest.py
@@ -9,6 +9,8 @@ import pytest
 
 from cognite.client import CogniteClient
 from cognite.client.data_classes.data_modeling import (
+    Container,
+    ContainerApply,
     DataModel,
     DataModelApply,
     EdgeApply,
@@ -18,6 +20,7 @@ from cognite.client.data_classes.data_modeling import (
     Space,
     SpaceApply,
     View,
+    ViewApply,
     ViewList,
 )
 from cognite.client.data_classes.data_modeling.ids import DataModelId, ViewId
@@ -79,6 +82,358 @@ def populated_movie(cognite_client: CogniteClient, movie_model: DataModel[View])
     created = cognite_client.data_modeling.instances.apply(nodes, edges)
     result = cognite_client.data_modeling.instances.retrieve(created.nodes.as_ids(), created.edges.as_ids())
     return result
+
+
+@pytest.fixture(scope="session")
+def primitive_nullable_container(cognite_client: CogniteClient, integration_test_space: Space) -> Container:
+    container_raw = f"""space: {integration_test_space.space}
+externalId: PrimitiveNullable
+name: PrimitiveNullable
+usedFor: node
+properties:
+  text:
+    type:
+      list: false
+      collation: ucs_basic
+      type: text
+    nullable: true
+    autoIncrement: false
+    name: text
+  boolean:
+    type:
+      list: false
+      type: boolean
+    nullable: true
+    autoIncrement: false
+    name: text
+  float32:
+    type:
+      list: false
+      type: float32
+    nullable: true
+    autoIncrement: false
+    name: float32
+  float64:
+    type:
+      list: false
+      type: float64
+    nullable: true
+    autoIncrement: false
+    name: float64
+  int32:
+    type:
+      list: false
+      type: int32
+    nullable: true
+    autoIncrement: false
+    name: int32
+  int64:
+    type:
+      list: false
+      type: int64
+    nullable: true
+    autoIncrement: false
+    name: int64
+  timestamp:
+    type:
+      list: false
+      type: timestamp
+    nullable: true
+    autoIncrement: false
+    name: timestamp
+  date:
+    type:
+      list: false
+      type: date
+    nullable: true
+    autoIncrement: false
+    name: date
+  json:
+    type:
+      list: false
+      type: json
+    nullable: true
+    autoIncrement: false
+    name: json
+  direct:
+    type:
+      list: false
+      type: direct
+    nullable: true
+    autoIncrement: false
+    name: direct
+"""
+
+    primitive_container = ContainerApply.load(container_raw)
+    container = cognite_client.data_modeling.containers.retrieve(primitive_container.as_id())
+    if container:
+        return container
+    return cognite_client.data_modeling.containers.apply(primitive_container)
+
+
+@pytest.fixture(scope="session")
+def primitive_nullable_view(cognite_client: CogniteClient, primitive_nullable_container: Container) -> View:
+    space = primitive_nullable_container.space
+    container = primitive_nullable_container.external_id
+    view_raw = f"""space: {space}
+externalId: PrimitiveNullable
+name: PrimitiveNullable
+version: '1'
+properties:
+  text:
+    container:
+      space: {space}
+      externalId: {container}
+      type: container
+    containerPropertyIdentifier: text
+    name: text
+  boolean:
+    container:
+      space: {space}
+      externalId: {container}
+      type: container
+    containerPropertyIdentifier: boolean
+    name: text
+  float32:
+    container:
+      space: {space}
+      externalId: {container}
+      type: container
+    containerPropertyIdentifier: float32
+    name: float32
+  float64:
+    container:
+      space: {space}
+      externalId: {container}
+      type: container
+    containerPropertyIdentifier: float64
+    name: float64
+  int32:
+    container:
+      space: {space}
+      externalId: {container}
+      type: container
+    containerPropertyIdentifier: int32
+    name: int32
+  int64:
+    container:
+      space: {space}
+      externalId: {container}
+      type: container
+    containerPropertyIdentifier: int64
+    name: int64
+  timestamp:
+    container:
+      space: {space}
+      externalId: {container}
+      type: container
+    containerPropertyIdentifier: timestamp
+    name: timestamp
+  date:
+    container:
+      space: {space}
+      externalId: {container}
+      type: container
+    containerPropertyIdentifier: date
+    name: date
+  json:
+    container:
+      space: {space}
+      externalId: {container}
+      type: container
+    containerPropertyIdentifier: json
+    name: json
+  direct:
+    container:
+      space: {space}
+      externalId: {container}
+      type: container
+    containerPropertyIdentifier: direct
+    name: direct
+"""
+
+    view_write = ViewApply.load(view_raw)
+    view = cognite_client.data_modeling.views.retrieve(view_write.as_id())
+    if view:
+        return view[0]
+    return cognite_client.data_modeling.views.apply(view_write)
+
+
+@pytest.fixture(scope="session")
+def primitive_nullable_listed_container(cognite_client: CogniteClient, integration_test_space: Space) -> Container:
+    container_raw = f"""space: {integration_test_space.space}
+externalId: PrimitiveListed
+name: PrimitiveListed
+usedFor: node
+properties:
+  text:
+    type:
+      list: true
+      collation: ucs_basic
+      type: text
+    nullable: true
+    autoIncrement: false
+    name: text
+  boolean:
+    type:
+      list: true
+      type: boolean
+    nullable: true
+    autoIncrement: false
+    name: text
+  float32:
+    type:
+      list: true
+      type: float32
+    nullable: true
+    autoIncrement: false
+    name: float32
+  float64:
+    type:
+      list: true
+      type: float64
+    nullable: true
+    autoIncrement: false
+    name: float64
+  int32:
+    type:
+      list: true
+      type: int32
+    nullable: true
+    autoIncrement: false
+    name: int32
+  int64:
+    type:
+      list: true
+      type: int64
+    nullable: true
+    autoIncrement: false
+    name: int64
+  timestamp:
+    type:
+      list: true
+      type: timestamp
+    nullable: true
+    autoIncrement: false
+    name: timestamp
+  date:
+    type:
+      list: true
+      type: date
+    nullable: true
+    autoIncrement: false
+    name: date
+  json:
+    type:
+      list: true
+      type: json
+    nullable: true
+    autoIncrement: false
+    name: json
+  direct:
+    type:
+      list: true
+      type: direct
+    nullable: true
+    autoIncrement: false
+    name: direct
+"""
+
+    primitive_container = ContainerApply.load(container_raw)
+    container = cognite_client.data_modeling.containers.retrieve(primitive_container.as_id())
+    if container:
+        return container
+    return cognite_client.data_modeling.containers.apply(primitive_container)
+
+
+@pytest.fixture(scope="session")
+def primitive_nullable_listed_view(
+    cognite_client: CogniteClient, primitive_nullable_listed_container: Container
+) -> View:
+    space = primitive_nullable_listed_container.space
+    container = primitive_nullable_listed_container.external_id
+    view_raw = f"""space: {space}
+externalId: PrimitiveListed
+name: PrimitiveListed
+version: '1'
+properties:
+  text:
+    container:
+      space: {space}
+      externalId: {container}
+      type: container
+    containerPropertyIdentifier: text
+    name: text
+  boolean:
+    container:
+      space: {space}
+      externalId: {container}
+      type: container
+    containerPropertyIdentifier: boolean
+    name: text
+  float32:
+    container:
+      space: {space}
+      externalId: {container}
+      type: container
+    containerPropertyIdentifier: float32
+    name: float32
+  float64:
+    container:
+      space: {space}
+      externalId: {container}
+      type: container
+    containerPropertyIdentifier: float64
+    name: float64
+  int32:
+    container:
+      space: {space}
+      externalId: {container}
+      type: container
+    containerPropertyIdentifier: int32
+    name: int32
+  int64:
+    container:
+      space: {space}
+      externalId: {container}
+      type: container
+    containerPropertyIdentifier: int64
+    name: int64
+  timestamp:
+    container:
+      space: {space}
+      externalId: {container}
+      type: container
+    containerPropertyIdentifier: timestamp
+    name: timestamp
+  date:
+    container:
+      space: {space}
+      externalId: {container}
+      type: container
+    containerPropertyIdentifier: date
+    name: date
+  json:
+    container:
+      space: {space}
+      externalId: {container}
+      type: container
+    containerPropertyIdentifier: json
+    name: json
+  direct:
+    container:
+      space: {space}
+      externalId: {container}
+      type: container
+    containerPropertyIdentifier: direct
+    name: direct
+"""
+
+    view_write = ViewApply.load(view_raw)
+    view = cognite_client.data_modeling.views.retrieve(view_write.as_id())
+    if view:
+        return view[0]
+    return cognite_client.data_modeling.views.apply(view_write)
 
 
 @dataclass

--- a/tests/tests_integration/test_api/test_data_modeling/test_instances.py
+++ b/tests/tests_integration/test_api/test_data_modeling/test_instances.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import json
 import math
 import time
+from dataclasses import dataclass
+from datetime import date, datetime
 from typing import Any, ClassVar, cast
 
 import pytest
@@ -41,7 +43,7 @@ from cognite.client.data_classes.data_modeling import (
     query,
 )
 from cognite.client.data_classes.data_modeling.data_types import UnitReference
-from cognite.client.data_classes.data_modeling.instances import TargetUnit
+from cognite.client.data_classes.data_modeling.instances import PropertyLike, TargetUnit
 from cognite.client.data_classes.data_modeling.query import (
     NodeResultSetExpression,
     Query,
@@ -119,6 +121,36 @@ def node_with_1_1_pressure_in_bar(
     )
     _ = cognite_client.data_modeling.instances.apply(node)
     return node
+
+
+@dataclass
+class PrimitiveNullable(PropertyLike):
+    _source = ViewId("IntegrationTestSpace", "PrimitiveNullable", "1")
+    text: str | None = None
+    boolean: bool | None = None
+    float32: float | None = None
+    float64: float | None = None
+    int32: int | None = None
+    int64: int | None = None
+    timestamp: datetime | None = None
+    date: date | None = None
+    json: dict | None = None
+    direct: DirectRelationReference | None = None
+
+
+@dataclass
+class PrimitiveListed(PropertyLike):
+    _source = ViewId("IntegrationTestSpace", "PrimitiveListed", "1")
+    text: list[str] | None = None
+    boolean: list[bool] | None = None
+    float32: list[float] | None = None
+    float64: list[float] | None = None
+    int32: list[int] | None = None
+    int64: list[int] | None = None
+    timestamp: list[datetime] | None = None
+    date: list[date] | None = None
+    json: list[dict] | None = None
+    direct: list[DirectRelationReference] | None = None
 
 
 class TestInstancesAPI:

--- a/tests/tests_unit/test_data_classes/test_data_models/test_instances.py
+++ b/tests/tests_unit/test_data_classes/test_data_models/test_instances.py
@@ -145,7 +145,7 @@ class TestNodeApply:
                     ),
                 )
             ],
-        ).as_property(WindTurbine)
+        ).property_as_type(WindTurbine)
 
         assert isinstance(node.sources, WindTurbine)
         assert node.sources.name == "MyWindTurbine"
@@ -199,7 +199,7 @@ class TestNode:
                     }
                 }
             ),
-        ).as_property(WindTurbine)
+        ).property_as_type(WindTurbine)
 
         assert isinstance(node.properties, WindTurbine)
         assert node.properties.name == "MyWindTurbine"

--- a/tests/tests_unit/test_data_classes/test_data_models/test_instances.py
+++ b/tests/tests_unit/test_data_classes/test_data_models/test_instances.py
@@ -69,7 +69,7 @@ class TestNodeOrEdgeData:
 
 @dataclass
 class WindTurbine(PropertyLike):
-    source = ViewId("power-models", "WindTurbine", "v1")
+    _source = ViewId("power-models", "WindTurbine", "v1")
     name: str
     wind_farm: str
     rotor: DirectRelationReference
@@ -137,7 +137,7 @@ class TestNodeApply:
             type=("someSpace", "someType"),
             sources=[
                 NodeOrEdgeData(
-                    source=WindTurbine.source,
+                    source=WindTurbine._source,
                     properties=dict(
                         name="MyWindTurbine",
                         wind_farm="Utsira Nord",

--- a/tests/tests_unit/test_data_classes/test_data_models/test_instances.py
+++ b/tests/tests_unit/test_data_classes/test_data_models/test_instances.py
@@ -18,7 +18,7 @@ from cognite.client.data_classes.data_modeling import (
     NodeOrEdgeData,
     ViewId,
 )
-from cognite.client.data_classes.data_modeling.instances import Instance, PropertyLike
+from cognite.client.data_classes.data_modeling.instances import Instance, Properties, PropertyLike
 
 
 class TestEdgeApply:
@@ -180,6 +180,34 @@ class TestNode:
             "type": {"externalId": "someType", "space": "someSpace"},
             "version": 1,
         }
+
+    def test_as_custom_properties(self) -> None:
+        node = Node(
+            space="IntegrationTestsImmutable",
+            external_id="shop:case:integration_test",
+            version=1,
+            type=DirectRelationReference("someSpace", "someType"),
+            last_updated_time=123,
+            created_time=123,
+            deleted_time=None,
+            properties=Properties(
+                {
+                    ViewId("power-models", "WindTurbine", "v1"): {
+                        "name": "MyWindTurbine",
+                        "wind_farm": "Utsira Nord",
+                        "rotor": DirectRelationReference("space", "external_id"),
+                    }
+                }
+            ),
+        ).as_property(WindTurbine)
+
+        assert isinstance(node.properties, WindTurbine)
+        assert node.properties.name == "MyWindTurbine"
+        assert node.properties.wind_farm == "Utsira Nord"
+        assert node.properties.rotor == DirectRelationReference("space", "external_id")
+
+        reloaded = Node.load(node.dump()).properties
+        assert isinstance(reloaded, Properties)
 
 
 @pytest.fixture

--- a/tests/tests_unit/test_data_classes/test_data_models/test_instances.py
+++ b/tests/tests_unit/test_data_classes/test_data_models/test_instances.py
@@ -209,6 +209,37 @@ class TestNode:
         reloaded = Node.load(node.dump()).properties
         assert isinstance(reloaded, Properties)
 
+    def test_node_list_as_custom_properties(self) -> None:
+        nodes = NodeList(
+            [
+                Node(
+                    space="IntegrationTestsImmutable",
+                    external_id="shop:case:integration_test",
+                    version=1,
+                    type=DirectRelationReference("someSpace", "someType"),
+                    last_updated_time=123,
+                    created_time=123,
+                    deleted_time=None,
+                    properties=Properties(
+                        {
+                            ViewId("power-models", "WindTurbine", "v1"): {
+                                "name": "MyWindTurbine",
+                                "wind_farm": "Utsira Nord",
+                                "rotor": DirectRelationReference("space", "external_id"),
+                            }
+                        }
+                    ),
+                ),
+            ]
+        ).property_as_type(WindTurbine)
+
+        assert len(nodes) == 1
+        for node in nodes:
+            assert isinstance(node.properties, WindTurbine)
+            assert node.properties.name == "MyWindTurbine"
+            assert node.properties.wind_farm == "Utsira Nord"
+            assert node.properties.rotor == DirectRelationReference("space", "external_id")
+
 
 @pytest.fixture
 def node_dumped() -> dict[str, Any]:

--- a/tests/tests_unit/test_data_classes/test_data_models/test_instances.py
+++ b/tests/tests_unit/test_data_classes/test_data_models/test_instances.py
@@ -18,7 +18,7 @@ from cognite.client.data_classes.data_modeling import (
     NodeOrEdgeData,
     ViewId,
 )
-from cognite.client.data_classes.data_modeling.instances import Instance, NodeOrEdgeLikeData
+from cognite.client.data_classes.data_modeling.instances import Instance, PropertyLike
 
 
 class TestEdgeApply:
@@ -68,7 +68,7 @@ class TestNodeOrEdgeData:
 
 
 @dataclass
-class WindTurbine(NodeOrEdgeLikeData):
+class WindTurbine(PropertyLike):
     source = ViewId("power-models", "WindTurbine", "v1")
     name: str
     wind_farm: str

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -34,6 +34,7 @@ from cognite.client.data_classes import (
 from cognite.client.data_classes._base import CogniteResourceList, Geometry
 from cognite.client.data_classes.aggregations import Buckets
 from cognite.client.data_classes.capabilities import Capability, LegacyCapability, UnknownAcl
+from cognite.client.data_classes.data_modeling.instances import EdgeApplyBase, EdgeBase, NodeApplyBase, NodeBase
 from cognite.client.data_classes.data_modeling.query import NodeResultSetExpression, Query
 from cognite.client.data_classes.datapoints import _INT_AGGREGATES, ALL_SORTED_DP_AGGS, Datapoints, DatapointsArray
 from cognite.client.data_classes.filters import Filter
@@ -80,7 +81,10 @@ def all_concrete_subclasses(base: T_Type) -> list[T_Type]:
     return [
         sub
         for sub in all_subclasses(base)
-        if all(base is not abc.ABC for base in sub.__bases__) and not inspect.isabstract(sub)
+        if all(base is not abc.ABC for base in sub.__bases__)
+        and not inspect.isabstract(sub)
+        # These are special classes that cannot be loaded in the normal way, even though they are concrete
+        and sub not in [NodeBase, NodeApplyBase, EdgeBase, EdgeApplyBase]
     ]
 
 


### PR DESCRIPTION
## Description

The basic idea is to allow for custom property types for nodes and edges:

```python
from typing import ClassVar
from cognite.client.data_classes.data_modeling.instances import PropertyLike, NodeApplyBase
from dataclasses import dataclass
from cognite.client import CogniteClient

@dataclass
class WindTurbine(PropertyLike):
    _source: ClassVar[ViewId] = ViewId("sp_power_model", "WindTurbine", "1")
    wind_farm: str
    manufacturer: str
    model: str
    capacity: float

my_turbine_node = NodeApplyBase[WindTurbine](
    space="sp_power_assets",
    external_id="my_turbine",
    sources=WindTurbine(
        wind_farm="Utsira Nord",
        manufacturer="Siemens",
        model="SWT-6.0-154",
        capacity=6.0
    )
)

client = CogniteClient()
client.data_modeling.instances.apply(my_turbine_node)

retrieved = client.data_modeling.instances.retrieve(
    my_turbine.as_id(), 
    sources=WindTurbine._source,
).nodes.property_as_type(WindTurbine)
for node in retrieved:
    wind_turbine = node.properties
    assert(wind_tubine, WindTurbine)
    print(wind_turbine.wind_farm)
    print(wind_turbine.capacity)

```


## Checklist:
- [ ] Tests added/updated.
- [ ] Documentation updated. Documentation is generated from docstrings - these must be updated according to your change.
  If a new method has been added it should be referenced in [cognite.rst](https://github.com/cognitedata/cognite-sdk-python/blob/master/docs/source/cognite.rst) in order to generate docs based on its docstring.
- [ ] Changelog updated in [CHANGELOG.md](https://github.com/cognitedata/cognite-sdk-python/blob/master/CHANGELOG.md).
- [ ] Version bumped. If triggering a new release is desired, bump the version number in [_version.py](https://github.com/cognitedata/cognite-sdk-python/blob/master/cognite/client/_version.py) and [pyproject.toml](https://github.com/cognitedata/cognite-sdk-python/blob/master/pyproject.toml) per [semantic versioning](https://semver.org/).
