### PR TITLE
Updated core model to version with required keywords and docstrings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,6 @@ Changes are grouped as follows
 - [Feature Preview] Updated the Core Model to require keyword arguments for all classes and include
   docstring.
 
-
 ## [7.54.8] - 2024-07-22
 ### Added
 - The method `client.functions.schedules.retrieve` now accepts the missing parameter `ignore_unknown_ids` as well

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,12 @@ Changes are grouped as follows
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
+## [7.54.9] - 2024-07-22
+### Changed
+- [Feature Preview] Updated the Core Model to require keyword arguments for all classes and include
+  docstring.
+
+
 ## [7.54.8] - 2024-07-22
 ### Added
 - The method `client.functions.schedules.retrieve` now accepts the missing parameter `ignore_unknown_ids` as well

--- a/cognite/client/_version.py
+++ b/cognite/client/_version.py
@@ -1,4 +1,4 @@
 from __future__ import annotations
 
-__version__ = "7.54.8"
+__version__ = "7.54.9"
 __api_subversion__ = "20230101"

--- a/cognite/client/data_classes/cdm/__init__.py
+++ b/cognite/client/data_classes/cdm/__init__.py
@@ -1,1 +1,5 @@
 from __future__ import annotations
+
+from cognite.client.utils._experimental import FeaturePreviewWarning
+
+FeaturePreviewWarning("alpha", "alpha", "Core Data Model").warn()

--- a/cognite/client/data_classes/cdm/v1.py
+++ b/cognite/client/data_classes/cdm/v1.py
@@ -21,7 +21,7 @@ class CogniteDescribableProperties:
 
 
 class CogniteDescribableNodeApply(CogniteDescribableProperties, TypedNodeApply):
-    """This represents the writing format of cognite describable node.
+    """This represents the writing format of Cognite describable node.
 
     It is used to when data is written to CDF.
 
@@ -30,7 +30,7 @@ class CogniteDescribableNodeApply(CogniteDescribableProperties, TypedNodeApply):
 
     Args:
         space (str): The space where the node is located.
-        external_id (str): The external id of the cognite describable node.
+        external_id (str): The external id of the Cognite describable node.
         name (str | None): Name of the instance
         description (str | None): Description of the instance
         tags (list[str] | None): Text based labels for generic use, limited to 1000
@@ -59,7 +59,7 @@ class CogniteDescribableNodeApply(CogniteDescribableProperties, TypedNodeApply):
 
 
 class CogniteDescribableNode(CogniteDescribableProperties, TypedNode):
-    """This represents the reading format of cognite describable node.
+    """This represents the reading format of Cognite describable node.
 
     It is used to when data is read from CDF.
 
@@ -68,7 +68,7 @@ class CogniteDescribableNode(CogniteDescribableProperties, TypedNode):
 
     Args:
         space (str): The space where the node is located.
-        external_id (str): The external id of the cognite describable node.
+        external_id (str): The external id of the Cognite describable node.
         version (int): DMS version.
         last_updated_time (int): The number of milliseconds since 00:00:00 Thursday, 1 January 1970, Coordinated Universal Time (UTC), minus leap seconds.
         created_time (int): The number of milliseconds since 00:00:00 Thursday, 1 January 1970, Coordinated Universal Time (UTC), minus leap seconds.
@@ -126,7 +126,7 @@ class CogniteSchedulableProperties:
 
 
 class CogniteSchedulableApply(CogniteSchedulableProperties, TypedNodeApply):
-    """This represents the writing format of cognite schedulable.
+    """This represents the writing format of Cognite schedulable.
 
     It is used to when data is written to CDF.
 
@@ -134,7 +134,7 @@ class CogniteSchedulableApply(CogniteSchedulableProperties, TypedNodeApply):
 
     Args:
         space (str): The space where the node is located.
-        external_id (str): The external id of the cognite schedulable.
+        external_id (str): The external id of the Cognite schedulable.
         start_time (datetime | None): The actual start time of an activity (or similar that extends this)
         end_time (datetime | None): The actual end time of an activity (or similar that extends this)
         scheduled_start_time (datetime | None): The planned start time of an activity (or similar that extends this)
@@ -163,7 +163,7 @@ class CogniteSchedulableApply(CogniteSchedulableProperties, TypedNodeApply):
 
 
 class CogniteSchedulable(CogniteSchedulableProperties, TypedNode):
-    """This represents the reading format of cognite schedulable.
+    """This represents the reading format of Cognite schedulable.
 
     It is used to when data is read from CDF.
 
@@ -171,7 +171,7 @@ class CogniteSchedulable(CogniteSchedulableProperties, TypedNode):
 
     Args:
         space (str): The space where the node is located.
-        external_id (str): The external id of the cognite schedulable.
+        external_id (str): The external id of the Cognite schedulable.
         version (int): DMS version.
         last_updated_time (int): The number of milliseconds since 00:00:00 Thursday, 1 January 1970, Coordinated Universal Time (UTC), minus leap seconds.
         created_time (int): The number of milliseconds since 00:00:00 Thursday, 1 January 1970, Coordinated Universal Time (UTC), minus leap seconds.
@@ -231,12 +231,12 @@ class CogniteSourceableProperties:
 
 
 class CogniteSourceableNodeApply(CogniteSourceableProperties, TypedNodeApply):
-    """This represents the writing format of cognite sourceable node.
+    """This represents the writing format of Cognite sourceable node.
 
     It is used to when data is written to CDF.
     Args:
         space (str): The space where the node is located.
-        external_id (str): The external id of the cognite sourceable node.
+        external_id (str): The external id of the Cognite sourceable node.
         source_id (str | None): Identifier from the source system
         source_context (str | None): Context of the source id. For systems where the sourceId is globally unique, the sourceContext is expected to not be set.
         source (DirectRelationReference | tuple[str, str] | None): Direct relation to a source system
@@ -274,13 +274,13 @@ class CogniteSourceableNodeApply(CogniteSourceableProperties, TypedNodeApply):
 
 
 class CogniteSourceableNode(CogniteSourceableProperties, TypedNode):
-    """This represents the reading format of cognite sourceable node.
+    """This represents the reading format of Cognite sourceable node.
 
     It is used to when data is read from CDF.
 
     Args:
         space (str): The space where the node is located.
-        external_id (str): The external id of the cognite sourceable node.
+        external_id (str): The external id of the Cognite sourceable node.
         version (int): DMS version.
         last_updated_time (int): The number of milliseconds since 00:00:00 Thursday, 1 January 1970, Coordinated Universal Time (UTC), minus leap seconds.
         created_time (int): The number of milliseconds since 00:00:00 Thursday, 1 January 1970, Coordinated Universal Time (UTC), minus leap seconds.
@@ -347,7 +347,7 @@ class CogniteVisualizableProperties:
 
 
 class CogniteVisualizableApply(CogniteVisualizableProperties, TypedNodeApply):
-    """This represents the writing format of cognite visualizable.
+    """This represents the writing format of Cognite visualizable.
 
     It is used to when data is written to CDF.
 
@@ -355,7 +355,7 @@ class CogniteVisualizableApply(CogniteVisualizableProperties, TypedNodeApply):
 
     Args:
         space (str): The space where the node is located.
-        external_id (str): The external id of the cognite visualizable.
+        external_id (str): The external id of the Cognite visualizable.
         object_3d (DirectRelationReference | tuple[str, str] | None): Direct relation to an Object3D instance representing the 3D resource
         existing_version (int | None): Fail the ingestion request if the node's version is greater than or equal to this value. If no existingVersion is specified, the ingestion will always overwrite any existing data for the node (for the specified container or node). If existingVersion is set to 0, the upsert will behave as an insert, so it will fail the bulk if the item already exists. If skipOnVersionConflict is set on the ingestion request, then the item will be skipped instead of failing the ingestion request.
         type (DirectRelationReference | tuple[str, str] | None): Direct relation pointing to the type node.
@@ -375,7 +375,7 @@ class CogniteVisualizableApply(CogniteVisualizableProperties, TypedNodeApply):
 
 
 class CogniteVisualizable(CogniteVisualizableProperties, TypedNode):
-    """This represents the reading format of cognite visualizable.
+    """This represents the reading format of Cognite visualizable.
 
     It is used to when data is read from CDF.
 
@@ -383,7 +383,7 @@ class CogniteVisualizable(CogniteVisualizableProperties, TypedNode):
 
     Args:
         space (str): The space where the node is located.
-        external_id (str): The external id of the cognite visualizable.
+        external_id (str): The external id of the Cognite visualizable.
         version (int): DMS version.
         last_updated_time (int): The number of milliseconds since 00:00:00 Thursday, 1 January 1970, Coordinated Universal Time (UTC), minus leap seconds.
         created_time (int): The number of milliseconds since 00:00:00 Thursday, 1 January 1970, Coordinated Universal Time (UTC), minus leap seconds.
@@ -427,7 +427,7 @@ class CogniteRevision3DProperties:
 
 
 class CogniteRevision3DApply(CogniteRevision3DProperties, TypedNodeApply):
-    """This represents the writing format of cognite revision 3d.
+    """This represents the writing format of Cognite revision 3D.
 
     It is used to when data is written to CDF.
 
@@ -436,11 +436,11 @@ class CogniteRevision3DApply(CogniteRevision3DProperties, TypedNodeApply):
 
     Args:
         space (str): The space where the node is located.
-        external_id (str): The external id of the cognite revision 3d.
+        external_id (str): The external id of the Cognite revision 3D.
         status (Literal["Done", "Failed", "Processing", "Queued"] | None): The status field.
         published (Literal["Done", "Failed", "Processing", "Queued"] | None): The published field.
         type_ (Literal["CAD", "Image360", "PointCloud"] | None): The type field.
-        model_3d (DirectRelationReference | tuple[str, str] | None): The model 3d field.
+        model_3d (DirectRelationReference | tuple[str, str] | None): The model 3D field.
         existing_version (int | None): Fail the ingestion request if the node's version is greater than or equal to this value. If no existingVersion is specified, the ingestion will always overwrite any existing data for the node (for the specified container or node). If existingVersion is set to 0, the upsert will behave as an insert, so it will fail the bulk if the item already exists. If skipOnVersionConflict is set on the ingestion request, then the item will be skipped instead of failing the ingestion request.
         type (DirectRelationReference | tuple[str, str] | None): Direct relation pointing to the type node.
     """
@@ -465,7 +465,7 @@ class CogniteRevision3DApply(CogniteRevision3DProperties, TypedNodeApply):
 
 
 class CogniteRevision3D(CogniteRevision3DProperties, TypedNode):
-    """This represents the reading format of cognite revision 3d.
+    """This represents the reading format of Cognite revision 3D.
 
     It is used to when data is read from CDF.
 
@@ -474,14 +474,14 @@ class CogniteRevision3D(CogniteRevision3DProperties, TypedNode):
 
     Args:
         space (str): The space where the node is located.
-        external_id (str): The external id of the cognite revision 3d.
+        external_id (str): The external id of the Cognite revision 3D.
         version (int): DMS version.
         last_updated_time (int): The number of milliseconds since 00:00:00 Thursday, 1 January 1970, Coordinated Universal Time (UTC), minus leap seconds.
         created_time (int): The number of milliseconds since 00:00:00 Thursday, 1 January 1970, Coordinated Universal Time (UTC), minus leap seconds.
         status (Literal["Done", "Failed", "Processing", "Queued"] | None): The status field.
         published (Literal["Done", "Failed", "Processing", "Queued"] | None): The published field.
         type_ (Literal["CAD", "Image360", "PointCloud"] | None): The type field.
-        model_3d (DirectRelationReference | None): The model 3d field.
+        model_3d (DirectRelationReference | None): The model 3D field.
         type (DirectRelationReference | None): Direct relation pointing to the type node.
         deleted_time (int | None): The number of milliseconds since 00:00:00 Thursday, 1 January 1970, Coordinated Universal Time (UTC), minus leap seconds. Timestamp when the instance was soft deleted. Note that deleted instances are filtered out of query results, but present in sync results
     """
@@ -527,7 +527,7 @@ class CogniteCubeMapProperties:
 
 
 class CogniteCubeMapApply(CogniteCubeMapProperties, TypedNodeApply):
-    """This represents the writing format of cognite cube map.
+    """This represents the writing format of Cognite cube map.
 
     It is used to when data is written to CDF.
 
@@ -536,7 +536,7 @@ class CogniteCubeMapApply(CogniteCubeMapProperties, TypedNodeApply):
 
     Args:
         space (str): The space where the node is located.
-        external_id (str): The external id of the cognite cube map.
+        external_id (str): The external id of the Cognite cube map.
         front (DirectRelationReference | tuple[str, str] | None): Direct relation to a file holding the front projection of the cube map
         back (DirectRelationReference | tuple[str, str] | None): Direct relation to a file holding the back projection of the cube map
         left (DirectRelationReference | tuple[str, str] | None): Direct relation to a file holding the left projection of the cube map
@@ -571,7 +571,7 @@ class CogniteCubeMapApply(CogniteCubeMapProperties, TypedNodeApply):
 
 
 class CogniteCubeMap(CogniteCubeMapProperties, TypedNode):
-    """This represents the reading format of cognite cube map.
+    """This represents the reading format of Cognite cube map.
 
     It is used to when data is read from CDF.
 
@@ -580,7 +580,7 @@ class CogniteCubeMap(CogniteCubeMapProperties, TypedNode):
 
     Args:
         space (str): The space where the node is located.
-        external_id (str): The external id of the cognite cube map.
+        external_id (str): The external id of the Cognite cube map.
         version (int): DMS version.
         last_updated_time (int): The number of milliseconds since 00:00:00 Thursday, 1 January 1970, Coordinated Universal Time (UTC), minus leap seconds.
         created_time (int): The number of milliseconds since 00:00:00 Thursday, 1 January 1970, Coordinated Universal Time (UTC), minus leap seconds.
@@ -651,7 +651,7 @@ class CogniteTransformation3DProperties:
 
 
 class CogniteTransformation3DNodeApply(CogniteTransformation3DProperties, TypedNodeApply):
-    """This represents the writing format of cognite transformation 3 d node.
+    """This represents the writing format of Cognite transformation 3D node.
 
     It is used to when data is written to CDF.
 
@@ -660,7 +660,7 @@ class CogniteTransformation3DNodeApply(CogniteTransformation3DProperties, TypedN
 
     Args:
         space (str): The space where the node is located.
-        external_id (str): The external id of the cognite transformation 3 d node.
+        external_id (str): The external id of the Cognite transformation 3D node.
         translation_x (float | None): The displacement of the object along the X-axis in 3D space
         translation_y (float | None): The displacement of the object along the Y-axis in 3D space
         translation_z (float | None): The displacement of the object along the Z-axis in 3D space
@@ -704,7 +704,7 @@ class CogniteTransformation3DNodeApply(CogniteTransformation3DProperties, TypedN
 
 
 class CogniteTransformation3DNode(CogniteTransformation3DProperties, TypedNode):
-    """This represents the reading format of cognite transformation 3 d node.
+    """This represents the reading format of Cognite transformation 3D node.
 
     It is used to when data is read from CDF.
 
@@ -713,7 +713,7 @@ class CogniteTransformation3DNode(CogniteTransformation3DProperties, TypedNode):
 
     Args:
         space (str): The space where the node is located.
-        external_id (str): The external id of the cognite transformation 3 d node.
+        external_id (str): The external id of the Cognite transformation 3D node.
         version (int): DMS version.
         last_updated_time (int): The number of milliseconds since 00:00:00 Thursday, 1 January 1970, Coordinated Universal Time (UTC), minus leap seconds.
         created_time (int): The number of milliseconds since 00:00:00 Thursday, 1 January 1970, Coordinated Universal Time (UTC), minus leap seconds.
@@ -786,7 +786,7 @@ class CogniteAssetClassProperties:
 
 
 class CogniteAssetClassApply(CogniteAssetClassProperties, CogniteDescribableNodeApply):
-    """This represents the writing format of cognite asset clas.
+    """This represents the writing format of Cognite asset class.
 
     It is used to when data is written to CDF.
 
@@ -794,7 +794,7 @@ class CogniteAssetClassApply(CogniteAssetClassProperties, CogniteDescribableNode
 
     Args:
         space (str): The space where the node is located.
-        external_id (str): The external id of the cognite asset clas.
+        external_id (str): The external id of the Cognite asset class.
         name (str | None): Name of the instance
         description (str | None): Description of the instance
         tags (list[str] | None): Text based labels for generic use, limited to 1000
@@ -834,7 +834,7 @@ class CogniteAssetClassApply(CogniteAssetClassProperties, CogniteDescribableNode
 
 
 class CogniteAssetClass(CogniteAssetClassProperties, CogniteDescribableNode):
-    """This represents the reading format of cognite asset clas.
+    """This represents the reading format of Cognite asset class.
 
     It is used to when data is read from CDF.
 
@@ -842,7 +842,7 @@ class CogniteAssetClass(CogniteAssetClassProperties, CogniteDescribableNode):
 
     Args:
         space (str): The space where the node is located.
-        external_id (str): The external id of the cognite asset clas.
+        external_id (str): The external id of the Cognite asset class.
         version (int): DMS version.
         last_updated_time (int): The number of milliseconds since 00:00:00 Thursday, 1 January 1970, Coordinated Universal Time (UTC), minus leap seconds.
         created_time (int): The number of milliseconds since 00:00:00 Thursday, 1 January 1970, Coordinated Universal Time (UTC), minus leap seconds.
@@ -913,7 +913,7 @@ class CogniteAssetTypeProperties:
 
 
 class CogniteAssetTypeApply(CogniteAssetTypeProperties, CogniteDescribableNodeApply):
-    """This represents the writing format of cognite asset type.
+    """This represents the writing format of Cognite asset type.
 
     It is used to when data is written to CDF.
 
@@ -921,7 +921,7 @@ class CogniteAssetTypeApply(CogniteAssetTypeProperties, CogniteDescribableNodeAp
 
     Args:
         space (str): The space where the node is located.
-        external_id (str): The external id of the cognite asset type.
+        external_id (str): The external id of the Cognite asset type.
         name (str | None): Name of the instance
         description (str | None): Description of the instance
         tags (list[str] | None): Text based labels for generic use, limited to 1000
@@ -961,7 +961,7 @@ class CogniteAssetTypeApply(CogniteAssetTypeProperties, CogniteDescribableNodeAp
 
 
 class CogniteAssetType(CogniteAssetTypeProperties, CogniteDescribableNode):
-    """This represents the reading format of cognite asset type.
+    """This represents the reading format of Cognite asset type.
 
     It is used to when data is read from CDF.
 
@@ -969,7 +969,7 @@ class CogniteAssetType(CogniteAssetTypeProperties, CogniteDescribableNode):
 
     Args:
         space (str): The space where the node is located.
-        external_id (str): The external id of the cognite asset type.
+        external_id (str): The external id of the Cognite asset type.
         version (int): DMS version.
         last_updated_time (int): The number of milliseconds since 00:00:00 Thursday, 1 January 1970, Coordinated Universal Time (UTC), minus leap seconds.
         created_time (int): The number of milliseconds since 00:00:00 Thursday, 1 January 1970, Coordinated Universal Time (UTC), minus leap seconds.
@@ -1044,7 +1044,7 @@ class CogniteCADNodeProperties:
 
 
 class CogniteCADNodeApply(CogniteCADNodeProperties, CogniteDescribableNodeApply):
-    """This represents the writing format of cognite cad node.
+    """This represents the writing format of Cognite cad node.
 
     It is used to when data is written to CDF.
 
@@ -1052,7 +1052,7 @@ class CogniteCADNodeApply(CogniteCADNodeProperties, CogniteDescribableNodeApply)
 
     Args:
         space (str): The space where the node is located.
-        external_id (str): The external id of the cognite cad node.
+        external_id (str): The external id of the Cognite cad node.
         name (str | None): Name of the instance
         description (str | None): Description of the instance
         tags (list[str] | None): Text based labels for generic use, limited to 1000
@@ -1104,7 +1104,7 @@ class CogniteCADNodeApply(CogniteCADNodeProperties, CogniteDescribableNodeApply)
 
 
 class CogniteCADNode(CogniteCADNodeProperties, CogniteDescribableNode):
-    """This represents the reading format of cognite cad node.
+    """This represents the reading format of Cognite cad node.
 
     It is used to when data is read from CDF.
 
@@ -1112,7 +1112,7 @@ class CogniteCADNode(CogniteCADNodeProperties, CogniteDescribableNode):
 
     Args:
         space (str): The space where the node is located.
-        external_id (str): The external id of the cognite cad node.
+        external_id (str): The external id of the Cognite cad node.
         version (int): DMS version.
         last_updated_time (int): The number of milliseconds since 00:00:00 Thursday, 1 January 1970, Coordinated Universal Time (UTC), minus leap seconds.
         created_time (int): The number of milliseconds since 00:00:00 Thursday, 1 January 1970, Coordinated Universal Time (UTC), minus leap seconds.
@@ -1200,7 +1200,7 @@ class CogniteEquipmentTypeProperties:
 
 
 class CogniteEquipmentTypeApply(CogniteEquipmentTypeProperties, CogniteDescribableNodeApply):
-    """This represents the writing format of cognite equipment type.
+    """This represents the writing format of Cognite equipment type.
 
     It is used to when data is written to CDF.
 
@@ -1208,7 +1208,7 @@ class CogniteEquipmentTypeApply(CogniteEquipmentTypeProperties, CogniteDescribab
 
     Args:
         space (str): The space where the node is located.
-        external_id (str): The external id of the cognite equipment type.
+        external_id (str): The external id of the Cognite equipment type.
         name (str | None): Name of the instance
         description (str | None): Description of the instance
         tags (list[str] | None): Text based labels for generic use, limited to 1000
@@ -1254,7 +1254,7 @@ class CogniteEquipmentTypeApply(CogniteEquipmentTypeProperties, CogniteDescribab
 
 
 class CogniteEquipmentType(CogniteEquipmentTypeProperties, CogniteDescribableNode):
-    """This represents the reading format of cognite equipment type.
+    """This represents the reading format of Cognite equipment type.
 
     It is used to when data is read from CDF.
 
@@ -1262,7 +1262,7 @@ class CogniteEquipmentType(CogniteEquipmentTypeProperties, CogniteDescribableNod
 
     Args:
         space (str): The space where the node is located.
-        external_id (str): The external id of the cognite equipment type.
+        external_id (str): The external id of the Cognite equipment type.
         version (int): DMS version.
         last_updated_time (int): The number of milliseconds since 00:00:00 Thursday, 1 January 1970, Coordinated Universal Time (UTC), minus leap seconds.
         created_time (int): The number of milliseconds since 00:00:00 Thursday, 1 January 1970, Coordinated Universal Time (UTC), minus leap seconds.
@@ -1341,7 +1341,7 @@ class CogniteFileCategoryProperties:
 
 
 class CogniteFileCategoryApply(CogniteFileCategoryProperties, CogniteDescribableNodeApply):
-    """This represents the writing format of cognite file category.
+    """This represents the writing format of Cognite file category.
 
     It is used to when data is written to CDF.
 
@@ -1349,7 +1349,7 @@ class CogniteFileCategoryApply(CogniteFileCategoryProperties, CogniteDescribable
 
     Args:
         space (str): The space where the node is located.
-        external_id (str): The external id of the cognite file category.
+        external_id (str): The external id of the Cognite file category.
         code (str): Identified category code, such as 'AA' for Accounting (from Norsok)
         name (str | None): Name of the instance
         description (str | None): Description of the instance
@@ -1392,7 +1392,7 @@ class CogniteFileCategoryApply(CogniteFileCategoryProperties, CogniteDescribable
 
 
 class CogniteFileCategory(CogniteFileCategoryProperties, CogniteDescribableNode):
-    """This represents the reading format of cognite file category.
+    """This represents the reading format of Cognite file category.
 
     It is used to when data is read from CDF.
 
@@ -1400,7 +1400,7 @@ class CogniteFileCategory(CogniteFileCategoryProperties, CogniteDescribableNode)
 
     Args:
         space (str): The space where the node is located.
-        external_id (str): The external id of the cognite file category.
+        external_id (str): The external id of the Cognite file category.
         version (int): DMS version.
         last_updated_time (int): The number of milliseconds since 00:00:00 Thursday, 1 January 1970, Coordinated Universal Time (UTC), minus leap seconds.
         created_time (int): The number of milliseconds since 00:00:00 Thursday, 1 January 1970, Coordinated Universal Time (UTC), minus leap seconds.
@@ -1475,7 +1475,7 @@ class CogniteImage360StationProperties:
 
 
 class CogniteImage360StationApply(CogniteImage360StationProperties, CogniteDescribableNodeApply):
-    """This represents the writing format of cognite image 360 station.
+    """This represents the writing format of Cognite image 360 station.
 
     It is used to when data is written to CDF.
 
@@ -1483,7 +1483,7 @@ class CogniteImage360StationApply(CogniteImage360StationProperties, CogniteDescr
 
     Args:
         space (str): The space where the node is located.
-        external_id (str): The external id of the cognite image 360 station.
+        external_id (str): The external id of the Cognite image 360 station.
         name (str | None): Name of the instance
         description (str | None): Description of the instance
         tags (list[str] | None): Text based labels for generic use, limited to 1000
@@ -1520,7 +1520,7 @@ class CogniteImage360StationApply(CogniteImage360StationProperties, CogniteDescr
 
 
 class CogniteImage360Station(CogniteImage360StationProperties, CogniteDescribableNode):
-    """This represents the reading format of cognite image 360 station.
+    """This represents the reading format of Cognite image 360 station.
 
     It is used to when data is read from CDF.
 
@@ -1528,7 +1528,7 @@ class CogniteImage360Station(CogniteImage360StationProperties, CogniteDescribabl
 
     Args:
         space (str): The space where the node is located.
-        external_id (str): The external id of the cognite image 360 station.
+        external_id (str): The external id of the Cognite image 360 station.
         version (int): DMS version.
         last_updated_time (int): The number of milliseconds since 00:00:00 Thursday, 1 January 1970, Coordinated Universal Time (UTC), minus leap seconds.
         created_time (int): The number of milliseconds since 00:00:00 Thursday, 1 January 1970, Coordinated Universal Time (UTC), minus leap seconds.
@@ -1595,7 +1595,7 @@ class CogniteModel3DProperties:
 
 
 class CogniteModel3DApply(CogniteModel3DProperties, CogniteDescribableNodeApply):
-    """This represents the writing format of cognite model 3d.
+    """This represents the writing format of Cognite model 3D.
 
     It is used to when data is written to CDF.
 
@@ -1603,7 +1603,7 @@ class CogniteModel3DApply(CogniteModel3DProperties, CogniteDescribableNodeApply)
 
     Args:
         space (str): The space where the node is located.
-        external_id (str): The external id of the cognite model 3d.
+        external_id (str): The external id of the Cognite model 3D.
         name (str | None): Name of the instance
         description (str | None): Description of the instance
         tags (list[str] | None): Text based labels for generic use, limited to 1000
@@ -1640,7 +1640,7 @@ class CogniteModel3DApply(CogniteModel3DProperties, CogniteDescribableNodeApply)
 
 
 class CogniteModel3D(CogniteModel3DProperties, CogniteDescribableNode):
-    """This represents the reading format of cognite model 3d.
+    """This represents the reading format of Cognite model 3D.
 
     It is used to when data is read from CDF.
 
@@ -1648,7 +1648,7 @@ class CogniteModel3D(CogniteModel3DProperties, CogniteDescribableNode):
 
     Args:
         space (str): The space where the node is located.
-        external_id (str): The external id of the cognite model 3d.
+        external_id (str): The external id of the Cognite model 3D.
         version (int): DMS version.
         last_updated_time (int): The number of milliseconds since 00:00:00 Thursday, 1 January 1970, Coordinated Universal Time (UTC), minus leap seconds.
         created_time (int): The number of milliseconds since 00:00:00 Thursday, 1 January 1970, Coordinated Universal Time (UTC), minus leap seconds.
@@ -1720,7 +1720,7 @@ class CogniteObject3DProperties:
 
 
 class CogniteObject3DApply(CogniteObject3DProperties, CogniteDescribableNodeApply):
-    """This represents the writing format of cognite object 3d.
+    """This represents the writing format of Cognite object 3D.
 
     It is used to when data is written to CDF.
 
@@ -1728,7 +1728,7 @@ class CogniteObject3DApply(CogniteObject3DProperties, CogniteDescribableNodeAppl
 
     Args:
         space (str): The space where the node is located.
-        external_id (str): The external id of the cognite object 3d.
+        external_id (str): The external id of the Cognite object 3D.
         name (str | None): Name of the instance
         description (str | None): Description of the instance
         tags (list[str] | None): Text based labels for generic use, limited to 1000
@@ -1780,7 +1780,7 @@ class CogniteObject3DApply(CogniteObject3DProperties, CogniteDescribableNodeAppl
 
 
 class CogniteObject3D(CogniteObject3DProperties, CogniteDescribableNode):
-    """This represents the reading format of cognite object 3d.
+    """This represents the reading format of Cognite object 3D.
 
     It is used to when data is read from CDF.
 
@@ -1788,7 +1788,7 @@ class CogniteObject3D(CogniteObject3DProperties, CogniteDescribableNode):
 
     Args:
         space (str): The space where the node is located.
-        external_id (str): The external id of the cognite object 3d.
+        external_id (str): The external id of the Cognite object 3D.
         version (int): DMS version.
         last_updated_time (int): The number of milliseconds since 00:00:00 Thursday, 1 January 1970, Coordinated Universal Time (UTC), minus leap seconds.
         created_time (int): The number of milliseconds since 00:00:00 Thursday, 1 January 1970, Coordinated Universal Time (UTC), minus leap seconds.
@@ -1879,7 +1879,7 @@ class CognitePointCloudVolumeProperties:
 
 
 class CognitePointCloudVolumeApply(CognitePointCloudVolumeProperties, CogniteDescribableNodeApply):
-    """This represents the writing format of cognite point cloud volume.
+    """This represents the writing format of Cognite point cloud volume.
 
     It is used to when data is written to CDF.
 
@@ -1887,7 +1887,7 @@ class CognitePointCloudVolumeApply(CognitePointCloudVolumeProperties, CogniteDes
 
     Args:
         space (str): The space where the node is located.
-        external_id (str): The external id of the cognite point cloud volume.
+        external_id (str): The external id of the Cognite point cloud volume.
         name (str | None): Name of the instance
         description (str | None): Description of the instance
         tags (list[str] | None): Text based labels for generic use, limited to 1000
@@ -1942,7 +1942,7 @@ class CognitePointCloudVolumeApply(CognitePointCloudVolumeProperties, CogniteDes
 
 
 class CognitePointCloudVolume(CognitePointCloudVolumeProperties, CogniteDescribableNode):
-    """This represents the reading format of cognite point cloud volume.
+    """This represents the reading format of Cognite point cloud volume.
 
     It is used to when data is read from CDF.
 
@@ -1950,7 +1950,7 @@ class CognitePointCloudVolume(CognitePointCloudVolumeProperties, CogniteDescriba
 
     Args:
         space (str): The space where the node is located.
-        external_id (str): The external id of the cognite point cloud volume.
+        external_id (str): The external id of the Cognite point cloud volume.
         version (int): DMS version.
         last_updated_time (int): The number of milliseconds since 00:00:00 Thursday, 1 January 1970, Coordinated Universal Time (UTC), minus leap seconds.
         created_time (int): The number of milliseconds since 00:00:00 Thursday, 1 January 1970, Coordinated Universal Time (UTC), minus leap seconds.
@@ -2041,7 +2041,7 @@ class CogniteSourceSystemProperties:
 
 
 class CogniteSourceSystemApply(CogniteSourceSystemProperties, CogniteDescribableNodeApply):
-    """This represents the writing format of cognite source system.
+    """This represents the writing format of Cognite source system.
 
     It is used to when data is written to CDF.
 
@@ -2049,7 +2049,7 @@ class CogniteSourceSystemApply(CogniteSourceSystemProperties, CogniteDescribable
 
     Args:
         space (str): The space where the node is located.
-        external_id (str): The external id of the cognite source system.
+        external_id (str): The external id of the Cognite source system.
         name (str | None): Name of the instance
         description (str | None): Description of the instance
         tags (list[str] | None): Text based labels for generic use, limited to 1000
@@ -2089,7 +2089,7 @@ class CogniteSourceSystemApply(CogniteSourceSystemProperties, CogniteDescribable
 
 
 class CogniteSourceSystem(CogniteSourceSystemProperties, CogniteDescribableNode):
-    """This represents the reading format of cognite source system.
+    """This represents the reading format of Cognite source system.
 
     It is used to when data is read from CDF.
 
@@ -2097,7 +2097,7 @@ class CogniteSourceSystem(CogniteSourceSystemProperties, CogniteDescribableNode)
 
     Args:
         space (str): The space where the node is located.
-        external_id (str): The external id of the cognite source system.
+        external_id (str): The external id of the Cognite source system.
         version (int): DMS version.
         last_updated_time (int): The number of milliseconds since 00:00:00 Thursday, 1 January 1970, Coordinated Universal Time (UTC), minus leap seconds.
         created_time (int): The number of milliseconds since 00:00:00 Thursday, 1 January 1970, Coordinated Universal Time (UTC), minus leap seconds.
@@ -2170,7 +2170,7 @@ class CogniteActivityProperties:
 class CogniteActivityApply(
     CogniteActivityProperties, CogniteDescribableNodeApply, CogniteSourceableNodeApply, CogniteSchedulableApply
 ):
-    """This represents the writing format of cognite activity.
+    """This represents the writing format of Cognite activity.
 
     It is used to when data is written to CDF.
 
@@ -2178,7 +2178,7 @@ class CogniteActivityApply(
 
     Args:
         space (str): The space where the node is located.
-        external_id (str): The external id of the cognite activity.
+        external_id (str): The external id of the Cognite activity.
         name (str | None): Name of the instance
         description (str | None): Description of the instance
         tags (list[str] | None): Text based labels for generic use, limited to 1000
@@ -2271,7 +2271,7 @@ class CogniteActivityApply(
 
 
 class CogniteActivity(CogniteActivityProperties, CogniteDescribableNode, CogniteSourceableNode, CogniteSchedulable):
-    """This represents the reading format of cognite activity.
+    """This represents the reading format of Cognite activity.
 
     It is used to when data is read from CDF.
 
@@ -2279,7 +2279,7 @@ class CogniteActivity(CogniteActivityProperties, CogniteDescribableNode, Cognite
 
     Args:
         space (str): The space where the node is located.
-        external_id (str): The external id of the cognite activity.
+        external_id (str): The external id of the Cognite activity.
         version (int): DMS version.
         last_updated_time (int): The number of milliseconds since 00:00:00 Thursday, 1 January 1970, Coordinated Universal Time (UTC), minus leap seconds.
         created_time (int): The number of milliseconds since 00:00:00 Thursday, 1 January 1970, Coordinated Universal Time (UTC), minus leap seconds.
@@ -2422,7 +2422,7 @@ class CogniteEquipmentProperties:
 
 
 class CogniteEquipmentApply(CogniteEquipmentProperties, CogniteDescribableNodeApply, CogniteSourceableNodeApply):
-    """This represents the writing format of cognite equipment.
+    """This represents the writing format of Cognite equipment.
 
     It is used to when data is written to CDF.
 
@@ -2430,7 +2430,7 @@ class CogniteEquipmentApply(CogniteEquipmentProperties, CogniteDescribableNodeAp
 
     Args:
         space (str): The space where the node is located.
-        external_id (str): The external id of the cognite equipment.
+        external_id (str): The external id of the Cognite equipment.
         name (str | None): Name of the instance
         description (str | None): Description of the instance
         tags (list[str] | None): Text based labels for generic use, limited to 1000
@@ -2505,7 +2505,7 @@ class CogniteEquipmentApply(CogniteEquipmentProperties, CogniteDescribableNodeAp
 
 
 class CogniteEquipment(CogniteEquipmentProperties, CogniteDescribableNode, CogniteSourceableNode):
-    """This represents the reading format of cognite equipment.
+    """This represents the reading format of Cognite equipment.
 
     It is used to when data is read from CDF.
 
@@ -2513,7 +2513,7 @@ class CogniteEquipment(CogniteEquipmentProperties, CogniteDescribableNode, Cogni
 
     Args:
         space (str): The space where the node is located.
-        external_id (str): The external id of the cognite equipment.
+        external_id (str): The external id of the Cognite equipment.
         version (int): DMS version.
         last_updated_time (int): The number of milliseconds since 00:00:00 Thursday, 1 January 1970, Coordinated Universal Time (UTC), minus leap seconds.
         created_time (int): The number of milliseconds since 00:00:00 Thursday, 1 January 1970, Coordinated Universal Time (UTC), minus leap seconds.
@@ -2633,7 +2633,7 @@ class CogniteFileProperties:
 
 
 class CogniteFileApply(CogniteFileProperties, CogniteDescribableNodeApply, CogniteSourceableNodeApply):
-    """This represents the writing format of cognite file.
+    """This represents the writing format of Cognite file.
 
     It is used to when data is written to CDF.
 
@@ -2641,7 +2641,7 @@ class CogniteFileApply(CogniteFileProperties, CogniteDescribableNodeApply, Cogni
 
     Args:
         space (str): The space where the node is located.
-        external_id (str): The external id of the cognite file.
+        external_id (str): The external id of the Cognite file.
         name (str | None): Name of the instance
         description (str | None): Description of the instance
         tags (list[str] | None): Text based labels for generic use, limited to 1000
@@ -2722,7 +2722,7 @@ class CogniteFileApply(CogniteFileProperties, CogniteDescribableNodeApply, Cogni
 
 
 class CogniteFile(CogniteFileProperties, CogniteDescribableNode, CogniteSourceableNode):
-    """This represents the reading format of cognite file.
+    """This represents the reading format of Cognite file.
 
     It is used to when data is read from CDF.
 
@@ -2730,7 +2730,7 @@ class CogniteFile(CogniteFileProperties, CogniteDescribableNode, CogniteSourceab
 
     Args:
         space (str): The space where the node is located.
-        external_id (str): The external id of the cognite file.
+        external_id (str): The external id of the Cognite file.
         version (int): DMS version.
         last_updated_time (int): The number of milliseconds since 00:00:00 Thursday, 1 January 1970, Coordinated Universal Time (UTC), minus leap seconds.
         created_time (int): The number of milliseconds since 00:00:00 Thursday, 1 January 1970, Coordinated Universal Time (UTC), minus leap seconds.
@@ -2858,12 +2858,12 @@ class CogniteTimeSeriesProperties:
 
 
 class CogniteTimeSeriesApply(CogniteTimeSeriesProperties, CogniteDescribableNodeApply, CogniteSourceableNodeApply):
-    """This represents the writing format of cognite time series.
+    """This represents the writing format of Cognite time series.
 
     It is used to when data is written to CDF.
     Args:
         space (str): The space where the node is located.
-        external_id (str): The external id of the cognite time series.
+        external_id (str): The external id of the Cognite time series.
         type_ (Literal["numeric", "string"]): Defines data type of the data points.
         name (str | None): Name of the instance
         description (str | None): Description of the instance
@@ -2944,13 +2944,13 @@ class CogniteTimeSeriesApply(CogniteTimeSeriesProperties, CogniteDescribableNode
 
 
 class CogniteTimeSeries(CogniteTimeSeriesProperties, CogniteDescribableNode, CogniteSourceableNode):
-    """This represents the reading format of cognite time series.
+    """This represents the reading format of Cognite time series.
 
     It is used to when data is read from CDF.
 
     Args:
         space (str): The space where the node is located.
-        external_id (str): The external id of the cognite time series.
+        external_id (str): The external id of the Cognite time series.
         version (int): DMS version.
         last_updated_time (int): The number of milliseconds since 00:00:00 Thursday, 1 January 1970, Coordinated Universal Time (UTC), minus leap seconds.
         created_time (int): The number of milliseconds since 00:00:00 Thursday, 1 January 1970, Coordinated Universal Time (UTC), minus leap seconds.
@@ -3080,7 +3080,7 @@ class CogniteAssetProperties:
 class CogniteAssetApply(
     CogniteAssetProperties, CogniteVisualizableApply, CogniteDescribableNodeApply, CogniteSourceableNodeApply
 ):
-    """This represents the writing format of cognite asset.
+    """This represents the writing format of Cognite asset.
 
     It is used to when data is written to CDF.
 
@@ -3088,7 +3088,7 @@ class CogniteAssetApply(
 
     Args:
         space (str): The space where the node is located.
-        external_id (str): The external id of the cognite asset.
+        external_id (str): The external id of the Cognite asset.
         object_3d (DirectRelationReference | tuple[str, str] | None): Direct relation to an Object3D instance representing the 3D resource
         name (str | None): Name of the instance
         description (str | None): Description of the instance
@@ -3177,7 +3177,7 @@ class CogniteAssetApply(
 
 
 class CogniteAsset(CogniteAssetProperties, CogniteVisualizable, CogniteDescribableNode, CogniteSourceableNode):
-    """This represents the reading format of cognite asset.
+    """This represents the reading format of Cognite asset.
 
     It is used to when data is read from CDF.
 
@@ -3185,7 +3185,7 @@ class CogniteAsset(CogniteAssetProperties, CogniteVisualizable, CogniteDescribab
 
     Args:
         space (str): The space where the node is located.
-        external_id (str): The external id of the cognite asset.
+        external_id (str): The external id of the Cognite asset.
         version (int): DMS version.
         last_updated_time (int): The number of milliseconds since 00:00:00 Thursday, 1 January 1970, Coordinated Universal Time (UTC), minus leap seconds.
         created_time (int): The number of milliseconds since 00:00:00 Thursday, 1 January 1970, Coordinated Universal Time (UTC), minus leap seconds.
@@ -3329,12 +3329,12 @@ class CogniteCADRevisionProperties:
 
 
 class CogniteCADRevisionApply(CogniteCADRevisionProperties, CogniteRevision3DApply):
-    """This represents the writing format of cognite cad revision.
+    """This represents the writing format of Cognite cad revision.
 
     It is used to when data is written to CDF.
     Args:
         space (str): The space where the node is located.
-        external_id (str): The external id of the cognite cad revision.
+        external_id (str): The external id of the Cognite cad revision.
         status (Literal["Done", "Failed", "Processing", "Queued"] | None): The status field.
         published (Literal["Done", "Failed", "Processing", "Queued"] | None): The published field.
         type_ (Literal["CAD", "Image360", "PointCloud"] | None): The type field.
@@ -3371,13 +3371,13 @@ class CogniteCADRevisionApply(CogniteCADRevisionProperties, CogniteRevision3DApp
 
 
 class CogniteCADRevision(CogniteCADRevisionProperties, CogniteRevision3D):
-    """This represents the reading format of cognite cad revision.
+    """This represents the reading format of Cognite cad revision.
 
     It is used to when data is read from CDF.
 
     Args:
         space (str): The space where the node is located.
-        external_id (str): The external id of the cognite cad revision.
+        external_id (str): The external id of the Cognite cad revision.
         version (int): DMS version.
         last_updated_time (int): The number of milliseconds since 00:00:00 Thursday, 1 January 1970, Coordinated Universal Time (UTC), minus leap seconds.
         created_time (int): The number of milliseconds since 00:00:00 Thursday, 1 January 1970, Coordinated Universal Time (UTC), minus leap seconds.
@@ -3444,7 +3444,7 @@ class CogniteImage360CollectionProperties:
 class CogniteImage360CollectionApply(
     CogniteImage360CollectionProperties, CogniteDescribableNodeApply, CogniteRevision3DApply
 ):
-    """This represents the writing format of cognite image 360 collection.
+    """This represents the writing format of Cognite image 360 collection.
 
     It is used to when data is written to CDF.
 
@@ -3452,7 +3452,7 @@ class CogniteImage360CollectionApply(
 
     Args:
         space (str): The space where the node is located.
-        external_id (str): The external id of the cognite image 360 collection.
+        external_id (str): The external id of the Cognite image 360 collection.
         name (str | None): Name of the instance
         description (str | None): Description of the instance
         tags (list[str] | None): Text based labels for generic use, limited to 1000
@@ -3460,7 +3460,7 @@ class CogniteImage360CollectionApply(
         status (Literal["Done", "Failed", "Processing", "Queued"] | None): The status field.
         published (Literal["Done", "Failed", "Processing", "Queued"] | None): The published field.
         type_ (Literal["CAD", "Image360", "PointCloud"] | None): The type field.
-        model_3d (DirectRelationReference | tuple[str, str] | None): The model 3d field.
+        model_3d (DirectRelationReference | tuple[str, str] | None): The model 3D field.
         existing_version (int | None): Fail the ingestion request if the node's version is greater than or equal to this value. If no existingVersion is specified, the ingestion will always overwrite any existing data for the node (for the specified container or node). If existingVersion is set to 0, the upsert will behave as an insert, so it will fail the bulk if the item already exists. If skipOnVersionConflict is set on the ingestion request, then the item will be skipped instead of failing the ingestion request.
         type (DirectRelationReference | tuple[str, str] | None): Direct relation pointing to the type node.
     """
@@ -3506,7 +3506,7 @@ class CogniteImage360CollectionApply(
 
 
 class CogniteImage360Collection(CogniteImage360CollectionProperties, CogniteDescribableNode, CogniteRevision3D):
-    """This represents the reading format of cognite image 360 collection.
+    """This represents the reading format of Cognite image 360 collection.
 
     It is used to when data is read from CDF.
 
@@ -3514,7 +3514,7 @@ class CogniteImage360Collection(CogniteImage360CollectionProperties, CogniteDesc
 
     Args:
         space (str): The space where the node is located.
-        external_id (str): The external id of the cognite image 360 collection.
+        external_id (str): The external id of the Cognite image 360 collection.
         version (int): DMS version.
         last_updated_time (int): The number of milliseconds since 00:00:00 Thursday, 1 January 1970, Coordinated Universal Time (UTC), minus leap seconds.
         created_time (int): The number of milliseconds since 00:00:00 Thursday, 1 January 1970, Coordinated Universal Time (UTC), minus leap seconds.
@@ -3525,7 +3525,7 @@ class CogniteImage360Collection(CogniteImage360CollectionProperties, CogniteDesc
         status (Literal["Done", "Failed", "Processing", "Queued"] | None): The status field.
         published (Literal["Done", "Failed", "Processing", "Queued"] | None): The published field.
         type_ (Literal["CAD", "Image360", "PointCloud"] | None): The type field.
-        model_3d (DirectRelationReference | None): The model 3d field.
+        model_3d (DirectRelationReference | None): The model 3D field.
         type (DirectRelationReference | None): Direct relation pointing to the type node.
         deleted_time (int | None): The number of milliseconds since 00:00:00 Thursday, 1 January 1970, Coordinated Universal Time (UTC), minus leap seconds. Timestamp when the instance was soft deleted. Note that deleted instances are filtered out of query results, but present in sync results
     """
@@ -3604,7 +3604,7 @@ class CognitePointCloudRevisionProperties:
 
 
 class CognitePointCloudRevisionApply(CognitePointCloudRevisionProperties, CogniteRevision3DApply):
-    """This represents the writing format of cognite point cloud revision.
+    """This represents the writing format of Cognite point cloud revision.
 
     It is used to when data is written to CDF.
 
@@ -3612,7 +3612,7 @@ class CognitePointCloudRevisionApply(CognitePointCloudRevisionProperties, Cognit
 
     Args:
         space (str): The space where the node is located.
-        external_id (str): The external id of the cognite point cloud revision.
+        external_id (str): The external id of the Cognite point cloud revision.
         status (Literal["Done", "Failed", "Processing", "Queued"] | None): The status field.
         published (Literal["Done", "Failed", "Processing", "Queued"] | None): The published field.
         type_ (Literal["CAD", "Image360", "PointCloud"] | None): The type field.
@@ -3649,7 +3649,7 @@ class CognitePointCloudRevisionApply(CognitePointCloudRevisionProperties, Cognit
 
 
 class CognitePointCloudRevision(CognitePointCloudRevisionProperties, CogniteRevision3D):
-    """This represents the reading format of cognite point cloud revision.
+    """This represents the reading format of Cognite point cloud revision.
 
     It is used to when data is read from CDF.
 
@@ -3657,7 +3657,7 @@ class CognitePointCloudRevision(CognitePointCloudRevisionProperties, CogniteRevi
 
     Args:
         space (str): The space where the node is located.
-        external_id (str): The external id of the cognite point cloud revision.
+        external_id (str): The external id of the Cognite point cloud revision.
         version (int): DMS version.
         last_updated_time (int): The number of milliseconds since 00:00:00 Thursday, 1 January 1970, Coordinated Universal Time (UTC), minus leap seconds.
         created_time (int): The number of milliseconds since 00:00:00 Thursday, 1 January 1970, Coordinated Universal Time (UTC), minus leap seconds.
@@ -3726,12 +3726,12 @@ class CogniteImage360Properties:
 
 
 class CogniteImage360Apply(CogniteImage360Properties, CogniteTransformation3DNodeApply, CogniteCubeMapApply):
-    """This represents the writing format of cognite image 360.
+    """This represents the writing format of Cognite image 360.
 
     It is used to when data is written to CDF.
     Args:
         space (str): The space where the node is located.
-        external_id (str): The external id of the cognite image 360.
+        external_id (str): The external id of the Cognite image 360.
         translation_x (float | None): The displacement of the object along the X-axis in 3D space
         translation_y (float | None): The displacement of the object along the Y-axis in 3D space
         translation_z (float | None): The displacement of the object along the Z-axis in 3D space
@@ -3815,13 +3815,13 @@ class CogniteImage360Apply(CogniteImage360Properties, CogniteTransformation3DNod
 
 
 class CogniteImage360(CogniteImage360Properties, CogniteTransformation3DNode, CogniteCubeMap):
-    """This represents the reading format of cognite image 360.
+    """This represents the reading format of Cognite image 360.
 
     It is used to when data is read from CDF.
 
     Args:
         space (str): The space where the node is located.
-        external_id (str): The external id of the cognite image 360.
+        external_id (str): The external id of the Cognite image 360.
         version (int): DMS version.
         last_updated_time (int): The number of milliseconds since 00:00:00 Thursday, 1 January 1970, Coordinated Universal Time (UTC), minus leap seconds.
         created_time (int): The number of milliseconds since 00:00:00 Thursday, 1 January 1970, Coordinated Universal Time (UTC), minus leap seconds.
@@ -3949,7 +3949,7 @@ class CogniteCADModelProperties:
 
 
 class CogniteCADModelApply(CogniteCADModelProperties, CogniteModel3DApply):
-    """This represents the writing format of cognite cad model.
+    """This represents the writing format of Cognite cad model.
 
     It is used to when data is written to CDF.
 
@@ -3957,7 +3957,7 @@ class CogniteCADModelApply(CogniteCADModelProperties, CogniteModel3DApply):
 
     Args:
         space (str): The space where the node is located.
-        external_id (str): The external id of the cognite cad model.
+        external_id (str): The external id of the Cognite cad model.
         name (str | None): Name of the instance
         description (str | None): Description of the instance
         tags (list[str] | None): Text based labels for generic use, limited to 1000
@@ -3994,7 +3994,7 @@ class CogniteCADModelApply(CogniteCADModelProperties, CogniteModel3DApply):
 
 
 class CogniteCADModel(CogniteCADModelProperties, CogniteModel3D):
-    """This represents the reading format of cognite cad model.
+    """This represents the reading format of Cognite cad model.
 
     It is used to when data is read from CDF.
 
@@ -4002,7 +4002,7 @@ class CogniteCADModel(CogniteCADModelProperties, CogniteModel3D):
 
     Args:
         space (str): The space where the node is located.
-        external_id (str): The external id of the cognite cad model.
+        external_id (str): The external id of the Cognite cad model.
         version (int): DMS version.
         last_updated_time (int): The number of milliseconds since 00:00:00 Thursday, 1 January 1970, Coordinated Universal Time (UTC), minus leap seconds.
         created_time (int): The number of milliseconds since 00:00:00 Thursday, 1 January 1970, Coordinated Universal Time (UTC), minus leap seconds.
@@ -4067,7 +4067,7 @@ class CogniteImage360ModelProperties:
 
 
 class CogniteImage360ModelApply(CogniteImage360ModelProperties, CogniteModel3DApply):
-    """This represents the writing format of cognite image 360 model.
+    """This represents the writing format of Cognite image 360 model.
 
     It is used to when data is written to CDF.
 
@@ -4075,7 +4075,7 @@ class CogniteImage360ModelApply(CogniteImage360ModelProperties, CogniteModel3DAp
 
     Args:
         space (str): The space where the node is located.
-        external_id (str): The external id of the cognite image 360 model.
+        external_id (str): The external id of the Cognite image 360 model.
         name (str | None): Name of the instance
         description (str | None): Description of the instance
         tags (list[str] | None): Text based labels for generic use, limited to 1000
@@ -4112,7 +4112,7 @@ class CogniteImage360ModelApply(CogniteImage360ModelProperties, CogniteModel3DAp
 
 
 class CogniteImage360Model(CogniteImage360ModelProperties, CogniteModel3D):
-    """This represents the reading format of cognite image 360 model.
+    """This represents the reading format of Cognite image 360 model.
 
     It is used to when data is read from CDF.
 
@@ -4120,7 +4120,7 @@ class CogniteImage360Model(CogniteImage360ModelProperties, CogniteModel3D):
 
     Args:
         space (str): The space where the node is located.
-        external_id (str): The external id of the cognite image 360 model.
+        external_id (str): The external id of the Cognite image 360 model.
         version (int): DMS version.
         last_updated_time (int): The number of milliseconds since 00:00:00 Thursday, 1 January 1970, Coordinated Universal Time (UTC), minus leap seconds.
         created_time (int): The number of milliseconds since 00:00:00 Thursday, 1 January 1970, Coordinated Universal Time (UTC), minus leap seconds.
@@ -4185,7 +4185,7 @@ class CognitePointCloudModelProperties:
 
 
 class CognitePointCloudModelApply(CognitePointCloudModelProperties, CogniteModel3DApply):
-    """This represents the writing format of cognite point cloud model.
+    """This represents the writing format of Cognite point cloud model.
 
     It is used to when data is written to CDF.
 
@@ -4193,7 +4193,7 @@ class CognitePointCloudModelApply(CognitePointCloudModelProperties, CogniteModel
 
     Args:
         space (str): The space where the node is located.
-        external_id (str): The external id of the cognite point cloud model.
+        external_id (str): The external id of the Cognite point cloud model.
         name (str | None): Name of the instance
         description (str | None): Description of the instance
         tags (list[str] | None): Text based labels for generic use, limited to 1000
@@ -4230,7 +4230,7 @@ class CognitePointCloudModelApply(CognitePointCloudModelProperties, CogniteModel
 
 
 class CognitePointCloudModel(CognitePointCloudModelProperties, CogniteModel3D):
-    """This represents the reading format of cognite point cloud model.
+    """This represents the reading format of Cognite point cloud model.
 
     It is used to when data is read from CDF.
 
@@ -4238,7 +4238,7 @@ class CognitePointCloudModel(CognitePointCloudModelProperties, CogniteModel3D):
 
     Args:
         space (str): The space where the node is located.
-        external_id (str): The external id of the cognite point cloud model.
+        external_id (str): The external id of the Cognite point cloud model.
         version (int): DMS version.
         last_updated_time (int): The number of milliseconds since 00:00:00 Thursday, 1 January 1970, Coordinated Universal Time (UTC), minus leap seconds.
         created_time (int): The number of milliseconds since 00:00:00 Thursday, 1 January 1970, Coordinated Universal Time (UTC), minus leap seconds.
@@ -4297,7 +4297,7 @@ class CognitePointCloudModel(CognitePointCloudModelProperties, CogniteModel3D):
 
 
 class CogniteDescribableEdgeApply(CogniteDescribableProperties, TypedEdgeApply):
-    """This represents the writing format of cognite describable edge.
+    """This represents the writing format of Cognite describable edge.
 
     It is used to when data is written to CDF.
 
@@ -4306,7 +4306,7 @@ class CogniteDescribableEdgeApply(CogniteDescribableProperties, TypedEdgeApply):
 
     Args:
         space (str): The space where the node is located.
-        external_id (str): The external id of the cognite describable edge.
+        external_id (str): The external id of the Cognite describable edge.
         type (DirectRelationReference | tuple[str, str]): The type of edge.
         start_node (DirectRelationReference | tuple[str, str]): Reference to the direct relation. The reference consists of a space and an external-id.
         end_node (DirectRelationReference | tuple[str, str]): Reference to the direct relation. The reference consists of a space and an external-id.
@@ -4339,7 +4339,7 @@ class CogniteDescribableEdgeApply(CogniteDescribableProperties, TypedEdgeApply):
 
 
 class CogniteDescribableEdge(CogniteDescribableProperties, TypedEdge):
-    """This represents the reading format of cognite describable edge.
+    """This represents the reading format of Cognite describable edge.
 
     It is used to when data is read from CDF.
 
@@ -4348,7 +4348,7 @@ class CogniteDescribableEdge(CogniteDescribableProperties, TypedEdge):
 
     Args:
         space (str): The space where the node is located.
-        external_id (str): The external id of the cognite describable edge.
+        external_id (str): The external id of the Cognite describable edge.
         type (DirectRelationReference): The type of edge.
         start_node (DirectRelationReference): Reference to the direct relation. The reference consists of a space and an external-id.
         end_node (DirectRelationReference): Reference to the direct relation. The reference consists of a space and an external-id.
@@ -4413,13 +4413,13 @@ class CogniteDescribableEdge(CogniteDescribableProperties, TypedEdge):
 
 
 class CogniteSourceableEdgeApply(CogniteSourceableProperties, TypedEdgeApply):
-    """This represents the writing format of cognite sourceable edge.
+    """This represents the writing format of Cognite sourceable edge.
 
     It is used to when data is written to CDF.
 
     Args:
         space (str): The space where the node is located.
-        external_id (str): The external id of the cognite sourceable edge.
+        external_id (str): The external id of the Cognite sourceable edge.
         type (DirectRelationReference | tuple[str, str]): The type of edge.
         start_node (DirectRelationReference | tuple[str, str]): Reference to the direct relation. The reference consists of a space and an external-id.
         end_node (DirectRelationReference | tuple[str, str]): Reference to the direct relation. The reference consists of a space and an external-id.
@@ -4461,13 +4461,13 @@ class CogniteSourceableEdgeApply(CogniteSourceableProperties, TypedEdgeApply):
 
 
 class CogniteSourceableEdge(CogniteSourceableProperties, TypedEdge):
-    """This represents the reading format of cognite sourceable edge.
+    """This represents the reading format of Cognite sourceable edge.
 
     It is used to when data is read from CDF.
 
     Args:
         space (str): The space where the node is located.
-        external_id (str): The external id of the cognite sourceable edge.
+        external_id (str): The external id of the Cognite sourceable edge.
         type (DirectRelationReference): The type of edge.
         start_node (DirectRelationReference): Reference to the direct relation. The reference consists of a space and an external-id.
         end_node (DirectRelationReference): Reference to the direct relation. The reference consists of a space and an external-id.
@@ -4544,7 +4544,7 @@ class CogniteSourceableEdge(CogniteSourceableProperties, TypedEdge):
 
 
 class CogniteTransformation3DEdgeApply(CogniteTransformation3DProperties, TypedEdgeApply):
-    """This represents the writing format of cognite transformation 3 d edge.
+    """This represents the writing format of Cognite transformation 3D edge.
 
     It is used to when data is written to CDF.
 
@@ -4553,7 +4553,7 @@ class CogniteTransformation3DEdgeApply(CogniteTransformation3DProperties, TypedE
 
     Args:
         space (str): The space where the node is located.
-        external_id (str): The external id of the cognite transformation 3 d edge.
+        external_id (str): The external id of the Cognite transformation 3D edge.
         type (DirectRelationReference | tuple[str, str]): The type of edge.
         start_node (DirectRelationReference | tuple[str, str]): Reference to the direct relation. The reference consists of a space and an external-id.
         end_node (DirectRelationReference | tuple[str, str]): Reference to the direct relation. The reference consists of a space and an external-id.
@@ -4601,7 +4601,7 @@ class CogniteTransformation3DEdgeApply(CogniteTransformation3DProperties, TypedE
 
 
 class CogniteTransformation3DEdge(CogniteTransformation3DProperties, TypedEdge):
-    """This represents the reading format of cognite transformation 3 d edge.
+    """This represents the reading format of Cognite transformation 3D edge.
 
     It is used to when data is read from CDF.
 
@@ -4610,7 +4610,7 @@ class CogniteTransformation3DEdge(CogniteTransformation3DProperties, TypedEdge):
 
     Args:
         space (str): The space where the node is located.
-        external_id (str): The external id of the cognite transformation 3 d edge.
+        external_id (str): The external id of the Cognite transformation 3D edge.
         type (DirectRelationReference): The type of edge.
         start_node (DirectRelationReference): Reference to the direct relation. The reference consists of a space and an external-id.
         end_node (DirectRelationReference): Reference to the direct relation. The reference consists of a space and an external-id.
@@ -4701,7 +4701,7 @@ class CogniteAnnotationProperties:
 
 
 class CogniteAnnotationApply(CogniteAnnotationProperties, CogniteDescribableEdgeApply, CogniteSourceableEdgeApply):
-    """This represents the writing format of cognite annotation.
+    """This represents the writing format of Cognite annotation.
 
     It is used to when data is written to CDF.
 
@@ -4709,7 +4709,7 @@ class CogniteAnnotationApply(CogniteAnnotationProperties, CogniteDescribableEdge
 
     Args:
         space (str): The space where the node is located.
-        external_id (str): The external id of the cognite annotation.
+        external_id (str): The external id of the Cognite annotation.
         type (DirectRelationReference | tuple[str, str]): The type of edge.
         start_node (DirectRelationReference | tuple[str, str]): Reference to the direct relation. The reference consists of a space and an external-id.
         end_node (DirectRelationReference | tuple[str, str]): Reference to the direct relation. The reference consists of a space and an external-id.
@@ -4786,7 +4786,7 @@ class CogniteAnnotationApply(CogniteAnnotationProperties, CogniteDescribableEdge
 
 
 class CogniteAnnotation(CogniteAnnotationProperties, CogniteDescribableEdge, CogniteSourceableEdge):
-    """This represents the reading format of cognite annotation.
+    """This represents the reading format of Cognite annotation.
 
     It is used to when data is read from CDF.
 
@@ -4794,7 +4794,7 @@ class CogniteAnnotation(CogniteAnnotationProperties, CogniteDescribableEdge, Cog
 
     Args:
         space (str): The space where the node is located.
-        external_id (str): The external id of the cognite annotation.
+        external_id (str): The external id of the Cognite annotation.
         type (DirectRelationReference): The type of edge.
         start_node (DirectRelationReference): Reference to the direct relation. The reference consists of a space and an external-id.
         end_node (DirectRelationReference): Reference to the direct relation. The reference consists of a space and an external-id.
@@ -4925,7 +4925,7 @@ class CogniteDiagramAnnotationProperties:
 
 
 class CogniteDiagramAnnotationApply(CogniteDiagramAnnotationProperties, CogniteAnnotationApply):
-    """This represents the writing format of cognite diagram annotation.
+    """This represents the writing format of Cognite diagram annotation.
 
     It is used to when data is written to CDF.
 
@@ -4933,7 +4933,7 @@ class CogniteDiagramAnnotationApply(CogniteDiagramAnnotationProperties, CogniteA
 
     Args:
         space (str): The space where the node is located.
-        external_id (str): The external id of the cognite diagram annotation.
+        external_id (str): The external id of the Cognite diagram annotation.
         type (DirectRelationReference | tuple[str, str]): The type of edge.
         start_node (DirectRelationReference | tuple[str, str]): Reference to the direct relation. The reference consists of a space and an external-id.
         end_node (DirectRelationReference | tuple[str, str]): Reference to the direct relation. The reference consists of a space and an external-id.
@@ -5036,7 +5036,7 @@ class CogniteDiagramAnnotationApply(CogniteDiagramAnnotationProperties, CogniteA
 
 
 class CogniteDiagramAnnotation(CogniteDiagramAnnotationProperties, CogniteAnnotation):
-    """This represents the reading format of cognite diagram annotation.
+    """This represents the reading format of Cognite diagram annotation.
 
     It is used to when data is read from CDF.
 
@@ -5044,7 +5044,7 @@ class CogniteDiagramAnnotation(CogniteDiagramAnnotationProperties, CogniteAnnota
 
     Args:
         space (str): The space where the node is located.
-        external_id (str): The external id of the cognite diagram annotation.
+        external_id (str): The external id of the Cognite diagram annotation.
         type (DirectRelationReference): The type of edge.
         start_node (DirectRelationReference): Reference to the direct relation. The reference consists of a space and an external-id.
         end_node (DirectRelationReference): Reference to the direct relation. The reference consists of a space and an external-id.
@@ -5199,13 +5199,13 @@ class CogniteImage360AnnotationProperties:
 
 
 class CogniteImage360AnnotationApply(CogniteImage360AnnotationProperties, CogniteAnnotationApply):
-    """This represents the writing format of cognite image 360 annotation.
+    """This represents the writing format of Cognite image 360 annotation.
 
     It is used to when data is written to CDF.
 
     Args:
         space (str): The space where the node is located.
-        external_id (str): The external id of the cognite image 360 annotation.
+        external_id (str): The external id of the Cognite image 360 annotation.
         type (DirectRelationReference | tuple[str, str]): The type of edge.
         start_node (DirectRelationReference | tuple[str, str]): Reference to the direct relation. The reference consists of a space and an external-id.
         end_node (DirectRelationReference | tuple[str, str]): Reference to the direct relation. The reference consists of a space and an external-id.
@@ -5278,13 +5278,13 @@ class CogniteImage360AnnotationApply(CogniteImage360AnnotationProperties, Cognit
 
 
 class CogniteImage360Annotation(CogniteImage360AnnotationProperties, CogniteAnnotation):
-    """This represents the reading format of cognite image 360 annotation.
+    """This represents the reading format of Cognite image 360 annotation.
 
     It is used to when data is read from CDF.
 
     Args:
         space (str): The space where the node is located.
-        external_id (str): The external id of the cognite image 360 annotation.
+        external_id (str): The external id of the Cognite image 360 annotation.
         type (DirectRelationReference): The type of edge.
         start_node (DirectRelationReference): Reference to the direct relation. The reference consists of a space and an external-id.
         end_node (DirectRelationReference): Reference to the direct relation. The reference consists of a space and an external-id.

--- a/cognite/client/data_classes/cdm/v1.py
+++ b/cognite/client/data_classes/cdm/v1.py
@@ -12,9 +12,6 @@ from cognite.client.data_classes.data_modeling.typed_instances import (
     TypedNode,
     TypedNodeApply,
 )
-from cognite.client.utils._experimental import FeaturePreviewWarning
-
-FeaturePreviewWarning("alpha", "alpha", "Core Data Model").warn()
 
 
 class CogniteDescribableProperties:

--- a/cognite/client/data_classes/cdm/v1.py
+++ b/cognite/client/data_classes/cdm/v1.py
@@ -2409,7 +2409,7 @@ class CogniteActivity(CogniteActivityProperties, CogniteDescribableNode, Cognite
             scheduled_end_time=self.scheduled_end_time,
             assets=self.assets,  # type: ignore[arg-type]
             equipment=self.equipment,  # type: ignore[arg-type]
-            time_series=self.time_series,  # type: ignore[arg-type]
+            time_series=self.time_series,
             existing_version=self.version,
             type=self.type,
         )

--- a/cognite/client/data_classes/cdm/v1.py
+++ b/cognite/client/data_classes/cdm/v1.py
@@ -17,6 +17,209 @@ from cognite.client.utils._experimental import FeaturePreviewWarning
 FeaturePreviewWarning("alpha", "alpha", "Core Data Model").warn()
 
 
+class CogniteDescribableProperties:
+    @classmethod
+    def get_source(cls) -> ViewId:
+        return ViewId("cdf_cdm_experimental", "CogniteDescribable", "v1")
+
+
+class CogniteDescribableNodeApply(CogniteDescribableProperties, TypedNodeApply):
+    """This represents the writing format of cognite describable node.
+
+    It is used to when data is written to CDF.
+
+    The describable core concept is used as a standard way of holding the bare minimum of information about the instance
+
+
+    Args:
+        space (str): The space where the node is located.
+        external_id (str): The external id of the cognite describable node.
+        name (str | None): Name of the instance
+        description (str | None): Description of the instance
+        tags (list[str] | None): Text based labels for generic use, limited to 1000
+        aliases (list[str] | None): Alternative names for the node
+        existing_version (int | None): Fail the ingestion request if the node's version is greater than or equal to this value. If no existingVersion is specified, the ingestion will always overwrite any existing data for the node (for the specified container or node). If existingVersion is set to 0, the upsert will behave as an insert, so it will fail the bulk if the item already exists. If skipOnVersionConflict is set on the ingestion request, then the item will be skipped instead of failing the ingestion request.
+        type (DirectRelationReference | tuple[str, str] | None): Direct relation pointing to the type node.
+    """
+
+    def __init__(
+        self,
+        space: str,
+        external_id: str,
+        *,
+        name: str | None = None,
+        description: str | None = None,
+        tags: list[str] | None = None,
+        aliases: list[str] | None = None,
+        existing_version: int | None = None,
+        type: DirectRelationReference | tuple[str, str] | None = None,
+    ) -> None:
+        TypedNodeApply.__init__(self, space, external_id, existing_version, None, type)
+        self.name = name
+        self.description = description
+        self.tags = tags
+        self.aliases = aliases
+
+
+class CogniteDescribableNode(CogniteDescribableProperties, TypedNode):
+    """This represents the reading format of cognite describable node.
+
+    It is used to when data is read from CDF.
+
+    The describable core concept is used as a standard way of holding the bare minimum of information about the instance
+
+
+    Args:
+        space (str): The space where the node is located.
+        external_id (str): The external id of the cognite describable node.
+        version (int): DMS version.
+        last_updated_time (int): The number of milliseconds since 00:00:00 Thursday, 1 January 1970, Coordinated Universal Time (UTC), minus leap seconds.
+        created_time (int): The number of milliseconds since 00:00:00 Thursday, 1 January 1970, Coordinated Universal Time (UTC), minus leap seconds.
+        name (str | None): Name of the instance
+        description (str | None): Description of the instance
+        tags (list[str] | None): Text based labels for generic use, limited to 1000
+        aliases (list[str] | None): Alternative names for the node
+        type (DirectRelationReference | None): Direct relation pointing to the type node.
+        deleted_time (int | None): The number of milliseconds since 00:00:00 Thursday, 1 January 1970, Coordinated Universal Time (UTC), minus leap seconds. Timestamp when the instance was soft deleted. Note that deleted instances are filtered out of query results, but present in sync results
+    """
+
+    def __init__(
+        self,
+        space: str,
+        external_id: str,
+        version: int,
+        last_updated_time: int,
+        created_time: int,
+        *,
+        name: str | None = None,
+        description: str | None = None,
+        tags: list[str] | None = None,
+        aliases: list[str] | None = None,
+        type: DirectRelationReference | None = None,
+        deleted_time: int | None = None,
+    ) -> None:
+        TypedNode.__init__(self, space, external_id, version, last_updated_time, created_time, deleted_time, None, type)
+        self.name = name
+        self.description = description
+        self.tags = tags
+        self.aliases = aliases
+
+    def as_write(self) -> CogniteDescribableNodeApply:
+        return CogniteDescribableNodeApply(
+            self.space,
+            self.external_id,
+            name=self.name,
+            description=self.description,
+            tags=self.tags,
+            aliases=self.aliases,
+            existing_version=self.version,
+            type=self.type,
+        )
+
+
+class CogniteSchedulableProperties:
+    start_time = PropertyOptions("startTime")
+    end_time = PropertyOptions("endTime")
+    scheduled_start_time = PropertyOptions("scheduledStartTime")
+    scheduled_end_time = PropertyOptions("scheduledEndTime")
+
+    @classmethod
+    def get_source(cls) -> ViewId:
+        return ViewId("cdf_cdm_experimental", "CogniteSchedulable", "v1")
+
+
+class CogniteSchedulableApply(CogniteSchedulableProperties, TypedNodeApply):
+    """This represents the writing format of cognite schedulable.
+
+    It is used to when data is written to CDF.
+
+    CogniteSchedulable represents the metadata about when an activity (or similar) starts and ends.
+
+    Args:
+        space (str): The space where the node is located.
+        external_id (str): The external id of the cognite schedulable.
+        start_time (datetime | None): The actual start time of an activity (or similar that extends this)
+        end_time (datetime | None): The actual end time of an activity (or similar that extends this)
+        scheduled_start_time (datetime | None): The planned start time of an activity (or similar that extends this)
+        scheduled_end_time (datetime | None): The planned end time of an activity (or similar that extends this)
+        existing_version (int | None): Fail the ingestion request if the node's version is greater than or equal to this value. If no existingVersion is specified, the ingestion will always overwrite any existing data for the node (for the specified container or node). If existingVersion is set to 0, the upsert will behave as an insert, so it will fail the bulk if the item already exists. If skipOnVersionConflict is set on the ingestion request, then the item will be skipped instead of failing the ingestion request.
+        type (DirectRelationReference | tuple[str, str] | None): Direct relation pointing to the type node.
+    """
+
+    def __init__(
+        self,
+        space: str,
+        external_id: str,
+        *,
+        start_time: datetime | None = None,
+        end_time: datetime | None = None,
+        scheduled_start_time: datetime | None = None,
+        scheduled_end_time: datetime | None = None,
+        existing_version: int | None = None,
+        type: DirectRelationReference | tuple[str, str] | None = None,
+    ) -> None:
+        TypedNodeApply.__init__(self, space, external_id, existing_version, None, type)
+        self.start_time = start_time
+        self.end_time = end_time
+        self.scheduled_start_time = scheduled_start_time
+        self.scheduled_end_time = scheduled_end_time
+
+
+class CogniteSchedulable(CogniteSchedulableProperties, TypedNode):
+    """This represents the reading format of cognite schedulable.
+
+    It is used to when data is read from CDF.
+
+    CogniteSchedulable represents the metadata about when an activity (or similar) starts and ends.
+
+    Args:
+        space (str): The space where the node is located.
+        external_id (str): The external id of the cognite schedulable.
+        version (int): DMS version.
+        last_updated_time (int): The number of milliseconds since 00:00:00 Thursday, 1 January 1970, Coordinated Universal Time (UTC), minus leap seconds.
+        created_time (int): The number of milliseconds since 00:00:00 Thursday, 1 January 1970, Coordinated Universal Time (UTC), minus leap seconds.
+        start_time (datetime | None): The actual start time of an activity (or similar that extends this)
+        end_time (datetime | None): The actual end time of an activity (or similar that extends this)
+        scheduled_start_time (datetime | None): The planned start time of an activity (or similar that extends this)
+        scheduled_end_time (datetime | None): The planned end time of an activity (or similar that extends this)
+        type (DirectRelationReference | None): Direct relation pointing to the type node.
+        deleted_time (int | None): The number of milliseconds since 00:00:00 Thursday, 1 January 1970, Coordinated Universal Time (UTC), minus leap seconds. Timestamp when the instance was soft deleted. Note that deleted instances are filtered out of query results, but present in sync results
+    """
+
+    def __init__(
+        self,
+        space: str,
+        external_id: str,
+        version: int,
+        last_updated_time: int,
+        created_time: int,
+        *,
+        start_time: datetime | None = None,
+        end_time: datetime | None = None,
+        scheduled_start_time: datetime | None = None,
+        scheduled_end_time: datetime | None = None,
+        type: DirectRelationReference | None = None,
+        deleted_time: int | None = None,
+    ) -> None:
+        TypedNode.__init__(self, space, external_id, version, last_updated_time, created_time, deleted_time, None, type)
+        self.start_time = start_time
+        self.end_time = end_time
+        self.scheduled_start_time = scheduled_start_time
+        self.scheduled_end_time = scheduled_end_time
+
+    def as_write(self) -> CogniteSchedulableApply:
+        return CogniteSchedulableApply(
+            self.space,
+            self.external_id,
+            start_time=self.start_time,
+            end_time=self.end_time,
+            scheduled_start_time=self.scheduled_start_time,
+            scheduled_end_time=self.scheduled_end_time,
+            existing_version=self.version,
+            type=self.type,
+        )
+
+
 class CogniteSourceableProperties:
     source_id = PropertyOptions("sourceId")
     source_context = PropertyOptions("sourceContext")
@@ -31,10 +234,28 @@ class CogniteSourceableProperties:
 
 
 class CogniteSourceableNodeApply(CogniteSourceableProperties, TypedNodeApply):
+    """This represents the writing format of cognite sourceable node.
+
+    It is used to when data is written to CDF.
+    Args:
+        space (str): The space where the node is located.
+        external_id (str): The external id of the cognite sourceable node.
+        source_id (str | None): Identifier from the source system
+        source_context (str | None): Context of the source id. For systems where the sourceId is globally unique, the sourceContext is expected to not be set.
+        source (DirectRelationReference | tuple[str, str] | None): Direct relation to a source system
+        source_created_time (datetime | None): When the instance was created in source system (if available)
+        source_updated_time (datetime | None): When the instance was last updated in the source system (if available)
+        source_created_user (str | None): User identifier from the source system on who created the source data. This identifier is not guaranteed to match the user identifiers in CDF
+        source_updated_user (str | None): User identifier from the source system on who last updated the source data. This identifier is not guaranteed to match the user identifiers in CDF
+        existing_version (int | None): Fail the ingestion request if the node's version is greater than or equal to this value. If no existingVersion is specified, the ingestion will always overwrite any existing data for the node (for the specified container or node). If existingVersion is set to 0, the upsert will behave as an insert, so it will fail the bulk if the item already exists. If skipOnVersionConflict is set on the ingestion request, then the item will be skipped instead of failing the ingestion request.
+        type (DirectRelationReference | tuple[str, str] | None): Direct relation pointing to the type node.
+    """
+
     def __init__(
         self,
         space: str,
         external_id: str,
+        *,
         source_id: str | None = None,
         source_context: str | None = None,
         source: DirectRelationReference | tuple[str, str] | None = None,
@@ -56,6 +277,27 @@ class CogniteSourceableNodeApply(CogniteSourceableProperties, TypedNodeApply):
 
 
 class CogniteSourceableNode(CogniteSourceableProperties, TypedNode):
+    """This represents the reading format of cognite sourceable node.
+
+    It is used to when data is read from CDF.
+
+    Args:
+        space (str): The space where the node is located.
+        external_id (str): The external id of the cognite sourceable node.
+        version (int): DMS version.
+        last_updated_time (int): The number of milliseconds since 00:00:00 Thursday, 1 January 1970, Coordinated Universal Time (UTC), minus leap seconds.
+        created_time (int): The number of milliseconds since 00:00:00 Thursday, 1 January 1970, Coordinated Universal Time (UTC), minus leap seconds.
+        source_id (str | None): Identifier from the source system
+        source_context (str | None): Context of the source id. For systems where the sourceId is globally unique, the sourceContext is expected to not be set.
+        source (DirectRelationReference | None): Direct relation to a source system
+        source_created_time (datetime | None): When the instance was created in source system (if available)
+        source_updated_time (datetime | None): When the instance was last updated in the source system (if available)
+        source_created_user (str | None): User identifier from the source system on who created the source data. This identifier is not guaranteed to match the user identifiers in CDF
+        source_updated_user (str | None): User identifier from the source system on who last updated the source data. This identifier is not guaranteed to match the user identifiers in CDF
+        type (DirectRelationReference | None): Direct relation pointing to the type node.
+        deleted_time (int | None): The number of milliseconds since 00:00:00 Thursday, 1 January 1970, Coordinated Universal Time (UTC), minus leap seconds. Timestamp when the instance was soft deleted. Note that deleted instances are filtered out of query results, but present in sync results
+    """
+
     def __init__(
         self,
         space: str,
@@ -63,6 +305,7 @@ class CogniteSourceableNode(CogniteSourceableProperties, TypedNode):
         version: int,
         last_updated_time: int,
         created_time: int,
+        *,
         source_id: str | None = None,
         source_context: str | None = None,
         source: DirectRelationReference | None = None,
@@ -86,143 +329,20 @@ class CogniteSourceableNode(CogniteSourceableProperties, TypedNode):
         return CogniteSourceableNodeApply(
             self.space,
             self.external_id,
-            self.source_id,
-            self.source_context,
-            self.source,
-            self.source_created_time,
-            self.source_updated_time,
-            self.source_created_user,
-            self.source_updated_user,
-            self.version,
-            self.type,
-        )
-
-
-class CogniteDescribableProperties:
-    @classmethod
-    def get_source(cls) -> ViewId:
-        return ViewId("cdf_cdm_experimental", "CogniteDescribable", "v1")
-
-
-class CogniteDescribableNodeApply(CogniteDescribableProperties, TypedNodeApply):
-    def __init__(
-        self,
-        space: str,
-        external_id: str,
-        name: str | None = None,
-        description: str | None = None,
-        tags: list[str] | None = None,
-        aliases: list[str] | None = None,
-        existing_version: int | None = None,
-        type: DirectRelationReference | tuple[str, str] | None = None,
-    ) -> None:
-        TypedNodeApply.__init__(self, space, external_id, existing_version, None, type)
-        self.name = name
-        self.description = description
-        self.tags = tags
-        self.aliases = aliases
-
-
-class CogniteDescribableNode(CogniteDescribableProperties, TypedNode):
-    def __init__(
-        self,
-        space: str,
-        external_id: str,
-        version: int,
-        last_updated_time: int,
-        created_time: int,
-        name: str | None = None,
-        description: str | None = None,
-        tags: list[str] | None = None,
-        aliases: list[str] | None = None,
-        type: DirectRelationReference | None = None,
-        deleted_time: int | None = None,
-    ) -> None:
-        TypedNode.__init__(self, space, external_id, version, last_updated_time, created_time, deleted_time, None, type)
-        self.name = name
-        self.description = description
-        self.tags = tags
-        self.aliases = aliases
-
-    def as_write(self) -> CogniteDescribableNodeApply:
-        return CogniteDescribableNodeApply(
-            self.space,
-            self.external_id,
-            self.name,
-            self.description,
-            self.tags,
-            self.aliases,
-            self.version,
-            self.type,
-        )
-
-
-class CogniteSchedulableProperties:
-    start_time = PropertyOptions("startTime")
-    end_time = PropertyOptions("endTime")
-    scheduled_start_time = PropertyOptions("scheduledStartTime")
-    scheduled_end_time = PropertyOptions("scheduledEndTime")
-
-    @classmethod
-    def get_source(cls) -> ViewId:
-        return ViewId("cdf_cdm_experimental", "CogniteSchedulable", "v1")
-
-
-class CogniteSchedulableApply(CogniteSchedulableProperties, TypedNodeApply):
-    def __init__(
-        self,
-        space: str,
-        external_id: str,
-        start_time: datetime | None = None,
-        end_time: datetime | None = None,
-        scheduled_start_time: datetime | None = None,
-        scheduled_end_time: datetime | None = None,
-        existing_version: int | None = None,
-        type: DirectRelationReference | tuple[str, str] | None = None,
-    ) -> None:
-        TypedNodeApply.__init__(self, space, external_id, existing_version, None, type)
-        self.start_time = start_time
-        self.end_time = end_time
-        self.scheduled_start_time = scheduled_start_time
-        self.scheduled_end_time = scheduled_end_time
-
-
-class CogniteSchedulable(CogniteSchedulableProperties, TypedNode):
-    def __init__(
-        self,
-        space: str,
-        external_id: str,
-        version: int,
-        last_updated_time: int,
-        created_time: int,
-        start_time: datetime | None = None,
-        end_time: datetime | None = None,
-        scheduled_start_time: datetime | None = None,
-        scheduled_end_time: datetime | None = None,
-        type: DirectRelationReference | None = None,
-        deleted_time: int | None = None,
-    ) -> None:
-        TypedNode.__init__(self, space, external_id, version, last_updated_time, created_time, deleted_time, None, type)
-        self.start_time = start_time
-        self.end_time = end_time
-        self.scheduled_start_time = scheduled_start_time
-        self.scheduled_end_time = scheduled_end_time
-
-    def as_write(self) -> CogniteSchedulableApply:
-        return CogniteSchedulableApply(
-            self.space,
-            self.external_id,
-            self.start_time,
-            self.end_time,
-            self.scheduled_start_time,
-            self.scheduled_end_time,
-            self.version,
-            self.type,
+            source_id=self.source_id,
+            source_context=self.source_context,
+            source=self.source,
+            source_created_time=self.source_created_time,
+            source_updated_time=self.source_updated_time,
+            source_created_user=self.source_created_user,
+            source_updated_user=self.source_updated_user,
+            existing_version=self.version,
+            type=self.type,
         )
 
 
 class CogniteVisualizableProperties:
-    object_3_d = PropertyOptions("object3D")
+    object_3d = PropertyOptions("object3D")
 
     @classmethod
     def get_source(cls) -> ViewId:
@@ -230,19 +350,51 @@ class CogniteVisualizableProperties:
 
 
 class CogniteVisualizableApply(CogniteVisualizableProperties, TypedNodeApply):
+    """This represents the writing format of cognite visualizable.
+
+    It is used to when data is written to CDF.
+
+    CogniteVisualizable defines the standard way to reference a related 3D resource
+
+    Args:
+        space (str): The space where the node is located.
+        external_id (str): The external id of the cognite visualizable.
+        object_3d (DirectRelationReference | tuple[str, str] | None): Direct relation to an Object3D instance representing the 3D resource
+        existing_version (int | None): Fail the ingestion request if the node's version is greater than or equal to this value. If no existingVersion is specified, the ingestion will always overwrite any existing data for the node (for the specified container or node). If existingVersion is set to 0, the upsert will behave as an insert, so it will fail the bulk if the item already exists. If skipOnVersionConflict is set on the ingestion request, then the item will be skipped instead of failing the ingestion request.
+        type (DirectRelationReference | tuple[str, str] | None): Direct relation pointing to the type node.
+    """
+
     def __init__(
         self,
         space: str,
         external_id: str,
-        object_3_d: DirectRelationReference | tuple[str, str] | None = None,
+        *,
+        object_3d: DirectRelationReference | tuple[str, str] | None = None,
         existing_version: int | None = None,
         type: DirectRelationReference | tuple[str, str] | None = None,
     ) -> None:
         TypedNodeApply.__init__(self, space, external_id, existing_version, None, type)
-        self.object_3_d = DirectRelationReference.load(object_3_d) if object_3_d else None
+        self.object_3d = DirectRelationReference.load(object_3d) if object_3d else None
 
 
 class CogniteVisualizable(CogniteVisualizableProperties, TypedNode):
+    """This represents the reading format of cognite visualizable.
+
+    It is used to when data is read from CDF.
+
+    CogniteVisualizable defines the standard way to reference a related 3D resource
+
+    Args:
+        space (str): The space where the node is located.
+        external_id (str): The external id of the cognite visualizable.
+        version (int): DMS version.
+        last_updated_time (int): The number of milliseconds since 00:00:00 Thursday, 1 January 1970, Coordinated Universal Time (UTC), minus leap seconds.
+        created_time (int): The number of milliseconds since 00:00:00 Thursday, 1 January 1970, Coordinated Universal Time (UTC), minus leap seconds.
+        object_3d (DirectRelationReference | None): Direct relation to an Object3D instance representing the 3D resource
+        type (DirectRelationReference | None): Direct relation pointing to the type node.
+        deleted_time (int | None): The number of milliseconds since 00:00:00 Thursday, 1 January 1970, Coordinated Universal Time (UTC), minus leap seconds. Timestamp when the instance was soft deleted. Note that deleted instances are filtered out of query results, but present in sync results
+    """
+
     def __init__(
         self,
         space: str,
@@ -250,26 +402,27 @@ class CogniteVisualizable(CogniteVisualizableProperties, TypedNode):
         version: int,
         last_updated_time: int,
         created_time: int,
-        object_3_d: DirectRelationReference | None = None,
+        *,
+        object_3d: DirectRelationReference | None = None,
         type: DirectRelationReference | None = None,
         deleted_time: int | None = None,
     ) -> None:
         TypedNode.__init__(self, space, external_id, version, last_updated_time, created_time, deleted_time, None, type)
-        self.object_3_d = DirectRelationReference.load(object_3_d) if object_3_d else None
+        self.object_3d = DirectRelationReference.load(object_3d) if object_3d else None
 
     def as_write(self) -> CogniteVisualizableApply:
         return CogniteVisualizableApply(
             self.space,
             self.external_id,
-            self.object_3_d,
-            self.version,
-            self.type,
+            object_3d=self.object_3d,
+            existing_version=self.version,
+            type=self.type,
         )
 
 
 class CogniteRevision3DProperties:
     type_ = PropertyOptions("type")
-    model_3_d = PropertyOptions("model3D")
+    model_3d = PropertyOptions("model3D")
 
     @classmethod
     def get_source(cls) -> ViewId:
@@ -277,14 +430,33 @@ class CogniteRevision3DProperties:
 
 
 class CogniteRevision3DApply(CogniteRevision3DProperties, TypedNodeApply):
+    """This represents the writing format of cognite revision 3d.
+
+    It is used to when data is written to CDF.
+
+    Shared revision information for various 3D data types. Normally not used directly, but through CognitePointCloudRevision, Image360Collection or CogniteCADRevision
+
+
+    Args:
+        space (str): The space where the node is located.
+        external_id (str): The external id of the cognite revision 3d.
+        status (Literal["Done", "Failed", "Processing", "Queued"] | None): The status field.
+        published (Literal["Done", "Failed", "Processing", "Queued"] | None): The published field.
+        type_ (Literal["CAD", "Image360", "PointCloud"] | None): The type field.
+        model_3d (DirectRelationReference | tuple[str, str] | None): The model 3d field.
+        existing_version (int | None): Fail the ingestion request if the node's version is greater than or equal to this value. If no existingVersion is specified, the ingestion will always overwrite any existing data for the node (for the specified container or node). If existingVersion is set to 0, the upsert will behave as an insert, so it will fail the bulk if the item already exists. If skipOnVersionConflict is set on the ingestion request, then the item will be skipped instead of failing the ingestion request.
+        type (DirectRelationReference | tuple[str, str] | None): Direct relation pointing to the type node.
+    """
+
     def __init__(
         self,
         space: str,
         external_id: str,
+        *,
         status: Literal["Done", "Failed", "Processing", "Queued"] | None = None,
         published: Literal["Done", "Failed", "Processing", "Queued"] | None = None,
         type_: Literal["CAD", "Image360", "PointCloud"] | None = None,
-        model_3_d: DirectRelationReference | tuple[str, str] | None = None,
+        model_3d: DirectRelationReference | tuple[str, str] | None = None,
         existing_version: int | None = None,
         type: DirectRelationReference | tuple[str, str] | None = None,
     ) -> None:
@@ -292,10 +464,31 @@ class CogniteRevision3DApply(CogniteRevision3DProperties, TypedNodeApply):
         self.status = status
         self.published = published
         self.type_ = type_
-        self.model_3_d = DirectRelationReference.load(model_3_d) if model_3_d else None
+        self.model_3d = DirectRelationReference.load(model_3d) if model_3d else None
 
 
 class CogniteRevision3D(CogniteRevision3DProperties, TypedNode):
+    """This represents the reading format of cognite revision 3d.
+
+    It is used to when data is read from CDF.
+
+    Shared revision information for various 3D data types. Normally not used directly, but through CognitePointCloudRevision, Image360Collection or CogniteCADRevision
+
+
+    Args:
+        space (str): The space where the node is located.
+        external_id (str): The external id of the cognite revision 3d.
+        version (int): DMS version.
+        last_updated_time (int): The number of milliseconds since 00:00:00 Thursday, 1 January 1970, Coordinated Universal Time (UTC), minus leap seconds.
+        created_time (int): The number of milliseconds since 00:00:00 Thursday, 1 January 1970, Coordinated Universal Time (UTC), minus leap seconds.
+        status (Literal["Done", "Failed", "Processing", "Queued"] | None): The status field.
+        published (Literal["Done", "Failed", "Processing", "Queued"] | None): The published field.
+        type_ (Literal["CAD", "Image360", "PointCloud"] | None): The type field.
+        model_3d (DirectRelationReference | None): The model 3d field.
+        type (DirectRelationReference | None): Direct relation pointing to the type node.
+        deleted_time (int | None): The number of milliseconds since 00:00:00 Thursday, 1 January 1970, Coordinated Universal Time (UTC), minus leap seconds. Timestamp when the instance was soft deleted. Note that deleted instances are filtered out of query results, but present in sync results
+    """
+
     def __init__(
         self,
         space: str,
@@ -303,10 +496,11 @@ class CogniteRevision3D(CogniteRevision3DProperties, TypedNode):
         version: int,
         last_updated_time: int,
         created_time: int,
+        *,
         status: Literal["Done", "Failed", "Processing", "Queued"] | None = None,
         published: Literal["Done", "Failed", "Processing", "Queued"] | None = None,
         type_: Literal["CAD", "Image360", "PointCloud"] | None = None,
-        model_3_d: DirectRelationReference | None = None,
+        model_3d: DirectRelationReference | None = None,
         type: DirectRelationReference | None = None,
         deleted_time: int | None = None,
     ) -> None:
@@ -314,18 +508,18 @@ class CogniteRevision3D(CogniteRevision3DProperties, TypedNode):
         self.status = status
         self.published = published
         self.type_ = type_
-        self.model_3_d = DirectRelationReference.load(model_3_d) if model_3_d else None
+        self.model_3d = DirectRelationReference.load(model_3d) if model_3d else None
 
     def as_write(self) -> CogniteRevision3DApply:
         return CogniteRevision3DApply(
             self.space,
             self.external_id,
-            self.status,
-            self.published,
-            self.type_,
-            self.model_3_d,
-            self.version,
-            self.type,
+            status=self.status,
+            published=self.published,
+            type_=self.type_,
+            model_3d=self.model_3d,
+            existing_version=self.version,
+            type=self.type,
         )
 
 
@@ -336,10 +530,31 @@ class CogniteCubeMapProperties:
 
 
 class CogniteCubeMapApply(CogniteCubeMapProperties, TypedNodeApply):
+    """This represents the writing format of cognite cube map.
+
+    It is used to when data is written to CDF.
+
+    The cube map holds references to projections for a cube surrounding an 3D entity extending this, such as CogniteImage360
+
+
+    Args:
+        space (str): The space where the node is located.
+        external_id (str): The external id of the cognite cube map.
+        front (DirectRelationReference | tuple[str, str] | None): Direct relation to a file holding the front projection of the cube map
+        back (DirectRelationReference | tuple[str, str] | None): Direct relation to a file holding the back projection of the cube map
+        left (DirectRelationReference | tuple[str, str] | None): Direct relation to a file holding the left projection of the cube map
+        right (DirectRelationReference | tuple[str, str] | None): Direct relation to a file holding the right projection of the cube map
+        top (DirectRelationReference | tuple[str, str] | None): Direct relation to a file holding the top projection of the cube map
+        bottom (DirectRelationReference | tuple[str, str] | None): Direct relation to a file holding the bottom projection of the cube map
+        existing_version (int | None): Fail the ingestion request if the node's version is greater than or equal to this value. If no existingVersion is specified, the ingestion will always overwrite any existing data for the node (for the specified container or node). If existingVersion is set to 0, the upsert will behave as an insert, so it will fail the bulk if the item already exists. If skipOnVersionConflict is set on the ingestion request, then the item will be skipped instead of failing the ingestion request.
+        type (DirectRelationReference | tuple[str, str] | None): Direct relation pointing to the type node.
+    """
+
     def __init__(
         self,
         space: str,
         external_id: str,
+        *,
         front: DirectRelationReference | tuple[str, str] | None = None,
         back: DirectRelationReference | tuple[str, str] | None = None,
         left: DirectRelationReference | tuple[str, str] | None = None,
@@ -359,6 +574,29 @@ class CogniteCubeMapApply(CogniteCubeMapProperties, TypedNodeApply):
 
 
 class CogniteCubeMap(CogniteCubeMapProperties, TypedNode):
+    """This represents the reading format of cognite cube map.
+
+    It is used to when data is read from CDF.
+
+    The cube map holds references to projections for a cube surrounding an 3D entity extending this, such as CogniteImage360
+
+
+    Args:
+        space (str): The space where the node is located.
+        external_id (str): The external id of the cognite cube map.
+        version (int): DMS version.
+        last_updated_time (int): The number of milliseconds since 00:00:00 Thursday, 1 January 1970, Coordinated Universal Time (UTC), minus leap seconds.
+        created_time (int): The number of milliseconds since 00:00:00 Thursday, 1 January 1970, Coordinated Universal Time (UTC), minus leap seconds.
+        front (DirectRelationReference | None): Direct relation to a file holding the front projection of the cube map
+        back (DirectRelationReference | None): Direct relation to a file holding the back projection of the cube map
+        left (DirectRelationReference | None): Direct relation to a file holding the left projection of the cube map
+        right (DirectRelationReference | None): Direct relation to a file holding the right projection of the cube map
+        top (DirectRelationReference | None): Direct relation to a file holding the top projection of the cube map
+        bottom (DirectRelationReference | None): Direct relation to a file holding the bottom projection of the cube map
+        type (DirectRelationReference | None): Direct relation pointing to the type node.
+        deleted_time (int | None): The number of milliseconds since 00:00:00 Thursday, 1 January 1970, Coordinated Universal Time (UTC), minus leap seconds. Timestamp when the instance was soft deleted. Note that deleted instances are filtered out of query results, but present in sync results
+    """
+
     def __init__(
         self,
         space: str,
@@ -366,6 +604,7 @@ class CogniteCubeMap(CogniteCubeMapProperties, TypedNode):
         version: int,
         last_updated_time: int,
         created_time: int,
+        *,
         front: DirectRelationReference | None = None,
         back: DirectRelationReference | None = None,
         left: DirectRelationReference | None = None,
@@ -387,14 +626,14 @@ class CogniteCubeMap(CogniteCubeMapProperties, TypedNode):
         return CogniteCubeMapApply(
             self.space,
             self.external_id,
-            self.front,
-            self.back,
-            self.left,
-            self.right,
-            self.top,
-            self.bottom,
-            self.version,
-            self.type,
+            front=self.front,
+            back=self.back,
+            left=self.left,
+            right=self.right,
+            top=self.top,
+            bottom=self.bottom,
+            existing_version=self.version,
+            type=self.type,
         )
 
 
@@ -415,10 +654,34 @@ class CogniteTransformation3DProperties:
 
 
 class CogniteTransformation3DNodeApply(CogniteTransformation3DProperties, TypedNodeApply):
+    """This represents the writing format of cognite transformation 3 d node.
+
+    It is used to when data is written to CDF.
+
+    The CogniteTransformation3D object defines a comprehensive 3D transformation, enabling precise adjustments to an object's position, orientation, and size in 3D space. It allows for the translation of objects along the three spatial axes, rotation around these axes using Euler angles, and scaling along each axis to modify the object's dimensions
+
+
+    Args:
+        space (str): The space where the node is located.
+        external_id (str): The external id of the cognite transformation 3 d node.
+        translation_x (float | None): The displacement of the object along the X-axis in 3D space
+        translation_y (float | None): The displacement of the object along the Y-axis in 3D space
+        translation_z (float | None): The displacement of the object along the Z-axis in 3D space
+        euler_rotation_x (float | None): The rotation of the object around the X-axis, measured in degrees
+        euler_rotation_y (float | None): The rotation of the object around the Y-axis, measured in degrees
+        euler_rotation_z (float | None): The rotation of the object around the Z-axis, measured in degrees
+        scale_x (float | None): The scaling factor applied to the object along the X-axis
+        scale_y (float | None): The scaling factor applied to the object along the Y-axis
+        scale_z (float | None): The scaling factor applied to the object along the Z-axis
+        existing_version (int | None): Fail the ingestion request if the node's version is greater than or equal to this value. If no existingVersion is specified, the ingestion will always overwrite any existing data for the node (for the specified container or node). If existingVersion is set to 0, the upsert will behave as an insert, so it will fail the bulk if the item already exists. If skipOnVersionConflict is set on the ingestion request, then the item will be skipped instead of failing the ingestion request.
+        type (DirectRelationReference | tuple[str, str] | None): Direct relation pointing to the type node.
+    """
+
     def __init__(
         self,
         space: str,
         external_id: str,
+        *,
         translation_x: float | None = None,
         translation_y: float | None = None,
         translation_z: float | None = None,
@@ -444,6 +707,32 @@ class CogniteTransformation3DNodeApply(CogniteTransformation3DProperties, TypedN
 
 
 class CogniteTransformation3DNode(CogniteTransformation3DProperties, TypedNode):
+    """This represents the reading format of cognite transformation 3 d node.
+
+    It is used to when data is read from CDF.
+
+    The CogniteTransformation3D object defines a comprehensive 3D transformation, enabling precise adjustments to an object's position, orientation, and size in 3D space. It allows for the translation of objects along the three spatial axes, rotation around these axes using Euler angles, and scaling along each axis to modify the object's dimensions
+
+
+    Args:
+        space (str): The space where the node is located.
+        external_id (str): The external id of the cognite transformation 3 d node.
+        version (int): DMS version.
+        last_updated_time (int): The number of milliseconds since 00:00:00 Thursday, 1 January 1970, Coordinated Universal Time (UTC), minus leap seconds.
+        created_time (int): The number of milliseconds since 00:00:00 Thursday, 1 January 1970, Coordinated Universal Time (UTC), minus leap seconds.
+        translation_x (float | None): The displacement of the object along the X-axis in 3D space
+        translation_y (float | None): The displacement of the object along the Y-axis in 3D space
+        translation_z (float | None): The displacement of the object along the Z-axis in 3D space
+        euler_rotation_x (float | None): The rotation of the object around the X-axis, measured in degrees
+        euler_rotation_y (float | None): The rotation of the object around the Y-axis, measured in degrees
+        euler_rotation_z (float | None): The rotation of the object around the Z-axis, measured in degrees
+        scale_x (float | None): The scaling factor applied to the object along the X-axis
+        scale_y (float | None): The scaling factor applied to the object along the Y-axis
+        scale_z (float | None): The scaling factor applied to the object along the Z-axis
+        type (DirectRelationReference | None): Direct relation pointing to the type node.
+        deleted_time (int | None): The number of milliseconds since 00:00:00 Thursday, 1 January 1970, Coordinated Universal Time (UTC), minus leap seconds. Timestamp when the instance was soft deleted. Note that deleted instances are filtered out of query results, but present in sync results
+    """
+
     def __init__(
         self,
         space: str,
@@ -451,6 +740,7 @@ class CogniteTransformation3DNode(CogniteTransformation3DProperties, TypedNode):
         version: int,
         last_updated_time: int,
         created_time: int,
+        *,
         translation_x: float | None = None,
         translation_y: float | None = None,
         translation_z: float | None = None,
@@ -478,17 +768,17 @@ class CogniteTransformation3DNode(CogniteTransformation3DProperties, TypedNode):
         return CogniteTransformation3DNodeApply(
             self.space,
             self.external_id,
-            self.translation_x,
-            self.translation_y,
-            self.translation_z,
-            self.euler_rotation_x,
-            self.euler_rotation_y,
-            self.euler_rotation_z,
-            self.scale_x,
-            self.scale_y,
-            self.scale_z,
-            self.version,
-            self.type,
+            translation_x=self.translation_x,
+            translation_y=self.translation_y,
+            translation_z=self.translation_z,
+            euler_rotation_x=self.euler_rotation_x,
+            euler_rotation_y=self.euler_rotation_y,
+            euler_rotation_z=self.euler_rotation_z,
+            scale_x=self.scale_x,
+            scale_y=self.scale_y,
+            scale_z=self.scale_z,
+            existing_version=self.version,
+            type=self.type,
         )
 
 
@@ -499,10 +789,30 @@ class CogniteAssetClassProperties:
 
 
 class CogniteAssetClassApply(CogniteAssetClassProperties, CogniteDescribableNodeApply):
+    """This represents the writing format of cognite asset clas.
+
+    It is used to when data is written to CDF.
+
+    This identifies the class of an asset
+
+    Args:
+        space (str): The space where the node is located.
+        external_id (str): The external id of the cognite asset clas.
+        name (str | None): Name of the instance
+        description (str | None): Description of the instance
+        tags (list[str] | None): Text based labels for generic use, limited to 1000
+        aliases (list[str] | None): Alternative names for the node
+        code (str | None): A unique identifier for the class of asset
+        standard (str | None): Textual string for which standard the code is from
+        existing_version (int | None): Fail the ingestion request if the node's version is greater than or equal to this value. If no existingVersion is specified, the ingestion will always overwrite any existing data for the node (for the specified container or node). If existingVersion is set to 0, the upsert will behave as an insert, so it will fail the bulk if the item already exists. If skipOnVersionConflict is set on the ingestion request, then the item will be skipped instead of failing the ingestion request.
+        type (DirectRelationReference | tuple[str, str] | None): Direct relation pointing to the type node.
+    """
+
     def __init__(
         self,
         space: str,
         external_id: str,
+        *,
         name: str | None = None,
         description: str | None = None,
         tags: list[str] | None = None,
@@ -512,12 +822,43 @@ class CogniteAssetClassApply(CogniteAssetClassProperties, CogniteDescribableNode
         existing_version: int | None = None,
         type: DirectRelationReference | tuple[str, str] | None = None,
     ) -> None:
-        super().__init__(space, external_id, name, description, tags, aliases, existing_version, type)
+        super().__init__(
+            space,
+            external_id,
+            name=name,
+            description=description,
+            tags=tags,
+            aliases=aliases,
+            existing_version=existing_version,
+            type=type,
+        )
         self.code = code
         self.standard = standard
 
 
 class CogniteAssetClass(CogniteAssetClassProperties, CogniteDescribableNode):
+    """This represents the reading format of cognite asset clas.
+
+    It is used to when data is read from CDF.
+
+    This identifies the class of an asset
+
+    Args:
+        space (str): The space where the node is located.
+        external_id (str): The external id of the cognite asset clas.
+        version (int): DMS version.
+        last_updated_time (int): The number of milliseconds since 00:00:00 Thursday, 1 January 1970, Coordinated Universal Time (UTC), minus leap seconds.
+        created_time (int): The number of milliseconds since 00:00:00 Thursday, 1 January 1970, Coordinated Universal Time (UTC), minus leap seconds.
+        name (str | None): Name of the instance
+        description (str | None): Description of the instance
+        tags (list[str] | None): Text based labels for generic use, limited to 1000
+        aliases (list[str] | None): Alternative names for the node
+        code (str | None): A unique identifier for the class of asset
+        standard (str | None): Textual string for which standard the code is from
+        type (DirectRelationReference | None): Direct relation pointing to the type node.
+        deleted_time (int | None): The number of milliseconds since 00:00:00 Thursday, 1 January 1970, Coordinated Universal Time (UTC), minus leap seconds. Timestamp when the instance was soft deleted. Note that deleted instances are filtered out of query results, but present in sync results
+    """
+
     def __init__(
         self,
         space: str,
@@ -525,6 +866,7 @@ class CogniteAssetClass(CogniteAssetClassProperties, CogniteDescribableNode):
         version: int,
         last_updated_time: int,
         created_time: int,
+        *,
         name: str | None = None,
         description: str | None = None,
         tags: list[str] | None = None,
@@ -540,12 +882,12 @@ class CogniteAssetClass(CogniteAssetClassProperties, CogniteDescribableNode):
             version,
             last_updated_time,
             created_time,
-            name,
-            description,
-            tags,
-            aliases,
-            type,
-            deleted_time,
+            name=name,
+            description=description,
+            tags=tags,
+            aliases=aliases,
+            type=type,
+            deleted_time=deleted_time,
         )
         self.code = code
         self.standard = standard
@@ -554,14 +896,14 @@ class CogniteAssetClass(CogniteAssetClassProperties, CogniteDescribableNode):
         return CogniteAssetClassApply(
             self.space,
             self.external_id,
-            self.name,
-            self.description,
-            self.tags,
-            self.aliases,
-            self.code,
-            self.standard,
-            self.version,
-            self.type,
+            name=self.name,
+            description=self.description,
+            tags=self.tags,
+            aliases=self.aliases,
+            code=self.code,
+            standard=self.standard,
+            existing_version=self.version,
+            type=self.type,
         )
 
 
@@ -574,10 +916,30 @@ class CogniteAssetTypeProperties:
 
 
 class CogniteAssetTypeApply(CogniteAssetTypeProperties, CogniteDescribableNodeApply):
+    """This represents the writing format of cognite asset type.
+
+    It is used to when data is written to CDF.
+
+    This identifies the type of an asset
+
+    Args:
+        space (str): The space where the node is located.
+        external_id (str): The external id of the cognite asset type.
+        name (str | None): Name of the instance
+        description (str | None): Description of the instance
+        tags (list[str] | None): Text based labels for generic use, limited to 1000
+        aliases (list[str] | None): Alternative names for the node
+        code (str | None): A unique identifier for the type of asset
+        asset_class (DirectRelationReference | tuple[str, str] | None): Class of this type, direct relation to CogniteAssetClass
+        existing_version (int | None): Fail the ingestion request if the node's version is greater than or equal to this value. If no existingVersion is specified, the ingestion will always overwrite any existing data for the node (for the specified container or node). If existingVersion is set to 0, the upsert will behave as an insert, so it will fail the bulk if the item already exists. If skipOnVersionConflict is set on the ingestion request, then the item will be skipped instead of failing the ingestion request.
+        type (DirectRelationReference | tuple[str, str] | None): Direct relation pointing to the type node.
+    """
+
     def __init__(
         self,
         space: str,
         external_id: str,
+        *,
         name: str | None = None,
         description: str | None = None,
         tags: list[str] | None = None,
@@ -587,12 +949,43 @@ class CogniteAssetTypeApply(CogniteAssetTypeProperties, CogniteDescribableNodeAp
         existing_version: int | None = None,
         type: DirectRelationReference | tuple[str, str] | None = None,
     ) -> None:
-        super().__init__(space, external_id, name, description, tags, aliases, existing_version, type)
+        super().__init__(
+            space,
+            external_id,
+            name=name,
+            description=description,
+            tags=tags,
+            aliases=aliases,
+            existing_version=existing_version,
+            type=type,
+        )
         self.code = code
         self.asset_class = DirectRelationReference.load(asset_class) if asset_class else None
 
 
 class CogniteAssetType(CogniteAssetTypeProperties, CogniteDescribableNode):
+    """This represents the reading format of cognite asset type.
+
+    It is used to when data is read from CDF.
+
+    This identifies the type of an asset
+
+    Args:
+        space (str): The space where the node is located.
+        external_id (str): The external id of the cognite asset type.
+        version (int): DMS version.
+        last_updated_time (int): The number of milliseconds since 00:00:00 Thursday, 1 January 1970, Coordinated Universal Time (UTC), minus leap seconds.
+        created_time (int): The number of milliseconds since 00:00:00 Thursday, 1 January 1970, Coordinated Universal Time (UTC), minus leap seconds.
+        name (str | None): Name of the instance
+        description (str | None): Description of the instance
+        tags (list[str] | None): Text based labels for generic use, limited to 1000
+        aliases (list[str] | None): Alternative names for the node
+        code (str | None): A unique identifier for the type of asset
+        asset_class (DirectRelationReference | None): Class of this type, direct relation to CogniteAssetClass
+        type (DirectRelationReference | None): Direct relation pointing to the type node.
+        deleted_time (int | None): The number of milliseconds since 00:00:00 Thursday, 1 January 1970, Coordinated Universal Time (UTC), minus leap seconds. Timestamp when the instance was soft deleted. Note that deleted instances are filtered out of query results, but present in sync results
+    """
+
     def __init__(
         self,
         space: str,
@@ -600,6 +993,7 @@ class CogniteAssetType(CogniteAssetTypeProperties, CogniteDescribableNode):
         version: int,
         last_updated_time: int,
         created_time: int,
+        *,
         name: str | None = None,
         description: str | None = None,
         tags: list[str] | None = None,
@@ -615,12 +1009,12 @@ class CogniteAssetType(CogniteAssetTypeProperties, CogniteDescribableNode):
             version,
             last_updated_time,
             created_time,
-            name,
-            description,
-            tags,
-            aliases,
-            type,
-            deleted_time,
+            name=name,
+            description=description,
+            tags=tags,
+            aliases=aliases,
+            type=type,
+            deleted_time=deleted_time,
         )
         self.code = code
         self.asset_class = DirectRelationReference.load(asset_class) if asset_class else None
@@ -629,20 +1023,20 @@ class CogniteAssetType(CogniteAssetTypeProperties, CogniteDescribableNode):
         return CogniteAssetTypeApply(
             self.space,
             self.external_id,
-            self.name,
-            self.description,
-            self.tags,
-            self.aliases,
-            self.code,
-            self.asset_class,
-            self.version,
-            self.type,
+            name=self.name,
+            description=self.description,
+            tags=self.tags,
+            aliases=self.aliases,
+            code=self.code,
+            asset_class=self.asset_class,
+            existing_version=self.version,
+            type=self.type,
         )
 
 
 class CogniteCADNodeProperties:
-    object_3_d = PropertyOptions("object3D")
-    model_3_d = PropertyOptions("model3D")
+    object_3d = PropertyOptions("object3D")
+    model_3d = PropertyOptions("model3D")
     cad_node_reference = PropertyOptions("cadNodeReference")
     tree_indexes = PropertyOptions("treeIndexes")
     sub_tree_sizes = PropertyOptions("subTreeSizes")
@@ -653,16 +1047,40 @@ class CogniteCADNodeProperties:
 
 
 class CogniteCADNodeApply(CogniteCADNodeProperties, CogniteDescribableNodeApply):
+    """This represents the writing format of cognite cad node.
+
+    It is used to when data is written to CDF.
+
+    Represents nodes from the 3D model that have been contextualized
+
+    Args:
+        space (str): The space where the node is located.
+        external_id (str): The external id of the cognite cad node.
+        name (str | None): Name of the instance
+        description (str | None): Description of the instance
+        tags (list[str] | None): Text based labels for generic use, limited to 1000
+        aliases (list[str] | None): Alternative names for the node
+        object_3d (DirectRelationReference | tuple[str, str] | None): Direct relation to object3D grouping for this node
+        model_3d (DirectRelationReference | tuple[str, str] | None): Direct relation to CogniteModel3D
+        cad_node_reference (str | None): Reference to a node within a CAD model from the 3D API
+        revisions (list[DirectRelationReference | tuple[str, str]] | None): List of direct relations to instances of CogniteRevision3D which this CogniteCADNode exists in.
+        tree_indexes (list[int] | None): List of tree indexes in the same order as revisions. Used by Reveal and similar applications to map from CogniteCADNode to tree index
+        sub_tree_sizes (list[int] | None): List of subtree sizes in the same order as revisions. Used by Reveal and similar applications to know how many nodes exists below this node in the hierarchy
+        existing_version (int | None): Fail the ingestion request if the node's version is greater than or equal to this value. If no existingVersion is specified, the ingestion will always overwrite any existing data for the node (for the specified container or node). If existingVersion is set to 0, the upsert will behave as an insert, so it will fail the bulk if the item already exists. If skipOnVersionConflict is set on the ingestion request, then the item will be skipped instead of failing the ingestion request.
+        type (DirectRelationReference | tuple[str, str] | None): Direct relation pointing to the type node.
+    """
+
     def __init__(
         self,
         space: str,
         external_id: str,
+        *,
         name: str | None = None,
         description: str | None = None,
         tags: list[str] | None = None,
         aliases: list[str] | None = None,
-        object_3_d: DirectRelationReference | tuple[str, str] | None = None,
-        model_3_d: DirectRelationReference | tuple[str, str] | None = None,
+        object_3d: DirectRelationReference | tuple[str, str] | None = None,
+        model_3d: DirectRelationReference | tuple[str, str] | None = None,
         cad_node_reference: str | None = None,
         revisions: list[DirectRelationReference | tuple[str, str]] | None = None,
         tree_indexes: list[int] | None = None,
@@ -670,9 +1088,18 @@ class CogniteCADNodeApply(CogniteCADNodeProperties, CogniteDescribableNodeApply)
         existing_version: int | None = None,
         type: DirectRelationReference | tuple[str, str] | None = None,
     ) -> None:
-        super().__init__(space, external_id, name, description, tags, aliases, existing_version, type)
-        self.object_3_d = DirectRelationReference.load(object_3_d) if object_3_d else None
-        self.model_3_d = DirectRelationReference.load(model_3_d) if model_3_d else None
+        super().__init__(
+            space,
+            external_id,
+            name=name,
+            description=description,
+            tags=tags,
+            aliases=aliases,
+            existing_version=existing_version,
+            type=type,
+        )
+        self.object_3d = DirectRelationReference.load(object_3d) if object_3d else None
+        self.model_3d = DirectRelationReference.load(model_3d) if model_3d else None
         self.cad_node_reference = cad_node_reference
         self.revisions = [DirectRelationReference.load(revision) for revision in revisions] if revisions else None
         self.tree_indexes = tree_indexes
@@ -680,6 +1107,32 @@ class CogniteCADNodeApply(CogniteCADNodeProperties, CogniteDescribableNodeApply)
 
 
 class CogniteCADNode(CogniteCADNodeProperties, CogniteDescribableNode):
+    """This represents the reading format of cognite cad node.
+
+    It is used to when data is read from CDF.
+
+    Represents nodes from the 3D model that have been contextualized
+
+    Args:
+        space (str): The space where the node is located.
+        external_id (str): The external id of the cognite cad node.
+        version (int): DMS version.
+        last_updated_time (int): The number of milliseconds since 00:00:00 Thursday, 1 January 1970, Coordinated Universal Time (UTC), minus leap seconds.
+        created_time (int): The number of milliseconds since 00:00:00 Thursday, 1 January 1970, Coordinated Universal Time (UTC), minus leap seconds.
+        name (str | None): Name of the instance
+        description (str | None): Description of the instance
+        tags (list[str] | None): Text based labels for generic use, limited to 1000
+        aliases (list[str] | None): Alternative names for the node
+        object_3d (DirectRelationReference | None): Direct relation to object3D grouping for this node
+        model_3d (DirectRelationReference | None): Direct relation to CogniteModel3D
+        cad_node_reference (str | None): Reference to a node within a CAD model from the 3D API
+        revisions (list[DirectRelationReference] | None): List of direct relations to instances of CogniteRevision3D which this CogniteCADNode exists in.
+        tree_indexes (list[int] | None): List of tree indexes in the same order as revisions. Used by Reveal and similar applications to map from CogniteCADNode to tree index
+        sub_tree_sizes (list[int] | None): List of subtree sizes in the same order as revisions. Used by Reveal and similar applications to know how many nodes exists below this node in the hierarchy
+        type (DirectRelationReference | None): Direct relation pointing to the type node.
+        deleted_time (int | None): The number of milliseconds since 00:00:00 Thursday, 1 January 1970, Coordinated Universal Time (UTC), minus leap seconds. Timestamp when the instance was soft deleted. Note that deleted instances are filtered out of query results, but present in sync results
+    """
+
     def __init__(
         self,
         space: str,
@@ -687,12 +1140,13 @@ class CogniteCADNode(CogniteCADNodeProperties, CogniteDescribableNode):
         version: int,
         last_updated_time: int,
         created_time: int,
+        *,
         name: str | None = None,
         description: str | None = None,
         tags: list[str] | None = None,
         aliases: list[str] | None = None,
-        object_3_d: DirectRelationReference | None = None,
-        model_3_d: DirectRelationReference | None = None,
+        object_3d: DirectRelationReference | None = None,
+        model_3d: DirectRelationReference | None = None,
         cad_node_reference: str | None = None,
         revisions: list[DirectRelationReference] | None = None,
         tree_indexes: list[int] | None = None,
@@ -706,15 +1160,15 @@ class CogniteCADNode(CogniteCADNodeProperties, CogniteDescribableNode):
             version,
             last_updated_time,
             created_time,
-            name,
-            description,
-            tags,
-            aliases,
-            type,
-            deleted_time,
+            name=name,
+            description=description,
+            tags=tags,
+            aliases=aliases,
+            type=type,
+            deleted_time=deleted_time,
         )
-        self.object_3_d = DirectRelationReference.load(object_3_d) if object_3_d else None
-        self.model_3_d = DirectRelationReference.load(model_3_d) if model_3_d else None
+        self.object_3d = DirectRelationReference.load(object_3d) if object_3d else None
+        self.model_3d = DirectRelationReference.load(model_3d) if model_3d else None
         self.cad_node_reference = cad_node_reference
         self.revisions = [DirectRelationReference.load(revision) for revision in revisions] if revisions else None
         self.tree_indexes = tree_indexes
@@ -724,159 +1178,18 @@ class CogniteCADNode(CogniteCADNodeProperties, CogniteDescribableNode):
         return CogniteCADNodeApply(
             self.space,
             self.external_id,
-            self.name,
-            self.description,
-            self.tags,
-            self.aliases,
-            self.object_3_d,
-            self.model_3_d,
-            self.cad_node_reference,
-            self.revisions,  # type: ignore[arg-type]
-            self.tree_indexes,
-            self.sub_tree_sizes,
-            self.version,
-            self.type,
-        )
-
-
-class CogniteEquipmentProperties:
-    serial_number = PropertyOptions("serialNumber")
-    equipment_type = PropertyOptions("equipmentType")
-
-    @classmethod
-    def get_source(cls) -> ViewId:
-        return ViewId("cdf_cdm_experimental", "CogniteEquipment", "v1")
-
-
-class CogniteEquipmentApply(CogniteEquipmentProperties, CogniteDescribableNodeApply, CogniteSourceableNodeApply):
-    def __init__(
-        self,
-        space: str,
-        external_id: str,
-        name: str | None = None,
-        description: str | None = None,
-        tags: list[str] | None = None,
-        aliases: list[str] | None = None,
-        source_id: str | None = None,
-        source_context: str | None = None,
-        source: DirectRelationReference | tuple[str, str] | None = None,
-        source_created_time: datetime | None = None,
-        source_updated_time: datetime | None = None,
-        source_created_user: str | None = None,
-        source_updated_user: str | None = None,
-        serial_number: str | None = None,
-        manufacturer: str | None = None,
-        equipment_type: DirectRelationReference | tuple[str, str] | None = None,
-        files: list[DirectRelationReference | tuple[str, str]] | None = None,
-        existing_version: int | None = None,
-        type: DirectRelationReference | tuple[str, str] | None = None,
-    ) -> None:
-        CogniteDescribableNodeApply.__init__(
-            self, space, external_id, name, description, tags, aliases, existing_version, type
-        )
-        CogniteSourceableNodeApply.__init__(
-            self,
-            space,
-            external_id,
-            source_id,
-            source_context,
-            source,
-            source_created_time,
-            source_updated_time,
-            source_created_user,
-            source_updated_user,
-            existing_version,
-            type,
-        )
-        self.serial_number = serial_number
-        self.manufacturer = manufacturer
-        self.equipment_type = DirectRelationReference.load(equipment_type) if equipment_type else None
-        self.files = [DirectRelationReference.load(file) for file in files] if files else None
-
-
-class CogniteEquipment(CogniteEquipmentProperties, CogniteDescribableNode, CogniteSourceableNode):
-    def __init__(
-        self,
-        space: str,
-        external_id: str,
-        version: int,
-        last_updated_time: int,
-        created_time: int,
-        name: str | None = None,
-        description: str | None = None,
-        tags: list[str] | None = None,
-        aliases: list[str] | None = None,
-        source_id: str | None = None,
-        source_context: str | None = None,
-        source: DirectRelationReference | None = None,
-        source_created_time: datetime | None = None,
-        source_updated_time: datetime | None = None,
-        source_created_user: str | None = None,
-        source_updated_user: str | None = None,
-        serial_number: str | None = None,
-        manufacturer: str | None = None,
-        equipment_type: DirectRelationReference | None = None,
-        files: list[DirectRelationReference] | None = None,
-        type: DirectRelationReference | None = None,
-        deleted_time: int | None = None,
-    ) -> None:
-        CogniteDescribableNode.__init__(
-            self,
-            space,
-            external_id,
-            version,
-            last_updated_time,
-            created_time,
-            name,
-            description,
-            tags,
-            aliases,
-            type,
-            deleted_time,
-        )
-        CogniteSourceableNode.__init__(
-            self,
-            space,
-            external_id,
-            version,
-            last_updated_time,
-            created_time,
-            source_id,
-            source_context,
-            source,
-            source_created_time,
-            source_updated_time,
-            source_created_user,
-            source_updated_user,
-            type,
-            deleted_time,
-        )
-        self.serial_number = serial_number
-        self.manufacturer = manufacturer
-        self.equipment_type = DirectRelationReference.load(equipment_type) if equipment_type else None
-        self.files = [DirectRelationReference.load(file) for file in files] if files else None
-
-    def as_write(self) -> CogniteEquipmentApply:
-        return CogniteEquipmentApply(
-            self.space,
-            self.external_id,
-            self.name,
-            self.description,
-            self.tags,
-            self.aliases,
-            self.source_id,
-            self.source_context,
-            self.source,
-            self.source_created_time,
-            self.source_updated_time,
-            self.source_created_user,
-            self.source_updated_user,
-            self.serial_number,
-            self.manufacturer,
-            self.equipment_type,
-            self.files,  # type: ignore[arg-type]
-            self.version,
-            self.type,
+            name=self.name,
+            description=self.description,
+            tags=self.tags,
+            aliases=self.aliases,
+            object_3d=self.object_3d,
+            model_3d=self.model_3d,
+            cad_node_reference=self.cad_node_reference,
+            revisions=self.revisions,  # type: ignore[arg-type]
+            tree_indexes=self.tree_indexes,
+            sub_tree_sizes=self.sub_tree_sizes,
+            existing_version=self.version,
+            type=self.type,
         )
 
 
@@ -890,10 +1203,32 @@ class CogniteEquipmentTypeProperties:
 
 
 class CogniteEquipmentTypeApply(CogniteEquipmentTypeProperties, CogniteDescribableNodeApply):
+    """This represents the writing format of cognite equipment type.
+
+    It is used to when data is written to CDF.
+
+    This identifies the type of an equipment
+
+    Args:
+        space (str): The space where the node is located.
+        external_id (str): The external id of the cognite equipment type.
+        name (str | None): Name of the instance
+        description (str | None): Description of the instance
+        tags (list[str] | None): Text based labels for generic use, limited to 1000
+        aliases (list[str] | None): Alternative names for the node
+        code (str | None): A unique identifier for the type of equipment
+        equipment_class (str | None): Class of equipment
+        standard (str | None): Identifier for which standard this equipment type is sourced from, such as ISO14224 or similar
+        standard_reference (str | None): Reference to the source of the equipment specification
+        existing_version (int | None): Fail the ingestion request if the node's version is greater than or equal to this value. If no existingVersion is specified, the ingestion will always overwrite any existing data for the node (for the specified container or node). If existingVersion is set to 0, the upsert will behave as an insert, so it will fail the bulk if the item already exists. If skipOnVersionConflict is set on the ingestion request, then the item will be skipped instead of failing the ingestion request.
+        type (DirectRelationReference | tuple[str, str] | None): Direct relation pointing to the type node.
+    """
+
     def __init__(
         self,
         space: str,
         external_id: str,
+        *,
         name: str | None = None,
         description: str | None = None,
         tags: list[str] | None = None,
@@ -905,7 +1240,16 @@ class CogniteEquipmentTypeApply(CogniteEquipmentTypeProperties, CogniteDescribab
         existing_version: int | None = None,
         type: DirectRelationReference | tuple[str, str] | None = None,
     ) -> None:
-        super().__init__(space, external_id, name, description, tags, aliases, existing_version, type)
+        super().__init__(
+            space,
+            external_id,
+            name=name,
+            description=description,
+            tags=tags,
+            aliases=aliases,
+            existing_version=existing_version,
+            type=type,
+        )
         self.code = code
         self.equipment_class = equipment_class
         self.standard = standard
@@ -913,6 +1257,30 @@ class CogniteEquipmentTypeApply(CogniteEquipmentTypeProperties, CogniteDescribab
 
 
 class CogniteEquipmentType(CogniteEquipmentTypeProperties, CogniteDescribableNode):
+    """This represents the reading format of cognite equipment type.
+
+    It is used to when data is read from CDF.
+
+    This identifies the type of an equipment
+
+    Args:
+        space (str): The space where the node is located.
+        external_id (str): The external id of the cognite equipment type.
+        version (int): DMS version.
+        last_updated_time (int): The number of milliseconds since 00:00:00 Thursday, 1 January 1970, Coordinated Universal Time (UTC), minus leap seconds.
+        created_time (int): The number of milliseconds since 00:00:00 Thursday, 1 January 1970, Coordinated Universal Time (UTC), minus leap seconds.
+        name (str | None): Name of the instance
+        description (str | None): Description of the instance
+        tags (list[str] | None): Text based labels for generic use, limited to 1000
+        aliases (list[str] | None): Alternative names for the node
+        code (str | None): A unique identifier for the type of equipment
+        equipment_class (str | None): Class of equipment
+        standard (str | None): Identifier for which standard this equipment type is sourced from, such as ISO14224 or similar
+        standard_reference (str | None): Reference to the source of the equipment specification
+        type (DirectRelationReference | None): Direct relation pointing to the type node.
+        deleted_time (int | None): The number of milliseconds since 00:00:00 Thursday, 1 January 1970, Coordinated Universal Time (UTC), minus leap seconds. Timestamp when the instance was soft deleted. Note that deleted instances are filtered out of query results, but present in sync results
+    """
+
     def __init__(
         self,
         space: str,
@@ -920,6 +1288,7 @@ class CogniteEquipmentType(CogniteEquipmentTypeProperties, CogniteDescribableNod
         version: int,
         last_updated_time: int,
         created_time: int,
+        *,
         name: str | None = None,
         description: str | None = None,
         tags: list[str] | None = None,
@@ -937,12 +1306,12 @@ class CogniteEquipmentType(CogniteEquipmentTypeProperties, CogniteDescribableNod
             version,
             last_updated_time,
             created_time,
-            name,
-            description,
-            tags,
-            aliases,
-            type,
-            deleted_time,
+            name=name,
+            description=description,
+            tags=tags,
+            aliases=aliases,
+            type=type,
+            deleted_time=deleted_time,
         )
         self.code = code
         self.equipment_class = equipment_class
@@ -953,168 +1322,16 @@ class CogniteEquipmentType(CogniteEquipmentTypeProperties, CogniteDescribableNod
         return CogniteEquipmentTypeApply(
             self.space,
             self.external_id,
-            self.name,
-            self.description,
-            self.tags,
-            self.aliases,
-            self.code,
-            self.equipment_class,
-            self.standard,
-            self.standard_reference,
-            self.version,
-            self.type,
-        )
-
-
-class CogniteFileProperties:
-    mime_type = PropertyOptions("mimeType")
-    is_uploaded = PropertyOptions("isUploaded")
-    uploaded_time = PropertyOptions("uploadedTime")
-
-    @classmethod
-    def get_source(cls) -> ViewId:
-        return ViewId("cdf_cdm_experimental", "CogniteFile", "v1")
-
-
-class CogniteFileApply(CogniteFileProperties, CogniteDescribableNodeApply, CogniteSourceableNodeApply):
-    def __init__(
-        self,
-        space: str,
-        external_id: str,
-        name: str | None = None,
-        description: str | None = None,
-        tags: list[str] | None = None,
-        aliases: list[str] | None = None,
-        source_id: str | None = None,
-        source_context: str | None = None,
-        source: DirectRelationReference | tuple[str, str] | None = None,
-        source_created_time: datetime | None = None,
-        source_updated_time: datetime | None = None,
-        source_created_user: str | None = None,
-        source_updated_user: str | None = None,
-        assets: list[DirectRelationReference | tuple[str, str]] | None = None,
-        mime_type: str | None = None,
-        directory: str | None = None,
-        is_uploaded: bool | None = None,
-        uploaded_time: datetime | None = None,
-        category: DirectRelationReference | tuple[str, str] | None = None,
-        existing_version: int | None = None,
-        type: DirectRelationReference | tuple[str, str] | None = None,
-    ) -> None:
-        CogniteDescribableNodeApply.__init__(
-            self, space, external_id, name, description, tags, aliases, existing_version, type
-        )
-        CogniteSourceableNodeApply.__init__(
-            self,
-            space,
-            external_id,
-            source_id,
-            source_context,
-            source,
-            source_created_time,
-            source_updated_time,
-            source_created_user,
-            source_updated_user,
-            existing_version,
-            type,
-        )
-        self.assets = [DirectRelationReference.load(asset) for asset in assets] if assets else None
-        self.mime_type = mime_type
-        self.directory = directory
-        self.is_uploaded = is_uploaded
-        self.uploaded_time = uploaded_time
-        self.category = DirectRelationReference.load(category) if category else None
-
-
-class CogniteFile(CogniteFileProperties, CogniteDescribableNode, CogniteSourceableNode):
-    def __init__(
-        self,
-        space: str,
-        external_id: str,
-        version: int,
-        last_updated_time: int,
-        created_time: int,
-        name: str | None = None,
-        description: str | None = None,
-        tags: list[str] | None = None,
-        aliases: list[str] | None = None,
-        source_id: str | None = None,
-        source_context: str | None = None,
-        source: DirectRelationReference | None = None,
-        source_created_time: datetime | None = None,
-        source_updated_time: datetime | None = None,
-        source_created_user: str | None = None,
-        source_updated_user: str | None = None,
-        assets: list[DirectRelationReference] | None = None,
-        mime_type: str | None = None,
-        directory: str | None = None,
-        is_uploaded: bool | None = None,
-        uploaded_time: datetime | None = None,
-        category: DirectRelationReference | None = None,
-        type: DirectRelationReference | None = None,
-        deleted_time: int | None = None,
-    ) -> None:
-        CogniteDescribableNode.__init__(
-            self,
-            space,
-            external_id,
-            version,
-            last_updated_time,
-            created_time,
-            name,
-            description,
-            tags,
-            aliases,
-            type,
-            deleted_time,
-        )
-        CogniteSourceableNode.__init__(
-            self,
-            space,
-            external_id,
-            version,
-            last_updated_time,
-            created_time,
-            source_id,
-            source_context,
-            source,
-            source_created_time,
-            source_updated_time,
-            source_created_user,
-            source_updated_user,
-            type,
-            deleted_time,
-        )
-        self.assets = [DirectRelationReference.load(asset) for asset in assets] if assets else None
-        self.mime_type = mime_type
-        self.directory = directory
-        self.is_uploaded = is_uploaded
-        self.uploaded_time = uploaded_time
-        self.category = DirectRelationReference.load(category) if category else None
-
-    def as_write(self) -> CogniteFileApply:
-        return CogniteFileApply(
-            self.space,
-            self.external_id,
-            self.name,
-            self.description,
-            self.tags,
-            self.aliases,
-            self.source_id,
-            self.source_context,
-            self.source,
-            self.source_created_time,
-            self.source_updated_time,
-            self.source_created_user,
-            self.source_updated_user,
-            self.assets,  # type: ignore[arg-type]
-            self.mime_type,
-            self.directory,
-            self.is_uploaded,
-            self.uploaded_time,
-            self.category,
-            self.version,
-            self.type,
+            name=self.name,
+            description=self.description,
+            tags=self.tags,
+            aliases=self.aliases,
+            code=self.code,
+            equipment_class=self.equipment_class,
+            standard=self.standard,
+            standard_reference=self.standard_reference,
+            existing_version=self.version,
+            type=self.type,
         )
 
 
@@ -1127,10 +1344,31 @@ class CogniteFileCategoryProperties:
 
 
 class CogniteFileCategoryApply(CogniteFileCategoryProperties, CogniteDescribableNodeApply):
+    """This represents the writing format of cognite file category.
+
+    It is used to when data is written to CDF.
+
+    This identifies the category of file as found through contextualization/categorization
+
+    Args:
+        space (str): The space where the node is located.
+        external_id (str): The external id of the cognite file category.
+        code (str): Identified category code, such as 'AA' for Accounting (from Norsok)
+        name (str | None): Name of the instance
+        description (str | None): Description of the instance
+        tags (list[str] | None): Text based labels for generic use, limited to 1000
+        aliases (list[str] | None): Alternative names for the node
+        standard (str | None): Name of the standard the category originates from, such as 'Norsok'
+        standard_reference (str | None): Reference to the source of the category standard
+        existing_version (int | None): Fail the ingestion request if the node's version is greater than or equal to this value. If no existingVersion is specified, the ingestion will always overwrite any existing data for the node (for the specified container or node). If existingVersion is set to 0, the upsert will behave as an insert, so it will fail the bulk if the item already exists. If skipOnVersionConflict is set on the ingestion request, then the item will be skipped instead of failing the ingestion request.
+        type (DirectRelationReference | tuple[str, str] | None): Direct relation pointing to the type node.
+    """
+
     def __init__(
         self,
         space: str,
         external_id: str,
+        *,
         code: str,
         name: str | None = None,
         description: str | None = None,
@@ -1141,13 +1379,45 @@ class CogniteFileCategoryApply(CogniteFileCategoryProperties, CogniteDescribable
         existing_version: int | None = None,
         type: DirectRelationReference | tuple[str, str] | None = None,
     ) -> None:
-        super().__init__(space, external_id, name, description, tags, aliases, existing_version, type)
+        super().__init__(
+            space,
+            external_id,
+            name=name,
+            description=description,
+            tags=tags,
+            aliases=aliases,
+            existing_version=existing_version,
+            type=type,
+        )
         self.code = code
         self.standard = standard
         self.standard_reference = standard_reference
 
 
 class CogniteFileCategory(CogniteFileCategoryProperties, CogniteDescribableNode):
+    """This represents the reading format of cognite file category.
+
+    It is used to when data is read from CDF.
+
+    This identifies the category of file as found through contextualization/categorization
+
+    Args:
+        space (str): The space where the node is located.
+        external_id (str): The external id of the cognite file category.
+        version (int): DMS version.
+        last_updated_time (int): The number of milliseconds since 00:00:00 Thursday, 1 January 1970, Coordinated Universal Time (UTC), minus leap seconds.
+        created_time (int): The number of milliseconds since 00:00:00 Thursday, 1 January 1970, Coordinated Universal Time (UTC), minus leap seconds.
+        code (str): Identified category code, such as 'AA' for Accounting (from Norsok)
+        name (str | None): Name of the instance
+        description (str | None): Description of the instance
+        tags (list[str] | None): Text based labels for generic use, limited to 1000
+        aliases (list[str] | None): Alternative names for the node
+        standard (str | None): Name of the standard the category originates from, such as 'Norsok'
+        standard_reference (str | None): Reference to the source of the category standard
+        type (DirectRelationReference | None): Direct relation pointing to the type node.
+        deleted_time (int | None): The number of milliseconds since 00:00:00 Thursday, 1 January 1970, Coordinated Universal Time (UTC), minus leap seconds. Timestamp when the instance was soft deleted. Note that deleted instances are filtered out of query results, but present in sync results
+    """
+
     def __init__(
         self,
         space: str,
@@ -1155,6 +1425,7 @@ class CogniteFileCategory(CogniteFileCategoryProperties, CogniteDescribableNode)
         version: int,
         last_updated_time: int,
         created_time: int,
+        *,
         code: str,
         name: str | None = None,
         description: str | None = None,
@@ -1171,12 +1442,12 @@ class CogniteFileCategory(CogniteFileCategoryProperties, CogniteDescribableNode)
             version,
             last_updated_time,
             created_time,
-            name,
-            description,
-            tags,
-            aliases,
-            type,
-            deleted_time,
+            name=name,
+            description=description,
+            tags=tags,
+            aliases=aliases,
+            type=type,
+            deleted_time=deleted_time,
         )
         self.code = code
         self.standard = standard
@@ -1186,15 +1457,15 @@ class CogniteFileCategory(CogniteFileCategoryProperties, CogniteDescribableNode)
         return CogniteFileCategoryApply(
             self.space,
             self.external_id,
-            self.code,
-            self.name,
-            self.description,
-            self.tags,
-            self.aliases,
-            self.standard,
-            self.standard_reference,
-            self.version,
-            self.type,
+            code=self.code,
+            name=self.name,
+            description=self.description,
+            tags=self.tags,
+            aliases=self.aliases,
+            standard=self.standard,
+            standard_reference=self.standard_reference,
+            existing_version=self.version,
+            type=self.type,
         )
 
 
@@ -1207,10 +1478,29 @@ class CogniteImage360StationProperties:
 
 
 class CogniteImage360StationApply(CogniteImage360StationProperties, CogniteDescribableNodeApply):
+    """This represents the writing format of cognite image 360 station.
+
+    It is used to when data is written to CDF.
+
+    Navigational aid for traversing multiple CogniteImage360 instances for a single station
+
+    Args:
+        space (str): The space where the node is located.
+        external_id (str): The external id of the cognite image 360 station.
+        name (str | None): Name of the instance
+        description (str | None): Description of the instance
+        tags (list[str] | None): Text based labels for generic use, limited to 1000
+        aliases (list[str] | None): Alternative names for the node
+        group_type (Literal['Station360'] | None): Type of group
+        existing_version (int | None): Fail the ingestion request if the node's version is greater than or equal to this value. If no existingVersion is specified, the ingestion will always overwrite any existing data for the node (for the specified container or node). If existingVersion is set to 0, the upsert will behave as an insert, so it will fail the bulk if the item already exists. If skipOnVersionConflict is set on the ingestion request, then the item will be skipped instead of failing the ingestion request.
+        type (DirectRelationReference | tuple[str, str] | None): Direct relation pointing to the type node.
+    """
+
     def __init__(
         self,
         space: str,
         external_id: str,
+        *,
         name: str | None = None,
         description: str | None = None,
         tags: list[str] | None = None,
@@ -1219,11 +1509,41 @@ class CogniteImage360StationApply(CogniteImage360StationProperties, CogniteDescr
         existing_version: int | None = None,
         type: DirectRelationReference | tuple[str, str] | None = None,
     ) -> None:
-        super().__init__(space, external_id, name, description, tags, aliases, existing_version, type)
+        super().__init__(
+            space,
+            external_id,
+            name=name,
+            description=description,
+            tags=tags,
+            aliases=aliases,
+            existing_version=existing_version,
+            type=type,
+        )
         self.group_type = group_type
 
 
 class CogniteImage360Station(CogniteImage360StationProperties, CogniteDescribableNode):
+    """This represents the reading format of cognite image 360 station.
+
+    It is used to when data is read from CDF.
+
+    Navigational aid for traversing multiple CogniteImage360 instances for a single station
+
+    Args:
+        space (str): The space where the node is located.
+        external_id (str): The external id of the cognite image 360 station.
+        version (int): DMS version.
+        last_updated_time (int): The number of milliseconds since 00:00:00 Thursday, 1 January 1970, Coordinated Universal Time (UTC), minus leap seconds.
+        created_time (int): The number of milliseconds since 00:00:00 Thursday, 1 January 1970, Coordinated Universal Time (UTC), minus leap seconds.
+        name (str | None): Name of the instance
+        description (str | None): Description of the instance
+        tags (list[str] | None): Text based labels for generic use, limited to 1000
+        aliases (list[str] | None): Alternative names for the node
+        group_type (Literal['Station360'] | None): Type of group
+        type (DirectRelationReference | None): Direct relation pointing to the type node.
+        deleted_time (int | None): The number of milliseconds since 00:00:00 Thursday, 1 January 1970, Coordinated Universal Time (UTC), minus leap seconds. Timestamp when the instance was soft deleted. Note that deleted instances are filtered out of query results, but present in sync results
+    """
+
     def __init__(
         self,
         space: str,
@@ -1231,6 +1551,7 @@ class CogniteImage360Station(CogniteImage360StationProperties, CogniteDescribabl
         version: int,
         last_updated_time: int,
         created_time: int,
+        *,
         name: str | None = None,
         description: str | None = None,
         tags: list[str] | None = None,
@@ -1245,12 +1566,12 @@ class CogniteImage360Station(CogniteImage360StationProperties, CogniteDescribabl
             version,
             last_updated_time,
             created_time,
-            name,
-            description,
-            tags,
-            aliases,
-            type,
-            deleted_time,
+            name=name,
+            description=description,
+            tags=tags,
+            aliases=aliases,
+            type=type,
+            deleted_time=deleted_time,
         )
         self.group_type = group_type
 
@@ -1258,13 +1579,13 @@ class CogniteImage360Station(CogniteImage360StationProperties, CogniteDescribabl
         return CogniteImage360StationApply(
             self.space,
             self.external_id,
-            self.name,
-            self.description,
-            self.tags,
-            self.aliases,
-            self.group_type,
-            self.version,
-            self.type,
+            name=self.name,
+            description=self.description,
+            tags=self.tags,
+            aliases=self.aliases,
+            group_type=self.group_type,
+            existing_version=self.version,
+            type=self.type,
         )
 
 
@@ -1277,10 +1598,29 @@ class CogniteModel3DProperties:
 
 
 class CogniteModel3DApply(CogniteModel3DProperties, CogniteDescribableNodeApply):
+    """This represents the writing format of cognite model 3d.
+
+    It is used to when data is written to CDF.
+
+    Groups revisions of 3D data of various kinds together (CAD, PointCloud, CogniteImage360)
+
+    Args:
+        space (str): The space where the node is located.
+        external_id (str): The external id of the cognite model 3d.
+        name (str | None): Name of the instance
+        description (str | None): Description of the instance
+        tags (list[str] | None): Text based labels for generic use, limited to 1000
+        aliases (list[str] | None): Alternative names for the node
+        type_ (Literal["CAD", "Image360", "PointCloud"] | None): CAD, PointCloud or CogniteImage360
+        existing_version (int | None): Fail the ingestion request if the node's version is greater than or equal to this value. If no existingVersion is specified, the ingestion will always overwrite any existing data for the node (for the specified container or node). If existingVersion is set to 0, the upsert will behave as an insert, so it will fail the bulk if the item already exists. If skipOnVersionConflict is set on the ingestion request, then the item will be skipped instead of failing the ingestion request.
+        type (DirectRelationReference | tuple[str, str] | None): Direct relation pointing to the type node.
+    """
+
     def __init__(
         self,
         space: str,
         external_id: str,
+        *,
         name: str | None = None,
         description: str | None = None,
         tags: list[str] | None = None,
@@ -1289,11 +1629,41 @@ class CogniteModel3DApply(CogniteModel3DProperties, CogniteDescribableNodeApply)
         existing_version: int | None = None,
         type: DirectRelationReference | tuple[str, str] | None = None,
     ) -> None:
-        super().__init__(space, external_id, name, description, tags, aliases, existing_version, type)
+        super().__init__(
+            space,
+            external_id,
+            name=name,
+            description=description,
+            tags=tags,
+            aliases=aliases,
+            existing_version=existing_version,
+            type=type,
+        )
         self.type_ = type_
 
 
 class CogniteModel3D(CogniteModel3DProperties, CogniteDescribableNode):
+    """This represents the reading format of cognite model 3d.
+
+    It is used to when data is read from CDF.
+
+    Groups revisions of 3D data of various kinds together (CAD, PointCloud, CogniteImage360)
+
+    Args:
+        space (str): The space where the node is located.
+        external_id (str): The external id of the cognite model 3d.
+        version (int): DMS version.
+        last_updated_time (int): The number of milliseconds since 00:00:00 Thursday, 1 January 1970, Coordinated Universal Time (UTC), minus leap seconds.
+        created_time (int): The number of milliseconds since 00:00:00 Thursday, 1 January 1970, Coordinated Universal Time (UTC), minus leap seconds.
+        name (str | None): Name of the instance
+        description (str | None): Description of the instance
+        tags (list[str] | None): Text based labels for generic use, limited to 1000
+        aliases (list[str] | None): Alternative names for the node
+        type_ (Literal["CAD", "Image360", "PointCloud"] | None): CAD, PointCloud or CogniteImage360
+        type (DirectRelationReference | None): Direct relation pointing to the type node.
+        deleted_time (int | None): The number of milliseconds since 00:00:00 Thursday, 1 January 1970, Coordinated Universal Time (UTC), minus leap seconds. Timestamp when the instance was soft deleted. Note that deleted instances are filtered out of query results, but present in sync results
+    """
+
     def __init__(
         self,
         space: str,
@@ -1301,6 +1671,7 @@ class CogniteModel3D(CogniteModel3DProperties, CogniteDescribableNode):
         version: int,
         last_updated_time: int,
         created_time: int,
+        *,
         name: str | None = None,
         description: str | None = None,
         tags: list[str] | None = None,
@@ -1315,12 +1686,12 @@ class CogniteModel3D(CogniteModel3DProperties, CogniteDescribableNode):
             version,
             last_updated_time,
             created_time,
-            name,
-            description,
-            tags,
-            aliases,
-            type,
-            deleted_time,
+            name=name,
+            description=description,
+            tags=tags,
+            aliases=aliases,
+            type=type,
+            deleted_time=deleted_time,
         )
         self.type_ = type_
 
@@ -1328,13 +1699,13 @@ class CogniteModel3D(CogniteModel3DProperties, CogniteDescribableNode):
         return CogniteModel3DApply(
             self.space,
             self.external_id,
-            self.name,
-            self.description,
-            self.tags,
-            self.aliases,
-            self.type_,
-            self.version,
-            self.type,
+            name=self.name,
+            description=self.description,
+            tags=self.tags,
+            aliases=self.aliases,
+            type_=self.type_,
+            existing_version=self.version,
+            type=self.type,
         )
 
 
@@ -1352,10 +1723,34 @@ class CogniteObject3DProperties:
 
 
 class CogniteObject3DApply(CogniteObject3DProperties, CogniteDescribableNodeApply):
+    """This represents the writing format of cognite object 3d.
+
+    It is used to when data is written to CDF.
+
+    This is a virtual representation of an object in world space, tied to an asset and 3D resources.
+
+    Args:
+        space (str): The space where the node is located.
+        external_id (str): The external id of the cognite object 3d.
+        name (str | None): Name of the instance
+        description (str | None): Description of the instance
+        tags (list[str] | None): Text based labels for generic use, limited to 1000
+        aliases (list[str] | None): Alternative names for the node
+        x_min (float | None): Lowest X value
+        x_max (float | None): Highest X value
+        y_min (float | None): Lowest Y value
+        y_max (float | None): Highest Y value
+        z_min (float | None): Lowest Z value
+        z_max (float | None): Highest Z value
+        existing_version (int | None): Fail the ingestion request if the node's version is greater than or equal to this value. If no existingVersion is specified, the ingestion will always overwrite any existing data for the node (for the specified container or node). If existingVersion is set to 0, the upsert will behave as an insert, so it will fail the bulk if the item already exists. If skipOnVersionConflict is set on the ingestion request, then the item will be skipped instead of failing the ingestion request.
+        type (DirectRelationReference | tuple[str, str] | None): Direct relation pointing to the type node.
+    """
+
     def __init__(
         self,
         space: str,
         external_id: str,
+        *,
         name: str | None = None,
         description: str | None = None,
         tags: list[str] | None = None,
@@ -1369,7 +1764,16 @@ class CogniteObject3DApply(CogniteObject3DProperties, CogniteDescribableNodeAppl
         existing_version: int | None = None,
         type: DirectRelationReference | tuple[str, str] | None = None,
     ) -> None:
-        super().__init__(space, external_id, name, description, tags, aliases, existing_version, type)
+        super().__init__(
+            space,
+            external_id,
+            name=name,
+            description=description,
+            tags=tags,
+            aliases=aliases,
+            existing_version=existing_version,
+            type=type,
+        )
         self.x_min = x_min
         self.x_max = x_max
         self.y_min = y_min
@@ -1379,6 +1783,32 @@ class CogniteObject3DApply(CogniteObject3DProperties, CogniteDescribableNodeAppl
 
 
 class CogniteObject3D(CogniteObject3DProperties, CogniteDescribableNode):
+    """This represents the reading format of cognite object 3d.
+
+    It is used to when data is read from CDF.
+
+    This is a virtual representation of an object in world space, tied to an asset and 3D resources.
+
+    Args:
+        space (str): The space where the node is located.
+        external_id (str): The external id of the cognite object 3d.
+        version (int): DMS version.
+        last_updated_time (int): The number of milliseconds since 00:00:00 Thursday, 1 January 1970, Coordinated Universal Time (UTC), minus leap seconds.
+        created_time (int): The number of milliseconds since 00:00:00 Thursday, 1 January 1970, Coordinated Universal Time (UTC), minus leap seconds.
+        name (str | None): Name of the instance
+        description (str | None): Description of the instance
+        tags (list[str] | None): Text based labels for generic use, limited to 1000
+        aliases (list[str] | None): Alternative names for the node
+        x_min (float | None): Lowest X value
+        x_max (float | None): Highest X value
+        y_min (float | None): Lowest Y value
+        y_max (float | None): Highest Y value
+        z_min (float | None): Lowest Z value
+        z_max (float | None): Highest Z value
+        type (DirectRelationReference | None): Direct relation pointing to the type node.
+        deleted_time (int | None): The number of milliseconds since 00:00:00 Thursday, 1 January 1970, Coordinated Universal Time (UTC), minus leap seconds. Timestamp when the instance was soft deleted. Note that deleted instances are filtered out of query results, but present in sync results
+    """
+
     def __init__(
         self,
         space: str,
@@ -1386,6 +1816,7 @@ class CogniteObject3D(CogniteObject3DProperties, CogniteDescribableNode):
         version: int,
         last_updated_time: int,
         created_time: int,
+        *,
         name: str | None = None,
         description: str | None = None,
         tags: list[str] | None = None,
@@ -1405,12 +1836,12 @@ class CogniteObject3D(CogniteObject3DProperties, CogniteDescribableNode):
             version,
             last_updated_time,
             created_time,
-            name,
-            description,
-            tags,
-            aliases,
-            type,
-            deleted_time,
+            name=name,
+            description=description,
+            tags=tags,
+            aliases=aliases,
+            type=type,
+            deleted_time=deleted_time,
         )
         self.x_min = x_min
         self.x_max = x_max
@@ -1423,24 +1854,24 @@ class CogniteObject3D(CogniteObject3DProperties, CogniteDescribableNode):
         return CogniteObject3DApply(
             self.space,
             self.external_id,
-            self.name,
-            self.description,
-            self.tags,
-            self.aliases,
-            self.x_min,
-            self.x_max,
-            self.y_min,
-            self.y_max,
-            self.z_min,
-            self.z_max,
-            self.version,
-            self.type,
+            name=self.name,
+            description=self.description,
+            tags=self.tags,
+            aliases=self.aliases,
+            x_min=self.x_min,
+            x_max=self.x_max,
+            y_min=self.y_min,
+            y_max=self.y_max,
+            z_min=self.z_min,
+            z_max=self.z_max,
+            existing_version=self.version,
+            type=self.type,
         )
 
 
 class CognitePointCloudVolumeProperties:
-    object_3_d = PropertyOptions("object3D")
-    model_3_d = PropertyOptions("model3D")
+    object_3d = PropertyOptions("object3D")
+    model_3d = PropertyOptions("model3D")
     volume_references = PropertyOptions("volumeReferences")
     volume_type = PropertyOptions("volumeType")
     format_version = PropertyOptions("formatVersion")
@@ -1451,16 +1882,41 @@ class CognitePointCloudVolumeProperties:
 
 
 class CognitePointCloudVolumeApply(CognitePointCloudVolumeProperties, CogniteDescribableNodeApply):
+    """This represents the writing format of cognite point cloud volume.
+
+    It is used to when data is written to CDF.
+
+    PointCloud volume definition
+
+    Args:
+        space (str): The space where the node is located.
+        external_id (str): The external id of the cognite point cloud volume.
+        name (str | None): Name of the instance
+        description (str | None): Description of the instance
+        tags (list[str] | None): Text based labels for generic use, limited to 1000
+        aliases (list[str] | None): Alternative names for the node
+        object_3d (DirectRelationReference | tuple[str, str] | None): Direct relation to object3D grouping for this node
+        model_3d (DirectRelationReference | tuple[str, str] | None): Direct relation to CogniteModel3D instance
+        volume_references (list[str] | None): Unique volume metric hashes used to access the 3D specialized data storage
+        revisions (list[DirectRelationReference | tuple[str, str]] | None): List of direct relations to revision information
+        volume_type (Literal["Box", "Cylinder"] | None): Type of volume (Cylinder or Box)
+        volume (list[float] | None): Relevant coordinates for the volume type, 9 floats in total, that defines the volume
+        format_version (str | None): Specifies the version the 'volume' field is following. Volume definition is today 9 floats (property volume)
+        existing_version (int | None): Fail the ingestion request if the node's version is greater than or equal to this value. If no existingVersion is specified, the ingestion will always overwrite any existing data for the node (for the specified container or node). If existingVersion is set to 0, the upsert will behave as an insert, so it will fail the bulk if the item already exists. If skipOnVersionConflict is set on the ingestion request, then the item will be skipped instead of failing the ingestion request.
+        type (DirectRelationReference | tuple[str, str] | None): Direct relation pointing to the type node.
+    """
+
     def __init__(
         self,
         space: str,
         external_id: str,
+        *,
         name: str | None = None,
         description: str | None = None,
         tags: list[str] | None = None,
         aliases: list[str] | None = None,
-        object_3_d: DirectRelationReference | tuple[str, str] | None = None,
-        model_3_d: DirectRelationReference | tuple[str, str] | None = None,
+        object_3d: DirectRelationReference | tuple[str, str] | None = None,
+        model_3d: DirectRelationReference | tuple[str, str] | None = None,
         volume_references: list[str] | None = None,
         revisions: list[DirectRelationReference | tuple[str, str]] | None = None,
         volume_type: Literal["Box", "Cylinder"] | None = None,
@@ -1469,9 +1925,18 @@ class CognitePointCloudVolumeApply(CognitePointCloudVolumeProperties, CogniteDes
         existing_version: int | None = None,
         type: DirectRelationReference | tuple[str, str] | None = None,
     ) -> None:
-        super().__init__(space, external_id, name, description, tags, aliases, existing_version, type)
-        self.object_3_d = DirectRelationReference.load(object_3_d) if object_3_d else None
-        self.model_3_d = DirectRelationReference.load(model_3_d) if model_3_d else None
+        super().__init__(
+            space,
+            external_id,
+            name=name,
+            description=description,
+            tags=tags,
+            aliases=aliases,
+            existing_version=existing_version,
+            type=type,
+        )
+        self.object_3d = DirectRelationReference.load(object_3d) if object_3d else None
+        self.model_3d = DirectRelationReference.load(model_3d) if model_3d else None
         self.volume_references = volume_references
         self.revisions = [DirectRelationReference.load(revision) for revision in revisions] if revisions else None
         self.volume_type = volume_type
@@ -1480,6 +1945,33 @@ class CognitePointCloudVolumeApply(CognitePointCloudVolumeProperties, CogniteDes
 
 
 class CognitePointCloudVolume(CognitePointCloudVolumeProperties, CogniteDescribableNode):
+    """This represents the reading format of cognite point cloud volume.
+
+    It is used to when data is read from CDF.
+
+    PointCloud volume definition
+
+    Args:
+        space (str): The space where the node is located.
+        external_id (str): The external id of the cognite point cloud volume.
+        version (int): DMS version.
+        last_updated_time (int): The number of milliseconds since 00:00:00 Thursday, 1 January 1970, Coordinated Universal Time (UTC), minus leap seconds.
+        created_time (int): The number of milliseconds since 00:00:00 Thursday, 1 January 1970, Coordinated Universal Time (UTC), minus leap seconds.
+        name (str | None): Name of the instance
+        description (str | None): Description of the instance
+        tags (list[str] | None): Text based labels for generic use, limited to 1000
+        aliases (list[str] | None): Alternative names for the node
+        object_3d (DirectRelationReference | None): Direct relation to object3D grouping for this node
+        model_3d (DirectRelationReference | None): Direct relation to CogniteModel3D instance
+        volume_references (list[str] | None): Unique volume metric hashes used to access the 3D specialized data storage
+        revisions (list[DirectRelationReference] | None): List of direct relations to revision information
+        volume_type (Literal["Box", "Cylinder"] | None): Type of volume (Cylinder or Box)
+        volume (list[float] | None): Relevant coordinates for the volume type, 9 floats in total, that defines the volume
+        format_version (str | None): Specifies the version the 'volume' field is following. Volume definition is today 9 floats (property volume)
+        type (DirectRelationReference | None): Direct relation pointing to the type node.
+        deleted_time (int | None): The number of milliseconds since 00:00:00 Thursday, 1 January 1970, Coordinated Universal Time (UTC), minus leap seconds. Timestamp when the instance was soft deleted. Note that deleted instances are filtered out of query results, but present in sync results
+    """
+
     def __init__(
         self,
         space: str,
@@ -1487,12 +1979,13 @@ class CognitePointCloudVolume(CognitePointCloudVolumeProperties, CogniteDescriba
         version: int,
         last_updated_time: int,
         created_time: int,
+        *,
         name: str | None = None,
         description: str | None = None,
         tags: list[str] | None = None,
         aliases: list[str] | None = None,
-        object_3_d: DirectRelationReference | None = None,
-        model_3_d: DirectRelationReference | None = None,
+        object_3d: DirectRelationReference | None = None,
+        model_3d: DirectRelationReference | None = None,
         volume_references: list[str] | None = None,
         revisions: list[DirectRelationReference] | None = None,
         volume_type: Literal["Box", "Cylinder"] | None = None,
@@ -1507,15 +2000,15 @@ class CognitePointCloudVolume(CognitePointCloudVolumeProperties, CogniteDescriba
             version,
             last_updated_time,
             created_time,
-            name,
-            description,
-            tags,
-            aliases,
-            type,
-            deleted_time,
+            name=name,
+            description=description,
+            tags=tags,
+            aliases=aliases,
+            type=type,
+            deleted_time=deleted_time,
         )
-        self.object_3_d = DirectRelationReference.load(object_3_d) if object_3_d else None
-        self.model_3_d = DirectRelationReference.load(model_3_d) if model_3_d else None
+        self.object_3d = DirectRelationReference.load(object_3d) if object_3d else None
+        self.model_3d = DirectRelationReference.load(model_3d) if model_3d else None
         self.volume_references = volume_references
         self.revisions = [DirectRelationReference.load(revision) for revision in revisions] if revisions else None
         self.volume_type = volume_type
@@ -1526,19 +2019,19 @@ class CognitePointCloudVolume(CognitePointCloudVolumeProperties, CogniteDescriba
         return CognitePointCloudVolumeApply(
             self.space,
             self.external_id,
-            self.name,
-            self.description,
-            self.tags,
-            self.aliases,
-            self.object_3_d,
-            self.model_3_d,
-            self.volume_references,
-            self.revisions,  # type: ignore[arg-type]
-            self.volume_type,
-            self.volume,
-            self.format_version,
-            self.version,
-            self.type,
+            name=self.name,
+            description=self.description,
+            tags=self.tags,
+            aliases=self.aliases,
+            object_3d=self.object_3d,
+            model_3d=self.model_3d,
+            volume_references=self.volume_references,
+            revisions=self.revisions,  # type: ignore[arg-type]
+            volume_type=self.volume_type,
+            volume=self.volume,
+            format_version=self.format_version,
+            existing_version=self.version,
+            type=self.type,
         )
 
 
@@ -1551,10 +2044,30 @@ class CogniteSourceSystemProperties:
 
 
 class CogniteSourceSystemApply(CogniteSourceSystemProperties, CogniteDescribableNodeApply):
+    """This represents the writing format of cognite source system.
+
+    It is used to when data is written to CDF.
+
+    The CogniteSourceSystem core concept is used to standardize the way source system is stored.
+
+    Args:
+        space (str): The space where the node is located.
+        external_id (str): The external id of the cognite source system.
+        name (str | None): Name of the instance
+        description (str | None): Description of the instance
+        tags (list[str] | None): Text based labels for generic use, limited to 1000
+        aliases (list[str] | None): Alternative names for the node
+        version_ (str | None): Version identifier for the source system
+        manufacturer (str | None): Manufacturer of the source system
+        existing_version (int | None): Fail the ingestion request if the node's version is greater than or equal to this value. If no existingVersion is specified, the ingestion will always overwrite any existing data for the node (for the specified container or node). If existingVersion is set to 0, the upsert will behave as an insert, so it will fail the bulk if the item already exists. If skipOnVersionConflict is set on the ingestion request, then the item will be skipped instead of failing the ingestion request.
+        type (DirectRelationReference | tuple[str, str] | None): Direct relation pointing to the type node.
+    """
+
     def __init__(
         self,
         space: str,
         external_id: str,
+        *,
         name: str | None = None,
         description: str | None = None,
         tags: list[str] | None = None,
@@ -1564,12 +2077,43 @@ class CogniteSourceSystemApply(CogniteSourceSystemProperties, CogniteDescribable
         existing_version: int | None = None,
         type: DirectRelationReference | tuple[str, str] | None = None,
     ) -> None:
-        super().__init__(space, external_id, name, description, tags, aliases, existing_version, type)
+        super().__init__(
+            space,
+            external_id,
+            name=name,
+            description=description,
+            tags=tags,
+            aliases=aliases,
+            existing_version=existing_version,
+            type=type,
+        )
         self.version_ = version_
         self.manufacturer = manufacturer
 
 
 class CogniteSourceSystem(CogniteSourceSystemProperties, CogniteDescribableNode):
+    """This represents the reading format of cognite source system.
+
+    It is used to when data is read from CDF.
+
+    The CogniteSourceSystem core concept is used to standardize the way source system is stored.
+
+    Args:
+        space (str): The space where the node is located.
+        external_id (str): The external id of the cognite source system.
+        version (int): DMS version.
+        last_updated_time (int): The number of milliseconds since 00:00:00 Thursday, 1 January 1970, Coordinated Universal Time (UTC), minus leap seconds.
+        created_time (int): The number of milliseconds since 00:00:00 Thursday, 1 January 1970, Coordinated Universal Time (UTC), minus leap seconds.
+        name (str | None): Name of the instance
+        description (str | None): Description of the instance
+        tags (list[str] | None): Text based labels for generic use, limited to 1000
+        aliases (list[str] | None): Alternative names for the node
+        version_ (str | None): Version identifier for the source system
+        manufacturer (str | None): Manufacturer of the source system
+        type (DirectRelationReference | None): Direct relation pointing to the type node.
+        deleted_time (int | None): The number of milliseconds since 00:00:00 Thursday, 1 January 1970, Coordinated Universal Time (UTC), minus leap seconds. Timestamp when the instance was soft deleted. Note that deleted instances are filtered out of query results, but present in sync results
+    """
+
     def __init__(
         self,
         space: str,
@@ -1577,6 +2121,7 @@ class CogniteSourceSystem(CogniteSourceSystemProperties, CogniteDescribableNode)
         version: int,
         last_updated_time: int,
         created_time: int,
+        *,
         name: str | None = None,
         description: str | None = None,
         tags: list[str] | None = None,
@@ -1592,12 +2137,12 @@ class CogniteSourceSystem(CogniteSourceSystemProperties, CogniteDescribableNode)
             version,
             last_updated_time,
             created_time,
-            name,
-            description,
-            tags,
-            aliases,
-            type,
-            deleted_time,
+            name=name,
+            description=description,
+            tags=tags,
+            aliases=aliases,
+            type=type,
+            deleted_time=deleted_time,
         )
         self.version_ = version_
         self.manufacturer = manufacturer
@@ -1606,166 +2151,14 @@ class CogniteSourceSystem(CogniteSourceSystemProperties, CogniteDescribableNode)
         return CogniteSourceSystemApply(
             self.space,
             self.external_id,
-            self.name,
-            self.description,
-            self.tags,
-            self.aliases,
-            self.version_,
-            self.manufacturer,
-            self.version,
-            self.type,
-        )
-
-
-class CogniteTimeSeriesProperties:
-    type_ = PropertyOptions("type")
-    is_step = PropertyOptions("isStep")
-    source_unit = PropertyOptions("sourceUnit")
-
-    @classmethod
-    def get_source(cls) -> ViewId:
-        return ViewId("cdf_cdm_experimental", "CogniteTimeSeries", "v1")
-
-
-class CogniteTimeSeriesApply(CogniteTimeSeriesProperties, CogniteDescribableNodeApply, CogniteSourceableNodeApply):
-    def __init__(
-        self,
-        space: str,
-        external_id: str,
-        type_: Literal["numeric", "string"],
-        name: str | None = None,
-        description: str | None = None,
-        tags: list[str] | None = None,
-        aliases: list[str] | None = None,
-        source_id: str | None = None,
-        source_context: str | None = None,
-        source: DirectRelationReference | tuple[str, str] | None = None,
-        source_created_time: datetime | None = None,
-        source_updated_time: datetime | None = None,
-        source_created_user: str | None = None,
-        source_updated_user: str | None = None,
-        is_step: bool | None = None,
-        source_unit: str | None = None,
-        unit: DirectRelationReference | tuple[str, str] | None = None,
-        assets: list[DirectRelationReference | tuple[str, str]] | None = None,
-        equipment: list[DirectRelationReference | tuple[str, str]] | None = None,
-        existing_version: int | None = None,
-        type: DirectRelationReference | tuple[str, str] | None = None,
-    ) -> None:
-        CogniteDescribableNodeApply.__init__(
-            self, space, external_id, name, description, tags, aliases, existing_version, type
-        )
-        CogniteSourceableNodeApply.__init__(
-            self,
-            space,
-            external_id,
-            source_id,
-            source_context,
-            source,
-            source_created_time,
-            source_updated_time,
-            source_created_user,
-            source_updated_user,
-            existing_version,
-            type,
-        )
-        self.type_ = type_
-        self.is_step = is_step
-        self.source_unit = source_unit
-        self.unit = DirectRelationReference.load(unit) if unit else None
-        self.assets = [DirectRelationReference.load(asset) for asset in assets] if assets else None
-        self.equipment = [DirectRelationReference.load(equipment) for equipment in equipment] if equipment else None
-
-
-class CogniteTimeSeries(CogniteTimeSeriesProperties, CogniteDescribableNode, CogniteSourceableNode):
-    def __init__(
-        self,
-        space: str,
-        external_id: str,
-        version: int,
-        last_updated_time: int,
-        created_time: int,
-        type_: Literal["numeric", "string"],
-        name: str | None = None,
-        description: str | None = None,
-        tags: list[str] | None = None,
-        aliases: list[str] | None = None,
-        source_id: str | None = None,
-        source_context: str | None = None,
-        source: DirectRelationReference | None = None,
-        source_created_time: datetime | None = None,
-        source_updated_time: datetime | None = None,
-        source_created_user: str | None = None,
-        source_updated_user: str | None = None,
-        is_step: bool | None = None,
-        source_unit: str | None = None,
-        unit: DirectRelationReference | None = None,
-        assets: list[DirectRelationReference] | None = None,
-        equipment: list[DirectRelationReference] | None = None,
-        type: DirectRelationReference | None = None,
-        deleted_time: int | None = None,
-    ) -> None:
-        CogniteDescribableNode.__init__(
-            self,
-            space,
-            external_id,
-            version,
-            last_updated_time,
-            created_time,
-            name,
-            description,
-            tags,
-            aliases,
-            type,
-            deleted_time,
-        )
-        CogniteSourceableNode.__init__(
-            self,
-            space,
-            external_id,
-            version,
-            last_updated_time,
-            created_time,
-            source_id,
-            source_context,
-            source,
-            source_created_time,
-            source_updated_time,
-            source_created_user,
-            source_updated_user,
-            type,
-            deleted_time,
-        )
-        self.type_ = type_
-        self.is_step = is_step
-        self.source_unit = source_unit
-        self.unit = DirectRelationReference.load(unit) if unit else None
-        self.assets = [DirectRelationReference.load(asset) for asset in assets] if assets else None
-        self.equipment = [DirectRelationReference.load(equipment) for equipment in equipment] if equipment else None
-
-    def as_write(self) -> CogniteTimeSeriesApply:
-        return CogniteTimeSeriesApply(
-            self.space,
-            self.external_id,
-            self.type_,
-            self.name,
-            self.description,
-            self.tags,
-            self.aliases,
-            self.source_id,
-            self.source_context,
-            self.source,
-            self.source_created_time,
-            self.source_updated_time,
-            self.source_created_user,
-            self.source_updated_user,
-            self.is_step,
-            self.source_unit,
-            self.unit,
-            self.assets,  # type: ignore[arg-type]
-            self.equipment,  # type: ignore[arg-type]
-            self.version,
-            self.type,
+            name=self.name,
+            description=self.description,
+            tags=self.tags,
+            aliases=self.aliases,
+            version_=self.version_,
+            manufacturer=self.manufacturer,
+            existing_version=self.version,
+            type=self.type,
         )
 
 
@@ -1780,10 +2173,42 @@ class CogniteActivityProperties:
 class CogniteActivityApply(
     CogniteActivityProperties, CogniteDescribableNodeApply, CogniteSourceableNodeApply, CogniteSchedulableApply
 ):
+    """This represents the writing format of cognite activity.
+
+    It is used to when data is written to CDF.
+
+    Represent an activity
+
+    Args:
+        space (str): The space where the node is located.
+        external_id (str): The external id of the cognite activity.
+        name (str | None): Name of the instance
+        description (str | None): Description of the instance
+        tags (list[str] | None): Text based labels for generic use, limited to 1000
+        aliases (list[str] | None): Alternative names for the node
+        source_id (str | None): Identifier from the source system
+        source_context (str | None): Context of the source id. For systems where the sourceId is globally unique, the sourceContext is expected to not be set.
+        source (DirectRelationReference | tuple[str, str] | None): Direct relation to a source system
+        source_created_time (datetime | None): When the instance was created in source system (if available)
+        source_updated_time (datetime | None): When the instance was last updated in the source system (if available)
+        source_created_user (str | None): User identifier from the source system on who created the source data. This identifier is not guaranteed to match the user identifiers in CDF
+        source_updated_user (str | None): User identifier from the source system on who last updated the source data. This identifier is not guaranteed to match the user identifiers in CDF
+        start_time (datetime | None): The actual start time of an activity (or similar that extends this)
+        end_time (datetime | None): The actual end time of an activity (or similar that extends this)
+        scheduled_start_time (datetime | None): The planned start time of an activity (or similar that extends this)
+        scheduled_end_time (datetime | None): The planned end time of an activity (or similar that extends this)
+        assets (list[DirectRelationReference | tuple[str, str]] | None): List of assets this activity relates to
+        equipment (list[DirectRelationReference | tuple[str, str]] | None): The list of equipment this activity relates to
+        time_series (list[DirectRelationReference | tuple[str, str]] | None): The list of time series this activity relates to
+        existing_version (int | None): Fail the ingestion request if the node's version is greater than or equal to this value. If no existingVersion is specified, the ingestion will always overwrite any existing data for the node (for the specified container or node). If existingVersion is set to 0, the upsert will behave as an insert, so it will fail the bulk if the item already exists. If skipOnVersionConflict is set on the ingestion request, then the item will be skipped instead of failing the ingestion request.
+        type (DirectRelationReference | tuple[str, str] | None): Direct relation pointing to the type node.
+    """
+
     def __init__(
         self,
         space: str,
         external_id: str,
+        *,
         name: str | None = None,
         description: str | None = None,
         tags: list[str] | None = None,
@@ -1806,32 +2231,40 @@ class CogniteActivityApply(
         type: DirectRelationReference | tuple[str, str] | None = None,
     ) -> None:
         CogniteDescribableNodeApply.__init__(
-            self, space, external_id, name, description, tags, aliases, existing_version, type
+            self,
+            space,
+            external_id,
+            name=name,
+            description=description,
+            tags=tags,
+            aliases=aliases,
+            existing_version=existing_version,
+            type=type,
         )
         CogniteSourceableNodeApply.__init__(
             self,
             space,
             external_id,
-            source_id,
-            source_context,
-            source,
-            source_created_time,
-            source_updated_time,
-            source_created_user,
-            source_updated_user,
-            existing_version,
-            type,
+            source_id=source_id,
+            source_context=source_context,
+            source=source,
+            source_created_time=source_created_time,
+            source_updated_time=source_updated_time,
+            source_created_user=source_created_user,
+            source_updated_user=source_updated_user,
+            existing_version=existing_version,
+            type=type,
         )
         CogniteSchedulableApply.__init__(
             self,
             space,
             external_id,
-            start_time,
-            end_time,
-            scheduled_start_time,
-            scheduled_end_time,
-            existing_version,
-            type,
+            start_time=start_time,
+            end_time=end_time,
+            scheduled_start_time=scheduled_start_time,
+            scheduled_end_time=scheduled_end_time,
+            existing_version=existing_version,
+            type=type,
         )
         self.assets = [DirectRelationReference.load(asset) for asset in assets] if assets else None
         self.equipment = [DirectRelationReference.load(equipment) for equipment in equipment] if equipment else None
@@ -1841,6 +2274,40 @@ class CogniteActivityApply(
 
 
 class CogniteActivity(CogniteActivityProperties, CogniteDescribableNode, CogniteSourceableNode, CogniteSchedulable):
+    """This represents the reading format of cognite activity.
+
+    It is used to when data is read from CDF.
+
+    Represent an activity
+
+    Args:
+        space (str): The space where the node is located.
+        external_id (str): The external id of the cognite activity.
+        version (int): DMS version.
+        last_updated_time (int): The number of milliseconds since 00:00:00 Thursday, 1 January 1970, Coordinated Universal Time (UTC), minus leap seconds.
+        created_time (int): The number of milliseconds since 00:00:00 Thursday, 1 January 1970, Coordinated Universal Time (UTC), minus leap seconds.
+        name (str | None): Name of the instance
+        description (str | None): Description of the instance
+        tags (list[str] | None): Text based labels for generic use, limited to 1000
+        aliases (list[str] | None): Alternative names for the node
+        source_id (str | None): Identifier from the source system
+        source_context (str | None): Context of the source id. For systems where the sourceId is globally unique, the sourceContext is expected to not be set.
+        source (DirectRelationReference | None): Direct relation to a source system
+        source_created_time (datetime | None): When the instance was created in source system (if available)
+        source_updated_time (datetime | None): When the instance was last updated in the source system (if available)
+        source_created_user (str | None): User identifier from the source system on who created the source data. This identifier is not guaranteed to match the user identifiers in CDF
+        source_updated_user (str | None): User identifier from the source system on who last updated the source data. This identifier is not guaranteed to match the user identifiers in CDF
+        start_time (datetime | None): The actual start time of an activity (or similar that extends this)
+        end_time (datetime | None): The actual end time of an activity (or similar that extends this)
+        scheduled_start_time (datetime | None): The planned start time of an activity (or similar that extends this)
+        scheduled_end_time (datetime | None): The planned end time of an activity (or similar that extends this)
+        assets (list[DirectRelationReference] | None): List of assets this activity relates to
+        equipment (list[DirectRelationReference] | None): The list of equipment this activity relates to
+        time_series (list[DirectRelationReference] | None): The list of time series this activity relates to
+        type (DirectRelationReference | None): Direct relation pointing to the type node.
+        deleted_time (int | None): The number of milliseconds since 00:00:00 Thursday, 1 January 1970, Coordinated Universal Time (UTC), minus leap seconds. Timestamp when the instance was soft deleted. Note that deleted instances are filtered out of query results, but present in sync results
+    """
+
     def __init__(
         self,
         space: str,
@@ -1848,6 +2315,7 @@ class CogniteActivity(CogniteActivityProperties, CogniteDescribableNode, Cognite
         version: int,
         last_updated_time: int,
         created_time: int,
+        *,
         name: str | None = None,
         description: str | None = None,
         tags: list[str] | None = None,
@@ -1876,12 +2344,12 @@ class CogniteActivity(CogniteActivityProperties, CogniteDescribableNode, Cognite
             version,
             last_updated_time,
             created_time,
-            name,
-            description,
-            tags,
-            aliases,
-            type,
-            deleted_time,
+            name=name,
+            description=description,
+            tags=tags,
+            aliases=aliases,
+            type=type,
+            deleted_time=deleted_time,
         )
         CogniteSourceableNode.__init__(
             self,
@@ -1890,15 +2358,15 @@ class CogniteActivity(CogniteActivityProperties, CogniteDescribableNode, Cognite
             version,
             last_updated_time,
             created_time,
-            source_id,
-            source_context,
-            source,
-            source_created_time,
-            source_updated_time,
-            source_created_user,
-            source_updated_user,
-            type,
-            deleted_time,
+            source_id=source_id,
+            source_context=source_context,
+            source=source,
+            source_created_time=source_created_time,
+            source_updated_time=source_updated_time,
+            source_created_user=source_created_user,
+            source_updated_user=source_updated_user,
+            type=type,
+            deleted_time=deleted_time,
         )
         CogniteSchedulable.__init__(
             self,
@@ -1907,12 +2375,12 @@ class CogniteActivity(CogniteActivityProperties, CogniteDescribableNode, Cognite
             version,
             last_updated_time,
             created_time,
-            start_time,
-            end_time,
-            scheduled_start_time,
-            scheduled_end_time,
-            type,
-            deleted_time,
+            start_time=start_time,
+            end_time=end_time,
+            scheduled_start_time=scheduled_start_time,
+            scheduled_end_time=scheduled_end_time,
+            type=type,
+            deleted_time=deleted_time,
         )
         self.assets = [DirectRelationReference.load(asset) for asset in assets] if assets else None
         self.equipment = [DirectRelationReference.load(equipment) for equipment in equipment] if equipment else None
@@ -1924,26 +2392,681 @@ class CogniteActivity(CogniteActivityProperties, CogniteDescribableNode, Cognite
         return CogniteActivityApply(
             self.space,
             self.external_id,
-            self.name,
-            self.description,
-            self.tags,
-            self.aliases,
-            self.source_id,
-            self.source_context,
-            self.source,
-            self.source_created_time,
-            self.source_updated_time,
-            self.source_created_user,
-            self.source_updated_user,
-            self.start_time,
-            self.end_time,
-            self.scheduled_start_time,
-            self.scheduled_end_time,
-            self.assets,  # type: ignore[arg-type]
-            self.equipment,  # type: ignore[arg-type]
-            self.time_series,
-            self.version,
-            self.type,
+            name=self.name,
+            description=self.description,
+            tags=self.tags,
+            aliases=self.aliases,
+            source_id=self.source_id,
+            source_context=self.source_context,
+            source=self.source,
+            source_created_time=self.source_created_time,
+            source_updated_time=self.source_updated_time,
+            source_created_user=self.source_created_user,
+            source_updated_user=self.source_updated_user,
+            start_time=self.start_time,
+            end_time=self.end_time,
+            scheduled_start_time=self.scheduled_start_time,
+            scheduled_end_time=self.scheduled_end_time,
+            assets=self.assets,  # type: ignore[arg-type]
+            equipment=self.equipment,  # type: ignore[arg-type]
+            time_series=self.time_series,  # type: ignore[arg-type]
+            existing_version=self.version,
+            type=self.type,
+        )
+
+
+class CogniteEquipmentProperties:
+    serial_number = PropertyOptions("serialNumber")
+    equipment_type = PropertyOptions("equipmentType")
+
+    @classmethod
+    def get_source(cls) -> ViewId:
+        return ViewId("cdf_cdm_experimental", "CogniteEquipment", "v1")
+
+
+class CogniteEquipmentApply(CogniteEquipmentProperties, CogniteDescribableNodeApply, CogniteSourceableNodeApply):
+    """This represents the writing format of cognite equipment.
+
+    It is used to when data is written to CDF.
+
+    Represent a physical piece of equipment
+
+    Args:
+        space (str): The space where the node is located.
+        external_id (str): The external id of the cognite equipment.
+        name (str | None): Name of the instance
+        description (str | None): Description of the instance
+        tags (list[str] | None): Text based labels for generic use, limited to 1000
+        aliases (list[str] | None): Alternative names for the node
+        source_id (str | None): Identifier from the source system
+        source_context (str | None): Context of the source id. For systems where the sourceId is globally unique, the sourceContext is expected to not be set.
+        source (DirectRelationReference | tuple[str, str] | None): Direct relation to a source system
+        source_created_time (datetime | None): When the instance was created in source system (if available)
+        source_updated_time (datetime | None): When the instance was last updated in the source system (if available)
+        source_created_user (str | None): User identifier from the source system on who created the source data. This identifier is not guaranteed to match the user identifiers in CDF
+        source_updated_user (str | None): User identifier from the source system on who last updated the source data. This identifier is not guaranteed to match the user identifiers in CDF
+        serial_number (str | None): Serial number of the equipment
+        manufacturer (str | None): Manufacturer of the equipment
+        equipment_type (DirectRelationReference | tuple[str, str] | None): Type of this equipment, direct relation to CogniteEquipmentType
+        files (list[DirectRelationReference | tuple[str, str]] | None): List of files this equipment relates to
+        existing_version (int | None): Fail the ingestion request if the node's version is greater than or equal to this value. If no existingVersion is specified, the ingestion will always overwrite any existing data for the node (for the specified container or node). If existingVersion is set to 0, the upsert will behave as an insert, so it will fail the bulk if the item already exists. If skipOnVersionConflict is set on the ingestion request, then the item will be skipped instead of failing the ingestion request.
+        type (DirectRelationReference | tuple[str, str] | None): Direct relation pointing to the type node.
+    """
+
+    def __init__(
+        self,
+        space: str,
+        external_id: str,
+        *,
+        name: str | None = None,
+        description: str | None = None,
+        tags: list[str] | None = None,
+        aliases: list[str] | None = None,
+        source_id: str | None = None,
+        source_context: str | None = None,
+        source: DirectRelationReference | tuple[str, str] | None = None,
+        source_created_time: datetime | None = None,
+        source_updated_time: datetime | None = None,
+        source_created_user: str | None = None,
+        source_updated_user: str | None = None,
+        serial_number: str | None = None,
+        manufacturer: str | None = None,
+        equipment_type: DirectRelationReference | tuple[str, str] | None = None,
+        files: list[DirectRelationReference | tuple[str, str]] | None = None,
+        existing_version: int | None = None,
+        type: DirectRelationReference | tuple[str, str] | None = None,
+    ) -> None:
+        CogniteDescribableNodeApply.__init__(
+            self,
+            space,
+            external_id,
+            name=name,
+            description=description,
+            tags=tags,
+            aliases=aliases,
+            existing_version=existing_version,
+            type=type,
+        )
+        CogniteSourceableNodeApply.__init__(
+            self,
+            space,
+            external_id,
+            source_id=source_id,
+            source_context=source_context,
+            source=source,
+            source_created_time=source_created_time,
+            source_updated_time=source_updated_time,
+            source_created_user=source_created_user,
+            source_updated_user=source_updated_user,
+            existing_version=existing_version,
+            type=type,
+        )
+        self.serial_number = serial_number
+        self.manufacturer = manufacturer
+        self.equipment_type = DirectRelationReference.load(equipment_type) if equipment_type else None
+        self.files = [DirectRelationReference.load(file) for file in files] if files else None
+
+
+class CogniteEquipment(CogniteEquipmentProperties, CogniteDescribableNode, CogniteSourceableNode):
+    """This represents the reading format of cognite equipment.
+
+    It is used to when data is read from CDF.
+
+    Represent a physical piece of equipment
+
+    Args:
+        space (str): The space where the node is located.
+        external_id (str): The external id of the cognite equipment.
+        version (int): DMS version.
+        last_updated_time (int): The number of milliseconds since 00:00:00 Thursday, 1 January 1970, Coordinated Universal Time (UTC), minus leap seconds.
+        created_time (int): The number of milliseconds since 00:00:00 Thursday, 1 January 1970, Coordinated Universal Time (UTC), minus leap seconds.
+        name (str | None): Name of the instance
+        description (str | None): Description of the instance
+        tags (list[str] | None): Text based labels for generic use, limited to 1000
+        aliases (list[str] | None): Alternative names for the node
+        source_id (str | None): Identifier from the source system
+        source_context (str | None): Context of the source id. For systems where the sourceId is globally unique, the sourceContext is expected to not be set.
+        source (DirectRelationReference | None): Direct relation to a source system
+        source_created_time (datetime | None): When the instance was created in source system (if available)
+        source_updated_time (datetime | None): When the instance was last updated in the source system (if available)
+        source_created_user (str | None): User identifier from the source system on who created the source data. This identifier is not guaranteed to match the user identifiers in CDF
+        source_updated_user (str | None): User identifier from the source system on who last updated the source data. This identifier is not guaranteed to match the user identifiers in CDF
+        serial_number (str | None): Serial number of the equipment
+        manufacturer (str | None): Manufacturer of the equipment
+        equipment_type (DirectRelationReference | None): Type of this equipment, direct relation to CogniteEquipmentType
+        files (list[DirectRelationReference] | None): List of files this equipment relates to
+        type (DirectRelationReference | None): Direct relation pointing to the type node.
+        deleted_time (int | None): The number of milliseconds since 00:00:00 Thursday, 1 January 1970, Coordinated Universal Time (UTC), minus leap seconds. Timestamp when the instance was soft deleted. Note that deleted instances are filtered out of query results, but present in sync results
+    """
+
+    def __init__(
+        self,
+        space: str,
+        external_id: str,
+        version: int,
+        last_updated_time: int,
+        created_time: int,
+        *,
+        name: str | None = None,
+        description: str | None = None,
+        tags: list[str] | None = None,
+        aliases: list[str] | None = None,
+        source_id: str | None = None,
+        source_context: str | None = None,
+        source: DirectRelationReference | None = None,
+        source_created_time: datetime | None = None,
+        source_updated_time: datetime | None = None,
+        source_created_user: str | None = None,
+        source_updated_user: str | None = None,
+        serial_number: str | None = None,
+        manufacturer: str | None = None,
+        equipment_type: DirectRelationReference | None = None,
+        files: list[DirectRelationReference] | None = None,
+        type: DirectRelationReference | None = None,
+        deleted_time: int | None = None,
+    ) -> None:
+        CogniteDescribableNode.__init__(
+            self,
+            space,
+            external_id,
+            version,
+            last_updated_time,
+            created_time,
+            name=name,
+            description=description,
+            tags=tags,
+            aliases=aliases,
+            type=type,
+            deleted_time=deleted_time,
+        )
+        CogniteSourceableNode.__init__(
+            self,
+            space,
+            external_id,
+            version,
+            last_updated_time,
+            created_time,
+            source_id=source_id,
+            source_context=source_context,
+            source=source,
+            source_created_time=source_created_time,
+            source_updated_time=source_updated_time,
+            source_created_user=source_created_user,
+            source_updated_user=source_updated_user,
+            type=type,
+            deleted_time=deleted_time,
+        )
+        self.serial_number = serial_number
+        self.manufacturer = manufacturer
+        self.equipment_type = DirectRelationReference.load(equipment_type) if equipment_type else None
+        self.files = [DirectRelationReference.load(file) for file in files] if files else None
+
+    def as_write(self) -> CogniteEquipmentApply:
+        return CogniteEquipmentApply(
+            self.space,
+            self.external_id,
+            name=self.name,
+            description=self.description,
+            tags=self.tags,
+            aliases=self.aliases,
+            source_id=self.source_id,
+            source_context=self.source_context,
+            source=self.source,
+            source_created_time=self.source_created_time,
+            source_updated_time=self.source_updated_time,
+            source_created_user=self.source_created_user,
+            source_updated_user=self.source_updated_user,
+            serial_number=self.serial_number,
+            manufacturer=self.manufacturer,
+            equipment_type=self.equipment_type,
+            files=self.files,  # type: ignore[arg-type]
+            existing_version=self.version,
+            type=self.type,
+        )
+
+
+class CogniteFileProperties:
+    mime_type = PropertyOptions("mimeType")
+    is_uploaded = PropertyOptions("isUploaded")
+    uploaded_time = PropertyOptions("uploadedTime")
+
+    @classmethod
+    def get_source(cls) -> ViewId:
+        return ViewId("cdf_cdm_experimental", "CogniteFile", "v1")
+
+
+class CogniteFileApply(CogniteFileProperties, CogniteDescribableNodeApply, CogniteSourceableNodeApply):
+    """This represents the writing format of cognite file.
+
+    It is used to when data is written to CDF.
+
+    This concept models the underlying file
+
+    Args:
+        space (str): The space where the node is located.
+        external_id (str): The external id of the cognite file.
+        name (str | None): Name of the instance
+        description (str | None): Description of the instance
+        tags (list[str] | None): Text based labels for generic use, limited to 1000
+        aliases (list[str] | None): Alternative names for the node
+        source_id (str | None): Identifier from the source system
+        source_context (str | None): Context of the source id. For systems where the sourceId is globally unique, the sourceContext is expected to not be set.
+        source (DirectRelationReference | tuple[str, str] | None): Direct relation to a source system
+        source_created_time (datetime | None): When the instance was created in source system (if available)
+        source_updated_time (datetime | None): When the instance was last updated in the source system (if available)
+        source_created_user (str | None): User identifier from the source system on who created the source data. This identifier is not guaranteed to match the user identifiers in CDF
+        source_updated_user (str | None): User identifier from the source system on who last updated the source data. This identifier is not guaranteed to match the user identifiers in CDF
+        assets (list[DirectRelationReference | tuple[str, str]] | None): List of assets this file relates to
+        mime_type (str | None): MIME type of the file
+        directory (str | None): Contains the path elements from the source (for when the source system has a file system hierarchy or similar)
+        is_uploaded (bool | None): Whether the file content has been uploaded to Cognite Data Fusion
+        uploaded_time (datetime | None): Point in time when the file upload was completed and the file was made available
+        category (DirectRelationReference | tuple[str, str] | None): Direct relation to an instance of CogniteFileCategory representing the detected categorization/class for the file
+        existing_version (int | None): Fail the ingestion request if the node's version is greater than or equal to this value. If no existingVersion is specified, the ingestion will always overwrite any existing data for the node (for the specified container or node). If existingVersion is set to 0, the upsert will behave as an insert, so it will fail the bulk if the item already exists. If skipOnVersionConflict is set on the ingestion request, then the item will be skipped instead of failing the ingestion request.
+        type (DirectRelationReference | tuple[str, str] | None): Direct relation pointing to the type node.
+    """
+
+    def __init__(
+        self,
+        space: str,
+        external_id: str,
+        *,
+        name: str | None = None,
+        description: str | None = None,
+        tags: list[str] | None = None,
+        aliases: list[str] | None = None,
+        source_id: str | None = None,
+        source_context: str | None = None,
+        source: DirectRelationReference | tuple[str, str] | None = None,
+        source_created_time: datetime | None = None,
+        source_updated_time: datetime | None = None,
+        source_created_user: str | None = None,
+        source_updated_user: str | None = None,
+        assets: list[DirectRelationReference | tuple[str, str]] | None = None,
+        mime_type: str | None = None,
+        directory: str | None = None,
+        is_uploaded: bool | None = None,
+        uploaded_time: datetime | None = None,
+        category: DirectRelationReference | tuple[str, str] | None = None,
+        existing_version: int | None = None,
+        type: DirectRelationReference | tuple[str, str] | None = None,
+    ) -> None:
+        CogniteDescribableNodeApply.__init__(
+            self,
+            space,
+            external_id,
+            name=name,
+            description=description,
+            tags=tags,
+            aliases=aliases,
+            existing_version=existing_version,
+            type=type,
+        )
+        CogniteSourceableNodeApply.__init__(
+            self,
+            space,
+            external_id,
+            source_id=source_id,
+            source_context=source_context,
+            source=source,
+            source_created_time=source_created_time,
+            source_updated_time=source_updated_time,
+            source_created_user=source_created_user,
+            source_updated_user=source_updated_user,
+            existing_version=existing_version,
+            type=type,
+        )
+        self.assets = [DirectRelationReference.load(asset) for asset in assets] if assets else None
+        self.mime_type = mime_type
+        self.directory = directory
+        self.is_uploaded = is_uploaded
+        self.uploaded_time = uploaded_time
+        self.category = DirectRelationReference.load(category) if category else None
+
+
+class CogniteFile(CogniteFileProperties, CogniteDescribableNode, CogniteSourceableNode):
+    """This represents the reading format of cognite file.
+
+    It is used to when data is read from CDF.
+
+    This concept models the underlying file
+
+    Args:
+        space (str): The space where the node is located.
+        external_id (str): The external id of the cognite file.
+        version (int): DMS version.
+        last_updated_time (int): The number of milliseconds since 00:00:00 Thursday, 1 January 1970, Coordinated Universal Time (UTC), minus leap seconds.
+        created_time (int): The number of milliseconds since 00:00:00 Thursday, 1 January 1970, Coordinated Universal Time (UTC), minus leap seconds.
+        name (str | None): Name of the instance
+        description (str | None): Description of the instance
+        tags (list[str] | None): Text based labels for generic use, limited to 1000
+        aliases (list[str] | None): Alternative names for the node
+        source_id (str | None): Identifier from the source system
+        source_context (str | None): Context of the source id. For systems where the sourceId is globally unique, the sourceContext is expected to not be set.
+        source (DirectRelationReference | None): Direct relation to a source system
+        source_created_time (datetime | None): When the instance was created in source system (if available)
+        source_updated_time (datetime | None): When the instance was last updated in the source system (if available)
+        source_created_user (str | None): User identifier from the source system on who created the source data. This identifier is not guaranteed to match the user identifiers in CDF
+        source_updated_user (str | None): User identifier from the source system on who last updated the source data. This identifier is not guaranteed to match the user identifiers in CDF
+        assets (list[DirectRelationReference] | None): List of assets this file relates to
+        mime_type (str | None): MIME type of the file
+        directory (str | None): Contains the path elements from the source (for when the source system has a file system hierarchy or similar)
+        is_uploaded (bool | None): Whether the file content has been uploaded to Cognite Data Fusion
+        uploaded_time (datetime | None): Point in time when the file upload was completed and the file was made available
+        category (DirectRelationReference | None): Direct relation to an instance of CogniteFileCategory representing the detected categorization/class for the file
+        type (DirectRelationReference | None): Direct relation pointing to the type node.
+        deleted_time (int | None): The number of milliseconds since 00:00:00 Thursday, 1 January 1970, Coordinated Universal Time (UTC), minus leap seconds. Timestamp when the instance was soft deleted. Note that deleted instances are filtered out of query results, but present in sync results
+    """
+
+    def __init__(
+        self,
+        space: str,
+        external_id: str,
+        version: int,
+        last_updated_time: int,
+        created_time: int,
+        *,
+        name: str | None = None,
+        description: str | None = None,
+        tags: list[str] | None = None,
+        aliases: list[str] | None = None,
+        source_id: str | None = None,
+        source_context: str | None = None,
+        source: DirectRelationReference | None = None,
+        source_created_time: datetime | None = None,
+        source_updated_time: datetime | None = None,
+        source_created_user: str | None = None,
+        source_updated_user: str | None = None,
+        assets: list[DirectRelationReference] | None = None,
+        mime_type: str | None = None,
+        directory: str | None = None,
+        is_uploaded: bool | None = None,
+        uploaded_time: datetime | None = None,
+        category: DirectRelationReference | None = None,
+        type: DirectRelationReference | None = None,
+        deleted_time: int | None = None,
+    ) -> None:
+        CogniteDescribableNode.__init__(
+            self,
+            space,
+            external_id,
+            version,
+            last_updated_time,
+            created_time,
+            name=name,
+            description=description,
+            tags=tags,
+            aliases=aliases,
+            type=type,
+            deleted_time=deleted_time,
+        )
+        CogniteSourceableNode.__init__(
+            self,
+            space,
+            external_id,
+            version,
+            last_updated_time,
+            created_time,
+            source_id=source_id,
+            source_context=source_context,
+            source=source,
+            source_created_time=source_created_time,
+            source_updated_time=source_updated_time,
+            source_created_user=source_created_user,
+            source_updated_user=source_updated_user,
+            type=type,
+            deleted_time=deleted_time,
+        )
+        self.assets = [DirectRelationReference.load(asset) for asset in assets] if assets else None
+        self.mime_type = mime_type
+        self.directory = directory
+        self.is_uploaded = is_uploaded
+        self.uploaded_time = uploaded_time
+        self.category = DirectRelationReference.load(category) if category else None
+
+    def as_write(self) -> CogniteFileApply:
+        return CogniteFileApply(
+            self.space,
+            self.external_id,
+            name=self.name,
+            description=self.description,
+            tags=self.tags,
+            aliases=self.aliases,
+            source_id=self.source_id,
+            source_context=self.source_context,
+            source=self.source,
+            source_created_time=self.source_created_time,
+            source_updated_time=self.source_updated_time,
+            source_created_user=self.source_created_user,
+            source_updated_user=self.source_updated_user,
+            assets=self.assets,  # type: ignore[arg-type]
+            mime_type=self.mime_type,
+            directory=self.directory,
+            is_uploaded=self.is_uploaded,
+            uploaded_time=self.uploaded_time,
+            category=self.category,
+            existing_version=self.version,
+            type=self.type,
+        )
+
+
+class CogniteTimeSeriesProperties:
+    type_ = PropertyOptions("type")
+    is_step = PropertyOptions("isStep")
+    source_unit = PropertyOptions("sourceUnit")
+
+    @classmethod
+    def get_source(cls) -> ViewId:
+        return ViewId("cdf_cdm_experimental", "CogniteTimeSeries", "v1")
+
+
+class CogniteTimeSeriesApply(CogniteTimeSeriesProperties, CogniteDescribableNodeApply, CogniteSourceableNodeApply):
+    """This represents the writing format of cognite time series.
+
+    It is used to when data is written to CDF.
+    Args:
+        space (str): The space where the node is located.
+        external_id (str): The external id of the cognite time series.
+        type_ (Literal["numeric", "string"]): Defines data type of the data points.
+        name (str | None): Name of the instance
+        description (str | None): Description of the instance
+        tags (list[str] | None): Text based labels for generic use, limited to 1000
+        aliases (list[str] | None): Alternative names for the node
+        source_id (str | None): Identifier from the source system
+        source_context (str | None): Context of the source id. For systems where the sourceId is globally unique, the sourceContext is expected to not be set.
+        source (DirectRelationReference | tuple[str, str] | None): Direct relation to a source system
+        source_created_time (datetime | None): When the instance was created in source system (if available)
+        source_updated_time (datetime | None): When the instance was last updated in the source system (if available)
+        source_created_user (str | None): User identifier from the source system on who created the source data. This identifier is not guaranteed to match the user identifiers in CDF
+        source_updated_user (str | None): User identifier from the source system on who last updated the source data. This identifier is not guaranteed to match the user identifiers in CDF
+        is_step (bool | None): Defines whether the time series is a step series or not.
+        source_unit (str | None): Unit as specified in the source system
+        unit (DirectRelationReference | tuple[str, str] | None): direct relation to unit in the `cdf_units` space
+        assets (list[DirectRelationReference | tuple[str, str]] | None): The asset field.
+        equipment (list[DirectRelationReference | tuple[str, str]] | None): The equipment field.
+        existing_version (int | None): Fail the ingestion request if the node's version is greater than or equal to this value. If no existingVersion is specified, the ingestion will always overwrite any existing data for the node (for the specified container or node). If existingVersion is set to 0, the upsert will behave as an insert, so it will fail the bulk if the item already exists. If skipOnVersionConflict is set on the ingestion request, then the item will be skipped instead of failing the ingestion request.
+        type (DirectRelationReference | tuple[str, str] | None): Direct relation pointing to the type node.
+    """
+
+    def __init__(
+        self,
+        space: str,
+        external_id: str,
+        *,
+        type_: Literal["numeric", "string"],
+        name: str | None = None,
+        description: str | None = None,
+        tags: list[str] | None = None,
+        aliases: list[str] | None = None,
+        source_id: str | None = None,
+        source_context: str | None = None,
+        source: DirectRelationReference | tuple[str, str] | None = None,
+        source_created_time: datetime | None = None,
+        source_updated_time: datetime | None = None,
+        source_created_user: str | None = None,
+        source_updated_user: str | None = None,
+        is_step: bool | None = None,
+        source_unit: str | None = None,
+        unit: DirectRelationReference | tuple[str, str] | None = None,
+        assets: list[DirectRelationReference | tuple[str, str]] | None = None,
+        equipment: list[DirectRelationReference | tuple[str, str]] | None = None,
+        existing_version: int | None = None,
+        type: DirectRelationReference | tuple[str, str] | None = None,
+    ) -> None:
+        CogniteDescribableNodeApply.__init__(
+            self,
+            space,
+            external_id,
+            name=name,
+            description=description,
+            tags=tags,
+            aliases=aliases,
+            existing_version=existing_version,
+            type=type,
+        )
+        CogniteSourceableNodeApply.__init__(
+            self,
+            space,
+            external_id,
+            source_id=source_id,
+            source_context=source_context,
+            source=source,
+            source_created_time=source_created_time,
+            source_updated_time=source_updated_time,
+            source_created_user=source_created_user,
+            source_updated_user=source_updated_user,
+            existing_version=existing_version,
+            type=type,
+        )
+        self.type_ = type_
+        self.is_step = is_step
+        self.source_unit = source_unit
+        self.unit = DirectRelationReference.load(unit) if unit else None
+        self.assets = [DirectRelationReference.load(asset) for asset in assets] if assets else None
+        self.equipment = [DirectRelationReference.load(equipment) for equipment in equipment] if equipment else None
+
+
+class CogniteTimeSeries(CogniteTimeSeriesProperties, CogniteDescribableNode, CogniteSourceableNode):
+    """This represents the reading format of cognite time series.
+
+    It is used to when data is read from CDF.
+
+    Args:
+        space (str): The space where the node is located.
+        external_id (str): The external id of the cognite time series.
+        version (int): DMS version.
+        last_updated_time (int): The number of milliseconds since 00:00:00 Thursday, 1 January 1970, Coordinated Universal Time (UTC), minus leap seconds.
+        created_time (int): The number of milliseconds since 00:00:00 Thursday, 1 January 1970, Coordinated Universal Time (UTC), minus leap seconds.
+        type_ (Literal["numeric", "string"]): Defines data type of the data points.
+        name (str | None): Name of the instance
+        description (str | None): Description of the instance
+        tags (list[str] | None): Text based labels for generic use, limited to 1000
+        aliases (list[str] | None): Alternative names for the node
+        source_id (str | None): Identifier from the source system
+        source_context (str | None): Context of the source id. For systems where the sourceId is globally unique, the sourceContext is expected to not be set.
+        source (DirectRelationReference | None): Direct relation to a source system
+        source_created_time (datetime | None): When the instance was created in source system (if available)
+        source_updated_time (datetime | None): When the instance was last updated in the source system (if available)
+        source_created_user (str | None): User identifier from the source system on who created the source data. This identifier is not guaranteed to match the user identifiers in CDF
+        source_updated_user (str | None): User identifier from the source system on who last updated the source data. This identifier is not guaranteed to match the user identifiers in CDF
+        is_step (bool | None): Defines whether the time series is a step series or not.
+        source_unit (str | None): Unit as specified in the source system
+        unit (DirectRelationReference | None): direct relation to unit in the `cdf_units` space
+        assets (list[DirectRelationReference] | None): The asset field.
+        equipment (list[DirectRelationReference] | None): The equipment field.
+        type (DirectRelationReference | None): Direct relation pointing to the type node.
+        deleted_time (int | None): The number of milliseconds since 00:00:00 Thursday, 1 January 1970, Coordinated Universal Time (UTC), minus leap seconds. Timestamp when the instance was soft deleted. Note that deleted instances are filtered out of query results, but present in sync results
+    """
+
+    def __init__(
+        self,
+        space: str,
+        external_id: str,
+        version: int,
+        last_updated_time: int,
+        created_time: int,
+        *,
+        type_: Literal["numeric", "string"],
+        name: str | None = None,
+        description: str | None = None,
+        tags: list[str] | None = None,
+        aliases: list[str] | None = None,
+        source_id: str | None = None,
+        source_context: str | None = None,
+        source: DirectRelationReference | None = None,
+        source_created_time: datetime | None = None,
+        source_updated_time: datetime | None = None,
+        source_created_user: str | None = None,
+        source_updated_user: str | None = None,
+        is_step: bool | None = None,
+        source_unit: str | None = None,
+        unit: DirectRelationReference | None = None,
+        assets: list[DirectRelationReference] | None = None,
+        equipment: list[DirectRelationReference] | None = None,
+        type: DirectRelationReference | None = None,
+        deleted_time: int | None = None,
+    ) -> None:
+        CogniteDescribableNode.__init__(
+            self,
+            space,
+            external_id,
+            version,
+            last_updated_time,
+            created_time,
+            name=name,
+            description=description,
+            tags=tags,
+            aliases=aliases,
+            type=type,
+            deleted_time=deleted_time,
+        )
+        CogniteSourceableNode.__init__(
+            self,
+            space,
+            external_id,
+            version,
+            last_updated_time,
+            created_time,
+            source_id=source_id,
+            source_context=source_context,
+            source=source,
+            source_created_time=source_created_time,
+            source_updated_time=source_updated_time,
+            source_created_user=source_created_user,
+            source_updated_user=source_updated_user,
+            type=type,
+            deleted_time=deleted_time,
+        )
+        self.type_ = type_
+        self.is_step = is_step
+        self.source_unit = source_unit
+        self.unit = DirectRelationReference.load(unit) if unit else None
+        self.assets = [DirectRelationReference.load(asset) for asset in assets] if assets else None
+        self.equipment = [DirectRelationReference.load(equipment) for equipment in equipment] if equipment else None
+
+    def as_write(self) -> CogniteTimeSeriesApply:
+        return CogniteTimeSeriesApply(
+            self.space,
+            self.external_id,
+            type_=self.type_,
+            name=self.name,
+            description=self.description,
+            tags=self.tags,
+            aliases=self.aliases,
+            source_id=self.source_id,
+            source_context=self.source_context,
+            source=self.source,
+            source_created_time=self.source_created_time,
+            source_updated_time=self.source_updated_time,
+            source_created_user=self.source_created_user,
+            source_updated_user=self.source_updated_user,
+            is_step=self.is_step,
+            source_unit=self.source_unit,
+            unit=self.unit,
+            assets=self.assets,  # type: ignore[arg-type]
+            equipment=self.equipment,  # type: ignore[arg-type]
+            existing_version=self.version,
+            type=self.type,
         )
 
 
@@ -1960,11 +3083,44 @@ class CogniteAssetProperties:
 class CogniteAssetApply(
     CogniteAssetProperties, CogniteVisualizableApply, CogniteDescribableNodeApply, CogniteSourceableNodeApply
 ):
+    """This represents the writing format of cognite asset.
+
+    It is used to when data is written to CDF.
+
+    The asset is the bare bone representation of assets in our asset centric world
+
+    Args:
+        space (str): The space where the node is located.
+        external_id (str): The external id of the cognite asset.
+        object_3d (DirectRelationReference | tuple[str, str] | None): Direct relation to an Object3D instance representing the 3D resource
+        name (str | None): Name of the instance
+        description (str | None): Description of the instance
+        tags (list[str] | None): Text based labels for generic use, limited to 1000
+        aliases (list[str] | None): Alternative names for the node
+        source_id (str | None): Identifier from the source system
+        source_context (str | None): Context of the source id. For systems where the sourceId is globally unique, the sourceContext is expected to not be set.
+        source (DirectRelationReference | tuple[str, str] | None): Direct relation to a source system
+        source_created_time (datetime | None): When the instance was created in source system (if available)
+        source_updated_time (datetime | None): When the instance was last updated in the source system (if available)
+        source_created_user (str | None): User identifier from the source system on who created the source data. This identifier is not guaranteed to match the user identifiers in CDF
+        source_updated_user (str | None): User identifier from the source system on who last updated the source data. This identifier is not guaranteed to match the user identifiers in CDF
+        parent (DirectRelationReference | tuple[str, str] | None): Parent of this asset
+        root (DirectRelationReference | tuple[str, str] | None): Asset at the top of the hierarchy.
+        path (list[DirectRelationReference | tuple[str, str]] | None): Materialized path of this asset
+        last_path_materialization_time (datetime | None): Last time the path materializer updated the path of this asset
+        equipment (DirectRelationReference | tuple[str, str] | None): Equipment associated with this asset
+        asset_class (DirectRelationReference | tuple[str, str] | None): Class of this asset
+        type_ (DirectRelationReference | tuple[str, str] | None): Type of this asset
+        existing_version (int | None): Fail the ingestion request if the node's version is greater than or equal to this value. If no existingVersion is specified, the ingestion will always overwrite any existing data for the node (for the specified container or node). If existingVersion is set to 0, the upsert will behave as an insert, so it will fail the bulk if the item already exists. If skipOnVersionConflict is set on the ingestion request, then the item will be skipped instead of failing the ingestion request.
+        type (DirectRelationReference | tuple[str, str] | None): Direct relation pointing to the type node.
+    """
+
     def __init__(
         self,
         space: str,
         external_id: str,
-        object_3_d: DirectRelationReference | tuple[str, str] | None = None,
+        *,
+        object_3d: DirectRelationReference | tuple[str, str] | None = None,
         name: str | None = None,
         description: str | None = None,
         tags: list[str] | None = None,
@@ -1986,23 +3142,33 @@ class CogniteAssetApply(
         existing_version: int | None = None,
         type: DirectRelationReference | tuple[str, str] | None = None,
     ) -> None:
-        CogniteVisualizableApply.__init__(self, space, external_id, object_3_d, existing_version, type)
+        CogniteVisualizableApply.__init__(
+            self, space, external_id, object_3d=object_3d, existing_version=existing_version, type=type
+        )
         CogniteDescribableNodeApply.__init__(
-            self, space, external_id, name, description, tags, aliases, existing_version, type
+            self,
+            space,
+            external_id,
+            name=name,
+            description=description,
+            tags=tags,
+            aliases=aliases,
+            existing_version=existing_version,
+            type=type,
         )
         CogniteSourceableNodeApply.__init__(
             self,
             space,
             external_id,
-            source_id,
-            source_context,
-            source,
-            source_created_time,
-            source_updated_time,
-            source_created_user,
-            source_updated_user,
-            existing_version,
-            type,
+            source_id=source_id,
+            source_context=source_context,
+            source=source,
+            source_created_time=source_created_time,
+            source_updated_time=source_updated_time,
+            source_created_user=source_created_user,
+            source_updated_user=source_updated_user,
+            existing_version=existing_version,
+            type=type,
         )
         self.parent = DirectRelationReference.load(parent) if parent else None
         self.root = DirectRelationReference.load(root) if root else None
@@ -2014,6 +3180,41 @@ class CogniteAssetApply(
 
 
 class CogniteAsset(CogniteAssetProperties, CogniteVisualizable, CogniteDescribableNode, CogniteSourceableNode):
+    """This represents the reading format of cognite asset.
+
+    It is used to when data is read from CDF.
+
+    The asset is the bare bone representation of assets in our asset centric world
+
+    Args:
+        space (str): The space where the node is located.
+        external_id (str): The external id of the cognite asset.
+        version (int): DMS version.
+        last_updated_time (int): The number of milliseconds since 00:00:00 Thursday, 1 January 1970, Coordinated Universal Time (UTC), minus leap seconds.
+        created_time (int): The number of milliseconds since 00:00:00 Thursday, 1 January 1970, Coordinated Universal Time (UTC), minus leap seconds.
+        object_3d (DirectRelationReference | None): Direct relation to an Object3D instance representing the 3D resource
+        name (str | None): Name of the instance
+        description (str | None): Description of the instance
+        tags (list[str] | None): Text based labels for generic use, limited to 1000
+        aliases (list[str] | None): Alternative names for the node
+        source_id (str | None): Identifier from the source system
+        source_context (str | None): Context of the source id. For systems where the sourceId is globally unique, the sourceContext is expected to not be set.
+        source (DirectRelationReference | None): Direct relation to a source system
+        source_created_time (datetime | None): When the instance was created in source system (if available)
+        source_updated_time (datetime | None): When the instance was last updated in the source system (if available)
+        source_created_user (str | None): User identifier from the source system on who created the source data. This identifier is not guaranteed to match the user identifiers in CDF
+        source_updated_user (str | None): User identifier from the source system on who last updated the source data. This identifier is not guaranteed to match the user identifiers in CDF
+        parent (DirectRelationReference | None): Parent of this asset
+        root (DirectRelationReference | None): Asset at the top of the hierarchy.
+        path (list[DirectRelationReference] | None): Materialized path of this asset
+        last_path_materialization_time (datetime | None): Last time the path materializer updated the path of this asset
+        equipment (DirectRelationReference | None): Equipment associated with this asset
+        asset_class (DirectRelationReference | None): Class of this asset
+        type_ (DirectRelationReference | None): Type of this asset
+        type (DirectRelationReference | None): Direct relation pointing to the type node.
+        deleted_time (int | None): The number of milliseconds since 00:00:00 Thursday, 1 January 1970, Coordinated Universal Time (UTC), minus leap seconds. Timestamp when the instance was soft deleted. Note that deleted instances are filtered out of query results, but present in sync results
+    """
+
     def __init__(
         self,
         space: str,
@@ -2021,7 +3222,8 @@ class CogniteAsset(CogniteAssetProperties, CogniteVisualizable, CogniteDescribab
         version: int,
         last_updated_time: int,
         created_time: int,
-        object_3_d: DirectRelationReference | None = None,
+        *,
+        object_3d: DirectRelationReference | None = None,
         name: str | None = None,
         description: str | None = None,
         tags: list[str] | None = None,
@@ -2044,7 +3246,15 @@ class CogniteAsset(CogniteAssetProperties, CogniteVisualizable, CogniteDescribab
         deleted_time: int | None = None,
     ) -> None:
         CogniteVisualizable.__init__(
-            self, space, external_id, version, last_updated_time, created_time, object_3_d, type, deleted_time
+            self,
+            space,
+            external_id,
+            version,
+            last_updated_time,
+            created_time,
+            object_3d=object_3d,
+            type=type,
+            deleted_time=deleted_time,
         )
         CogniteDescribableNode.__init__(
             self,
@@ -2053,12 +3263,12 @@ class CogniteAsset(CogniteAssetProperties, CogniteVisualizable, CogniteDescribab
             version,
             last_updated_time,
             created_time,
-            name,
-            description,
-            tags,
-            aliases,
-            type,
-            deleted_time,
+            name=name,
+            description=description,
+            tags=tags,
+            aliases=aliases,
+            type=type,
+            deleted_time=deleted_time,
         )
         CogniteSourceableNode.__init__(
             self,
@@ -2067,15 +3277,15 @@ class CogniteAsset(CogniteAssetProperties, CogniteVisualizable, CogniteDescribab
             version,
             last_updated_time,
             created_time,
-            source_id,
-            source_context,
-            source,
-            source_created_time,
-            source_updated_time,
-            source_created_user,
-            source_updated_user,
-            type,
-            deleted_time,
+            source_id=source_id,
+            source_context=source_context,
+            source=source,
+            source_created_time=source_created_time,
+            source_updated_time=source_updated_time,
+            source_created_user=source_created_user,
+            source_updated_user=source_updated_user,
+            type=type,
+            deleted_time=deleted_time,
         )
         self.parent = DirectRelationReference.load(parent) if parent else None
         self.root = DirectRelationReference.load(root) if root else None
@@ -2089,27 +3299,27 @@ class CogniteAsset(CogniteAssetProperties, CogniteVisualizable, CogniteDescribab
         return CogniteAssetApply(
             self.space,
             self.external_id,
-            self.object_3_d,
-            self.name,
-            self.description,
-            self.tags,
-            self.aliases,
-            self.source_id,
-            self.source_context,
-            self.source,
-            self.source_created_time,
-            self.source_updated_time,
-            self.source_created_user,
-            self.source_updated_user,
-            self.parent,
-            self.root,
-            self.path,  # type: ignore[arg-type]
-            self.last_path_materialization_time,
-            self.equipment,
-            self.asset_class,
-            self.type_,
-            self.version,
-            self.type,
+            object_3d=self.object_3d,
+            name=self.name,
+            description=self.description,
+            tags=self.tags,
+            aliases=self.aliases,
+            source_id=self.source_id,
+            source_context=self.source_context,
+            source=self.source,
+            source_created_time=self.source_created_time,
+            source_updated_time=self.source_updated_time,
+            source_created_user=self.source_created_user,
+            source_updated_user=self.source_updated_user,
+            parent=self.parent,
+            root=self.root,
+            path=self.path,  # type: ignore[arg-type]
+            last_path_materialization_time=self.last_path_materialization_time,
+            equipment=self.equipment,
+            asset_class=self.asset_class,
+            type_=self.type_,
+            existing_version=self.version,
+            type=self.type,
         )
 
 
@@ -2122,23 +3332,67 @@ class CogniteCADRevisionProperties:
 
 
 class CogniteCADRevisionApply(CogniteCADRevisionProperties, CogniteRevision3DApply):
+    """This represents the writing format of cognite cad revision.
+
+    It is used to when data is written to CDF.
+    Args:
+        space (str): The space where the node is located.
+        external_id (str): The external id of the cognite cad revision.
+        status (Literal["Done", "Failed", "Processing", "Queued"] | None): The status field.
+        published (Literal["Done", "Failed", "Processing", "Queued"] | None): The published field.
+        type_ (Literal["CAD", "Image360", "PointCloud"] | None): The type field.
+        model_3d (DirectRelationReference | tuple[str, str] | None): .
+        revision_id (int | None): The 3D API revision identifier for this CAD model
+        existing_version (int | None): Fail the ingestion request if the node's version is greater than or equal to this value. If no existingVersion is specified, the ingestion will always overwrite any existing data for the node (for the specified container or node). If existingVersion is set to 0, the upsert will behave as an insert, so it will fail the bulk if the item already exists. If skipOnVersionConflict is set on the ingestion request, then the item will be skipped instead of failing the ingestion request.
+        type (DirectRelationReference | tuple[str, str] | None): Direct relation pointing to the type node.
+    """
+
     def __init__(
         self,
         space: str,
         external_id: str,
+        *,
         status: Literal["Done", "Failed", "Processing", "Queued"] | None = None,
         published: Literal["Done", "Failed", "Processing", "Queued"] | None = None,
         type_: Literal["CAD", "Image360", "PointCloud"] | None = None,
-        model_3_d: DirectRelationReference | tuple[str, str] | None = None,
+        model_3d: DirectRelationReference | tuple[str, str] | None = None,
         revision_id: int | None = None,
         existing_version: int | None = None,
         type: DirectRelationReference | tuple[str, str] | None = None,
     ) -> None:
-        super().__init__(space, external_id, status, published, type_, model_3_d, existing_version, type)
+        super().__init__(
+            space,
+            external_id,
+            status=status,
+            published=published,
+            type_=type_,
+            model_3d=model_3d,
+            existing_version=existing_version,
+            type=type,
+        )
         self.revision_id = revision_id
 
 
 class CogniteCADRevision(CogniteCADRevisionProperties, CogniteRevision3D):
+    """This represents the reading format of cognite cad revision.
+
+    It is used to when data is read from CDF.
+
+    Args:
+        space (str): The space where the node is located.
+        external_id (str): The external id of the cognite cad revision.
+        version (int): DMS version.
+        last_updated_time (int): The number of milliseconds since 00:00:00 Thursday, 1 January 1970, Coordinated Universal Time (UTC), minus leap seconds.
+        created_time (int): The number of milliseconds since 00:00:00 Thursday, 1 January 1970, Coordinated Universal Time (UTC), minus leap seconds.
+        status (Literal["Done", "Failed", "Processing", "Queued"] | None): The status field.
+        published (Literal["Done", "Failed", "Processing", "Queued"] | None): The published field.
+        type_ (Literal["CAD", "Image360", "PointCloud"] | None): The type field.
+        model_3d (DirectRelationReference | None): .
+        revision_id (int | None): The 3D API revision identifier for this CAD model
+        type (DirectRelationReference | None): Direct relation pointing to the type node.
+        deleted_time (int | None): The number of milliseconds since 00:00:00 Thursday, 1 January 1970, Coordinated Universal Time (UTC), minus leap seconds. Timestamp when the instance was soft deleted. Note that deleted instances are filtered out of query results, but present in sync results
+    """
+
     def __init__(
         self,
         space: str,
@@ -2146,10 +3400,11 @@ class CogniteCADRevision(CogniteCADRevisionProperties, CogniteRevision3D):
         version: int,
         last_updated_time: int,
         created_time: int,
+        *,
         status: Literal["Done", "Failed", "Processing", "Queued"] | None = None,
         published: Literal["Done", "Failed", "Processing", "Queued"] | None = None,
         type_: Literal["CAD", "Image360", "PointCloud"] | None = None,
-        model_3_d: DirectRelationReference | None = None,
+        model_3d: DirectRelationReference | None = None,
         revision_id: int | None = None,
         type: DirectRelationReference | None = None,
         deleted_time: int | None = None,
@@ -2160,12 +3415,12 @@ class CogniteCADRevision(CogniteCADRevisionProperties, CogniteRevision3D):
             version,
             last_updated_time,
             created_time,
-            status,
-            published,
-            type_,
-            model_3_d,
-            type,
-            deleted_time,
+            status=status,
+            published=published,
+            type_=type_,
+            model_3d=model_3d,
+            type=type,
+            deleted_time=deleted_time,
         )
         self.revision_id = revision_id
 
@@ -2173,13 +3428,13 @@ class CogniteCADRevision(CogniteCADRevisionProperties, CogniteRevision3D):
         return CogniteCADRevisionApply(
             self.space,
             self.external_id,
-            self.status,
-            self.published,
-            self.type_,
-            self.model_3_d,
-            self.revision_id,
-            self.version,
-            self.type,
+            status=self.status,
+            published=self.published,
+            type_=self.type_,
+            model_3d=self.model_3d,
+            revision_id=self.revision_id,
+            existing_version=self.version,
+            type=self.type,
         )
 
 
@@ -2192,10 +3447,32 @@ class CogniteImage360CollectionProperties:
 class CogniteImage360CollectionApply(
     CogniteImage360CollectionProperties, CogniteDescribableNodeApply, CogniteRevision3DApply
 ):
+    """This represents the writing format of cognite image 360 collection.
+
+    It is used to when data is written to CDF.
+
+    Represents a logical collection of CogniteImage360 instances
+
+    Args:
+        space (str): The space where the node is located.
+        external_id (str): The external id of the cognite image 360 collection.
+        name (str | None): Name of the instance
+        description (str | None): Description of the instance
+        tags (list[str] | None): Text based labels for generic use, limited to 1000
+        aliases (list[str] | None): Alternative names for the node
+        status (Literal["Done", "Failed", "Processing", "Queued"] | None): The status field.
+        published (Literal["Done", "Failed", "Processing", "Queued"] | None): The published field.
+        type_ (Literal["CAD", "Image360", "PointCloud"] | None): The type field.
+        model_3d (DirectRelationReference | tuple[str, str] | None): The model 3d field.
+        existing_version (int | None): Fail the ingestion request if the node's version is greater than or equal to this value. If no existingVersion is specified, the ingestion will always overwrite any existing data for the node (for the specified container or node). If existingVersion is set to 0, the upsert will behave as an insert, so it will fail the bulk if the item already exists. If skipOnVersionConflict is set on the ingestion request, then the item will be skipped instead of failing the ingestion request.
+        type (DirectRelationReference | tuple[str, str] | None): Direct relation pointing to the type node.
+    """
+
     def __init__(
         self,
         space: str,
         external_id: str,
+        *,
         name: str | None = None,
         description: str | None = None,
         tags: list[str] | None = None,
@@ -2203,19 +3480,59 @@ class CogniteImage360CollectionApply(
         status: Literal["Done", "Failed", "Processing", "Queued"] | None = None,
         published: Literal["Done", "Failed", "Processing", "Queued"] | None = None,
         type_: Literal["CAD", "Image360", "PointCloud"] | None = None,
-        model_3_d: DirectRelationReference | tuple[str, str] | None = None,
+        model_3d: DirectRelationReference | tuple[str, str] | None = None,
         existing_version: int | None = None,
         type: DirectRelationReference | tuple[str, str] | None = None,
     ) -> None:
         CogniteDescribableNodeApply.__init__(
-            self, space, external_id, name, description, tags, aliases, existing_version, type
+            self,
+            space,
+            external_id,
+            name=name,
+            description=description,
+            tags=tags,
+            aliases=aliases,
+            existing_version=existing_version,
+            type=type,
         )
         CogniteRevision3DApply.__init__(
-            self, space, external_id, status, published, type_, model_3_d, existing_version, type
+            self,
+            space,
+            external_id,
+            status=status,
+            published=published,
+            type_=type_,
+            model_3d=model_3d,
+            existing_version=existing_version,
+            type=type,
         )
 
 
 class CogniteImage360Collection(CogniteImage360CollectionProperties, CogniteDescribableNode, CogniteRevision3D):
+    """This represents the reading format of cognite image 360 collection.
+
+    It is used to when data is read from CDF.
+
+    Represents a logical collection of CogniteImage360 instances
+
+    Args:
+        space (str): The space where the node is located.
+        external_id (str): The external id of the cognite image 360 collection.
+        version (int): DMS version.
+        last_updated_time (int): The number of milliseconds since 00:00:00 Thursday, 1 January 1970, Coordinated Universal Time (UTC), minus leap seconds.
+        created_time (int): The number of milliseconds since 00:00:00 Thursday, 1 January 1970, Coordinated Universal Time (UTC), minus leap seconds.
+        name (str | None): Name of the instance
+        description (str | None): Description of the instance
+        tags (list[str] | None): Text based labels for generic use, limited to 1000
+        aliases (list[str] | None): Alternative names for the node
+        status (Literal["Done", "Failed", "Processing", "Queued"] | None): The status field.
+        published (Literal["Done", "Failed", "Processing", "Queued"] | None): The published field.
+        type_ (Literal["CAD", "Image360", "PointCloud"] | None): The type field.
+        model_3d (DirectRelationReference | None): The model 3d field.
+        type (DirectRelationReference | None): Direct relation pointing to the type node.
+        deleted_time (int | None): The number of milliseconds since 00:00:00 Thursday, 1 January 1970, Coordinated Universal Time (UTC), minus leap seconds. Timestamp when the instance was soft deleted. Note that deleted instances are filtered out of query results, but present in sync results
+    """
+
     def __init__(
         self,
         space: str,
@@ -2223,6 +3540,7 @@ class CogniteImage360Collection(CogniteImage360CollectionProperties, CogniteDesc
         version: int,
         last_updated_time: int,
         created_time: int,
+        *,
         name: str | None = None,
         description: str | None = None,
         tags: list[str] | None = None,
@@ -2230,7 +3548,7 @@ class CogniteImage360Collection(CogniteImage360CollectionProperties, CogniteDesc
         status: Literal["Done", "Failed", "Processing", "Queued"] | None = None,
         published: Literal["Done", "Failed", "Processing", "Queued"] | None = None,
         type_: Literal["CAD", "Image360", "PointCloud"] | None = None,
-        model_3_d: DirectRelationReference | None = None,
+        model_3d: DirectRelationReference | None = None,
         type: DirectRelationReference | None = None,
         deleted_time: int | None = None,
     ) -> None:
@@ -2241,12 +3559,12 @@ class CogniteImage360Collection(CogniteImage360CollectionProperties, CogniteDesc
             version,
             last_updated_time,
             created_time,
-            name,
-            description,
-            tags,
-            aliases,
-            type,
-            deleted_time,
+            name=name,
+            description=description,
+            tags=tags,
+            aliases=aliases,
+            type=type,
+            deleted_time=deleted_time,
         )
         CogniteRevision3D.__init__(
             self,
@@ -2255,28 +3573,28 @@ class CogniteImage360Collection(CogniteImage360CollectionProperties, CogniteDesc
             version,
             last_updated_time,
             created_time,
-            status,
-            published,
-            type_,
-            model_3_d,
-            type,
-            deleted_time,
+            status=status,
+            published=published,
+            type_=type_,
+            model_3d=model_3d,
+            type=type,
+            deleted_time=deleted_time,
         )
 
     def as_write(self) -> CogniteImage360CollectionApply:
         return CogniteImage360CollectionApply(
             self.space,
             self.external_id,
-            self.name,
-            self.description,
-            self.tags,
-            self.aliases,
-            self.status,
-            self.published,
-            self.type_,
-            self.model_3_d,
-            self.version,
-            self.type,
+            name=self.name,
+            description=self.description,
+            tags=self.tags,
+            aliases=self.aliases,
+            status=self.status,
+            published=self.published,
+            type_=self.type_,
+            model_3d=self.model_3d,
+            existing_version=self.version,
+            type=self.type,
         )
 
 
@@ -2289,23 +3607,72 @@ class CognitePointCloudRevisionProperties:
 
 
 class CognitePointCloudRevisionApply(CognitePointCloudRevisionProperties, CogniteRevision3DApply):
+    """This represents the writing format of cognite point cloud revision.
+
+    It is used to when data is written to CDF.
+
+    Navigational aid for traversing CognitePointCloudRevision instances
+
+    Args:
+        space (str): The space where the node is located.
+        external_id (str): The external id of the cognite point cloud revision.
+        status (Literal["Done", "Failed", "Processing", "Queued"] | None): The status field.
+        published (Literal["Done", "Failed", "Processing", "Queued"] | None): The published field.
+        type_ (Literal["CAD", "Image360", "PointCloud"] | None): The type field.
+        model_3d (DirectRelationReference | tuple[str, str] | None): .
+        revision_id (int | None): The 3D API revision identifier for this PointCloud model
+        existing_version (int | None): Fail the ingestion request if the node's version is greater than or equal to this value. If no existingVersion is specified, the ingestion will always overwrite any existing data for the node (for the specified container or node). If existingVersion is set to 0, the upsert will behave as an insert, so it will fail the bulk if the item already exists. If skipOnVersionConflict is set on the ingestion request, then the item will be skipped instead of failing the ingestion request.
+        type (DirectRelationReference | tuple[str, str] | None): Direct relation pointing to the type node.
+    """
+
     def __init__(
         self,
         space: str,
         external_id: str,
+        *,
         status: Literal["Done", "Failed", "Processing", "Queued"] | None = None,
         published: Literal["Done", "Failed", "Processing", "Queued"] | None = None,
         type_: Literal["CAD", "Image360", "PointCloud"] | None = None,
-        model_3_d: DirectRelationReference | tuple[str, str] | None = None,
+        model_3d: DirectRelationReference | tuple[str, str] | None = None,
         revision_id: int | None = None,
         existing_version: int | None = None,
         type: DirectRelationReference | tuple[str, str] | None = None,
     ) -> None:
-        super().__init__(space, external_id, status, published, type_, model_3_d, existing_version, type)
+        super().__init__(
+            space,
+            external_id,
+            status=status,
+            published=published,
+            type_=type_,
+            model_3d=model_3d,
+            existing_version=existing_version,
+            type=type,
+        )
         self.revision_id = revision_id
 
 
 class CognitePointCloudRevision(CognitePointCloudRevisionProperties, CogniteRevision3D):
+    """This represents the reading format of cognite point cloud revision.
+
+    It is used to when data is read from CDF.
+
+    Navigational aid for traversing CognitePointCloudRevision instances
+
+    Args:
+        space (str): The space where the node is located.
+        external_id (str): The external id of the cognite point cloud revision.
+        version (int): DMS version.
+        last_updated_time (int): The number of milliseconds since 00:00:00 Thursday, 1 January 1970, Coordinated Universal Time (UTC), minus leap seconds.
+        created_time (int): The number of milliseconds since 00:00:00 Thursday, 1 January 1970, Coordinated Universal Time (UTC), minus leap seconds.
+        status (Literal["Done", "Failed", "Processing", "Queued"] | None): The status field.
+        published (Literal["Done", "Failed", "Processing", "Queued"] | None): The published field.
+        type_ (Literal["CAD", "Image360", "PointCloud"] | None): The type field.
+        model_3d (DirectRelationReference | None): .
+        revision_id (int | None): The 3D API revision identifier for this PointCloud model
+        type (DirectRelationReference | None): Direct relation pointing to the type node.
+        deleted_time (int | None): The number of milliseconds since 00:00:00 Thursday, 1 January 1970, Coordinated Universal Time (UTC), minus leap seconds. Timestamp when the instance was soft deleted. Note that deleted instances are filtered out of query results, but present in sync results
+    """
+
     def __init__(
         self,
         space: str,
@@ -2313,10 +3680,11 @@ class CognitePointCloudRevision(CognitePointCloudRevisionProperties, CogniteRevi
         version: int,
         last_updated_time: int,
         created_time: int,
+        *,
         status: Literal["Done", "Failed", "Processing", "Queued"] | None = None,
         published: Literal["Done", "Failed", "Processing", "Queued"] | None = None,
         type_: Literal["CAD", "Image360", "PointCloud"] | None = None,
-        model_3_d: DirectRelationReference | None = None,
+        model_3d: DirectRelationReference | None = None,
         revision_id: int | None = None,
         type: DirectRelationReference | None = None,
         deleted_time: int | None = None,
@@ -2327,12 +3695,12 @@ class CognitePointCloudRevision(CognitePointCloudRevisionProperties, CogniteRevi
             version,
             last_updated_time,
             created_time,
-            status,
-            published,
-            type_,
-            model_3_d,
-            type,
-            deleted_time,
+            status=status,
+            published=published,
+            type_=type_,
+            model_3d=model_3d,
+            type=type,
+            deleted_time=deleted_time,
         )
         self.revision_id = revision_id
 
@@ -2340,13 +3708,13 @@ class CognitePointCloudRevision(CognitePointCloudRevisionProperties, CogniteRevi
         return CognitePointCloudRevisionApply(
             self.space,
             self.external_id,
-            self.status,
-            self.published,
-            self.type_,
-            self.model_3_d,
-            self.revision_id,
-            self.version,
-            self.type,
+            status=self.status,
+            published=self.published,
+            type_=self.type_,
+            model_3d=self.model_3d,
+            revision_id=self.revision_id,
+            existing_version=self.version,
+            type=self.type,
         )
 
 
@@ -2361,10 +3729,39 @@ class CogniteImage360Properties:
 
 
 class CogniteImage360Apply(CogniteImage360Properties, CogniteTransformation3DNodeApply, CogniteCubeMapApply):
+    """This represents the writing format of cognite image 360.
+
+    It is used to when data is written to CDF.
+    Args:
+        space (str): The space where the node is located.
+        external_id (str): The external id of the cognite image 360.
+        translation_x (float | None): The displacement of the object along the X-axis in 3D space
+        translation_y (float | None): The displacement of the object along the Y-axis in 3D space
+        translation_z (float | None): The displacement of the object along the Z-axis in 3D space
+        euler_rotation_x (float | None): The rotation of the object around the X-axis, measured in degrees
+        euler_rotation_y (float | None): The rotation of the object around the Y-axis, measured in degrees
+        euler_rotation_z (float | None): The rotation of the object around the Z-axis, measured in degrees
+        scale_x (float | None): The scaling factor applied to the object along the X-axis
+        scale_y (float | None): The scaling factor applied to the object along the Y-axis
+        scale_z (float | None): The scaling factor applied to the object along the Z-axis
+        front (DirectRelationReference | tuple[str, str] | None): Direct relation to a file holding the front projection of the cube map
+        back (DirectRelationReference | tuple[str, str] | None): Direct relation to a file holding the back projection of the cube map
+        left (DirectRelationReference | tuple[str, str] | None): Direct relation to a file holding the left projection of the cube map
+        right (DirectRelationReference | tuple[str, str] | None): Direct relation to a file holding the right projection of the cube map
+        top (DirectRelationReference | tuple[str, str] | None): Direct relation to a file holding the top projection of the cube map
+        bottom (DirectRelationReference | tuple[str, str] | None): Direct relation to a file holding the bottom projection of the cube map
+        collection_360 (DirectRelationReference | tuple[str, str] | None): Direct relation to CogniteImage360Collection
+        station_360 (DirectRelationReference | tuple[str, str] | None): Direct relation to CogniteGroup3D instance that groups different CogniteImage360 instances to the same station
+        taken_at (datetime | None): The timestamp when the 6 photos were taken.
+        existing_version (int | None): Fail the ingestion request if the node's version is greater than or equal to this value. If no existingVersion is specified, the ingestion will always overwrite any existing data for the node (for the specified container or node). If existingVersion is set to 0, the upsert will behave as an insert, so it will fail the bulk if the item already exists. If skipOnVersionConflict is set on the ingestion request, then the item will be skipped instead of failing the ingestion request.
+        type (DirectRelationReference | tuple[str, str] | None): Direct relation pointing to the type node.
+    """
+
     def __init__(
         self,
         space: str,
         external_id: str,
+        *,
         translation_x: float | None = None,
         translation_y: float | None = None,
         translation_z: float | None = None,
@@ -2390,20 +3787,30 @@ class CogniteImage360Apply(CogniteImage360Properties, CogniteTransformation3DNod
             self,
             space,
             external_id,
-            translation_x,
-            translation_y,
-            translation_z,
-            euler_rotation_x,
-            euler_rotation_y,
-            euler_rotation_z,
-            scale_x,
-            scale_y,
-            scale_z,
-            existing_version,
-            type,
+            translation_x=translation_x,
+            translation_y=translation_y,
+            translation_z=translation_z,
+            euler_rotation_x=euler_rotation_x,
+            euler_rotation_y=euler_rotation_y,
+            euler_rotation_z=euler_rotation_z,
+            scale_x=scale_x,
+            scale_y=scale_y,
+            scale_z=scale_z,
+            existing_version=existing_version,
+            type=type,
         )
         CogniteCubeMapApply.__init__(
-            self, space, external_id, front, back, left, right, top, bottom, existing_version, type
+            self,
+            space,
+            external_id,
+            front=front,
+            back=back,
+            left=left,
+            right=right,
+            top=top,
+            bottom=bottom,
+            existing_version=existing_version,
+            type=type,
         )
         self.collection_360 = DirectRelationReference.load(collection_360) if collection_360 else None
         self.station_360 = DirectRelationReference.load(station_360) if station_360 else None
@@ -2411,6 +3818,38 @@ class CogniteImage360Apply(CogniteImage360Properties, CogniteTransformation3DNod
 
 
 class CogniteImage360(CogniteImage360Properties, CogniteTransformation3DNode, CogniteCubeMap):
+    """This represents the reading format of cognite image 360.
+
+    It is used to when data is read from CDF.
+
+    Args:
+        space (str): The space where the node is located.
+        external_id (str): The external id of the cognite image 360.
+        version (int): DMS version.
+        last_updated_time (int): The number of milliseconds since 00:00:00 Thursday, 1 January 1970, Coordinated Universal Time (UTC), minus leap seconds.
+        created_time (int): The number of milliseconds since 00:00:00 Thursday, 1 January 1970, Coordinated Universal Time (UTC), minus leap seconds.
+        translation_x (float | None): The displacement of the object along the X-axis in 3D space
+        translation_y (float | None): The displacement of the object along the Y-axis in 3D space
+        translation_z (float | None): The displacement of the object along the Z-axis in 3D space
+        euler_rotation_x (float | None): The rotation of the object around the X-axis, measured in degrees
+        euler_rotation_y (float | None): The rotation of the object around the Y-axis, measured in degrees
+        euler_rotation_z (float | None): The rotation of the object around the Z-axis, measured in degrees
+        scale_x (float | None): The scaling factor applied to the object along the X-axis
+        scale_y (float | None): The scaling factor applied to the object along the Y-axis
+        scale_z (float | None): The scaling factor applied to the object along the Z-axis
+        front (DirectRelationReference | None): Direct relation to a file holding the front projection of the cube map
+        back (DirectRelationReference | None): Direct relation to a file holding the back projection of the cube map
+        left (DirectRelationReference | None): Direct relation to a file holding the left projection of the cube map
+        right (DirectRelationReference | None): Direct relation to a file holding the right projection of the cube map
+        top (DirectRelationReference | None): Direct relation to a file holding the top projection of the cube map
+        bottom (DirectRelationReference | None): Direct relation to a file holding the bottom projection of the cube map
+        collection_360 (DirectRelationReference | None): Direct relation to CogniteImage360Collection
+        station_360 (DirectRelationReference | None): Direct relation to CogniteGroup3D instance that groups different CogniteImage360 instances to the same station
+        taken_at (datetime | None): The timestamp when the 6 photos were taken.
+        type (DirectRelationReference | None): Direct relation pointing to the type node.
+        deleted_time (int | None): The number of milliseconds since 00:00:00 Thursday, 1 January 1970, Coordinated Universal Time (UTC), minus leap seconds. Timestamp when the instance was soft deleted. Note that deleted instances are filtered out of query results, but present in sync results
+    """
+
     def __init__(
         self,
         space: str,
@@ -2418,6 +3857,7 @@ class CogniteImage360(CogniteImage360Properties, CogniteTransformation3DNode, Co
         version: int,
         last_updated_time: int,
         created_time: int,
+        *,
         translation_x: float | None = None,
         translation_y: float | None = None,
         translation_z: float | None = None,
@@ -2446,17 +3886,17 @@ class CogniteImage360(CogniteImage360Properties, CogniteTransformation3DNode, Co
             version,
             last_updated_time,
             created_time,
-            translation_x,
-            translation_y,
-            translation_z,
-            euler_rotation_x,
-            euler_rotation_y,
-            euler_rotation_z,
-            scale_x,
-            scale_y,
-            scale_z,
-            type,
-            deleted_time,
+            translation_x=translation_x,
+            translation_y=translation_y,
+            translation_z=translation_z,
+            euler_rotation_x=euler_rotation_x,
+            euler_rotation_y=euler_rotation_y,
+            euler_rotation_z=euler_rotation_z,
+            scale_x=scale_x,
+            scale_y=scale_y,
+            scale_z=scale_z,
+            type=type,
+            deleted_time=deleted_time,
         )
         CogniteCubeMap.__init__(
             self,
@@ -2465,14 +3905,14 @@ class CogniteImage360(CogniteImage360Properties, CogniteTransformation3DNode, Co
             version,
             last_updated_time,
             created_time,
-            front,
-            back,
-            left,
-            right,
-            top,
-            bottom,
-            type,
-            deleted_time,
+            front=front,
+            back=back,
+            left=left,
+            right=right,
+            top=top,
+            bottom=bottom,
+            type=type,
+            deleted_time=deleted_time,
         )
         self.collection_360 = DirectRelationReference.load(collection_360) if collection_360 else None
         self.station_360 = DirectRelationReference.load(station_360) if station_360 else None
@@ -2482,26 +3922,26 @@ class CogniteImage360(CogniteImage360Properties, CogniteTransformation3DNode, Co
         return CogniteImage360Apply(
             self.space,
             self.external_id,
-            self.translation_x,
-            self.translation_y,
-            self.translation_z,
-            self.euler_rotation_x,
-            self.euler_rotation_y,
-            self.euler_rotation_z,
-            self.scale_x,
-            self.scale_y,
-            self.scale_z,
-            self.front,
-            self.back,
-            self.left,
-            self.right,
-            self.top,
-            self.bottom,
-            self.collection_360,
-            self.station_360,
-            self.taken_at,
-            self.version,
-            self.type,
+            translation_x=self.translation_x,
+            translation_y=self.translation_y,
+            translation_z=self.translation_z,
+            euler_rotation_x=self.euler_rotation_x,
+            euler_rotation_y=self.euler_rotation_y,
+            euler_rotation_z=self.euler_rotation_z,
+            scale_x=self.scale_x,
+            scale_y=self.scale_y,
+            scale_z=self.scale_z,
+            front=self.front,
+            back=self.back,
+            left=self.left,
+            right=self.right,
+            top=self.top,
+            bottom=self.bottom,
+            collection_360=self.collection_360,
+            station_360=self.station_360,
+            taken_at=self.taken_at,
+            existing_version=self.version,
+            type=self.type,
         )
 
 
@@ -2512,10 +3952,29 @@ class CogniteCADModelProperties:
 
 
 class CogniteCADModelApply(CogniteCADModelProperties, CogniteModel3DApply):
+    """This represents the writing format of cognite cad model.
+
+    It is used to when data is written to CDF.
+
+    Navigational aid for traversing CogniteCADModel instances
+
+    Args:
+        space (str): The space where the node is located.
+        external_id (str): The external id of the cognite cad model.
+        name (str | None): Name of the instance
+        description (str | None): Description of the instance
+        tags (list[str] | None): Text based labels for generic use, limited to 1000
+        aliases (list[str] | None): Alternative names for the node
+        type_ (Literal["CAD", "Image360", "PointCloud"] | None): CAD, PointCloud or CogniteImage360
+        existing_version (int | None): Fail the ingestion request if the node's version is greater than or equal to this value. If no existingVersion is specified, the ingestion will always overwrite any existing data for the node (for the specified container or node). If existingVersion is set to 0, the upsert will behave as an insert, so it will fail the bulk if the item already exists. If skipOnVersionConflict is set on the ingestion request, then the item will be skipped instead of failing the ingestion request.
+        type (DirectRelationReference | tuple[str, str] | None): Direct relation pointing to the type node.
+    """
+
     def __init__(
         self,
         space: str,
         external_id: str,
+        *,
         name: str | None = None,
         description: str | None = None,
         tags: list[str] | None = None,
@@ -2524,10 +3983,41 @@ class CogniteCADModelApply(CogniteCADModelProperties, CogniteModel3DApply):
         existing_version: int | None = None,
         type: DirectRelationReference | tuple[str, str] | None = None,
     ) -> None:
-        super().__init__(space, external_id, name, description, tags, aliases, type_, existing_version, type)
+        super().__init__(
+            space,
+            external_id,
+            name=name,
+            description=description,
+            tags=tags,
+            aliases=aliases,
+            type_=type_,
+            existing_version=existing_version,
+            type=type,
+        )
 
 
 class CogniteCADModel(CogniteCADModelProperties, CogniteModel3D):
+    """This represents the reading format of cognite cad model.
+
+    It is used to when data is read from CDF.
+
+    Navigational aid for traversing CogniteCADModel instances
+
+    Args:
+        space (str): The space where the node is located.
+        external_id (str): The external id of the cognite cad model.
+        version (int): DMS version.
+        last_updated_time (int): The number of milliseconds since 00:00:00 Thursday, 1 January 1970, Coordinated Universal Time (UTC), minus leap seconds.
+        created_time (int): The number of milliseconds since 00:00:00 Thursday, 1 January 1970, Coordinated Universal Time (UTC), minus leap seconds.
+        name (str | None): Name of the instance
+        description (str | None): Description of the instance
+        tags (list[str] | None): Text based labels for generic use, limited to 1000
+        aliases (list[str] | None): Alternative names for the node
+        type_ (Literal["CAD", "Image360", "PointCloud"] | None): CAD, PointCloud or CogniteImage360
+        type (DirectRelationReference | None): Direct relation pointing to the type node.
+        deleted_time (int | None): The number of milliseconds since 00:00:00 Thursday, 1 January 1970, Coordinated Universal Time (UTC), minus leap seconds. Timestamp when the instance was soft deleted. Note that deleted instances are filtered out of query results, but present in sync results
+    """
+
     def __init__(
         self,
         space: str,
@@ -2535,6 +4025,7 @@ class CogniteCADModel(CogniteCADModelProperties, CogniteModel3D):
         version: int,
         last_updated_time: int,
         created_time: int,
+        *,
         name: str | None = None,
         description: str | None = None,
         tags: list[str] | None = None,
@@ -2549,26 +4040,26 @@ class CogniteCADModel(CogniteCADModelProperties, CogniteModel3D):
             version,
             last_updated_time,
             created_time,
-            name,
-            description,
-            tags,
-            aliases,
-            type_,
-            type,
-            deleted_time,
+            name=name,
+            description=description,
+            tags=tags,
+            aliases=aliases,
+            type_=type_,
+            type=type,
+            deleted_time=deleted_time,
         )
 
     def as_write(self) -> CogniteCADModelApply:
         return CogniteCADModelApply(
             self.space,
             self.external_id,
-            self.name,
-            self.description,
-            self.tags,
-            self.aliases,
-            self.type_,
-            self.version,
-            self.type,
+            name=self.name,
+            description=self.description,
+            tags=self.tags,
+            aliases=self.aliases,
+            type_=self.type_,
+            existing_version=self.version,
+            type=self.type,
         )
 
 
@@ -2579,10 +4070,29 @@ class CogniteImage360ModelProperties:
 
 
 class CogniteImage360ModelApply(CogniteImage360ModelProperties, CogniteModel3DApply):
+    """This represents the writing format of cognite image 360 model.
+
+    It is used to when data is written to CDF.
+
+    Navigational aid for traversing CogniteImage360Model instances
+
+    Args:
+        space (str): The space where the node is located.
+        external_id (str): The external id of the cognite image 360 model.
+        name (str | None): Name of the instance
+        description (str | None): Description of the instance
+        tags (list[str] | None): Text based labels for generic use, limited to 1000
+        aliases (list[str] | None): Alternative names for the node
+        type_ (Literal["CAD", "Image360", "PointCloud"] | None): CAD, PointCloud or CogniteImage360
+        existing_version (int | None): Fail the ingestion request if the node's version is greater than or equal to this value. If no existingVersion is specified, the ingestion will always overwrite any existing data for the node (for the specified container or node). If existingVersion is set to 0, the upsert will behave as an insert, so it will fail the bulk if the item already exists. If skipOnVersionConflict is set on the ingestion request, then the item will be skipped instead of failing the ingestion request.
+        type (DirectRelationReference | tuple[str, str] | None): Direct relation pointing to the type node.
+    """
+
     def __init__(
         self,
         space: str,
         external_id: str,
+        *,
         name: str | None = None,
         description: str | None = None,
         tags: list[str] | None = None,
@@ -2591,10 +4101,41 @@ class CogniteImage360ModelApply(CogniteImage360ModelProperties, CogniteModel3DAp
         existing_version: int | None = None,
         type: DirectRelationReference | tuple[str, str] | None = None,
     ) -> None:
-        super().__init__(space, external_id, name, description, tags, aliases, type_, existing_version, type)
+        super().__init__(
+            space,
+            external_id,
+            name=name,
+            description=description,
+            tags=tags,
+            aliases=aliases,
+            type_=type_,
+            existing_version=existing_version,
+            type=type,
+        )
 
 
 class CogniteImage360Model(CogniteImage360ModelProperties, CogniteModel3D):
+    """This represents the reading format of cognite image 360 model.
+
+    It is used to when data is read from CDF.
+
+    Navigational aid for traversing CogniteImage360Model instances
+
+    Args:
+        space (str): The space where the node is located.
+        external_id (str): The external id of the cognite image 360 model.
+        version (int): DMS version.
+        last_updated_time (int): The number of milliseconds since 00:00:00 Thursday, 1 January 1970, Coordinated Universal Time (UTC), minus leap seconds.
+        created_time (int): The number of milliseconds since 00:00:00 Thursday, 1 January 1970, Coordinated Universal Time (UTC), minus leap seconds.
+        name (str | None): Name of the instance
+        description (str | None): Description of the instance
+        tags (list[str] | None): Text based labels for generic use, limited to 1000
+        aliases (list[str] | None): Alternative names for the node
+        type_ (Literal["CAD", "Image360", "PointCloud"] | None): CAD, PointCloud or CogniteImage360
+        type (DirectRelationReference | None): Direct relation pointing to the type node.
+        deleted_time (int | None): The number of milliseconds since 00:00:00 Thursday, 1 January 1970, Coordinated Universal Time (UTC), minus leap seconds. Timestamp when the instance was soft deleted. Note that deleted instances are filtered out of query results, but present in sync results
+    """
+
     def __init__(
         self,
         space: str,
@@ -2602,6 +4143,7 @@ class CogniteImage360Model(CogniteImage360ModelProperties, CogniteModel3D):
         version: int,
         last_updated_time: int,
         created_time: int,
+        *,
         name: str | None = None,
         description: str | None = None,
         tags: list[str] | None = None,
@@ -2616,26 +4158,26 @@ class CogniteImage360Model(CogniteImage360ModelProperties, CogniteModel3D):
             version,
             last_updated_time,
             created_time,
-            name,
-            description,
-            tags,
-            aliases,
-            type_,
-            type,
-            deleted_time,
+            name=name,
+            description=description,
+            tags=tags,
+            aliases=aliases,
+            type_=type_,
+            type=type,
+            deleted_time=deleted_time,
         )
 
     def as_write(self) -> CogniteImage360ModelApply:
         return CogniteImage360ModelApply(
             self.space,
             self.external_id,
-            self.name,
-            self.description,
-            self.tags,
-            self.aliases,
-            self.type_,
-            self.version,
-            self.type,
+            name=self.name,
+            description=self.description,
+            tags=self.tags,
+            aliases=self.aliases,
+            type_=self.type_,
+            existing_version=self.version,
+            type=self.type,
         )
 
 
@@ -2646,10 +4188,29 @@ class CognitePointCloudModelProperties:
 
 
 class CognitePointCloudModelApply(CognitePointCloudModelProperties, CogniteModel3DApply):
+    """This represents the writing format of cognite point cloud model.
+
+    It is used to when data is written to CDF.
+
+    Navigational aid for traversing CognitePointCloudModel instances
+
+    Args:
+        space (str): The space where the node is located.
+        external_id (str): The external id of the cognite point cloud model.
+        name (str | None): Name of the instance
+        description (str | None): Description of the instance
+        tags (list[str] | None): Text based labels for generic use, limited to 1000
+        aliases (list[str] | None): Alternative names for the node
+        type_ (Literal["CAD", "Image360", "PointCloud"] | None): CAD, PointCloud or CogniteImage360
+        existing_version (int | None): Fail the ingestion request if the node's version is greater than or equal to this value. If no existingVersion is specified, the ingestion will always overwrite any existing data for the node (for the specified container or node). If existingVersion is set to 0, the upsert will behave as an insert, so it will fail the bulk if the item already exists. If skipOnVersionConflict is set on the ingestion request, then the item will be skipped instead of failing the ingestion request.
+        type (DirectRelationReference | tuple[str, str] | None): Direct relation pointing to the type node.
+    """
+
     def __init__(
         self,
         space: str,
         external_id: str,
+        *,
         name: str | None = None,
         description: str | None = None,
         tags: list[str] | None = None,
@@ -2658,10 +4219,41 @@ class CognitePointCloudModelApply(CognitePointCloudModelProperties, CogniteModel
         existing_version: int | None = None,
         type: DirectRelationReference | tuple[str, str] | None = None,
     ) -> None:
-        super().__init__(space, external_id, name, description, tags, aliases, type_, existing_version, type)
+        super().__init__(
+            space,
+            external_id,
+            name=name,
+            description=description,
+            tags=tags,
+            aliases=aliases,
+            type_=type_,
+            existing_version=existing_version,
+            type=type,
+        )
 
 
 class CognitePointCloudModel(CognitePointCloudModelProperties, CogniteModel3D):
+    """This represents the reading format of cognite point cloud model.
+
+    It is used to when data is read from CDF.
+
+    Navigational aid for traversing CognitePointCloudModel instances
+
+    Args:
+        space (str): The space where the node is located.
+        external_id (str): The external id of the cognite point cloud model.
+        version (int): DMS version.
+        last_updated_time (int): The number of milliseconds since 00:00:00 Thursday, 1 January 1970, Coordinated Universal Time (UTC), minus leap seconds.
+        created_time (int): The number of milliseconds since 00:00:00 Thursday, 1 January 1970, Coordinated Universal Time (UTC), minus leap seconds.
+        name (str | None): Name of the instance
+        description (str | None): Description of the instance
+        tags (list[str] | None): Text based labels for generic use, limited to 1000
+        aliases (list[str] | None): Alternative names for the node
+        type_ (Literal["CAD", "Image360", "PointCloud"] | None): CAD, PointCloud or CogniteImage360
+        type (DirectRelationReference | None): Direct relation pointing to the type node.
+        deleted_time (int | None): The number of milliseconds since 00:00:00 Thursday, 1 January 1970, Coordinated Universal Time (UTC), minus leap seconds. Timestamp when the instance was soft deleted. Note that deleted instances are filtered out of query results, but present in sync results
+    """
+
     def __init__(
         self,
         space: str,
@@ -2669,6 +4261,7 @@ class CognitePointCloudModel(CognitePointCloudModelProperties, CogniteModel3D):
         version: int,
         last_updated_time: int,
         created_time: int,
+        *,
         name: str | None = None,
         description: str | None = None,
         tags: list[str] | None = None,
@@ -2683,30 +4276,50 @@ class CognitePointCloudModel(CognitePointCloudModelProperties, CogniteModel3D):
             version,
             last_updated_time,
             created_time,
-            name,
-            description,
-            tags,
-            aliases,
-            type_,
-            type,
-            deleted_time,
+            name=name,
+            description=description,
+            tags=tags,
+            aliases=aliases,
+            type_=type_,
+            type=type,
+            deleted_time=deleted_time,
         )
 
     def as_write(self) -> CognitePointCloudModelApply:
         return CognitePointCloudModelApply(
             self.space,
             self.external_id,
-            self.name,
-            self.description,
-            self.tags,
-            self.aliases,
-            self.type_,
-            self.version,
-            self.type,
+            name=self.name,
+            description=self.description,
+            tags=self.tags,
+            aliases=self.aliases,
+            type_=self.type_,
+            existing_version=self.version,
+            type=self.type,
         )
 
 
 class CogniteDescribableEdgeApply(CogniteDescribableProperties, TypedEdgeApply):
+    """This represents the writing format of cognite describable edge.
+
+    It is used to when data is written to CDF.
+
+    The describable core concept is used as a standard way of holding the bare minimum of information about the instance
+
+
+    Args:
+        space (str): The space where the node is located.
+        external_id (str): The external id of the cognite describable edge.
+        type (DirectRelationReference | tuple[str, str]): The type of edge.
+        start_node (DirectRelationReference | tuple[str, str]): Reference to the direct relation. The reference consists of a space and an external-id.
+        end_node (DirectRelationReference | tuple[str, str]): Reference to the direct relation. The reference consists of a space and an external-id.
+        name (str | None): Name of the instance
+        description (str | None): Description of the instance
+        tags (list[str] | None): Text based labels for generic use, limited to 1000
+        aliases (list[str] | None): Alternative names for the node
+        existing_version (int | None): Fail the ingestion request if the edge's version is greater than or equal to this value. If no existingVersion is specified, the ingestion will always overwrite any existing data for the edge (for the specified container or edge). If existingVersion is set to 0, the upsert will behave as an insert, so it will fail the bulk if the item already exists. If skipOnVersionConflict is set on the ingestion request, then the item will be skipped instead of failing the ingestion request.
+    """
+
     def __init__(
         self,
         space: str,
@@ -2714,6 +4327,7 @@ class CogniteDescribableEdgeApply(CogniteDescribableProperties, TypedEdgeApply):
         type: DirectRelationReference | tuple[str, str],
         start_node: DirectRelationReference | tuple[str, str],
         end_node: DirectRelationReference | tuple[str, str],
+        *,
         name: str | None = None,
         description: str | None = None,
         tags: list[str] | None = None,
@@ -2728,6 +4342,29 @@ class CogniteDescribableEdgeApply(CogniteDescribableProperties, TypedEdgeApply):
 
 
 class CogniteDescribableEdge(CogniteDescribableProperties, TypedEdge):
+    """This represents the reading format of cognite describable edge.
+
+    It is used to when data is read from CDF.
+
+    The describable core concept is used as a standard way of holding the bare minimum of information about the instance
+
+
+    Args:
+        space (str): The space where the node is located.
+        external_id (str): The external id of the cognite describable edge.
+        type (DirectRelationReference): The type of edge.
+        start_node (DirectRelationReference): Reference to the direct relation. The reference consists of a space and an external-id.
+        end_node (DirectRelationReference): Reference to the direct relation. The reference consists of a space and an external-id.
+        version (int): DMS version.
+        last_updated_time (int): The number of milliseconds since 00:00:00 Thursday, 1 January 1970, Coordinated Universal Time (UTC), minus leap seconds.
+        created_time (int): The number of milliseconds since 00:00:00 Thursday, 1 January 1970, Coordinated Universal Time (UTC), minus leap seconds.
+        name (str | None): Name of the instance
+        description (str | None): Description of the instance
+        tags (list[str] | None): Text based labels for generic use, limited to 1000
+        aliases (list[str] | None): Alternative names for the node
+        deleted_time (int | None): The number of milliseconds since 00:00:00 Thursday, 1 January 1970, Coordinated Universal Time (UTC), minus leap seconds. Timestamp when the instance was soft deleted. Note that deleted instances are filtered out of query results, but present in sync results
+    """
+
     def __init__(
         self,
         space: str,
@@ -2738,6 +4375,7 @@ class CogniteDescribableEdge(CogniteDescribableProperties, TypedEdge):
         version: int,
         last_updated_time: int,
         created_time: int,
+        *,
         name: str | None = None,
         description: str | None = None,
         tags: list[str] | None = None,
@@ -2769,15 +4407,35 @@ class CogniteDescribableEdge(CogniteDescribableProperties, TypedEdge):
             self.type,
             self.start_node,
             self.end_node,
-            self.name,
-            self.description,
-            self.tags,
-            self.aliases,
-            self.version,
+            name=self.name,
+            description=self.description,
+            tags=self.tags,
+            aliases=self.aliases,
+            existing_version=self.version,
         )
 
 
 class CogniteSourceableEdgeApply(CogniteSourceableProperties, TypedEdgeApply):
+    """This represents the writing format of cognite sourceable edge.
+
+    It is used to when data is written to CDF.
+
+    Args:
+        space (str): The space where the node is located.
+        external_id (str): The external id of the cognite sourceable edge.
+        type (DirectRelationReference | tuple[str, str]): The type of edge.
+        start_node (DirectRelationReference | tuple[str, str]): Reference to the direct relation. The reference consists of a space and an external-id.
+        end_node (DirectRelationReference | tuple[str, str]): Reference to the direct relation. The reference consists of a space and an external-id.
+        source_id (str | None): Identifier from the source system
+        source_context (str | None): Context of the source id. For systems where the sourceId is globally unique, the sourceContext is expected to not be set.
+        source (DirectRelationReference | tuple[str, str] | None): Direct relation to a source system
+        source_created_time (datetime | None): When the instance was created in source system (if available)
+        source_updated_time (datetime | None): When the instance was last updated in the source system (if available)
+        source_created_user (str | None): User identifier from the source system on who created the source data. This identifier is not guaranteed to match the user identifiers in CDF
+        source_updated_user (str | None): User identifier from the source system on who last updated the source data. This identifier is not guaranteed to match the user identifiers in CDF
+        existing_version (int | None): Fail the ingestion request if the edge's version is greater than or equal to this value. If no existingVersion is specified, the ingestion will always overwrite any existing data for the edge (for the specified container or edge). If existingVersion is set to 0, the upsert will behave as an insert, so it will fail the bulk if the item already exists. If skipOnVersionConflict is set on the ingestion request, then the item will be skipped instead of failing the ingestion request.
+    """
+
     def __init__(
         self,
         space: str,
@@ -2785,6 +4443,7 @@ class CogniteSourceableEdgeApply(CogniteSourceableProperties, TypedEdgeApply):
         type: DirectRelationReference | tuple[str, str],
         start_node: DirectRelationReference | tuple[str, str],
         end_node: DirectRelationReference | tuple[str, str],
+        *,
         source_id: str | None = None,
         source_context: str | None = None,
         source: DirectRelationReference | tuple[str, str] | None = None,
@@ -2805,6 +4464,29 @@ class CogniteSourceableEdgeApply(CogniteSourceableProperties, TypedEdgeApply):
 
 
 class CogniteSourceableEdge(CogniteSourceableProperties, TypedEdge):
+    """This represents the reading format of cognite sourceable edge.
+
+    It is used to when data is read from CDF.
+
+    Args:
+        space (str): The space where the node is located.
+        external_id (str): The external id of the cognite sourceable edge.
+        type (DirectRelationReference): The type of edge.
+        start_node (DirectRelationReference): Reference to the direct relation. The reference consists of a space and an external-id.
+        end_node (DirectRelationReference): Reference to the direct relation. The reference consists of a space and an external-id.
+        version (int): DMS version.
+        last_updated_time (int): The number of milliseconds since 00:00:00 Thursday, 1 January 1970, Coordinated Universal Time (UTC), minus leap seconds.
+        created_time (int): The number of milliseconds since 00:00:00 Thursday, 1 January 1970, Coordinated Universal Time (UTC), minus leap seconds.
+        source_id (str | None): Identifier from the source system
+        source_context (str | None): Context of the source id. For systems where the sourceId is globally unique, the sourceContext is expected to not be set.
+        source (DirectRelationReference | None): Direct relation to a source system
+        source_created_time (datetime | None): When the instance was created in source system (if available)
+        source_updated_time (datetime | None): When the instance was last updated in the source system (if available)
+        source_created_user (str | None): User identifier from the source system on who created the source data. This identifier is not guaranteed to match the user identifiers in CDF
+        source_updated_user (str | None): User identifier from the source system on who last updated the source data. This identifier is not guaranteed to match the user identifiers in CDF
+        deleted_time (int | None): The number of milliseconds since 00:00:00 Thursday, 1 January 1970, Coordinated Universal Time (UTC), minus leap seconds. Timestamp when the instance was soft deleted. Note that deleted instances are filtered out of query results, but present in sync results
+    """
+
     def __init__(
         self,
         space: str,
@@ -2815,6 +4497,7 @@ class CogniteSourceableEdge(CogniteSourceableProperties, TypedEdge):
         version: int,
         last_updated_time: int,
         created_time: int,
+        *,
         source_id: str | None = None,
         source_context: str | None = None,
         source: DirectRelationReference | None = None,
@@ -2852,18 +4535,43 @@ class CogniteSourceableEdge(CogniteSourceableProperties, TypedEdge):
             self.type,
             self.start_node,
             self.end_node,
-            self.source_id,
-            self.source_context,
-            self.source,
-            self.source_created_time,
-            self.source_updated_time,
-            self.source_created_user,
-            self.source_updated_user,
-            self.version,
+            source_id=self.source_id,
+            source_context=self.source_context,
+            source=self.source,
+            source_created_time=self.source_created_time,
+            source_updated_time=self.source_updated_time,
+            source_created_user=self.source_created_user,
+            source_updated_user=self.source_updated_user,
+            existing_version=self.version,
         )
 
 
 class CogniteTransformation3DEdgeApply(CogniteTransformation3DProperties, TypedEdgeApply):
+    """This represents the writing format of cognite transformation 3 d edge.
+
+    It is used to when data is written to CDF.
+
+    The CogniteTransformation3D object defines a comprehensive 3D transformation, enabling precise adjustments to an object's position, orientation, and size in 3D space. It allows for the translation of objects along the three spatial axes, rotation around these axes using Euler angles, and scaling along each axis to modify the object's dimensions
+
+
+    Args:
+        space (str): The space where the node is located.
+        external_id (str): The external id of the cognite transformation 3 d edge.
+        type (DirectRelationReference | tuple[str, str]): The type of edge.
+        start_node (DirectRelationReference | tuple[str, str]): Reference to the direct relation. The reference consists of a space and an external-id.
+        end_node (DirectRelationReference | tuple[str, str]): Reference to the direct relation. The reference consists of a space and an external-id.
+        translation_x (float | None): The displacement of the object along the X-axis in 3D space
+        translation_y (float | None): The displacement of the object along the Y-axis in 3D space
+        translation_z (float | None): The displacement of the object along the Z-axis in 3D space
+        euler_rotation_x (float | None): The rotation of the object around the X-axis, measured in degrees
+        euler_rotation_y (float | None): The rotation of the object around the Y-axis, measured in degrees
+        euler_rotation_z (float | None): The rotation of the object around the Z-axis, measured in degrees
+        scale_x (float | None): The scaling factor applied to the object along the X-axis
+        scale_y (float | None): The scaling factor applied to the object along the Y-axis
+        scale_z (float | None): The scaling factor applied to the object along the Z-axis
+        existing_version (int | None): Fail the ingestion request if the edge's version is greater than or equal to this value. If no existingVersion is specified, the ingestion will always overwrite any existing data for the edge (for the specified container or edge). If existingVersion is set to 0, the upsert will behave as an insert, so it will fail the bulk if the item already exists. If skipOnVersionConflict is set on the ingestion request, then the item will be skipped instead of failing the ingestion request.
+    """
+
     def __init__(
         self,
         space: str,
@@ -2871,6 +4579,7 @@ class CogniteTransformation3DEdgeApply(CogniteTransformation3DProperties, TypedE
         type: DirectRelationReference | tuple[str, str],
         start_node: DirectRelationReference | tuple[str, str],
         end_node: DirectRelationReference | tuple[str, str],
+        *,
         translation_x: float | None = None,
         translation_y: float | None = None,
         translation_z: float | None = None,
@@ -2895,6 +4604,34 @@ class CogniteTransformation3DEdgeApply(CogniteTransformation3DProperties, TypedE
 
 
 class CogniteTransformation3DEdge(CogniteTransformation3DProperties, TypedEdge):
+    """This represents the reading format of cognite transformation 3 d edge.
+
+    It is used to when data is read from CDF.
+
+    The CogniteTransformation3D object defines a comprehensive 3D transformation, enabling precise adjustments to an object's position, orientation, and size in 3D space. It allows for the translation of objects along the three spatial axes, rotation around these axes using Euler angles, and scaling along each axis to modify the object's dimensions
+
+
+    Args:
+        space (str): The space where the node is located.
+        external_id (str): The external id of the cognite transformation 3 d edge.
+        type (DirectRelationReference): The type of edge.
+        start_node (DirectRelationReference): Reference to the direct relation. The reference consists of a space and an external-id.
+        end_node (DirectRelationReference): Reference to the direct relation. The reference consists of a space and an external-id.
+        version (int): DMS version.
+        last_updated_time (int): The number of milliseconds since 00:00:00 Thursday, 1 January 1970, Coordinated Universal Time (UTC), minus leap seconds.
+        created_time (int): The number of milliseconds since 00:00:00 Thursday, 1 January 1970, Coordinated Universal Time (UTC), minus leap seconds.
+        translation_x (float | None): The displacement of the object along the X-axis in 3D space
+        translation_y (float | None): The displacement of the object along the Y-axis in 3D space
+        translation_z (float | None): The displacement of the object along the Z-axis in 3D space
+        euler_rotation_x (float | None): The rotation of the object around the X-axis, measured in degrees
+        euler_rotation_y (float | None): The rotation of the object around the Y-axis, measured in degrees
+        euler_rotation_z (float | None): The rotation of the object around the Z-axis, measured in degrees
+        scale_x (float | None): The scaling factor applied to the object along the X-axis
+        scale_y (float | None): The scaling factor applied to the object along the Y-axis
+        scale_z (float | None): The scaling factor applied to the object along the Z-axis
+        deleted_time (int | None): The number of milliseconds since 00:00:00 Thursday, 1 January 1970, Coordinated Universal Time (UTC), minus leap seconds. Timestamp when the instance was soft deleted. Note that deleted instances are filtered out of query results, but present in sync results
+    """
+
     def __init__(
         self,
         space: str,
@@ -2905,6 +4642,7 @@ class CogniteTransformation3DEdge(CogniteTransformation3DProperties, TypedEdge):
         version: int,
         last_updated_time: int,
         created_time: int,
+        *,
         translation_x: float | None = None,
         translation_y: float | None = None,
         translation_z: float | None = None,
@@ -2946,16 +4684,16 @@ class CogniteTransformation3DEdge(CogniteTransformation3DProperties, TypedEdge):
             self.type,
             self.start_node,
             self.end_node,
-            self.translation_x,
-            self.translation_y,
-            self.translation_z,
-            self.euler_rotation_x,
-            self.euler_rotation_y,
-            self.euler_rotation_z,
-            self.scale_x,
-            self.scale_y,
-            self.scale_z,
-            self.version,
+            translation_x=self.translation_x,
+            translation_y=self.translation_y,
+            translation_z=self.translation_z,
+            euler_rotation_x=self.euler_rotation_x,
+            euler_rotation_y=self.euler_rotation_y,
+            euler_rotation_z=self.euler_rotation_z,
+            scale_x=self.scale_x,
+            scale_y=self.scale_y,
+            scale_z=self.scale_z,
+            existing_version=self.version,
         )
 
 
@@ -2966,6 +4704,34 @@ class CogniteAnnotationProperties:
 
 
 class CogniteAnnotationApply(CogniteAnnotationProperties, CogniteDescribableEdgeApply, CogniteSourceableEdgeApply):
+    """This represents the writing format of cognite annotation.
+
+    It is used to when data is written to CDF.
+
+    Annotation represents contextualization results or links
+
+    Args:
+        space (str): The space where the node is located.
+        external_id (str): The external id of the cognite annotation.
+        type (DirectRelationReference | tuple[str, str]): The type of edge.
+        start_node (DirectRelationReference | tuple[str, str]): Reference to the direct relation. The reference consists of a space and an external-id.
+        end_node (DirectRelationReference | tuple[str, str]): Reference to the direct relation. The reference consists of a space and an external-id.
+        name (str | None): Name of the instance
+        description (str | None): Description of the instance
+        tags (list[str] | None): Text based labels for generic use, limited to 1000
+        aliases (list[str] | None): Alternative names for the node
+        source_id (str | None): Identifier from the source system
+        source_context (str | None): Context of the source id. For systems where the sourceId is globally unique, the sourceContext is expected to not be set.
+        source (DirectRelationReference | tuple[str, str] | None): Direct relation to a source system
+        source_created_time (datetime | None): When the instance was created in source system (if available)
+        source_updated_time (datetime | None): When the instance was last updated in the source system (if available)
+        source_created_user (str | None): User identifier from the source system on who created the source data. This identifier is not guaranteed to match the user identifiers in CDF
+        source_updated_user (str | None): User identifier from the source system on who last updated the source data. This identifier is not guaranteed to match the user identifiers in CDF
+        confidence (float | None): The confidence that the annotation is a good match
+        status (Literal["Approved", "Rejected", "Suggested"] | None): The confidence that the annotation is a good match
+        existing_version (int | None): Fail the ingestion request if the edge's version is greater than or equal to this value. If no existingVersion is specified, the ingestion will always overwrite any existing data for the edge (for the specified container or edge). If existingVersion is set to 0, the upsert will behave as an insert, so it will fail the bulk if the item already exists. If skipOnVersionConflict is set on the ingestion request, then the item will be skipped instead of failing the ingestion request.
+    """
+
     def __init__(
         self,
         space: str,
@@ -2973,6 +4739,7 @@ class CogniteAnnotationApply(CogniteAnnotationProperties, CogniteDescribableEdge
         type: DirectRelationReference | tuple[str, str],
         start_node: DirectRelationReference | tuple[str, str],
         end_node: DirectRelationReference | tuple[str, str],
+        *,
         name: str | None = None,
         description: str | None = None,
         tags: list[str] | None = None,
@@ -2989,7 +4756,17 @@ class CogniteAnnotationApply(CogniteAnnotationProperties, CogniteDescribableEdge
         existing_version: int | None = None,
     ) -> None:
         CogniteDescribableEdgeApply.__init__(
-            self, space, external_id, type, start_node, end_node, name, description, tags, aliases, existing_version
+            self,
+            space,
+            external_id,
+            type,
+            start_node,
+            end_node,
+            name=name,
+            description=description,
+            tags=tags,
+            aliases=aliases,
+            existing_version=existing_version,
         )
         CogniteSourceableEdgeApply.__init__(
             self,
@@ -2998,20 +4775,51 @@ class CogniteAnnotationApply(CogniteAnnotationProperties, CogniteDescribableEdge
             type,
             start_node,
             end_node,
-            source_id,
-            source_context,
-            source,
-            source_created_time,
-            source_updated_time,
-            source_created_user,
-            source_updated_user,
-            existing_version,
+            source_id=source_id,
+            source_context=source_context,
+            source=source,
+            source_created_time=source_created_time,
+            source_updated_time=source_updated_time,
+            source_created_user=source_created_user,
+            source_updated_user=source_updated_user,
+            existing_version=existing_version,
         )
         self.confidence = confidence
         self.status = status
 
 
 class CogniteAnnotation(CogniteAnnotationProperties, CogniteDescribableEdge, CogniteSourceableEdge):
+    """This represents the reading format of cognite annotation.
+
+    It is used to when data is read from CDF.
+
+    Annotation represents contextualization results or links
+
+    Args:
+        space (str): The space where the node is located.
+        external_id (str): The external id of the cognite annotation.
+        type (DirectRelationReference): The type of edge.
+        start_node (DirectRelationReference): Reference to the direct relation. The reference consists of a space and an external-id.
+        end_node (DirectRelationReference): Reference to the direct relation. The reference consists of a space and an external-id.
+        version (int): DMS version.
+        last_updated_time (int): The number of milliseconds since 00:00:00 Thursday, 1 January 1970, Coordinated Universal Time (UTC), minus leap seconds.
+        created_time (int): The number of milliseconds since 00:00:00 Thursday, 1 January 1970, Coordinated Universal Time (UTC), minus leap seconds.
+        name (str | None): Name of the instance
+        description (str | None): Description of the instance
+        tags (list[str] | None): Text based labels for generic use, limited to 1000
+        aliases (list[str] | None): Alternative names for the node
+        source_id (str | None): Identifier from the source system
+        source_context (str | None): Context of the source id. For systems where the sourceId is globally unique, the sourceContext is expected to not be set.
+        source (DirectRelationReference | None): Direct relation to a source system
+        source_created_time (datetime | None): When the instance was created in source system (if available)
+        source_updated_time (datetime | None): When the instance was last updated in the source system (if available)
+        source_created_user (str | None): User identifier from the source system on who created the source data. This identifier is not guaranteed to match the user identifiers in CDF
+        source_updated_user (str | None): User identifier from the source system on who last updated the source data. This identifier is not guaranteed to match the user identifiers in CDF
+        confidence (float | None): The confidence that the annotation is a good match
+        status (Literal["Approved", "Rejected", "Suggested"] | None): The confidence that the annotation is a good match
+        deleted_time (int | None): The number of milliseconds since 00:00:00 Thursday, 1 January 1970, Coordinated Universal Time (UTC), minus leap seconds. Timestamp when the instance was soft deleted. Note that deleted instances are filtered out of query results, but present in sync results
+    """
+
     def __init__(
         self,
         space: str,
@@ -3022,6 +4830,7 @@ class CogniteAnnotation(CogniteAnnotationProperties, CogniteDescribableEdge, Cog
         version: int,
         last_updated_time: int,
         created_time: int,
+        *,
         name: str | None = None,
         description: str | None = None,
         tags: list[str] | None = None,
@@ -3047,11 +4856,11 @@ class CogniteAnnotation(CogniteAnnotationProperties, CogniteDescribableEdge, Cog
             version,
             last_updated_time,
             created_time,
-            name,
-            description,
-            tags,
-            aliases,
-            deleted_time,
+            name=name,
+            description=description,
+            tags=tags,
+            aliases=aliases,
+            deleted_time=deleted_time,
         )
         CogniteSourceableEdge.__init__(
             self,
@@ -3063,14 +4872,14 @@ class CogniteAnnotation(CogniteAnnotationProperties, CogniteDescribableEdge, Cog
             version,
             last_updated_time,
             created_time,
-            source_id,
-            source_context,
-            source,
-            source_created_time,
-            source_updated_time,
-            source_created_user,
-            source_updated_user,
-            deleted_time,
+            source_id=source_id,
+            source_context=source_context,
+            source=source,
+            source_created_time=source_created_time,
+            source_updated_time=source_updated_time,
+            source_created_user=source_created_user,
+            source_updated_user=source_updated_user,
+            deleted_time=deleted_time,
         )
         self.confidence = confidence
         self.status = status
@@ -3082,20 +4891,20 @@ class CogniteAnnotation(CogniteAnnotationProperties, CogniteDescribableEdge, Cog
             self.type,
             self.start_node,
             self.end_node,
-            self.name,
-            self.description,
-            self.tags,
-            self.aliases,
-            self.source_id,
-            self.source_context,
-            self.source,
-            self.source_created_time,
-            self.source_updated_time,
-            self.source_created_user,
-            self.source_updated_user,
-            self.confidence,
-            self.status,
-            self.version,
+            name=self.name,
+            description=self.description,
+            tags=self.tags,
+            aliases=self.aliases,
+            source_id=self.source_id,
+            source_context=self.source_context,
+            source=self.source,
+            source_created_time=self.source_created_time,
+            source_updated_time=self.source_updated_time,
+            source_created_user=self.source_created_user,
+            source_updated_user=self.source_updated_user,
+            confidence=self.confidence,
+            status=self.status,
+            existing_version=self.version,
         )
 
 
@@ -3119,6 +4928,46 @@ class CogniteDiagramAnnotationProperties:
 
 
 class CogniteDiagramAnnotationApply(CogniteDiagramAnnotationProperties, CogniteAnnotationApply):
+    """This represents the writing format of cognite diagram annotation.
+
+    It is used to when data is written to CDF.
+
+    Annotation for diagrams
+
+    Args:
+        space (str): The space where the node is located.
+        external_id (str): The external id of the cognite diagram annotation.
+        type (DirectRelationReference | tuple[str, str]): The type of edge.
+        start_node (DirectRelationReference | tuple[str, str]): Reference to the direct relation. The reference consists of a space and an external-id.
+        end_node (DirectRelationReference | tuple[str, str]): Reference to the direct relation. The reference consists of a space and an external-id.
+        name (str | None): Name of the instance
+        description (str | None): Description of the instance
+        tags (list[str] | None): Text based labels for generic use, limited to 1000
+        aliases (list[str] | None): Alternative names for the node
+        source_id (str | None): Identifier from the source system
+        source_context (str | None): Context of the source id. For systems where the sourceId is globally unique, the sourceContext is expected to not be set.
+        source (DirectRelationReference | tuple[str, str] | None): Direct relation to a source system
+        source_created_time (datetime | None): When the instance was created in source system (if available)
+        source_updated_time (datetime | None): When the instance was last updated in the source system (if available)
+        source_created_user (str | None): User identifier from the source system on who created the source data. This identifier is not guaranteed to match the user identifiers in CDF
+        source_updated_user (str | None): User identifier from the source system on who last updated the source data. This identifier is not guaranteed to match the user identifiers in CDF
+        confidence (float | None): The confidence that the annotation is a good match
+        status (Literal["Approved", "Rejected", "Suggested"] | None): The confidence that the annotation is a good match
+        start_node_page_number (int | None): The number of the page on which this annotation is located in `startNode` File. The first page has number 1
+        end_node_page_number (int | None): The number of the page on which this annotation is located in the endNode File if an endNode is present. The first page has number 1
+        start_node_x_min (float | None): Value between [0,1]. Minimum abscissa of the bounding box (left edge). Must be strictly less than startNodeXMax
+        start_node_x_max (float | None): Value between [0,1]. Maximum abscissa of the bounding box (right edge). Must be strictly more than startNodeXMin
+        start_node_y_min (float | None): Value between [0,1]. Minimum ordinate of the bounding box (bottom edge). Must be strictly less than startNodeYMax
+        start_node_y_max (float | None): Value between [0,1]. Maximum ordinate of the bounding box (top edge). Must be strictly more than startNodeYMin
+        start_node_text (str | None): The text extracted from within the bounding box on the startNode
+        end_node_x_min (float | None): Value between [0,1]. Minimum abscissa of the bounding box (left edge). Must be strictly less than endNodeXMax. Only applicable if an endNode is defined
+        end_node_x_max (float | None): Value between [0,1]. Maximum abscissa of the bounding box (right edge). Must be strictly more than endNodeXMin. Only applicable if an endNode is defined
+        end_node_y_min (float | None): Value between [0,1]. Minimum ordinate of the bounding box (bottom edge). Must be strictly less than endNodeYMax. Only applicable if an endNode is defined
+        end_node_y_max (float | None): Value between [0,1]. Maximum ordinate of the bounding box (top edge). Must be strictly more than endNodeYMin. Only applicable if an endNode is defined
+        end_node_text (str | None): The text extracted from within the bounding box on the endNode. Only applicable if an endNode is defined
+        existing_version (int | None): Fail the ingestion request if the edge's version is greater than or equal to this value. If no existingVersion is specified, the ingestion will always overwrite any existing data for the edge (for the specified container or edge). If existingVersion is set to 0, the upsert will behave as an insert, so it will fail the bulk if the item already exists. If skipOnVersionConflict is set on the ingestion request, then the item will be skipped instead of failing the ingestion request.
+    """
+
     def __init__(
         self,
         space: str,
@@ -3126,6 +4975,7 @@ class CogniteDiagramAnnotationApply(CogniteDiagramAnnotationProperties, CogniteA
         type: DirectRelationReference | tuple[str, str],
         start_node: DirectRelationReference | tuple[str, str],
         end_node: DirectRelationReference | tuple[str, str],
+        *,
         name: str | None = None,
         description: str | None = None,
         tags: list[str] | None = None,
@@ -3159,20 +5009,20 @@ class CogniteDiagramAnnotationApply(CogniteDiagramAnnotationProperties, CogniteA
             type,
             start_node,
             end_node,
-            name,
-            description,
-            tags,
-            aliases,
-            source_id,
-            source_context,
-            source,
-            source_created_time,
-            source_updated_time,
-            source_created_user,
-            source_updated_user,
-            confidence,
-            status,
-            existing_version,
+            name=name,
+            description=description,
+            tags=tags,
+            aliases=aliases,
+            source_id=source_id,
+            source_context=source_context,
+            source=source,
+            source_created_time=source_created_time,
+            source_updated_time=source_updated_time,
+            source_created_user=source_created_user,
+            source_updated_user=source_updated_user,
+            confidence=confidence,
+            status=status,
+            existing_version=existing_version,
         )
         self.start_node_page_number = start_node_page_number
         self.end_node_page_number = end_node_page_number
@@ -3189,6 +5039,49 @@ class CogniteDiagramAnnotationApply(CogniteDiagramAnnotationProperties, CogniteA
 
 
 class CogniteDiagramAnnotation(CogniteDiagramAnnotationProperties, CogniteAnnotation):
+    """This represents the reading format of cognite diagram annotation.
+
+    It is used to when data is read from CDF.
+
+    Annotation for diagrams
+
+    Args:
+        space (str): The space where the node is located.
+        external_id (str): The external id of the cognite diagram annotation.
+        type (DirectRelationReference): The type of edge.
+        start_node (DirectRelationReference): Reference to the direct relation. The reference consists of a space and an external-id.
+        end_node (DirectRelationReference): Reference to the direct relation. The reference consists of a space and an external-id.
+        version (int): DMS version.
+        last_updated_time (int): The number of milliseconds since 00:00:00 Thursday, 1 January 1970, Coordinated Universal Time (UTC), minus leap seconds.
+        created_time (int): The number of milliseconds since 00:00:00 Thursday, 1 January 1970, Coordinated Universal Time (UTC), minus leap seconds.
+        name (str | None): Name of the instance
+        description (str | None): Description of the instance
+        tags (list[str] | None): Text based labels for generic use, limited to 1000
+        aliases (list[str] | None): Alternative names for the node
+        source_id (str | None): Identifier from the source system
+        source_context (str | None): Context of the source id. For systems where the sourceId is globally unique, the sourceContext is expected to not be set.
+        source (DirectRelationReference | None): Direct relation to a source system
+        source_created_time (datetime | None): When the instance was created in source system (if available)
+        source_updated_time (datetime | None): When the instance was last updated in the source system (if available)
+        source_created_user (str | None): User identifier from the source system on who created the source data. This identifier is not guaranteed to match the user identifiers in CDF
+        source_updated_user (str | None): User identifier from the source system on who last updated the source data. This identifier is not guaranteed to match the user identifiers in CDF
+        confidence (float | None): The confidence that the annotation is a good match
+        status (Literal["Approved", "Rejected", "Suggested"] | None): The confidence that the annotation is a good match
+        start_node_page_number (int | None): The number of the page on which this annotation is located in `startNode` File. The first page has number 1
+        end_node_page_number (int | None): The number of the page on which this annotation is located in the endNode File if an endNode is present. The first page has number 1
+        start_node_x_min (float | None): Value between [0,1]. Minimum abscissa of the bounding box (left edge). Must be strictly less than startNodeXMax
+        start_node_x_max (float | None): Value between [0,1]. Maximum abscissa of the bounding box (right edge). Must be strictly more than startNodeXMin
+        start_node_y_min (float | None): Value between [0,1]. Minimum ordinate of the bounding box (bottom edge). Must be strictly less than startNodeYMax
+        start_node_y_max (float | None): Value between [0,1]. Maximum ordinate of the bounding box (top edge). Must be strictly more than startNodeYMin
+        start_node_text (str | None): The text extracted from within the bounding box on the startNode
+        end_node_x_min (float | None): Value between [0,1]. Minimum abscissa of the bounding box (left edge). Must be strictly less than endNodeXMax. Only applicable if an endNode is defined
+        end_node_x_max (float | None): Value between [0,1]. Maximum abscissa of the bounding box (right edge). Must be strictly more than endNodeXMin. Only applicable if an endNode is defined
+        end_node_y_min (float | None): Value between [0,1]. Minimum ordinate of the bounding box (bottom edge). Must be strictly less than endNodeYMax. Only applicable if an endNode is defined
+        end_node_y_max (float | None): Value between [0,1]. Maximum ordinate of the bounding box (top edge). Must be strictly more than endNodeYMin. Only applicable if an endNode is defined
+        end_node_text (str | None): The text extracted from within the bounding box on the endNode. Only applicable if an endNode is defined
+        deleted_time (int | None): The number of milliseconds since 00:00:00 Thursday, 1 January 1970, Coordinated Universal Time (UTC), minus leap seconds. Timestamp when the instance was soft deleted. Note that deleted instances are filtered out of query results, but present in sync results
+    """
+
     def __init__(
         self,
         space: str,
@@ -3199,6 +5092,7 @@ class CogniteDiagramAnnotation(CogniteDiagramAnnotationProperties, CogniteAnnota
         version: int,
         last_updated_time: int,
         created_time: int,
+        *,
         name: str | None = None,
         description: str | None = None,
         tags: list[str] | None = None,
@@ -3235,20 +5129,20 @@ class CogniteDiagramAnnotation(CogniteDiagramAnnotationProperties, CogniteAnnota
             version,
             last_updated_time,
             created_time,
-            name,
-            description,
-            tags,
-            aliases,
-            source_id,
-            source_context,
-            source,
-            source_created_time,
-            source_updated_time,
-            source_created_user,
-            source_updated_user,
-            confidence,
-            status,
-            deleted_time,
+            name=name,
+            description=description,
+            tags=tags,
+            aliases=aliases,
+            source_id=source_id,
+            source_context=source_context,
+            source=source,
+            source_created_time=source_created_time,
+            source_updated_time=source_updated_time,
+            source_created_user=source_created_user,
+            source_updated_user=source_updated_user,
+            confidence=confidence,
+            status=status,
+            deleted_time=deleted_time,
         )
         self.start_node_page_number = start_node_page_number
         self.end_node_page_number = end_node_page_number
@@ -3270,32 +5164,32 @@ class CogniteDiagramAnnotation(CogniteDiagramAnnotationProperties, CogniteAnnota
             self.type,
             self.start_node,
             self.end_node,
-            self.name,
-            self.description,
-            self.tags,
-            self.aliases,
-            self.source_id,
-            self.source_context,
-            self.source,
-            self.source_created_time,
-            self.source_updated_time,
-            self.source_created_user,
-            self.source_updated_user,
-            self.confidence,
-            self.status,
-            self.start_node_page_number,
-            self.end_node_page_number,
-            self.start_node_x_min,
-            self.start_node_x_max,
-            self.start_node_y_min,
-            self.start_node_y_max,
-            self.start_node_text,
-            self.end_node_x_min,
-            self.end_node_x_max,
-            self.end_node_y_min,
-            self.end_node_y_max,
-            self.end_node_text,
-            self.version,
+            name=self.name,
+            description=self.description,
+            tags=self.tags,
+            aliases=self.aliases,
+            source_id=self.source_id,
+            source_context=self.source_context,
+            source=self.source,
+            source_created_time=self.source_created_time,
+            source_updated_time=self.source_updated_time,
+            source_created_user=self.source_created_user,
+            source_updated_user=self.source_updated_user,
+            confidence=self.confidence,
+            status=self.status,
+            start_node_page_number=self.start_node_page_number,
+            end_node_page_number=self.end_node_page_number,
+            start_node_x_min=self.start_node_x_min,
+            start_node_x_max=self.start_node_x_max,
+            start_node_y_min=self.start_node_y_min,
+            start_node_y_max=self.start_node_y_max,
+            start_node_text=self.start_node_text,
+            end_node_x_min=self.end_node_x_min,
+            end_node_x_max=self.end_node_x_max,
+            end_node_y_min=self.end_node_y_min,
+            end_node_y_max=self.end_node_y_max,
+            end_node_text=self.end_node_text,
+            existing_version=self.version,
         )
 
 
@@ -3308,6 +5202,34 @@ class CogniteImage360AnnotationProperties:
 
 
 class CogniteImage360AnnotationApply(CogniteImage360AnnotationProperties, CogniteAnnotationApply):
+    """This represents the writing format of cognite image 360 annotation.
+
+    It is used to when data is written to CDF.
+
+    Args:
+        space (str): The space where the node is located.
+        external_id (str): The external id of the cognite image 360 annotation.
+        type (DirectRelationReference | tuple[str, str]): The type of edge.
+        start_node (DirectRelationReference | tuple[str, str]): Reference to the direct relation. The reference consists of a space and an external-id.
+        end_node (DirectRelationReference | tuple[str, str]): Reference to the direct relation. The reference consists of a space and an external-id.
+        name (str | None): Name of the instance
+        description (str | None): Description of the instance
+        tags (list[str] | None): Text based labels for generic use, limited to 1000
+        aliases (list[str] | None): Alternative names for the node
+        source_id (str | None): Identifier from the source system
+        source_context (str | None): Context of the source id. For systems where the sourceId is globally unique, the sourceContext is expected to not be set.
+        source (DirectRelationReference | tuple[str, str] | None): Direct relation to a source system
+        source_created_time (datetime | None): When the instance was created in source system (if available)
+        source_updated_time (datetime | None): When the instance was last updated in the source system (if available)
+        source_created_user (str | None): User identifier from the source system on who created the source data. This identifier is not guaranteed to match the user identifiers in CDF
+        source_updated_user (str | None): User identifier from the source system on who last updated the source data. This identifier is not guaranteed to match the user identifiers in CDF
+        confidence (float | None): The confidence that the annotation is a good match
+        status (Literal["Approved", "Rejected", "Suggested"] | None): The confidence that the annotation is a good match
+        polygon (list[float] | None): List of floats representing the polygon. Format depends on formatVersion
+        format_version (str | None): Specifies the storage representation for the polygon property
+        existing_version (int | None): Fail the ingestion request if the edge's version is greater than or equal to this value. If no existingVersion is specified, the ingestion will always overwrite any existing data for the edge (for the specified container or edge). If existingVersion is set to 0, the upsert will behave as an insert, so it will fail the bulk if the item already exists. If skipOnVersionConflict is set on the ingestion request, then the item will be skipped instead of failing the ingestion request.
+    """
+
     def __init__(
         self,
         space: str,
@@ -3315,6 +5237,7 @@ class CogniteImage360AnnotationApply(CogniteImage360AnnotationProperties, Cognit
         type: DirectRelationReference | tuple[str, str],
         start_node: DirectRelationReference | tuple[str, str],
         end_node: DirectRelationReference | tuple[str, str],
+        *,
         name: str | None = None,
         description: str | None = None,
         tags: list[str] | None = None,
@@ -3338,26 +5261,57 @@ class CogniteImage360AnnotationApply(CogniteImage360AnnotationProperties, Cognit
             type,
             start_node,
             end_node,
-            name,
-            description,
-            tags,
-            aliases,
-            source_id,
-            source_context,
-            source,
-            source_created_time,
-            source_updated_time,
-            source_created_user,
-            source_updated_user,
-            confidence,
-            status,
-            existing_version,
+            name=name,
+            description=description,
+            tags=tags,
+            aliases=aliases,
+            source_id=source_id,
+            source_context=source_context,
+            source=source,
+            source_created_time=source_created_time,
+            source_updated_time=source_updated_time,
+            source_created_user=source_created_user,
+            source_updated_user=source_updated_user,
+            confidence=confidence,
+            status=status,
+            existing_version=existing_version,
         )
         self.polygon = polygon
         self.format_version = format_version
 
 
 class CogniteImage360Annotation(CogniteImage360AnnotationProperties, CogniteAnnotation):
+    """This represents the reading format of cognite image 360 annotation.
+
+    It is used to when data is read from CDF.
+
+    Args:
+        space (str): The space where the node is located.
+        external_id (str): The external id of the cognite image 360 annotation.
+        type (DirectRelationReference): The type of edge.
+        start_node (DirectRelationReference): Reference to the direct relation. The reference consists of a space and an external-id.
+        end_node (DirectRelationReference): Reference to the direct relation. The reference consists of a space and an external-id.
+        version (int): DMS version.
+        last_updated_time (int): The number of milliseconds since 00:00:00 Thursday, 1 January 1970, Coordinated Universal Time (UTC), minus leap seconds.
+        created_time (int): The number of milliseconds since 00:00:00 Thursday, 1 January 1970, Coordinated Universal Time (UTC), minus leap seconds.
+        name (str | None): Name of the instance
+        description (str | None): Description of the instance
+        tags (list[str] | None): Text based labels for generic use, limited to 1000
+        aliases (list[str] | None): Alternative names for the node
+        source_id (str | None): Identifier from the source system
+        source_context (str | None): Context of the source id. For systems where the sourceId is globally unique, the sourceContext is expected to not be set.
+        source (DirectRelationReference | None): Direct relation to a source system
+        source_created_time (datetime | None): When the instance was created in source system (if available)
+        source_updated_time (datetime | None): When the instance was last updated in the source system (if available)
+        source_created_user (str | None): User identifier from the source system on who created the source data. This identifier is not guaranteed to match the user identifiers in CDF
+        source_updated_user (str | None): User identifier from the source system on who last updated the source data. This identifier is not guaranteed to match the user identifiers in CDF
+        confidence (float | None): The confidence that the annotation is a good match
+        status (Literal["Approved", "Rejected", "Suggested"] | None): The confidence that the annotation is a good match
+        polygon (list[float] | None): List of floats representing the polygon. Format depends on formatVersion
+        format_version (str | None): Specifies the storage representation for the polygon property
+        deleted_time (int | None): The number of milliseconds since 00:00:00 Thursday, 1 January 1970, Coordinated Universal Time (UTC), minus leap seconds. Timestamp when the instance was soft deleted. Note that deleted instances are filtered out of query results, but present in sync results
+    """
+
     def __init__(
         self,
         space: str,
@@ -3368,6 +5322,7 @@ class CogniteImage360Annotation(CogniteImage360AnnotationProperties, CogniteAnno
         version: int,
         last_updated_time: int,
         created_time: int,
+        *,
         name: str | None = None,
         description: str | None = None,
         tags: list[str] | None = None,
@@ -3394,20 +5349,20 @@ class CogniteImage360Annotation(CogniteImage360AnnotationProperties, CogniteAnno
             version,
             last_updated_time,
             created_time,
-            name,
-            description,
-            tags,
-            aliases,
-            source_id,
-            source_context,
-            source,
-            source_created_time,
-            source_updated_time,
-            source_created_user,
-            source_updated_user,
-            confidence,
-            status,
-            deleted_time,
+            name=name,
+            description=description,
+            tags=tags,
+            aliases=aliases,
+            source_id=source_id,
+            source_context=source_context,
+            source=source,
+            source_created_time=source_created_time,
+            source_updated_time=source_updated_time,
+            source_created_user=source_created_user,
+            source_updated_user=source_updated_user,
+            confidence=confidence,
+            status=status,
+            deleted_time=deleted_time,
         )
         self.polygon = polygon
         self.format_version = format_version
@@ -3419,20 +5374,20 @@ class CogniteImage360Annotation(CogniteImage360AnnotationProperties, CogniteAnno
             self.type,
             self.start_node,
             self.end_node,
-            self.name,
-            self.description,
-            self.tags,
-            self.aliases,
-            self.source_id,
-            self.source_context,
-            self.source,
-            self.source_created_time,
-            self.source_updated_time,
-            self.source_created_user,
-            self.source_updated_user,
-            self.confidence,
-            self.status,
-            self.polygon,
-            self.format_version,
-            self.version,
+            name=self.name,
+            description=self.description,
+            tags=self.tags,
+            aliases=self.aliases,
+            source_id=self.source_id,
+            source_context=self.source_context,
+            source=self.source,
+            source_created_time=self.source_created_time,
+            source_updated_time=self.source_updated_time,
+            source_created_user=self.source_created_user,
+            source_updated_user=self.source_updated_user,
+            confidence=self.confidence,
+            status=self.status,
+            polygon=self.polygon,
+            format_version=self.format_version,
+            existing_version=self.version,
         )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "cognite-sdk"
 
-version = "7.54.8"
+version = "7.54.9"
 description = "Cognite Python SDK"
 readme = "README.md"
 documentation = "https://cognite-sdk-python.readthedocs-hosted.com"

--- a/scripts/generate_core_model.py
+++ b/scripts/generate_core_model.py
@@ -1,0 +1,23 @@
+"""This script requires pygen to be installed. It generates typed classes for the core data model v1.
+
+`pip install cognite-pygen==0.99.28`
+"""
+
+from pathlib import Path
+
+from cognite.pygen._generator import generate_typed
+from tests.tests_integration.conftest import make_cognite_client
+
+THIS_REPO = Path(__file__).resolve().parent.parent
+
+OUTPUT_FILE = THIS_REPO / "cognite" / "client" / "data_classes" / "cdm" / "v1.py"
+
+
+def main() -> None:
+    client = make_cognite_client(beta=False)
+
+    generate_typed(("cdf_cdm_experimental", "core_data_model", "v1"), OUTPUT_FILE, client, format_code=False)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/generate_core_model.py
+++ b/scripts/generate_core_model.py
@@ -1,6 +1,9 @@
 """This script requires pygen to be installed. It generates typed classes for the core data model v1.
 
 `pip install cognite-pygen==0.99.28`
+
+Note that `pygen` requires `Python 3.9` or later`, so if you develop in an older version of Python,
+you need to run this script in a Python 3.9 environment.
 """
 
 from pathlib import Path


### PR DESCRIPTION
## Description
* The core model itself is not updated but the code for generating it has changed.
  * Required keyword args
  * Docstrings
  * Snake caseing of words with `3D` correctly: `object_3d` instead of `object_3_d`
* Added  the script for generating the core model. Note I did not add a CICD as there are a few manual changes that is required and linting to run for the output of the generator to match exactly what is committed to history.

## Checklist:
- [ ] Tests added/updated.
- [ ] Documentation updated. Documentation is generated from docstrings - these must be updated according to your change.
  If a new method has been added it should be referenced in [cognite.rst](https://github.com/cognitedata/cognite-sdk-python/blob/master/docs/source/cognite.rst) in order to generate docs based on its docstring.
- [ ] Changelog updated in [CHANGELOG.md](https://github.com/cognitedata/cognite-sdk-python/blob/master/CHANGELOG.md).
- [ ] Version bumped. If triggering a new release is desired, bump the version number in [_version.py](https://github.com/cognitedata/cognite-sdk-python/blob/master/cognite/client/_version.py) and [pyproject.toml](https://github.com/cognitedata/cognite-sdk-python/blob/master/pyproject.toml) per [semantic versioning](https://semver.org/).
