### PR TITLE
Support loading non-items in API responses

### DIFF
--- a/cognite/client/_api_client.py
+++ b/cognite/client/_api_client.py
@@ -453,7 +453,7 @@ class APIClient:
             next_cursor = response.get("nextCursor")
             total_retrieved += len(response["items"])
             if total_retrieved == limit or next_cursor is None:
-                if unprocessed_items:  # can only happen when using chunk_size
+                if unprocessed_items:  # may only happen when -not- yielding one-by-one
                     yield list_cls._load(unprocessed_items, cognite_client=self._cognite_client)
                 break
 

--- a/cognite/client/_api_client.py
+++ b/cognite/client/_api_client.py
@@ -355,6 +355,7 @@ class APIClient:
         params: dict[str, Any] | None = None,
         executor: ThreadPoolExecutor | None = None,
         api_subversion: str | None = None,
+        load_raw_response: bool = False,
     ) -> T_CogniteResourceList | T_CogniteResource | None:
         resource_path = resource_path or self._RESOURCE_PATH
 
@@ -388,6 +389,13 @@ class APIClient:
             if identifiers.is_singleton():
                 return None
             raise
+
+        if load_raw_response:
+            # The API response include one or more top-level keys than items we care about:
+            loaded = list_cls._load_raw_api_response(
+                tasks_summary.raw_api_responses, cognite_client=self._cognite_client
+            )
+            return (loaded[0] if loaded else None) if identifiers.is_singleton() else loaded
 
         retrieved_items = tasks_summary.joined_results(lambda res: res.json()["items"])
 

--- a/cognite/client/_api_client.py
+++ b/cognite/client/_api_client.py
@@ -327,6 +327,7 @@ class APIClient:
         params: dict[str, Any] | None = None,
         executor: ThreadPoolExecutor | None = None,
         api_subversion: str | None = None,
+        settings_forcing_raw_response_loading: list[str] | None = None,
     ) -> T_CogniteResource | None: ...
 
     @overload
@@ -342,6 +343,7 @@ class APIClient:
         params: dict[str, Any] | None = None,
         executor: ThreadPoolExecutor | None = None,
         api_subversion: str | None = None,
+        settings_forcing_raw_response_loading: list[str] | None = None,
     ) -> T_CogniteResourceList: ...
 
     def _retrieve_multiple(

--- a/cognite/client/data_classes/_base.py
+++ b/cognite/client/data_classes/_base.py
@@ -405,6 +405,12 @@ class CogniteResourceList(UserList, Generic[T_CogniteResource], _WithClientMixin
         resources = [cls._RESOURCE._load(resource, cognite_client=cognite_client) for resource in resource_list]
         return cls(resources, cognite_client=cognite_client)
 
+    @classmethod
+    def _load_raw_api_response(cls, responses: list[dict[str, Any]], cognite_client: CogniteClient) -> Self:
+        # Certain classes may need more than just 'items' from the raw repsonse. These need to provide
+        # an implementation of this method
+        raise NotImplementedError
+
 
 T_CogniteResourceList = TypeVar("T_CogniteResourceList", bound=CogniteResourceList)
 

--- a/cognite/client/utils/_concurrency.py
+++ b/cognite/client/utils/_concurrency.py
@@ -49,6 +49,10 @@ class TasksSummary:
                 joined_results.append(unwrapped)
         return joined_results
 
+    @property
+    def raw_api_responses(self) -> list[dict[str, Any]]:
+        return [res.json() for res in self.results]
+
     def raise_compound_exception_if_failed_tasks(
         self,
         task_unwrap_fn: Callable = no_op,


### PR DESCRIPTION
## Description
Adds the possibility of loading the full response(s) - and hence any other data than items - to `_retrieve_multiple` and `_list` via `_list_generator_raw_responses`.

It also simplifies and abstracts out a lot of details from `_list_generator` to ease future dev work.