### PR TITLE
[CDF-21996] Make sdk data workflows test more robust

### DIFF
--- a/tests/tests_integration/test_api/test_data_workflows.py
+++ b/tests/tests_integration/test_api/test_data_workflows.py
@@ -218,7 +218,7 @@ def workflow_execution_list(
         time.sleep(0.5)
         if time.time() - t0 > 60:
             raise TimeoutError("Workflow execution did not complete in time")
-    return cognite_client.workflows.executions.list(workflow_version_ids=add_multiply_workflow.as_id(), limit=5)
+    return cognite_client.workflows.executions.list(workflow_version_ids=add_multiply_workflow.as_id(), limit=10)
 
 
 @pytest.fixture()
@@ -393,7 +393,9 @@ class TestWorkflowExecutions:
         workflow_execution_list: WorkflowExecutionList,
     ) -> None:
         assert workflow_execution_list, "There should be at least one workflow execution to test retrieve detailed with"
-        terminal_execution = next((execution for execution in workflow_execution_list if execution.status == "completed"), None)
+        terminal_execution = next(
+            (execution for execution in workflow_execution_list if execution.status == "completed"), None
+        )
         assert terminal_execution is not None, "There should be at least one completed workflow execution"
 
         retrieved = cognite_client.workflows.executions.retrieve_detailed(terminal_execution.id)

--- a/tests/tests_integration/test_api/test_data_workflows.py
+++ b/tests/tests_integration/test_api/test_data_workflows.py
@@ -196,7 +196,7 @@ def add_multiply_workflow(
 def workflow_execution_list(
     cognite_client: CogniteClient, add_multiply_workflow: WorkflowVersion
 ) -> WorkflowExecutionList:
-    executions = cognite_client.workflows.executions.list(workflow_version_ids=add_multiply_workflow.as_id(), limit=5)
+    executions = cognite_client.workflows.executions.list(workflow_version_ids=add_multiply_workflow.as_id(), limit=10)
     if executions:
         return executions
     # Creating at least one execution

--- a/tests/tests_integration/test_api/test_data_workflows.py
+++ b/tests/tests_integration/test_api/test_data_workflows.py
@@ -196,7 +196,7 @@ def add_multiply_workflow(
 def workflow_execution_list(
     cognite_client: CogniteClient, add_multiply_workflow: WorkflowVersion
 ) -> WorkflowExecutionList:
-    executions = cognite_client.workflows.executions.list(workflow_version_ids=add_multiply_workflow.as_id(), limit=10)
+    executions = cognite_client.workflows.executions.list(workflow_version_ids=add_multiply_workflow.as_id(), limit=5)
     if executions:
         return executions
     # Creating at least one execution
@@ -218,7 +218,7 @@ def workflow_execution_list(
         time.sleep(0.5)
         if time.time() - t0 > 60:
             raise TimeoutError("Workflow execution did not complete in time")
-    return cognite_client.workflows.executions.list(workflow_version_ids=add_multiply_workflow.as_id(), limit=10)
+    return cognite_client.workflows.executions.list(workflow_version_ids=add_multiply_workflow.as_id(), limit=5)
 
 
 @pytest.fixture()

--- a/tests/tests_integration/test_api/test_data_workflows.py
+++ b/tests/tests_integration/test_api/test_data_workflows.py
@@ -392,15 +392,12 @@ class TestWorkflowExecutions:
         cognite_client: CogniteClient,
         workflow_execution_list: WorkflowExecutionList,
     ) -> None:
-        assert workflow_execution_list, "There should be at least one workflow execution to test retrieve detailed with"
-        terminal_execution = next(
-            (execution for execution in workflow_execution_list if execution.status == "completed"), None
-        )
-        assert terminal_execution is not None, "There should be at least one completed workflow execution"
-
-        retrieved = cognite_client.workflows.executions.retrieve_detailed(terminal_execution.id)
-
-        assert retrieved.as_execution().dump() == terminal_execution.dump()
+        workflow_execution_completed = cognite_client.workflows.executions.list(statuses="completed", limit=1)
+        assert (
+            workflow_execution_completed
+        ), "There should be at least one workflow execution to test retrieve detailed with"
+        retrieved = cognite_client.workflows.executions.retrieve_detailed(workflow_execution_completed[0].id)
+        assert retrieved.as_execution().dump() == workflow_execution_completed[0].dump()
         assert retrieved.executed_tasks
 
     def test_retrieve_non_existing_workflow_execution(self, cognite_client: CogniteClient) -> None:

--- a/tests/tests_integration/test_api/test_data_workflows.py
+++ b/tests/tests_integration/test_api/test_data_workflows.py
@@ -393,9 +393,12 @@ class TestWorkflowExecutions:
         workflow_execution_list: WorkflowExecutionList,
     ) -> None:
         assert workflow_execution_list, "There should be at least one workflow execution to test retrieve detailed with"
-        retrieved = cognite_client.workflows.executions.retrieve_detailed(workflow_execution_list[0].id)
+        terminal_execution = next((execution for execution in workflow_execution_list if execution.status == "completed"), None)
+        assert terminal_execution is not None, "There should be at least one completed workflow execution"
 
-        assert retrieved.as_execution().dump() == workflow_execution_list[0].dump()
+        retrieved = cognite_client.workflows.executions.retrieve_detailed(terminal_execution.id)
+
+        assert retrieved.as_execution().dump() == terminal_execution.dump()
         assert retrieved.executed_tasks
 
     def test_retrieve_non_existing_workflow_execution(self, cognite_client: CogniteClient) -> None:


### PR DESCRIPTION
## Description
Initially, only a single execution was created for the test suite, which always was successful before the fixture dependant tests ran. Now, however, there's multiple executions and some are not terminal yet. To fix the test, we just select the first completed (i.e., now immutable) execution.
