### PR TITLE
Allow Write in datapoint_subscription.update

### DIFF
--- a/cognite/client/_api/datapoints_subscriptions.py
+++ b/cognite/client/_api/datapoints_subscriptions.py
@@ -162,14 +162,14 @@ class DatapointsSubscriptionAPI(APIClient):
             other_params={"externalId": external_id},
         )
 
-    def update(self, update: DataPointSubscriptionUpdate) -> DatapointSubscription:
+    def update(self, update: DataPointSubscriptionUpdate | DataPointSubscriptionWrite) -> DatapointSubscription:
         """`Update a subscriptions <https://api-docs.cognite.com/20230101/tag/Data-point-subscriptions/operation/updateSubscriptions>`_
 
         Update a subscription. Note that Fields that are not included in the request are not changed.
         Furthermore, the subscription partition cannot be changed.
 
         Args:
-            update (DataPointSubscriptionUpdate): The subscription update.
+            update (DataPointSubscriptionUpdate | DataPointSubscriptionWrite): The subscription update.
 
         Returns:
             DatapointSubscription: Updated subscription.

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -8,6 +8,7 @@ import importlib
 import inspect
 import math
 import os
+import platform
 import random
 import string
 import sys
@@ -61,6 +62,11 @@ if sys.version_info >= (3, 10):
     from types import UnionType
 
     UNION_TYPES.add(UnionType)
+
+
+# This is needed as we run tests for two different versions of Python in parallel.
+# The platform.system() is not used, but is here in case we start testing on Windows as well.
+RUN_UNIQUE_ID = f"{platform.system()}_{sys.version_info.major}_{sys.version_info.minor}"
 
 
 def all_subclasses(base: T_Type) -> list[T_Type]:


### PR DESCRIPTION
## Description
Please describe the change you have made.

## Checklist:
- [ ] Tests added/updated.
- [ ] Documentation updated. Documentation is generated from docstrings - these must be updated according to your change.
  If a new method has been added it should be referenced in [cognite.rst](https://github.com/cognitedata/cognite-sdk-python/blob/master/docs/source/cognite.rst) in order to generate docs based on its docstring.
- [ ] Changelog updated in [CHANGELOG.md](https://github.com/cognitedata/cognite-sdk-python/blob/master/CHANGELOG.md).
- [ ] Version bumped. If triggering a new release is desired, bump the version number in [_version.py](https://github.com/cognitedata/cognite-sdk-python/blob/master/cognite/client/_version.py) and [pyproject.toml](https://github.com/cognitedata/cognite-sdk-python/blob/master/pyproject.toml) per [semantic versioning](https://semver.org/).
