### PR TITLE
Workflow Execution.trigger method deprecation

### DIFF
--- a/cognite/client/_api/workflows.py
+++ b/cognite/client/_api/workflows.py
@@ -83,7 +83,7 @@ class WorkflowTaskAPI(APIClient):
 
                 >>> from cognite.client import CogniteClient
                 >>> client = CogniteClient()
-                >>> res = client.workflows.executions.trigger("my workflow", "1")
+                >>> res = client.workflows.executions.run("my workflow", "1")
                 >>> res = client.workflows.executions.retrieve_detailed(res.id)
                 >>> res = client.workflows.tasks.update(res.tasks[1].id, "completed")
 
@@ -134,7 +134,7 @@ class WorkflowExecutionAPI(APIClient):
             raise
         return WorkflowExecutionDetailed._load(response.json())
 
-    def trigger(
+    def run(
         self,
         workflow_external_id: str,
         version: str,
@@ -142,7 +142,7 @@ class WorkflowExecutionAPI(APIClient):
         metadata: dict | None = None,
         client_credentials: ClientCredentials | None = None,
     ) -> WorkflowExecution:
-        """`Trigger a workflow execution. <https://api-docs.cognite.com/20230101/tag/Workflow-executions/operation/TriggerRunOfSpecificVersionOfWorkflow>`_
+        """`Run a workflow execution. <https://api-docs.cognite.com/20230101/tag/Workflow-executions/operation/TriggerRunOfSpecificVersionOfWorkflow>`_
 
         Args:
             workflow_external_id (str): External id of the workflow.
@@ -171,18 +171,18 @@ class WorkflowExecutionAPI(APIClient):
 
                 >>> from cognite.client import CogniteClient
                 >>> client = CogniteClient()
-                >>> res = client.workflows.executions.trigger("foo", "1")
+                >>> res = client.workflows.executions.run("foo", "1")
 
             Trigger a workflow execution with input data:
 
-                >>> res = client.workflows.executions.trigger("foo", "1", input={"a": 1, "b": 2})
+                >>> res = client.workflows.executions.run("foo", "1", input={"a": 1, "b": 2})
 
             Trigger a workflow execution using a specific set of client credentials (i.e. not your current credentials):
 
                 >>> import os
                 >>> from cognite.client.data_classes import ClientCredentials
                 >>> credentials = ClientCredentials("my-client-id", os.environ["MY_CLIENT_SECRET"])
-                >>> res = client.workflows.executions.trigger("foo", "1", client_credentials=credentials)
+                >>> res = client.workflows.executions.run("foo", "1", client_credentials=credentials)
         """
         nonce = create_session_and_return_nonce(
             self._cognite_client, api_name="Workflow API", client_credentials=client_credentials
@@ -275,7 +275,7 @@ class WorkflowExecutionAPI(APIClient):
 
                 >>> from cognite.client import CogniteClient
                 >>> client = CogniteClient()
-                >>> res = client.workflows.executions.trigger("foo", "1")
+                >>> res = client.workflows.executions.run("foo", "1")
                 >>> client.workflows.executions.cancel(id="foo", reason="test cancelation")
         """
         response = self._post(
@@ -304,7 +304,7 @@ class WorkflowExecutionAPI(APIClient):
 
                 >>> from cognite.client import CogniteClient
                 >>> client = CogniteClient()
-                >>> res = client.workflows.executions.trigger("foo", "1")
+                >>> res = client.workflows.executions.run("foo", "1")
                 >>> client.workflows.executions.cancel(id=res.id, reason="test cancellation")
                 >>> client.workflows.executions.retry(res.id)
         """

--- a/cognite/client/_api/workflows.py
+++ b/cognite/client/_api/workflows.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import warnings
 from collections.abc import Iterator
 from typing import TYPE_CHECKING, Any, Literal, MutableSequence, Tuple, Union, overload
 from urllib.parse import quote
@@ -133,6 +134,34 @@ class WorkflowExecutionAPI(APIClient):
                 return None
             raise
         return WorkflowExecutionDetailed._load(response.json())
+
+    def trigger(
+        self,
+        workflow_external_id: str,
+        version: str,
+        input: dict | None = None,
+        metadata: dict | None = None,
+        client_credentials: ClientCredentials | None = None,
+    ) -> WorkflowExecution:
+        """`[DEPRECATED]Trigger a workflow execution. <https://api-docs.cognite.com/20230101/tag/Workflow-executions/operation/TriggerRunOfSpecificVersionOfWorkflow>`_
+
+        This method is deprecated, use '.run' instead. It will be completely removed October 2024.
+
+        Args:
+            workflow_external_id (str): External id of the workflow.
+            version (str): Version of the workflow.
+            input (dict | None): The input to the workflow execution. This will be available for tasks that have specified it as an input with the string "${workflow.input}" See tip below for more information.
+            metadata (dict | None): Application specific metadata. Keys have a maximum length of 32 characters, values a maximum of 255, and there can be a maximum of 10 key-value pairs.
+            client_credentials (ClientCredentials | None): Specific credentials that should be used to trigger the workflow execution. When passed will take precedence over the current credentials.
+        Returns:
+            WorkflowExecution: No description.
+        """
+        warnings.warn(
+            "This methods has been deprecated, use '.run' instead. It will be completely removed October 2024.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return self.run(workflow_external_id, version, input, metadata, client_credentials)
 
     def run(
         self,

--- a/docs/source/workflow_orchestration.rst
+++ b/docs/source/workflow_orchestration.rst
@@ -49,9 +49,9 @@ Retrieve Detailed Workflow Execution
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. automethod:: cognite.client._api.workflows.WorkflowExecutionAPI.retrieve_detailed
 
-Trigger Workflow Execution
+Run Workflow Execution
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. automethod:: cognite.client._api.workflows.WorkflowExecutionAPI.trigger
+.. automethod:: cognite.client._api.workflows.WorkflowExecutionAPI.run
 
 Cancel Workflow Execution
 ^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/source/workflow_orchestration.rst
+++ b/docs/source/workflow_orchestration.rst
@@ -53,6 +53,10 @@ Run Workflow Execution
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. automethod:: cognite.client._api.workflows.WorkflowExecutionAPI.run
 
+Trigger Workflow Execution
+^^^^^^^^^^^^^^^^^^^^^^^^^^
+.. automethod:: cognite.client._api.workflows.WorkflowExecutionAPI.trigger
+
 Cancel Workflow Execution
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. automethod:: cognite.client._api.workflows.WorkflowExecutionAPI.cancel

--- a/tests/tests_integration/test_api/test_data_workflows.py
+++ b/tests/tests_integration/test_api/test_data_workflows.py
@@ -200,7 +200,7 @@ def workflow_execution_list(
     if executions:
         return executions
     # Creating at least one execution
-    result = cognite_client.workflows.executions.trigger(
+    result = cognite_client.workflows.executions.run(
         add_multiply_workflow.workflow_external_id,
         add_multiply_workflow.version,
         {"a": 5, "b": 6},
@@ -415,7 +415,7 @@ class TestWorkflowExecutions:
         cognite_client: CogniteClient,
         add_multiply_workflow: WorkflowVersion,
     ) -> None:
-        workflow_execution = cognite_client.workflows.executions.trigger(
+        workflow_execution = cognite_client.workflows.executions.run(
             add_multiply_workflow.workflow_external_id,
             add_multiply_workflow.version,
         )
@@ -434,7 +434,7 @@ class TestWorkflowExecutions:
     def test_trigger_cancel_retry_workflow(
         self, cognite_client: CogniteClient, add_multiply_workflow: WorkflowVersion
     ) -> None:
-        workflow_execution = cognite_client.workflows.executions.trigger(
+        workflow_execution = cognite_client.workflows.executions.run(
             add_multiply_workflow.workflow_external_id,
             add_multiply_workflow.version,
         )


### PR DESCRIPTION
## Description
FYI: Not worth a new release of the SDK.

## Checklist:
- [ ] Tests added/updated.
- [ ] Documentation updated. Documentation is generated from docstrings - these must be updated according to your change.
  If a new method has been added it should be referenced in [cognite.rst](https://github.com/cognitedata/cognite-sdk-python/blob/master/docs/source/cognite.rst) in order to generate docs based on its docstring.
- [ ] Changelog updated in [CHANGELOG.md](https://github.com/cognitedata/cognite-sdk-python/blob/master/CHANGELOG.md).
- [ ] Version bumped. If triggering a new release is desired, bump the version number in [_version.py](https://github.com/cognitedata/cognite-sdk-python/blob/master/cognite/client/_version.py) and [pyproject.toml](https://github.com/cognitedata/cognite-sdk-python/blob/master/pyproject.toml) per [semantic versioning](https://semver.org/).
