### PR TITLE
Add ignore_unknown_ids to files.delete

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ Changes are grouped as follows
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
+## [7.59.0] - 2024-09-12
+### Added
+- Added `ignore_unknown_ids` to `client.files.delete`.
+
 ## [7.58.8] - 2024-09-10
 ### Added
 - Added missing `WorkflowTriggerCreateList` to `cognite.client.data_classes.workflows`.

--- a/cognite/client/_api/files.py
+++ b/cognite/client/_api/files.py
@@ -333,13 +333,17 @@ class FilesAPI(APIClient):
         return self._aggregate(filter=filter, cls=CountAggregate)
 
     def delete(
-        self, id: int | Sequence[int] | None = None, external_id: str | SequenceNotStr[str] | None = None
+        self,
+        id: int | Sequence[int] | None = None,
+        external_id: str | SequenceNotStr[str] | None = None,
+        ignore_unknown_ids: bool = False,
     ) -> None:
         """`Delete files <https://developer.cognite.com/api#tag/Files/operation/deleteFiles>`_
 
         Args:
             id (int | Sequence[int] | None): Id or list of ids
             external_id (str | SequenceNotStr[str] | None): str or list of str
+            ignore_unknown_ids (bool): Ignore IDs and external IDs that are not found rather than throw an exception.
 
         Examples:
 
@@ -349,7 +353,11 @@ class FilesAPI(APIClient):
                 >>> client = CogniteClient()
                 >>> client.files.delete(id=[1,2,3], external_id="3")
         """
-        self._delete_multiple(identifiers=IdentifierSequence.load(ids=id, external_ids=external_id), wrap_ids=True)
+        self._delete_multiple(
+            identifiers=IdentifierSequence.load(ids=id, external_ids=external_id),
+            wrap_ids=True,
+            extra_body_fields={"ignoreUnknownIds": ignore_unknown_ids},
+        )
 
     @overload
     def update(self, item: FileMetadata | FileMetadataWrite | FileMetadataUpdate) -> FileMetadata: ...

--- a/cognite/client/_version.py
+++ b/cognite/client/_version.py
@@ -1,4 +1,4 @@
 from __future__ import annotations
 
-__version__ = "7.58.8"
+__version__ = "7.59.0"
 __api_subversion__ = "20230101"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "cognite-sdk"
 
-version = "7.58.8"
+version = "7.59.0"
 description = "Cognite Python SDK"
 readme = "README.md"
 documentation = "https://cognite-sdk-python.readthedocs-hosted.com"

--- a/tests/tests_integration/test_api/test_files.py
+++ b/tests/tests_integration/test_api/test_files.py
@@ -305,3 +305,8 @@ class TestFilesAPI:
             assert retrieved.dump() == [updated.dump()]
         finally:
             cognite_client_alpha.data_modeling.instances.delete(nodes=instance_id)
+
+    def test_create_delete_ignore_unknown_ids(self, cognite_client: CogniteClient) -> None:
+        file_metadata = FileMetadata(name="mytestfile")
+        returned_file_metadata, upload_url = cognite_client.files.create(file_metadata)
+        cognite_client.files.delete(id=[returned_file_metadata.id, 1], ignore_unknown_ids=True)

--- a/tests/tests_unit/test_api/test_files.py
+++ b/tests/tests_unit/test_api/test_files.py
@@ -342,12 +342,12 @@ class TestFilesAPI:
 
     def test_delete_single(self, cognite_client, mock_files_response):
         res = cognite_client.files.delete(id=1)
-        assert {"items": [{"id": 1}]} == jsgz_load(mock_files_response.calls[0].request.body)
+        assert {"items": [{"id": 1}], "ignoreUnknownIds": False} == jsgz_load(mock_files_response.calls[0].request.body)
         assert res is None
 
     def test_delete_multiple(self, cognite_client, mock_files_response):
         res = cognite_client.files.delete(id=[1])
-        assert {"items": [{"id": 1}]} == jsgz_load(mock_files_response.calls[0].request.body)
+        assert {"items": [{"id": 1}], "ignoreUnknownIds": False} == jsgz_load(mock_files_response.calls[0].request.body)
         assert res is None
 
     def test_update_with_resource_class(self, cognite_client, mock_files_response):


### PR DESCRIPTION
## Description
Added ignore_unknown_ids to files.delete, ref change in https://github.com/cognitedata/ark/pull/10855

## Checklist:
- [x] Tests added/updated.
- [x] Documentation updated. Documentation is generated from docstrings - these must be updated according to your change.
  If a new method has been added it should be referenced in [cognite.rst](https://github.com/cognitedata/cognite-sdk-python/blob/master/docs/source/cognite.rst) in order to generate docs based on its docstring.
- [x] Changelog updated in [CHANGELOG.md](https://github.com/cognitedata/cognite-sdk-python/blob/master/CHANGELOG.md).
- [x] Version bumped. If triggering a new release is desired, bump the version number in [_version.py](https://github.com/cognitedata/cognite-sdk-python/blob/master/cognite/client/_version.py) and [pyproject.toml](https://github.com/cognitedata/cognite-sdk-python/blob/master/pyproject.toml) per [semantic versioning](https://semver.org/).
