### PR TITLE
workflow_orchestration is now data_workflows rst and add trigger doc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ Changes are grouped as follows
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
+## [7.55.2] - 2024-08-29
+### Fixed
+- Turn workflow_orchestration into data_workflows and add trigger doc 
+
 ## [7.55.1] - 2024-08-29
 ### Fixed
 - Missing exports for workflow triggers 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ Changes are grouped as follows
 
 ## [7.55.2] - 2024-08-29
 ### Fixed
-- Turn workflow_orchestration into data_workflows and add trigger doc 
+- Turn workflow_orchestration into data_workflows and add trigger doc, fix attribute names in data classes
 
 ## [7.55.1] - 2024-08-29
 ### Fixed

--- a/cognite/client/_version.py
+++ b/cognite/client/_version.py
@@ -1,4 +1,4 @@
 from __future__ import annotations
 
-__version__ = "7.55.1"
+__version__ = "7.55.2"
 __api_subversion__ = "20230101"

--- a/cognite/client/data_classes/workflows.py
+++ b/cognite/client/data_classes/workflows.py
@@ -1381,26 +1381,33 @@ class WorkflowTriggerRun(CogniteResource):
 
     def __init__(
         self,
-        trigger_external_id: str,
-        trigger_fire_time: int,
+        external_id: str,
+        fire_time: int,
         workflow_external_id: str,
         workflow_version: str,
         workflow_execution_id: str,
+        status: Literal["success", "failed"],
+        reason_for_failure: str | None = None,
     ) -> None:
-        self.trigger_external_id = trigger_external_id
-        self.trigger_fire_time = trigger_fire_time
+        self.external_id = external_id
+        self.fire_time = fire_time
         self.workflow_external_id = workflow_external_id
         self.workflow_version = workflow_version
         self.workflow_execution_id = workflow_execution_id
+        self.status = status
+        self.reason_for_failure = reason_for_failure
 
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         item = {
-            "external_id": self.trigger_external_id,
-            "fire_time": self.trigger_fire_time,
+            "external_id": self.external_id,
+            "fire_time": self.fire_time,
             "workflow_external_id": self.workflow_external_id,
             "workflow_version": self.workflow_version,
             "workflow_execution_id": self.workflow_execution_id,
+            "status": self.status,
         }
+        if self.reason_for_failure:
+            item["reason_for_failure"] = self.reason_for_failure
         if camel_case:
             return convert_all_keys_to_camel_case(item)
         return item
@@ -1408,11 +1415,13 @@ class WorkflowTriggerRun(CogniteResource):
     @classmethod
     def _load(cls, resource: dict, cognite_client: CogniteClient | None = None) -> WorkflowTriggerRun:
         return cls(
-            trigger_external_id=resource["externalId"],
-            trigger_fire_time=resource["fireTime"],
+            external_id=resource["externalId"],
+            fire_time=resource["fireTime"],
             workflow_external_id=resource["workflowExternalId"],
             workflow_version=resource["workflowVersion"],
             workflow_execution_id=resource["workflowExecutionId"],
+            status=resource["status"],
+            reason_for_failure=resource.get("reasonForFailure"),
         )
 
 

--- a/cognite/client/data_classes/workflows.py
+++ b/cognite/client/data_classes/workflows.py
@@ -1385,18 +1385,21 @@ class WorkflowTriggerRun(CogniteResource):
         trigger_fire_time: int,
         workflow_external_id: str,
         workflow_version: str,
+        workflow_execution_id: str,
     ) -> None:
         self.trigger_external_id = trigger_external_id
         self.trigger_fire_time = trigger_fire_time
         self.workflow_external_id = workflow_external_id
         self.workflow_version = workflow_version
+        self.workflow_execution_id = workflow_execution_id
 
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         item = {
-            "trigger_external_id": self.trigger_external_id,
-            "trigger_fire_time": self.trigger_fire_time,
+            "external_id": self.trigger_external_id,
+            "fire_time": self.trigger_fire_time,
             "workflow_external_id": self.workflow_external_id,
             "workflow_version": self.workflow_version,
+            "workflow_execution_id": self.workflow_execution_id,
         }
         if camel_case:
             return convert_all_keys_to_camel_case(item)
@@ -1405,10 +1408,11 @@ class WorkflowTriggerRun(CogniteResource):
     @classmethod
     def _load(cls, resource: dict, cognite_client: CogniteClient | None = None) -> WorkflowTriggerRun:
         return cls(
-            trigger_external_id=resource["triggerExternalId"],
-            trigger_fire_time=resource["triggerFireTime"],
+            trigger_external_id=resource["externalId"],
+            trigger_fire_time=resource["fireTime"],
             workflow_external_id=resource["workflowExternalId"],
             workflow_version=resource["workflowVersion"],
+            workflow_execution_id=resource["workflowExecutionId"],
         )
 
 

--- a/docs/source/data_workflows.rst
+++ b/docs/source/data_workflows.rst
@@ -71,6 +71,23 @@ Update Status of Async Task
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. automethod:: cognite.client._api.workflows.WorkflowTaskAPI.update
 
+Workflow Triggers
+-------------------
+Create triggers for workflow executions
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+.. automethod:: cognite.client._api.workflows.WorkflowTriggerAPI.create
+
+Delete triggers for workflow executions
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+.. automethod:: cognite.client._api.workflows.WorkflowTriggerAPI.delete
+
+Get triggers for workflow executions
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+.. automethod:: cognite.client._api.workflows.WorkflowTriggerAPI.get_triggers
+
+Get trigger run history for a workflow trigger
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+.. automethod:: cognite.client._api.workflows.WorkflowTriggerAPI.get_trigger_run_history
 
 Data Workflows data classes
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/source/data_workflows.rst
+++ b/docs/source/data_workflows.rst
@@ -74,19 +74,19 @@ Update Status of Async Task
 Workflow Triggers
 -------------------
 Create triggers for workflow executions
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. automethod:: cognite.client._api.workflows.WorkflowTriggerAPI.create
 
 Delete triggers for workflow executions
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. automethod:: cognite.client._api.workflows.WorkflowTriggerAPI.delete
 
 Get triggers for workflow executions
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. automethod:: cognite.client._api.workflows.WorkflowTriggerAPI.get_triggers
 
 Get trigger run history for a workflow trigger
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. automethod:: cognite.client._api.workflows.WorkflowTriggerAPI.get_trigger_run_history
 
 Data Workflows data classes

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -53,7 +53,7 @@ Contents
    data_organization
    transformations
    functions
-   workflow_orchestration
+   data_workflows
    unit_catalog
    filters
    deprecated

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "cognite-sdk"
 
-version = "7.55.1"
+version = "7.55.2"
 description = "Cognite Python SDK"
 readme = "README.md"
 documentation = "https://cognite-sdk-python.readthedocs-hosted.com"

--- a/tests/tests_integration/test_api/test_data_workflows.py
+++ b/tests/tests_integration/test_api/test_data_workflows.py
@@ -253,7 +253,7 @@ def workflow_scheduled_trigger(cognite_client: CogniteClient, add_multiply_workf
     trigger = cognite_client.workflows.triggers.create(
         WorkflowTriggerCreate(
             external_id="integration_test-workflow-scheduled-trigger",
-            trigger_rule=WorkflowScheduledTriggerRule(cron_expression="0 0 * * *"),
+            trigger_rule=WorkflowScheduledTriggerRule(cron_expression="* * * * *"),
             workflow_external_id="integration_test-workflow-add_multiply",
             workflow_version="1",
             input={"a": 1, "b": 2},
@@ -490,7 +490,7 @@ class TestWorkflowTriggers:
     ) -> None:
         assert workflow_scheduled_trigger is not None
         assert workflow_scheduled_trigger.external_id == "integration_test-workflow-scheduled-trigger"
-        assert workflow_scheduled_trigger.trigger_rule == WorkflowScheduledTriggerRule(cron_expression="0 0 * * *")
+        assert workflow_scheduled_trigger.trigger_rule == WorkflowScheduledTriggerRule(cron_expression="* * * * *")
         assert workflow_scheduled_trigger.workflow_external_id == "integration_test-workflow-add_multiply"
         assert workflow_scheduled_trigger.workflow_version == "1"
         assert workflow_scheduled_trigger.input == {"a": 1, "b": 2}


### PR DESCRIPTION
## Description
- workflow_orchestration.rst is now data_workflows.rst
- add missing doc methods
- fix property names according to latest api spec

## Checklist:
- [x] Tests added/updated.
- [x] Documentation updated. Documentation is generated from docstrings - these must be updated according to your change.
  If a new method has been added it should be referenced in [cognite.rst](https://github.com/cognitedata/cognite-sdk-python/blob/master/docs/source/cognite.rst) in order to generate docs based on its docstring.
- [x] Changelog updated in [CHANGELOG.md](https://github.com/cognitedata/cognite-sdk-python/blob/master/CHANGELOG.md).
- [x] Version bumped. If triggering a new release is desired, bump the version number in [_version.py](https://github.com/cognitedata/cognite-sdk-python/blob/master/cognite/client/_version.py) and [pyproject.toml](https://github.com/cognitedata/cognite-sdk-python/blob/master/pyproject.toml) per [semantic versioning](https://semver.org/).
