### PR TITLE
Fix json decode error for users using simplejson instead of built-in json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ Changes are grouped as follows
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
+## [7.59.3] - 2024-09-12
+### Fixed
+- JSONDecodeError can no longer be raised in environemnts where simplejson is used instead of built-in.
+
 ## [7.59.2] - 2024-09-12
 ### Fixed
 - A bug in `client.sequences.data.retrieve_dataframe(...)` where passing a column to `column_external_ids` caused a TypeError.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ Changes are grouped as follows
 
 ## [7.59.3] - 2024-09-12
 ### Fixed
-- JSONDecodeError can no longer be raised in environemnts where simplejson is used instead of built-in.
+- JSONDecodeError can no longer be raised in environments where simplejson is used instead of built-in json.
 
 ## [7.59.2] - 2024-09-12
 ### Fixed

--- a/cognite/client/_api_client.py
+++ b/cognite/client/_api_client.py
@@ -7,7 +7,6 @@ import logging
 import re
 import warnings
 from collections import UserList
-from json.decoder import JSONDecodeError
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -27,6 +26,7 @@ from urllib.parse import urljoin
 
 import requests.utils
 from requests import Response
+from requests.exceptions import JSONDecodeError as RequestsJSONDecodeError
 from requests.structures import CaseInsensitiveDict
 
 from cognite.client._http_client import HTTPClient, HTTPClientConfig, get_global_requests_session
@@ -63,6 +63,7 @@ from cognite.client.utils._identifier import (
     IdentifierSequenceCore,
     SingletonIdentifierSequence,
 )
+from cognite.client.utils._json import JSONDecodeError
 from cognite.client.utils._text import convert_all_keys_to_camel_case, shorten, to_camel_case, to_snake_case
 from cognite.client.utils._validation import assert_type, verify_limit
 from cognite.client.utils.useful_types import SequenceNotStr
@@ -1338,7 +1339,7 @@ class APIClient:
     def _get_response_content_safe(res: Response) -> str:
         try:
             return _json.dumps(res.json())
-        except JSONDecodeError:
+        except (JSONDecodeError, RequestsJSONDecodeError):
             pass
 
         try:

--- a/cognite/client/_version.py
+++ b/cognite/client/_version.py
@@ -1,4 +1,4 @@
 from __future__ import annotations
 
-__version__ = "7.59.2"
+__version__ = "7.59.3"
 __api_subversion__ = "20230101"

--- a/cognite/client/utils/_json.py
+++ b/cognite/client/utils/_json.py
@@ -1,13 +1,27 @@
 from __future__ import annotations
 
-import json
 import math
 import numbers
 from decimal import Decimal
 from types import MappingProxyType
 from typing import Any
 
-__all__ = ["dumps", "loads", "convert_to_float", "convert_nonfinite_float_to_str"]
+# Copied from requests.compat.py (except for type ignores):
+# json/simplejson module import resolution
+has_simplejson = False
+try:
+    import simplejson as json
+
+    has_simplejson = True
+except ImportError:
+    import json  # type: ignore [no-redef]
+
+if has_simplejson:
+    from simplejson import JSONDecodeError
+else:
+    from json import JSONDecodeError  # type: ignore [assignment]
+
+__all__ = ["dumps", "loads", "JSONDecodeError", "convert_to_float", "convert_nonfinite_float_to_str"]
 
 
 def _default_json_encoder(obj: Any) -> Any:

--- a/cognite/client/utils/_json.py
+++ b/cognite/client/utils/_json.py
@@ -6,19 +6,14 @@ from decimal import Decimal
 from types import MappingProxyType
 from typing import Any
 
-# Copied from requests.compat.py (except for type ignores):
-# json/simplejson module import resolution
-has_simplejson = False
+# Users are seeing JSONDecodeError coming from a block that intercepts JSONDecodeError
+# (i.e. shouldn't be possible). It seems Python runtimes like e.g. Databricks patches the
+# built-in json library with simplejson and thus simplejson.JSONDecodeError != json.JSONDecodeError
 try:
     import simplejson as json
-
-    has_simplejson = True
+    from simplejson import JSONDecodeError
 except ImportError:
     import json  # type: ignore [no-redef]
-
-if has_simplejson:
-    from simplejson import JSONDecodeError
-else:
     from json import JSONDecodeError  # type: ignore [assignment]
 
 __all__ = ["dumps", "loads", "JSONDecodeError", "convert_to_float", "convert_nonfinite_float_to_str"]

--- a/poetry.lock
+++ b/poetry.lock
@@ -2665,6 +2665,17 @@ files = [
 urllib3 = ">=2"
 
 [[package]]
+name = "types-simplejson"
+version = "3.19.0.20240801"
+description = "Typing stubs for simplejson"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "types-simplejson-3.19.0.20240801.tar.gz", hash = "sha256:ef90cc81dd915f26c452fa2b5e0cbd3a36af81074ae63878fcf8a477e7594e4d"},
+    {file = "types_simplejson-3.19.0.20240801-py3-none-any.whl", hash = "sha256:37f1b33c8626d7f072ea87737629310674845d54d187f12387fe33d31c938288"},
+]
+
+[[package]]
 name = "types-urllib3"
 version = "1.26.25.14"
 description = "Typing stubs for urllib3"
@@ -2777,4 +2788,4 @@ yaml = ["PyYAML"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8"
-content-hash = "9e456775447549841733cf93df8ec207a099cbffc1e752fccfaa5acdb98d2da9"
+content-hash = "f9fa579062a7458a8248db8fae842263cb3eb5a958f1313b1963d71dc40bbbcc"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,6 +88,7 @@ packaging = ">=23"
 IPython = ">=7.0.0"  # Used in docstring examples
 PyYAML = "^6.0"
 pytest-icdiff = "*"  # Used for better diffs in pytest
+types-simplejson = "^3.19.0.20240801"
 
 [build-system]
 requires = ["poetry-core"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,8 +1,7 @@
 [tool.poetry]
 name = "cognite-sdk"
 
-
-version = "7.59.2"
+version = "7.59.3"
 description = "Cognite Python SDK"
 readme = "README.md"
 documentation = "https://cognite-sdk-python.readthedocs-hosted.com"


### PR DESCRIPTION
## Description
Users are seeing `JSONDecodeError` coming from a block that intercepts `JSONDecodeError` (i.e. shouldn't be possible). It seems Databricks patches the built-in `json` library with `simplejson`, and thus `simplejson.JSONDecodeError != json.JSONDecodeError`

#### Example stack trace:
```
/databricks/python/lib/python3.8/site-packages/cognite/client/_api_client.py in _get_response_content_safe(cls, res)
    881     def _get_response_content_safe(cls, res: Response) -> str:
    882         try:
--> 883             return _json.dumps(res.json())
    884         except JSONDecodeError:
    885             pass

/databricks/python/lib/python3.8/site-packages/requests/models.py in json(self, **kwargs)
    898                     # used.
    899                     pass
--> 900         return complexjson.loads(self.text, **kwargs)

(...)

/databricks/python/lib/python3.8/site-packages/simplejson/decoder.py in raw_decode(self, s, idx, _w, _PY3)
    398             elif ord0 == 0xef and s[idx:idx + 3] == '\xef\xbb\xbf':
    399                 idx += 3
--> 400         return self.scan_once(s, idx=_w(s, idx).end())

JSONDecodeError: Expecting value: line 1 column 1 (char 0)
```