### PR TITLE
Retrieve/list responses with more than items

### DIFF
--- a/cognite/client/_api/data_modeling/instances.py
+++ b/cognite/client/_api/data_modeling/instances.py
@@ -106,6 +106,8 @@ class _NodeOrEdgeResourceAdapter(Generic[T_Node, T_Edge]):
 
 
 class _TypedNodeOrEdgeListAdapter:
+    _support_dict_load = False
+
     def __init__(self, instance_cls: type) -> None:
         self._instance_cls = instance_cls
         self._list_cls = NodeList if issubclass(instance_cls, TypedNode) else EdgeList

--- a/cognite/client/_api_client.py
+++ b/cognite/client/_api_client.py
@@ -549,7 +549,7 @@ class APIClient:
             )
 
         resource_path = resource_path or self._RESOURCE_PATH
-        items: list[T_CogniteResource] = []
+        items: T_CogniteResourceList | None = None
         for resource_list in self._list_generator(
             list_cls=list_cls,
             resource_cls=resource_cls,
@@ -566,8 +566,11 @@ class APIClient:
             advanced_filter=advanced_filter,
             api_subversion=api_subversion,
         ):
-            items.extend(cast(T_CogniteResourceList, resource_list).data)
-        return list_cls(items, cognite_client=self._cognite_client)
+            if items is None:
+                items = cast(T_CogniteResourceList, resource_list)
+            else:
+                items.data.extend(cast(T_CogniteResourceList, resource_list).data)
+        return items if items is not None else list_cls([], cognite_client=self._cognite_client)
 
     def _list_partitioned(
         self,

--- a/cognite/client/_api_client.py
+++ b/cognite/client/_api_client.py
@@ -504,9 +504,12 @@ class APIClient:
             if total_items_retrieved == limit or next_cursor is None:
                 if chunk_size and unprocessed_items:
                     if list_cls._support_dict_load:
-                        yield list_cls._load({"items": chunk, **first_response}, cognite_client=self._cognite_client)  # type: ignore[dict-item]
+                        yield list_cls._load(
+                            {"items": unprocessed_items, **first_response},  # type: ignore[dict-item]
+                            cognite_client=self._cognite_client,
+                        )
                     else:
-                        yield list_cls._load(chunk, cognite_client=self._cognite_client)
+                        yield list_cls._load(unprocessed_items, cognite_client=self._cognite_client)
                 break
 
     def _list(

--- a/cognite/client/_api_client.py
+++ b/cognite/client/_api_client.py
@@ -398,7 +398,13 @@ class APIClient:
                 # Not all APIs (such as the Data Modeling API) return an error when unknown ids are provided,
                 # so we need to handle the unknown singleton identifier case here as well.
                 return None
-        return list_cls._load(retrieved_items, cognite_client=self._cognite_client)
+        if list_cls._support_dict_load:
+            other_responses = tasks_summary.first_result(
+                lambda res: {k: v for k, v in res.json().items() if k != "items"}
+            )
+            return list_cls._load({"items": retrieved_items, **other_responses}, cognite_client=self._cognite_client)  # type: ignore[dict-item]
+        else:
+            return list_cls._load(retrieved_items, cognite_client=self._cognite_client)
 
     def _list_generator(
         self,

--- a/cognite/client/data_classes/_base.py
+++ b/cognite/client/data_classes/_base.py
@@ -258,6 +258,7 @@ T_WritableCogniteResource = TypeVar("T_WritableCogniteResource", bound=Writeable
 
 
 class CogniteResourceList(UserList, Generic[T_CogniteResource], _WithClientMixin):
+    _support_dict_load = False
     _RESOURCE: type[T_CogniteResource]
     __cognite_client: CogniteClient | None
 

--- a/cognite/client/utils/_concurrency.py
+++ b/cognite/client/utils/_concurrency.py
@@ -49,6 +49,9 @@ class TasksSummary:
                 joined_results.append(unwrapped)
         return joined_results
 
+    def first_result(self, unwrap_fn: Callable = no_op) -> dict:
+        return unwrap_fn(self.results[0]) if self.results else {}
+
     def raise_compound_exception_if_failed_tasks(
         self,
         task_unwrap_fn: Callable = no_op,


### PR DESCRIPTION
## Description
This is a preparation for #1691 

### Problem
The `_list` and `_retrieve_multiple` methods does account for any other than `items` in the response object:
![image](https://github.com/cognitedata/cognite-sdk-python/assets/60234212/90cc6849-dc12-47c5-bdc4-5c3c0d60e570)

This PR gives the option to get the `typing` key from the response.

## Checklist:
- [ ] Tests added/updated.
- [ ] Documentation updated. Documentation is generated from docstrings - these must be updated according to your change.
  If a new method has been added it should be referenced in [cognite.rst](https://github.com/cognitedata/cognite-sdk-python/blob/master/docs/source/cognite.rst) in order to generate docs based on its docstring.
- [ ] Changelog updated in [CHANGELOG.md](https://github.com/cognitedata/cognite-sdk-python/blob/master/CHANGELOG.md).
- [ ] Version bumped. If triggering a new release is desired, bump the version number in [_version.py](https://github.com/cognitedata/cognite-sdk-python/blob/master/cognite/client/_version.py) and [pyproject.toml](https://github.com/cognitedata/cognite-sdk-python/blob/master/pyproject.toml) per [semantic versioning](https://semver.org/).
