### PR TITLE
improve space filter ergonomics to more easily list global nodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,12 @@ Changes are grouped as follows
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
+## [7.58.6] - 2024-09-05
+### Fixed
+- Data modeling convenience filter `SpaceFilter` now allows listing of global nodes by using `equals`
+  (when a single space is requested (requirement)). This also affects the `space` parameter to e.g.
+  `client.data_modeling.instances.list(...)`
+
 ## [7.58.5] - 2024-09-04
 ### Added
 - Data modeling filters now support properties that are lists.

--- a/cognite/client/_version.py
+++ b/cognite/client/_version.py
@@ -1,4 +1,4 @@
 from __future__ import annotations
 
-__version__ = "7.58.5"
+__version__ = "7.58.6"
 __api_subversion__ = "20230101"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "cognite-sdk"
 
-version = "7.58.5"
+version = "7.58.6"
 description = "Cognite Python SDK"
 readme = "README.md"
 documentation = "https://cognite-sdk-python.readthedocs-hosted.com"

--- a/tests/tests_integration/test_api/test_data_modeling/test_instances.py
+++ b/tests/tests_integration/test_api/test_data_modeling/test_instances.py
@@ -1083,6 +1083,22 @@ class TestInstancesAPI:
         assert len(persons) > 0
         assert all(isinstance(person, PersonRead) for person in persons)
 
+    def test_listing_global_nodes(self, cognite_client: CogniteClient) -> None:
+        from cognite.client.data_classes.data_modeling.cdm.v1 import CogniteUnit
+
+        # Space must be explicitly specified or nothing will be returned:
+        no_nodes = cognite_client.data_modeling.instances.list(
+            sources=CogniteUnit.get_source(),
+        )
+        assert len(no_nodes) == 0
+
+        nodes = cognite_client.data_modeling.instances.list(
+            space="cdf_cdm_units",
+            sources=CogniteUnit.get_source(),
+            limit=5,
+        )
+        assert len(nodes) == 5
+
 
 class TestInstancesSync:
     def test_sync_movies_released_in_1994(self, cognite_client: CogniteClient, movie_view: View) -> None:

--- a/tests/tests_integration/test_api/test_data_modeling/test_instances.py
+++ b/tests/tests_integration/test_api/test_data_modeling/test_instances.py
@@ -1087,15 +1087,11 @@ class TestInstancesAPI:
         from cognite.client.data_classes.data_modeling.cdm.v1 import CogniteUnit
 
         # Space must be explicitly specified or nothing will be returned:
-        no_nodes = cognite_client.data_modeling.instances.list(
-            sources=CogniteUnit.get_source(),
-        )
+        no_nodes = cognite_client.data_modeling.instances.list(sources=CogniteUnit.get_source())
         assert len(no_nodes) == 0
 
         nodes = cognite_client.data_modeling.instances.list(
-            space="cdf_cdm_units",
-            sources=CogniteUnit.get_source(),
-            limit=5,
+            space="cdf_cdm_units", sources=CogniteUnit.get_source(), limit=5
         )
         assert len(nodes) == 5
 


### PR DESCRIPTION
## Description
https://cognitedata.atlassian.net/browse/DM-2075

## Checklist:
- [x] Tests added/updated.
- [ ] Documentation updated. Documentation is generated from docstrings - these must be updated according to your change.
  If a new method has been added it should be referenced in [cognite.rst](https://github.com/cognitedata/cognite-sdk-python/blob/master/docs/source/cognite.rst) in order to generate docs based on its docstring.
- [x] Changelog updated in [CHANGELOG.md](https://github.com/cognitedata/cognite-sdk-python/blob/master/CHANGELOG.md).
- [x] Version bumped. If triggering a new release is desired, bump the version number in [_version.py](https://github.com/cognitedata/cognite-sdk-python/blob/master/cognite/client/_version.py) and [pyproject.toml](https://github.com/cognitedata/cognite-sdk-python/blob/master/pyproject.toml) per [semantic versioning](https://semver.org/).
