### PR TITLE
Fix column remapping for TypedInstance.to_pandas()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ Changes are grouped as follows
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
+## [7.60.4] - 2024-09-15
+### Added
+Fix bug in column name remapping for `TypedInstance.to_pandas()`
+
 ## [7.60.3] - 2024-09-14
 ### Changed
 - The Core Model and Extractor Extension (`cognite.client.data_classes.data_modeling.cdm/extractor_extension`) are

--- a/cognite/client/_version.py
+++ b/cognite/client/_version.py
@@ -1,4 +1,4 @@
 from __future__ import annotations
 
-__version__ = "7.60.3"
+__version__ = "7.60.4"
 __api_subversion__ = "20230101"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "cognite-sdk"
 
-version = "7.60.3"
+version = "7.60.4"
 description = "Cognite Python SDK"
 readme = "README.md"
 documentation = "https://cognite-sdk-python.readthedocs-hosted.com"

--- a/tests/tests_unit/test_data_classes/test_data_models/test_typed_instances.py
+++ b/tests/tests_unit/test_data_classes/test_data_models/test_typed_instances.py
@@ -408,8 +408,6 @@ class TestCDMv1Classes:
     def test_cognite_asset_read_and_write__to_pandas(
         self, cognite_asset_kwargs: dict[str, Any], camel_case: bool
     ) -> None:
-        import pandas as pd
-
         # When calling to_pandas, `use_attribute_name = not camel_case` due to how we expect
         # attributes to be snake cased in python (in general).
         asset_write = CogniteAssetApply(**cognite_asset_kwargs)
@@ -421,18 +419,13 @@ class TestCDMv1Classes:
         read_expanded_df = asset_read.to_pandas(expand_properties=True, camel_case=camel_case)
 
         xid = "externalId" if camel_case else "external_id"
-        for df in [write_df, read_df]:
+        for df in [write_df, read_df, read_expanded_df]:
             assert df.index.is_unique
             assert df.index[1] == xid
             assert df.at["type", "value"] == {"space": "should-be", xid: "at-root"}
 
-        expected_type_series = pd.Series(
-            [{"space": "should-be", xid: "at-root"}],
-            index=["value"],
-            name="type",
-        )
-        pd.testing.assert_series_equal(read_expanded_df.loc["type"], expected_type_series)
         assert "source_created_time" in read_expanded_df.index
+        assert "asset_type" in read_expanded_df.index
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Description
Please describe the change you have made.

## Checklist:
- [ ] Tests added/updated.
- [ ] Documentation updated. Documentation is generated from docstrings - these must be updated according to your change.
  If a new method has been added it should be referenced in [cognite.rst](https://github.com/cognitedata/cognite-sdk-python/blob/master/docs/source/cognite.rst) in order to generate docs based on its docstring.
- [ ] Changelog updated in [CHANGELOG.md](https://github.com/cognitedata/cognite-sdk-python/blob/master/CHANGELOG.md).
- [ ] Version bumped. If triggering a new release is desired, bump the version number in [_version.py](https://github.com/cognitedata/cognite-sdk-python/blob/master/cognite/client/_version.py) and [pyproject.toml](https://github.com/cognitedata/cognite-sdk-python/blob/master/pyproject.toml) per [semantic versioning](https://semver.org/).
