### PR TITLE
Add partitions param to `retrieve_dataframe()` of `RawRowsAPI`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,10 +17,13 @@ Changes are grouped as follows
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
+## [7.51.2] - 2024-06-18
+### Added
+- Added `partitions` parameter to `retrieve_dataframe()` method of the `RawRowsAPI`.
+
 ## [7.51.1] - 2024-06-18
 ### Fixed
-
-- Added support for serializing Node/Edge properties of type `list` of `NodeId`and `DirectRelationReference`, 
+- Added support for serializing Node/Edge properties of type `list` of `NodeId`and `DirectRelationReference`,
   `date`, `datetime` and list of `date` and `datetime` to `json` format.
 
 ## [7.51.0] - 2024-06-16

--- a/cognite/client/_version.py
+++ b/cognite/client/_version.py
@@ -1,4 +1,4 @@
 from __future__ import annotations
 
-__version__ = "7.51.1"
+__version__ = "7.51.2"
 __api_subversion__ = "20230101"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "cognite-sdk"
 
-version = "7.51.1"
+version = "7.51.2"
 description = "Cognite Python SDK"
 readme = "README.md"
 documentation = "https://cognite-sdk-python.readthedocs-hosted.com"


### PR DESCRIPTION
## Description
Support partitions param in `retrieve_dataframe` to allow for parallelized rows retrieval.

## Checklist:
- [ ] Tests added/updated.
- [ ] Documentation updated. Documentation is generated from docstrings - these must be updated according to your change.
  If a new method has been added it should be referenced in [cognite.rst](https://github.com/cognitedata/cognite-sdk-python/blob/master/docs/source/cognite.rst) in order to generate docs based on its docstring.
- [ ] Changelog updated in [CHANGELOG.md](https://github.com/cognitedata/cognite-sdk-python/blob/master/CHANGELOG.md).
- [ ] Version bumped. If triggering a new release is desired, bump the version number in [_version.py](https://github.com/cognitedata/cognite-sdk-python/blob/master/cognite/client/_version.py) and [pyproject.toml](https://github.com/cognitedata/cognite-sdk-python/blob/master/pyproject.toml) per [semantic versioning](https://semver.org/).
