### PR TITLE
auto-expand properties in notebooks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,11 @@ Changes are grouped as follows
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
-## [7.54.3] - 2024-07-17
+## [7.54.4] - 2024-07-19
+### Changed
+- Instance classes like `Node` and `NodeList` now expand properties by default in notebook-like environments.
+
+## [7.54.3] - 2024-07-18
 ### Added
 - [Feature Preview] Support for `enum` as container property type in the data modeling APIs. Note that this is not
   yet supported in the API, and is an experimental feature that may change without warning.

--- a/cognite/client/_version.py
+++ b/cognite/client/_version.py
@@ -1,4 +1,4 @@
 from __future__ import annotations
 
-__version__ = "7.54.3"
+__version__ = "7.54.4"
 __api_subversion__ = "20230101"

--- a/cognite/client/utils/_pandas_helpers.py
+++ b/cognite/client/utils/_pandas_helpers.py
@@ -88,9 +88,13 @@ def concat_dps_dataframe_list(
 
 
 def notebook_display_with_fallback(inst: T_CogniteResource | T_CogniteResourceList, **kwargs: Any) -> str:
-    if "camel_case" in signature(inst.to_pandas).parameters:
-        # Default of False enforced (when accepted by method):
+    params = signature(inst.to_pandas).parameters
+    # Default of False enforced (when accepted by method):
+    if "camel_case" in params:
         kwargs["camel_case"] = False
+    # TODO: Next major, flip this default to True in the method itself (and delete here):
+    if "expand_properties" in params:
+        kwargs["expand_properties"] = True
     try:
         return inst.to_pandas(**kwargs)._repr_html_()
     except CogniteImportError:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "cognite-sdk"
 
-version = "7.54.3"
+version = "7.54.4"
 description = "Cognite Python SDK"
 readme = "README.md"
 documentation = "https://cognite-sdk-python.readthedocs-hosted.com"


### PR DESCRIPTION
## [7.54.4] - 2024-07-19
### Changed
- Instance classes like `Node` and `NodeList` now expand properties by default in notebook-like environments.

https://cognitedata.atlassian.net/browse/DM-1911