### PR TITLE
Fix deadlock in RelationshipsAPI.list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,8 +17,11 @@ Changes are grouped as follows
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
-## [7.54.1] - 2024-07-13
+## [7.54.2] - 2024-07-16
+### Fixed
+- A bug in the list method of the RelationshipsAPI that could cause a thread deadlock.
 
+## [7.54.1] - 2024-07-15
 ### Fixed
 - Calling `client.functions.retrieve` or `client.functions.delete` with more than 10 ids no longer
   raises a `CogniteAPIError`.

--- a/cognite/client/_api/relationships.py
+++ b/cognite/client/_api/relationships.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import copy
-from typing import TYPE_CHECKING, Any, Iterator, Literal, Sequence, overload
+from typing import TYPE_CHECKING, Iterator, Literal, Sequence, overload
 
 from cognite.client._api_client import APIClient
 from cognite.client._constants import DEFAULT_LIMIT_READ
@@ -31,36 +31,6 @@ class RelationshipsAPI(APIClient):
     def __init__(self, config: ClientConfig, api_version: str | None, cognite_client: CogniteClient) -> None:
         super().__init__(config, api_version, cognite_client)
         self._LIST_SUBQUERY_LIMIT = 1000
-
-    def _create_filter(
-        self,
-        source_external_ids: SequenceNotStr[str] | None = None,
-        source_types: SequenceNotStr[str] | None = None,
-        target_external_ids: SequenceNotStr[str] | None = None,
-        target_types: SequenceNotStr[str] | None = None,
-        data_set_ids: Sequence[dict[str, Any]] | None = None,
-        start_time: dict[str, int] | None = None,
-        end_time: dict[str, int] | None = None,
-        confidence: dict[str, int] | None = None,
-        last_updated_time: dict[str, int] | None = None,
-        created_time: dict[str, int] | None = None,
-        active_at_time: dict[str, int] | None = None,
-        labels: LabelFilter | None = None,
-    ) -> dict[str, Any]:
-        return RelationshipFilter(
-            source_external_ids=source_external_ids,
-            source_types=source_types,
-            target_external_ids=target_external_ids,
-            target_types=target_types,
-            data_set_ids=data_set_ids,
-            start_time=start_time,
-            end_time=end_time,
-            confidence=confidence,
-            last_updated_time=last_updated_time,
-            created_time=created_time,
-            active_at_time=active_at_time,
-            labels=labels,
-        ).dump(camel_case=True)
 
     @overload
     def __call__(
@@ -153,8 +123,7 @@ class RelationshipsAPI(APIClient):
             Iterator[Relationship] | Iterator[RelationshipList]: yields Relationship one by one if chunk_size is not specified, else RelationshipList objects.
         """
         data_set_ids_processed = process_data_set_ids(data_set_ids, data_set_external_ids)
-
-        filter = self._create_filter(
+        filter = RelationshipFilter(
             source_external_ids=source_external_ids,
             source_types=source_types,
             target_external_ids=target_external_ids,
@@ -167,7 +136,7 @@ class RelationshipsAPI(APIClient):
             created_time=created_time,
             active_at_time=active_at_time,
             labels=labels,
-        )
+        ).dump(camel_case=True)
         if (
             len(filter.get("targetExternalIds", [])) > self._LIST_SUBQUERY_LIMIT
             or len(filter.get("sourceExternalIds", [])) > self._LIST_SUBQUERY_LIMIT
@@ -313,8 +282,7 @@ class RelationshipsAPI(APIClient):
                 ...     relationship # do something with the relationship
         """
         data_set_ids_processed = process_data_set_ids(data_set_ids, data_set_external_ids)
-
-        filter = self._create_filter(
+        filter = RelationshipFilter(
             source_external_ids=source_external_ids,
             source_types=source_types,
             target_external_ids=target_external_ids,
@@ -327,7 +295,7 @@ class RelationshipsAPI(APIClient):
             created_time=created_time,
             active_at_time=active_at_time,
             labels=labels,
-        )
+        ).dump(camel_case=True)
         target_external_id_list: list[str] = filter.get("targetExternalIds", [])
         source_external_id_list: list[str] = filter.get("sourceExternalIds", [])
         if (

--- a/cognite/client/_version.py
+++ b/cognite/client/_version.py
@@ -1,4 +1,4 @@
 from __future__ import annotations
 
-__version__ = "7.54.1"
+__version__ = "7.54.2"
 __api_subversion__ = "20230101"

--- a/cognite/client/utils/_auxiliary.py
+++ b/cognite/client/utils/_auxiliary.py
@@ -178,11 +178,7 @@ def split_into_n_parts(seq: Sequence[T], *, n: int) -> Iterator[Sequence[T]]:
 
 
 @overload
-def split_into_chunks(collection: SequenceNotStr[T], chunk_size: int) -> list[list[T]]: ...
-
-
-@overload
-def split_into_chunks(collection: set[T], chunk_size: int) -> list[list[T]]: ...
+def split_into_chunks(collection: set[T] | SequenceNotStr[T], chunk_size: int) -> list[list[T]]: ...
 
 
 @overload

--- a/cognite/client/utils/_auxiliary.py
+++ b/cognite/client/utils/_auxiliary.py
@@ -27,12 +27,14 @@ from cognite.client.utils._text import (
     to_snake_case,
 )
 from cognite.client.utils._version_checker import get_newest_version_in_major_release
+from cognite.client.utils.useful_types import SequenceNotStr
 
 if TYPE_CHECKING:
     from cognite.client import CogniteClient
     from cognite.client.data_classes._base import T_CogniteObject, T_CogniteResource
 
 T = TypeVar("T")
+K = TypeVar("K")
 THashable = TypeVar("THashable", bound=Hashable)
 
 
@@ -176,19 +178,25 @@ def split_into_n_parts(seq: Sequence[T], *, n: int) -> Iterator[Sequence[T]]:
 
 
 @overload
-def split_into_chunks(collection: set | list, chunk_size: int) -> list[list]: ...
+def split_into_chunks(collection: SequenceNotStr[T], chunk_size: int) -> list[list[T]]: ...
 
 
 @overload
-def split_into_chunks(collection: dict, chunk_size: int) -> list[dict]: ...
+def split_into_chunks(collection: set[T], chunk_size: int) -> list[list[T]]: ...
 
 
-def split_into_chunks(collection: set | list | dict, chunk_size: int) -> list[list] | list[dict]:
+@overload
+def split_into_chunks(collection: dict[K, T], chunk_size: int) -> list[dict[K, T]]: ...
+
+
+def split_into_chunks(
+    collection: SequenceNotStr[T] | set[T] | dict[K, T], chunk_size: int
+) -> list[list[T]] | list[dict[K, T]]:
     if isinstance(collection, set):
         collection = list(collection)
 
-    if isinstance(collection, list):
-        return [collection[i : i + chunk_size] for i in range(0, len(collection), chunk_size)]
+    if isinstance(collection, SequenceNotStr):
+        return [list(collection[i : i + chunk_size]) for i in range(0, len(collection), chunk_size)]
 
     if isinstance(collection, dict):
         collection = list(collection.items())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "cognite-sdk"
 
-version = "7.54.1"
+version = "7.54.2"
 description = "Cognite Python SDK"
 readme = "README.md"
 documentation = "https://cognite-sdk-python.readthedocs-hosted.com"


### PR DESCRIPTION
From issue: #1831 

DM-1896: https://cognitedata.atlassian.net/browse/DM-1896

## Description
## [7.54.2] - 2024-07-16
### Fixed
- A bug in the list method of the RelationshipsAPI that could cause a thread deadlock.

## Checklist:
- [ ] Tests added/updated.
- [ ] Documentation updated. Documentation is generated from docstrings - these must be updated according to your change.
  If a new method has been added it should be referenced in [cognite.rst](https://github.com/cognitedata/cognite-sdk-python/blob/master/docs/source/cognite.rst) in order to generate docs based on its docstring.
- [x] Changelog updated in [CHANGELOG.md](https://github.com/cognitedata/cognite-sdk-python/blob/master/CHANGELOG.md).
- [x] Version bumped. If triggering a new release is desired, bump the version number in [_version.py](https://github.com/cognitedata/cognite-sdk-python/blob/master/cognite/client/_version.py) and [pyproject.toml](https://github.com/cognitedata/cognite-sdk-python/blob/master/pyproject.toml) per [semantic versioning](https://semver.org/).
