### PR TITLE
fix ambiguous identifiers in data modeling resource lists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,12 +17,12 @@ Changes are grouped as follows
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
-## [7.54.12] - 2024-08-02
+## [7.54.12] - 2024-08-05
 ### Fixed
 - NodeList and EdgeList (and subclasses) now expects an instance ID, `(space, external_id)` in the `.get` method.
   Using just an `external_id` is still possible, but deprecated as it is ambiguous in the absence of the space
-  identifier, and will just return the first matching instance (as previously).
-- SpaceList now expects a space identifier in the `.get` method.
+  identifier, and will just return the last matching instance (as previously).
+- SpaceList.get now works and expects a space identifier in the `.get` method.
 
 ## [7.54.11] - 2024-07-26
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ Changes are grouped as follows
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
-## [7.54.12] - 2024-08-05
+## [7.54.12] - 2024-08-08
 ### Fixed
 - NodeList and EdgeList (and subclasses) now expects an instance ID, `(space, external_id)` in the `.get` method.
   Using just an `external_id` is still possible, but deprecated as it is ambiguous in the absence of the space

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,13 @@ Changes are grouped as follows
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
+## [7.54.12] - 2024-08-02
+### Fixed
+- NodeList and EdgeList (and subclasses) now expects an instance ID, `(space, external_id)` in the `.get` method.
+  Using just an `external_id` is still possible, but deprecated as it is ambiguous in the absence of the space
+  identifier, and will just return the first matching instance (as previously).
+- SpaceList now expects a space identifier in the `.get` method.
+
 ## [7.54.11] - 2024-07-26
 ### Fixed
 - Creating a Group with an `UnknownAcl` supported by the API no longer raises a client-side `ValueError` after
@@ -43,7 +50,7 @@ Changes are grouped as follows
 
 ## [7.54.7] - 2024-07-22
 ### Fixed
-- The method `client.three_d.models.update` no longer accepts `ThreeDModelWrite` as this will raise a `ValueError`. 
+- The method `client.three_d.models.update` no longer accepts `ThreeDModelWrite` as this will raise a `ValueError`.
 - The method `client.three_d.models.create` now supports creating multiple models with different metdata fields
   in a single call.
 

--- a/cognite/client/_version.py
+++ b/cognite/client/_version.py
@@ -1,4 +1,4 @@
 from __future__ import annotations
 
-__version__ = "7.54.11"
+__version__ = "7.54.12"
 __api_subversion__ = "20230101"

--- a/cognite/client/data_classes/_base.py
+++ b/cognite/client/data_classes/_base.py
@@ -270,14 +270,16 @@ class CogniteResourceList(UserList, Generic[T_CogniteResource], _WithClientMixin
                 )
         self._cognite_client = cast("CogniteClient", cognite_client)
         super().__init__(resources)
+        self._build_id_mappings()
+
+    def _build_id_mappings(self) -> None:
         self._id_to_item, self._external_id_to_item = {}, {}
-        if self.data:
-            if hasattr(self.data[0], "external_id"):
-                self._external_id_to_item = {
-                    item.external_id: item for item in self.data if item.external_id is not None
-                }
-            if hasattr(self.data[0], "id"):
-                self._id_to_item = {item.id: item for item in self.data if item.id is not None}
+        if not self.data:
+            return
+        if hasattr(self.data[0], "external_id"):
+            self._external_id_to_item = {item.external_id: item for item in self.data if item.external_id is not None}
+        if hasattr(self.data[0], "id"):
+            self._id_to_item = {item.id: item for item in self.data if item.id is not None}
 
     def pop(self, i: int = -1) -> T_CogniteResource:
         return super().pop(i)

--- a/cognite/client/data_classes/_base.py
+++ b/cognite/client/data_classes/_base.py
@@ -308,7 +308,7 @@ class CogniteResourceList(UserList, Generic[T_CogniteResource], _WithClientMixin
     # TODO: We inherit a lot from UserList that we don't actually support...
     def extend(self, other: Iterable[Any]) -> None:
         other_res_list = type(self)(other)  # See if we can accept the types
-        if set(self._id_to_item).isdisjoint(other_res_list._id_to_item):
+        if self._id_to_item.keys().isdisjoint(other_res_list._id_to_item):
             super().extend(other)
             self._external_id_to_item.update(other_res_list._external_id_to_item)
             self._id_to_item.update(other_res_list._id_to_item)

--- a/cognite/client/data_classes/_base.py
+++ b/cognite/client/data_classes/_base.py
@@ -261,7 +261,7 @@ class CogniteResourceList(UserList, Generic[T_CogniteResource], _WithClientMixin
     _RESOURCE: type[T_CogniteResource]
     __cognite_client: CogniteClient | None
 
-    def __init__(self, resources: Collection[Any], cognite_client: CogniteClient | None = None) -> None:
+    def __init__(self, resources: Iterable[Any], cognite_client: CogniteClient | None = None) -> None:
         for resource in resources:
             if not isinstance(resource, self._RESOURCE):
                 raise TypeError(
@@ -306,7 +306,7 @@ class CogniteResourceList(UserList, Generic[T_CogniteResource], _WithClientMixin
         return _json.dumps(item, indent=4)
 
     # TODO: We inherit a lot from UserList that we don't actually support...
-    def extend(self, other: Collection[Any]) -> None:  # type: ignore [override]
+    def extend(self, other: Iterable[Any]) -> None:
         other_res_list = type(self)(other)  # See if we can accept the types
         if set(self._id_to_item).isdisjoint(other_res_list._id_to_item):
             super().extend(other)

--- a/cognite/client/data_classes/data_modeling/_validation.py
+++ b/cognite/client/data_classes/data_modeling/_validation.py
@@ -45,6 +45,6 @@ RESERVED_PROPERTIES = frozenset(
 
 def validate_data_modeling_identifier(space: str | None, external_id: str | None = None) -> None:
     if space and space in RESERVED_SPACE_IDS:
-        raise ValueError(f"The space ID: {space} is reserved. Please use another ID.")
+        raise ValueError(f"The space ID: {space!r} is reserved. Please use another ID.")
     if external_id and external_id in RESERVED_EXTERNAL_IDS:
-        raise ValueError(f"The external ID: {external_id} is reserved. Please use another ID.")
+        raise ValueError(f"The external ID: {external_id!r} is reserved. Please use another ID.")

--- a/cognite/client/data_classes/data_modeling/instances.py
+++ b/cognite/client/data_classes/data_modeling/instances.py
@@ -1094,8 +1094,13 @@ class NodeListWithCursor(NodeList[T_Node]):
     def extend(self, other: NodeListWithCursor) -> None:  # type: ignore[override]
         if not isinstance(other, type(self)):
             raise TypeError("Unable to extend as the types do not match")
-        super().extend(other)
-        self.cursor = other.cursor
+        other_res_list = type(self)(other, other.cursor)  # See if we can accept the types
+        if self._instance_id_to_item.keys().isdisjoint(other_res_list._instance_id_to_item):
+            self.data.extend(other.data)
+            self._instance_id_to_item.update(other_res_list._instance_id_to_item)
+            self.cursor = other.cursor
+        else:
+            raise ValueError("Unable to extend as this would introduce duplicates")
 
 
 class EdgeApplyResultList(CogniteResourceList[EdgeApplyResult]):
@@ -1185,8 +1190,13 @@ class EdgeListWithCursor(EdgeList):
     def extend(self, other: EdgeListWithCursor) -> None:  # type: ignore[override]
         if not isinstance(other, type(self)):
             raise TypeError("Unable to extend as the types do not match")
-        super().extend(other)
-        self.cursor = other.cursor
+        other_res_list = type(self)(other, other.cursor)  # See if we can accept the types
+        if self._instance_id_to_item.keys().isdisjoint(other_res_list._instance_id_to_item):
+            self.data.extend(other.data)
+            self._instance_id_to_item.update(other_res_list._instance_id_to_item)
+            self.cursor = other.cursor
+        else:
+            raise ValueError("Unable to extend as this would introduce duplicates")
 
 
 # This is a utility class. It is not used by in the SDK codebase, but used in projects that use the SDK.

--- a/cognite/client/data_classes/data_modeling/instances.py
+++ b/cognite/client/data_classes/data_modeling/instances.py
@@ -978,7 +978,7 @@ class DataModelingInstancesList(WriteableCogniteResourceList[T_WriteClass, T_Ins
             id = id.as_tuple()
         return self._instance_id_to_item.get(id)  # type: ignore [arg-type]
 
-    def extend(self, other: Collection[Any]) -> None:  # type: ignore [override]
+    def extend(self, other: Iterable[Any]) -> None:
         other_res_list = type(self)(other)  # See if we can accept the types
         if set(self._instance_id_to_item).isdisjoint(other_res_list._instance_id_to_item):
             super().extend(other)

--- a/cognite/client/data_classes/data_modeling/instances.py
+++ b/cognite/client/data_classes/data_modeling/instances.py
@@ -980,7 +980,7 @@ class DataModelingInstancesList(WriteableCogniteResourceList[T_WriteClass, T_Ins
 
     def extend(self, other: Iterable[Any]) -> None:
         other_res_list = type(self)(other)  # See if we can accept the types
-        if set(self._instance_id_to_item).isdisjoint(other_res_list._instance_id_to_item):
+        if self._instance_id_to_item.keys().isdisjoint(other_res_list._instance_id_to_item):
             super().extend(other)
             self._instance_id_to_item.update(other_res_list._instance_id_to_item)
         else:

--- a/cognite/client/data_classes/data_modeling/instances.py
+++ b/cognite/client/data_classes/data_modeling/instances.py
@@ -58,6 +58,7 @@ from cognite.client.data_classes.data_modeling.ids import (
     ViewIdentifier,
 )
 from cognite.client.utils._auxiliary import flatten_dict
+from cognite.client.utils._identifier import InstanceId
 from cognite.client.utils._importing import local_import
 from cognite.client.utils._text import convert_all_keys_to_snake_case
 
@@ -193,7 +194,7 @@ class InstanceApply(WritableInstanceCore[T_CogniteResource], ABC):
         space (str): The workspace for the instance, a unique identifier for the space.
         external_id (str): Combined with the space is the unique identifier of the instance.
         instance_type (Literal["node", "edge"]): No description.
-        existing_version (int | None): Fail the ingestion request if the node's version is greater than or equal to this value. If no existingVersion is specified, the ingestion will always overwrite any existing data for the edge (for the specified container or instance). If existingVersion is set to 0, the upsert will behave as an insert, so it will fail the bulk if the item already exists. If skipOnVersionConflict is set on the ingestion request, then the item will be skipped instead of failing the ingestion request.
+        existing_version (int | None): Fail the ingestion request if the instance's version is greater than or equal to this value. If no existingVersion is specified, the ingestion will always overwrite any existing data for the instance (for the specified container or instance). If existingVersion is set to 0, the upsert will behave as an insert, so it will fail the bulk if the instance already exists. If skipOnVersionConflict is set on the ingestion request, then the instance will be skipped instead of failing the ingestion request.
         sources (list[NodeOrEdgeData] | None): List of source properties to write. The properties are from the instance and/or container the container(s) making up this node.
     """
 
@@ -947,6 +948,44 @@ T_Instance = TypeVar("T_Instance", bound=Instance)
 
 
 class DataModelingInstancesList(WriteableCogniteResourceList[T_WriteClass, T_Instance], ABC):
+    def _build_id_mappings(self) -> None:
+        self._instance_id_to_item = {(inst.space, inst.external_id): inst for inst in self.data}
+
+    def get(
+        self,
+        id: InstanceId | tuple[str, str] | None = None,  # type: ignore [override]
+        external_id: str | None = None,
+    ) -> T_Instance | None:
+        """Get an instance from this list by instance ID.
+
+        Args:
+            id (InstanceId | tuple[str, str] | None): The instance ID to get. A tuple on the form (space, external_id) is also accepted.
+            external_id (str | None): DEPRECATED (reason: ambiguous). The external ID of the instance to return.
+
+        Returns:
+            T_Instance | None: The requested instance if present, else None
+        """
+        # TODO: Remove when we ditch PY3.8
+        if external_id is not None:
+            warnings.warn(
+                "Calling .get with an external ID is deprecated due to being ambiguous in the absense of 'space', and "
+                "will be removed as of Oct, 2024. Pass an instance ID instead (or a tuple of (space, external_id)).",
+                UserWarning,
+            )
+            # Gotta do a linear search and stop at first match to keep existing behaviour:
+            return next((inst for (space, xid), inst in self._instance_id_to_item.items() if xid == external_id), None)
+        if isinstance(id, InstanceId):
+            id = id.as_tuple()
+        return self._instance_id_to_item.get(id)  # type: ignore [arg-type]
+
+    def extend(self, other: Collection[Any]) -> None:  # type: ignore [override]
+        other_res_list = type(self)(other)  # See if we can accept the types
+        if set(self._instance_id_to_item).isdisjoint(other_res_list._instance_id_to_item):
+            super().extend(other)
+            self._instance_id_to_item.update(other_res_list._instance_id_to_item)
+        else:
+            raise ValueError("Unable to extend as this would introduce duplicates")
+
     def to_pandas(  # type: ignore [override]
         self,
         camel_case: bool = False,
@@ -988,7 +1027,7 @@ class DataModelingInstancesList(WriteableCogniteResourceList[T_WriteClass, T_Ins
                 prop_df.columns = prop_df.columns.str.removeprefix("{}.{}/{}.".format(*view_id.as_tuple()))
             else:
                 warnings.warn(
-                    "Can't remove view ID prefix from expanded property columns as source was not unique",
+                    "Can't remove view ID prefix from expanded property columns as multiple sources exist",
                     RuntimeWarning,
                 )
         return df.join(prop_df)
@@ -1055,13 +1094,8 @@ class NodeListWithCursor(NodeList[T_Node]):
     def extend(self, other: NodeListWithCursor) -> None:  # type: ignore[override]
         if not isinstance(other, type(self)):
             raise TypeError("Unable to extend as the types do not match")
-        other_res_list = type(self)(other, other.cursor)  # See if we can accept the types
-        if self._external_id_to_item.keys().isdisjoint(other_res_list._external_id_to_item):
-            self.data.extend(other.data)
-            self._external_id_to_item.update(other_res_list._external_id_to_item)
-            self.cursor = other.cursor
-        else:
-            raise ValueError("Unable to extend as this would introduce duplicates")
+        super().extend(other)
+        self.cursor = other.cursor
 
 
 class EdgeApplyResultList(CogniteResourceList[EdgeApplyResult]):
@@ -1151,13 +1185,8 @@ class EdgeListWithCursor(EdgeList):
     def extend(self, other: EdgeListWithCursor) -> None:  # type: ignore[override]
         if not isinstance(other, type(self)):
             raise TypeError("Unable to extend as the types do not match")
-        other_res_list = type(self)(other, other.cursor)  # See if we can accept the types
-        if self._external_id_to_item.keys().isdisjoint(other_res_list._external_id_to_item):
-            self.data.extend(other.data)
-            self._external_id_to_item.update(other_res_list._external_id_to_item)
-            self.cursor = other.cursor
-        else:
-            raise ValueError("Unable to extend as this would introduce duplicates")
+        super().extend(other)
+        self.cursor = other.cursor
 
 
 # This is a utility class. It is not used by in the SDK codebase, but used in projects that use the SDK.

--- a/cognite/client/data_classes/data_modeling/instances.py
+++ b/cognite/client/data_classes/data_modeling/instances.py
@@ -950,6 +950,8 @@ T_Instance = TypeVar("T_Instance", bound=Instance)
 class DataModelingInstancesList(WriteableCogniteResourceList[T_WriteClass, T_Instance], ABC):
     def _build_id_mappings(self) -> None:
         self._instance_id_to_item = {(inst.space, inst.external_id): inst for inst in self.data}
+        # TODO: Remove when we ditch PY3.8 (Oct, 2024), reason: ambiguous without space:
+        self._ext_id_to_item = {inst.external_id: inst for inst in self.data}
 
     def get(
         self,
@@ -972,8 +974,8 @@ class DataModelingInstancesList(WriteableCogniteResourceList[T_WriteClass, T_Ins
                 "will be removed as of Oct, 2024. Pass an instance ID instead (or a tuple of (space, external_id)).",
                 UserWarning,
             )
-            # Gotta do a linear search and stop at first match to keep existing behaviour:
-            return next((inst for (space, xid), inst in self._instance_id_to_item.items() if xid == external_id), None)
+            return self._ext_id_to_item.get(external_id)
+
         if isinstance(id, InstanceId):
             id = id.as_tuple()
         return self._instance_id_to_item.get(id)  # type: ignore [arg-type]

--- a/cognite/client/data_classes/data_modeling/instances.py
+++ b/cognite/client/data_classes/data_modeling/instances.py
@@ -983,7 +983,7 @@ class DataModelingInstancesList(WriteableCogniteResourceList[T_WriteClass, T_Ins
     def extend(self, other: Iterable[Any]) -> None:
         other_res_list = type(self)(other)  # See if we can accept the types
         if self._instance_id_to_item.keys().isdisjoint(other_res_list._instance_id_to_item):
-            super().extend(other)
+            self.data.extend(other_res_list.data)
             self._instance_id_to_item.update(other_res_list._instance_id_to_item)
         else:
             raise ValueError("Unable to extend as this would introduce duplicates")

--- a/cognite/client/data_classes/data_modeling/spaces.py
+++ b/cognite/client/data_classes/data_modeling/spaces.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from abc import ABC
-from typing import TYPE_CHECKING, Any, Collection
+from typing import TYPE_CHECKING, Any, Iterable
 
 from typing_extensions import Self
 
@@ -138,7 +138,7 @@ class SpaceList(WriteableCogniteResourceList[SpaceApply, Space]):
         """
         return self._space_to_item.get(space)
 
-    def extend(self, other: Collection[Any]) -> None:  # type: ignore [override]
+    def extend(self, other: Iterable[Any]) -> None:
         other_res_list = type(self)(other)  # See if we can accept the types
         if set(self._space_to_item).isdisjoint(other_res_list._space_to_item):
             super().extend(other)

--- a/cognite/client/data_classes/data_modeling/spaces.py
+++ b/cognite/client/data_classes/data_modeling/spaces.py
@@ -141,7 +141,7 @@ class SpaceList(WriteableCogniteResourceList[SpaceApply, Space]):
     def extend(self, other: Iterable[Any]) -> None:
         other_res_list = type(self)(other)  # See if we can accept the types
         if self._space_to_item.keys().isdisjoint(other_res_list._space_to_item):
-            super().extend(other)
+            self.data.extend(other_res_list.data)
             self._space_to_item.update(other_res_list._space_to_item)
         else:
             raise ValueError("Unable to extend as this would introduce duplicates")

--- a/cognite/client/data_classes/data_modeling/spaces.py
+++ b/cognite/client/data_classes/data_modeling/spaces.py
@@ -140,7 +140,7 @@ class SpaceList(WriteableCogniteResourceList[SpaceApply, Space]):
 
     def extend(self, other: Iterable[Any]) -> None:
         other_res_list = type(self)(other)  # See if we can accept the types
-        if set(self._space_to_item).isdisjoint(other_res_list._space_to_item):
+        if self._space_to_item.keys().isdisjoint(other_res_list._space_to_item):
             super().extend(other)
             self._space_to_item.update(other_res_list._space_to_item)
         else:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "cognite-sdk"
 
-version = "7.54.11"
+version = "7.54.12"
 description = "Cognite Python SDK"
 readme = "README.md"
 documentation = "https://cognite-sdk-python.readthedocs-hosted.com"

--- a/tests/tests_unit/test_data_classes/test_data_models/test_resource_class_methods.py
+++ b/tests/tests_unit/test_data_classes/test_data_models/test_resource_class_methods.py
@@ -9,6 +9,7 @@ from typing import Any
 
 import pytest
 
+from cognite.client.data_classes._base import CogniteResourceList
 from cognite.client.data_classes.data_modeling import Edge, EdgeId, EdgeList, Node, NodeId, NodeList, Space, SpaceList
 from cognite.client.data_classes.data_modeling.instances import DataModelingInstancesList
 from cognite.client.utils._identifier import InstanceId
@@ -78,3 +79,17 @@ def test_get_space_list(space_lst: SpaceList, space: str) -> None:
     assert item.space == space  # type: ignore [union-attr]
 
     assert space_lst.get(space + "doesnt-exist") is None  # type: ignore [union-attr]
+
+
+@pytest.mark.parametrize("which", ("space", "node", "edge"))
+def test_extend_method(node_lst: NodeList, edge_lst: EdgeList, space_lst: SpaceList, which: str) -> None:
+    lst: CogniteResourceList = {"node": node_lst, "edge": edge_lst, "space": space_lst}[which]  # type: ignore [assignment]
+    empty = lst[:0]
+    overlapping = lst[:]
+    not_overlapping = lst[2:]
+    lst = lst[:2]
+
+    lst.extend(empty)
+    lst.extend(not_overlapping)
+    with pytest.raises(ValueError, match=r"^Unable to extend as this would introduce duplicates$"):
+        lst.extend(overlapping)

--- a/tests/tests_unit/test_data_classes/test_data_models/test_resource_class_methods.py
+++ b/tests/tests_unit/test_data_classes/test_data_models/test_resource_class_methods.py
@@ -78,7 +78,7 @@ def test_get_space_list(space_lst: SpaceList, space: str) -> None:
     item = space_lst.get(space)
     assert item.space == space  # type: ignore [union-attr]
 
-    assert space_lst.get(space + "doesnt-exist") is None  # type: ignore [union-attr]
+    assert space_lst.get(space + "doesnt-exist") is None
 
 
 @pytest.mark.parametrize("which", ("space", "node", "edge"))

--- a/tests/tests_unit/test_data_classes/test_data_models/test_resource_class_methods.py
+++ b/tests/tests_unit/test_data_classes/test_data_models/test_resource_class_methods.py
@@ -10,7 +10,7 @@ from typing import Any
 import pytest
 
 from cognite.client.data_classes._base import CogniteResourceList
-from cognite.client.data_classes.data_modeling import Edge, EdgeId, EdgeList, Node, NodeId, NodeList, Space, SpaceList
+from cognite.client.data_classes.data_modeling import EdgeId, EdgeList, Node, NodeId, NodeList, Space, SpaceList
 from cognite.client.data_classes.data_modeling.instances import DataModelingInstancesList
 from cognite.client.utils._identifier import InstanceId
 

--- a/tests/tests_unit/test_data_classes/test_data_models/test_resource_class_methods.py
+++ b/tests/tests_unit/test_data_classes/test_data_models/test_resource_class_methods.py
@@ -1,0 +1,80 @@
+"""
+This file contains tests for the methods for the various resource classes in
+data modelling, like `NodeList.get`, `SpaceList.extend` etc.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from cognite.client.data_classes.data_modeling import Edge, EdgeId, EdgeList, Node, NodeId, NodeList, Space, SpaceList
+from cognite.client.data_classes.data_modeling.instances import DataModelingInstancesList
+from cognite.client.utils._identifier import InstanceId
+
+
+@pytest.fixture
+def instance_lst() -> list[dict[str, Any]]:
+    return [
+        {
+            "space": f"foo{i}",
+            "externalId": "constant",
+            "version": 3 + i,
+            "lastUpdatedTime": 1705935251161 + i,
+            "createdTime": 1694600277822 + i,
+            "properties": {"foo": {"Asset/v1": {"prop": i}}},
+        }
+        for i in range(3)
+    ]
+
+
+@pytest.fixture
+def node_lst(instance_lst: list[dict[str, Any]]) -> NodeList:
+    return NodeList([Node.load({"instanceType": "node", **inst}) for inst in instance_lst])
+
+
+@pytest.fixture
+def edge_lst(instance_lst: list[dict[str, Any]]) -> EdgeList:
+    for inst in instance_lst:
+        inst.update(
+            instanceType="edge",
+            type={"space": "foo", "externalId": "bar"},
+            startNode={"space": "foo", "externalId": "bar2"},
+            endNode={"space": "foo", "externalId": "bar3"},
+        )
+    return EdgeList([Edge.load(inst) for inst in instance_lst])
+
+
+@pytest.fixture
+def space_lst(instance_lst: list[dict[str, Any]]) -> SpaceList:
+    return SpaceList(
+        [Space(space=dct["space"], is_global=False, last_updated_time=1, created_time=1) for dct in instance_lst]
+    )
+
+
+@pytest.mark.parametrize("space", ["foo0", "foo1", "foo2"])
+@pytest.mark.parametrize("node_or_edge", ["node", "edge"])
+def test_get_instance_lists(node_lst: NodeList, edge_lst: EdgeList, space: str, node_or_edge: str) -> None:
+    inst_lst: DataModelingInstancesList = {"node": node_lst, "edge": edge_lst}[node_or_edge]  # type: ignore [assignment]
+
+    for _id_cls in EdgeId, NodeId, InstanceId:  # pass by id object
+        inst = inst_lst.get(_id_cls(space, "constant"))
+        assert inst.space == space  # type: ignore [union-attr]
+
+        assert inst_lst.get((space, "doesnt-exist")) is None
+
+    inst = inst_lst.get((space, "constant"))  # pass by tuple
+    assert inst.space == space  # type: ignore [union-attr]
+
+    # Since ext.id is ambiguous, we always get the last (deprecated):
+    inst = inst_lst.get(external_id="constant")
+    assert inst.space == "foo2"  # type: ignore [union-attr]
+
+
+@pytest.mark.parametrize("space", ["foo0", "foo1", "foo2"])
+def test_get_space_list(space_lst: SpaceList, space: str) -> None:
+    item = space_lst.get(space)
+    assert item.space == space  # type: ignore [union-attr]
+
+    assert space_lst.get(space + "doesnt-exist") is None  # type: ignore [union-attr]

--- a/tests/tests_unit/test_data_classes/test_data_models/test_resource_class_methods.py
+++ b/tests/tests_unit/test_data_classes/test_data_models/test_resource_class_methods.py
@@ -44,7 +44,7 @@ def edge_lst(instance_lst: list[dict[str, Any]]) -> EdgeList:
             startNode={"space": "foo", "externalId": "bar2"},
             endNode={"space": "foo", "externalId": "bar3"},
         )
-    return EdgeList([Edge.load(inst) for inst in instance_lst])
+    return EdgeList.load(instance_lst)
 
 
 @pytest.fixture


### PR DESCRIPTION
## [7.54.12] - 2024-08-02
### Fixed
- NodeList and EdgeList (and subclasses) now expects an instance ID, `(space, external_id)` in the `.get` method.
  Using just an `external_id` is still possible, but deprecated as it is ambiguous in the absence of the space
  identifier, and will just return the first matching instance (as previously).
- SpaceList now expects a space identifier in the `.get` method.

## TODO: 

- [x] Add tests

https://cognitedata.atlassian.net/browse/DM-1962