### PR TITLE
Fix bug in sequences.data.retrieve_dataframe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ Changes are grouped as follows
 - `Removed` for now removed features.
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
+## [7.59.1] - 2024-09-12
+### Added
+- A bug in `client.sequences.data.retrieve_dataframe(...)`.
 
 ## [7.59.0] - 2024-09-12
 ### Added
@@ -100,8 +103,8 @@ Changes are grouped as follows
   through Data Modelling).
 
 ## [7.54.17] - 2024-08-22
-### Added
-- [Feature Preview]  Added `ExtractorExtension` model of the Core Model.
+### Fixed
+- A bug in 
 
 ## [7.54.16] - 2024-08-22
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,9 +16,6 @@ Changes are grouped as follows
 - `Removed` for now removed features.
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
-## [7.59.1] - 2024-09-12
-### Added
-- A bug in `client.sequences.data.retrieve_dataframe(...)`.
 
 ## [7.59.0] - 2024-09-12
 ### Added
@@ -103,8 +100,8 @@ Changes are grouped as follows
   through Data Modelling).
 
 ## [7.54.17] - 2024-08-22
-### Fixed
-- A bug in 
+### Added
+- [Feature Preview]  Added `ExtractorExtension` model of the Core Model.
 
 ## [7.54.16] - 2024-08-22
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ Changes are grouped as follows
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
+## [7.59.1] - 2024-09-12
+### Fixed
+- A bug in `client.sequences.data.retrieve_dataframe(...)` where passing a column to `column_external_ids` caused a TypeError.
+
 ## [7.59.0] - 2024-09-12
 ### Added
 - Added `ignore_unknown_ids` to `client.files.delete`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,16 +17,14 @@ Changes are grouped as follows
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
-## [7.59.1] - 2024-09-12
-<<<<<<< fix/sequences_retrieve_dataframe
+## [7.59.2] - 2024-09-12
 ### Fixed
 - A bug in `client.sequences.data.retrieve_dataframe(...)` where passing a column to `column_external_ids` caused a TypeError.
-=======
 
+## [7.59.1] - 2024-09-12
 ### Fixed
 - Creating a function using files dated before 1980 no longer raises ValueError,
   by overriding the timestamps to 1980-01-01.
->>>>>>> master
 
 ## [7.59.0] - 2024-09-12
 ### Added

--- a/cognite/client/_api/sequences.py
+++ b/cognite/client/_api/sequences.py
@@ -1295,11 +1295,13 @@ class SequencesDataAPI(APIClient):
             column_names_default = "columnExternalId"
 
         if external_id is not None and id is None:
-            return self.retrieve(external_id=external_id, start=start, end=end, limit=limit, columns = column_external_ids).to_pandas(
+            return self.retrieve(
+                external_id=external_id, start=start, end=end, limit=limit, columns=column_external_ids
+            ).to_pandas(
                 column_names=column_names or column_names_default,  # type: ignore  [arg-type]
             )
         elif id is not None and external_id is None:
-            return self.retrieve(id=id, start=start, end=end, limit=limit, columns = column_external_ids).to_pandas(
+            return self.retrieve(id=id, start=start, end=end, limit=limit, columns=column_external_ids).to_pandas(
                 column_names=column_names or column_names_default,  # type: ignore  [arg-type]
             )
         else:

--- a/cognite/client/_api/sequences.py
+++ b/cognite/client/_api/sequences.py
@@ -1296,12 +1296,10 @@ class SequencesDataAPI(APIClient):
 
         if external_id is not None and id is None:
             return self.retrieve(external_id=external_id, start=start, end=end, limit=limit, columns = column_external_ids).to_pandas(
-                # TODO(doctrino): Is this supported: `column_names=column_external_ids` ?
                 column_names=column_names or column_names_default,  # type: ignore  [arg-type]
             )
         elif id is not None and external_id is None:
             return self.retrieve(id=id, start=start, end=end, limit=limit, columns = column_external_ids).to_pandas(
-                # TODO(doctrino): Is this supported: `column_names=column_external_ids` ?
                 column_names=column_names or column_names_default,  # type: ignore  [arg-type]
             )
         else:

--- a/cognite/client/_api/sequences.py
+++ b/cognite/client/_api/sequences.py
@@ -1295,14 +1295,14 @@ class SequencesDataAPI(APIClient):
             column_names_default = "columnExternalId"
 
         if external_id is not None and id is None:
-            return self.retrieve(external_id=external_id, start=start, end=end, limit=limit).to_pandas(
+            return self.retrieve(external_id=external_id, start=start, end=end, limit=limit, columns = column_external_ids).to_pandas(
                 # TODO(doctrino): Is this supported: `column_names=column_external_ids` ?
-                column_names=column_external_ids or column_names_default,  # type: ignore  [arg-type]
+                column_names=column_names or column_names_default,  # type: ignore  [arg-type]
             )
         elif id is not None and external_id is None:
-            return self.retrieve(id=id, start=start, end=end, limit=limit).to_pandas(
+            return self.retrieve(id=id, start=start, end=end, limit=limit, columns = column_external_ids).to_pandas(
                 # TODO(doctrino): Is this supported: `column_names=column_external_ids` ?
-                column_names=column_external_ids or column_names_default,  # type: ignore  [arg-type]
+                column_names=column_names or column_names_default,  # type: ignore  [arg-type]
             )
         else:
             raise ValueError("Either external_id or id must be specified")

--- a/cognite/client/_version.py
+++ b/cognite/client/_version.py
@@ -1,4 +1,4 @@
 from __future__ import annotations
 
-__version__ = "7.59.1"
+__version__ = "7.59.2"
 __api_subversion__ = "20230101"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "cognite-sdk"
 
-version = "7.59.0"
+version = "7.59.1"
 description = "Cognite Python SDK"
 readme = "README.md"
 documentation = "https://cognite-sdk-python.readthedocs-hosted.com"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "cognite-sdk"
 
-version = "7.59.1"
+version = "7.59.0"
 description = "Cognite Python SDK"
 readme = "README.md"
 documentation = "https://cognite-sdk-python.readthedocs-hosted.com"

--- a/tests/tests_unit/test_api/test_sequences.py
+++ b/tests/tests_unit/test_api/test_sequences.py
@@ -568,8 +568,12 @@ class TestSequencesPandasIntegration:
     def test_retrieve_dataframe_columns_filter(
         self, cognite_client, mock_seq_response, mock_get_sequence_data_two_col_with_zero
     ):
-        data_1 = cognite_client.sequences.data.retrieve_dataframe(external_id="foo", start=0, end=100, column_external_ids = ["ceid1"])
-        data_2 = cognite_client.sequences.data.retrieve(external_id="foo", start=0, end=100, columns = ["ceid1"]).to_pandas()
+        data_1 = cognite_client.sequences.data.retrieve_dataframe(
+            external_id="foo", start=0, end=100, column_external_ids=["ceid1"]
+        )
+        data_2 = cognite_client.sequences.data.retrieve(
+            external_id="foo", start=0, end=100, columns=["ceid1"]
+        ).to_pandas()
         assert data_1.equals(data_2)
 
     def test_retrieve_dataframe_columns_many_extid(self, cognite_client, mock_get_sequence_data_many_columns):

--- a/tests/tests_unit/test_api/test_sequences.py
+++ b/tests/tests_unit/test_api/test_sequences.py
@@ -568,7 +568,6 @@ class TestSequencesPandasIntegration:
     def test_retrieve_dataframe_columns_filter(
         self, cognite_client, mock_seq_response, mock_get_sequence_data_two_col_with_zero
     ):
-        import pandas as pd
         data_1 = cognite_client.sequences.data.retrieve_dataframe(external_id="foo", start=0, end=100, column_external_ids = ["ceid1"])
         data_2 = cognite_client.sequences.data.retrieve(external_id="foo", start=0, end=100, columns = ["ceid1"]).to_pandas()
         assert data_1.equals(data_2)

--- a/tests/tests_unit/test_api/test_sequences.py
+++ b/tests/tests_unit/test_api/test_sequences.py
@@ -565,6 +565,14 @@ class TestSequencesPandasIntegration:
         )
         pd.testing.assert_frame_equal(expected_df, data)
 
+    def test_retrieve_dataframe_columns_filter(
+        self, cognite_client, mock_seq_response, mock_get_sequence_data_two_col_with_zero
+    ):
+        import pandas as pd
+        data_1 = cognite_client.sequences.data.retrieve_dataframe(external_id="foo", start=0, end=100, column_external_ids = ["ceid1"])
+        data_2 = cognite_client.sequences.data.retrieve(external_id="foo", start=0, end=100, columns = ["ceid1"]).to_pandas()
+        assert data_1.equals(data_2)
+
     def test_retrieve_dataframe_columns_many_extid(self, cognite_client, mock_get_sequence_data_many_columns):
         data = cognite_client.sequences.data.retrieve(external_id="foo", start=1000000, end=1100000)
         assert isinstance(data, SequenceRows)


### PR DESCRIPTION
## Description
Running sequences.data.retrieve_dataframe with the parameter column_external_ids returned an error.

## Checklist:
- [x] Tests added/updated.
- [ ] Documentation updated. Documentation is generated from docstrings - these must be updated according to your change.
  If a new method has been added it should be referenced in [cognite.rst](https://github.com/cognitedata/cognite-sdk-python/blob/master/docs/source/cognite.rst) in order to generate docs based on its docstring.
- [x] Changelog updated in [CHANGELOG.md](https://github.com/cognitedata/cognite-sdk-python/blob/master/CHANGELOG.md).
- [x] Version bumped. If triggering a new release is desired, bump the version number in [_version.py](https://github.com/cognitedata/cognite-sdk-python/blob/master/cognite/client/_version.py) and [pyproject.toml](https://github.com/cognitedata/cognite-sdk-python/blob/master/pyproject.toml) per [semantic versioning](https://semver.org/).
