### PR TITLE
Remove warning instance id ts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,16 @@ Changes are grouped as follows
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
+## [7.61.0] - 2024-09-18
+### Changed
+- TimeSeriesAPI and DatapointsAPI support for `instance_id` reaches general availability (GA).
+### Added
+- `instance_id` can now be used freely alongside `id` and `external_id`, and is now accepted by
+  retrieve/retrieve_array/retrieve_dataframe.
+- `instance_id` now works in `to_pandas` methods, with fallbacks on `external_id` and `id`.
+### Fixed
+- A bug caused all datapoints objects to load an empty instance_id.
+
 ## [7.60.6] - 2024-09-17
 ### Fixed
 - Fixed bug in `replace` upsert mode which caused objects to not be cleared.

--- a/cognite/client/_api/datapoint_tasks.py
+++ b/cognite/client/_api/datapoint_tasks.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import datetime
 import math
-import numbers
 import operator as op
 import warnings
 from abc import ABC, abstractmethod
@@ -15,7 +14,6 @@ from typing import (
     Any,
     Callable,
     DefaultDict,
-    Dict,
     Iterator,
     List,
     Literal,
@@ -84,11 +82,9 @@ DatapointRaw = Union[NumericDatapoint, StringDatapoint]
 DatapointsRaw = Union[NumericDatapoints, StringDatapoints]
 
 RawDatapointValue = Union[float, str]
-DatapointsId = Union[int, DatapointsQuery, Dict[str, Any], Sequence[Union[int, DatapointsQuery, Dict[str, Any]]]]
-DatapointsExternalId = Union[
-    str, DatapointsQuery, Dict[str, Any], SequenceNotStr[Union[str, DatapointsQuery, Dict[str, Any]]]
-]
-DatapointsInstanceId = Union[InstanceId, Sequence[InstanceId]]
+DatapointsId = Union[int, DatapointsQuery, Sequence[Union[int, DatapointsQuery]]]
+DatapointsExternalId = Union[str, DatapointsQuery, SequenceNotStr[Union[str, DatapointsQuery]]]
+DatapointsInstanceId = Union[NodeId, DatapointsQuery, Sequence[Union[NodeId, DatapointsQuery]]]
 
 
 @dataclass
@@ -102,7 +98,7 @@ class _FullDatapointsQuery:
     end: int | str | datetime.datetime | None = None
     id: DatapointsId | None = None
     external_id: DatapointsExternalId | None = None
-    instance_id: InstanceId | Sequence[InstanceId] | None = None
+    instance_id: DatapointsInstanceId | None = None
     aggregates: Aggregate | str | list[Aggregate | str] | None = None
     granularity: str | None = None
     timezone: str | datetime.timezone | ZoneInfo | None = None
@@ -148,35 +144,35 @@ class _FullDatapointsQuery:
     def parse_into_queries(self) -> list[DatapointsQuery]:
         queries = []
         if (id_ := self.id) is not None:
-            queries.extend(self._parse(id_, arg_name="id", exp_type=numbers.Integral))
+            queries.extend(self._parse(id_, arg_name="id", exp_type=int))
         if (xid := self.external_id) is not None:
             queries.extend(self._parse(xid, arg_name="external_id", exp_type=str))
         if (iid := self.instance_id) is not None:
-            queries.extend(self._parse(iid, arg_name="instance_id", exp_type=InstanceId))
+            queries.extend(self._parse(iid, arg_name="instance_id", exp_type=NodeId))
         if queries:
             return queries
-        raise ValueError("Pass at least one time series `id` or `external_id`!")
+        raise ValueError("Pass at least one time series `id`, `external_id` or `instance_id`!")
 
     def _parse(
         self,
-        id_or_xid: DatapointsId | DatapointsExternalId | DatapointsInstanceId,
+        identifier: DatapointsId | DatapointsExternalId | DatapointsInstanceId,
         arg_name: Literal["id", "external_id", "instance_id"],
         exp_type: type,
     ) -> list[DatapointsQuery]:
-        user_queries: SequenceNotStr[int | str | DatapointsQuery | dict[str, Any]]
-        if isinstance(id_or_xid, (dict, DatapointsQuery, exp_type)):
+        user_queries: SequenceNotStr[int | str | NodeId | DatapointsQuery]
+        if isinstance(identifier, (dict, DatapointsQuery, exp_type)):
             # Lazy - we postpone evaluation:
-            user_queries = [cast(Union[int, str, DatapointsQuery, Dict[str, Any]], id_or_xid)]
+            user_queries = [identifier]
 
-        elif isinstance(id_or_xid, SequenceNotStr):
+        elif isinstance(identifier, SequenceNotStr):
             # We use Sequence because we require an ordering of elements
-            user_queries = id_or_xid
+            user_queries = identifier
         else:
-            self._raise_on_wrong_ts_identifier_type(id_or_xid, arg_name, exp_type)
+            self._raise_on_wrong_ts_identifier_type(identifier, arg_name, exp_type)
 
         parsed_queries = []
         for query in user_queries:
-            # We merge 'defaults' and given user query; the query takes precedence:
+            # We merge 'defaults' and the given user query; the query takes precedence:
             if isinstance(query, exp_type):
                 id_dct = {arg_name: query}
                 query = DatapointsQuery(**self.top_level_defaults, **id_dct)  # type: ignore [misc, arg-type]
@@ -195,13 +191,13 @@ class _FullDatapointsQuery:
 
     @staticmethod
     def _raise_on_wrong_ts_identifier_type(
-        id_or_xid: object,  # This fn is only called when gotten the wrong type
+        identifier: object,  # This fn is only called when gotten the wrong type
         arg_name: str,
         exp_type: type,
     ) -> NoReturn:
         raise TypeError(
-            f"Got unsupported type {type(id_or_xid)}, as, or part of argument `{arg_name}`. Expected one of "
-            f"{exp_type}, {DatapointsQuery} or {dict} (deprecated), or a (mixed) list of these, but got `{id_or_xid}`."
+            f"Got unsupported type {type(identifier)}, as, or part of argument `{arg_name}`. Expected one of "
+            f"{exp_type}, {DatapointsQuery}, or a (mixed) list of these, but got `{identifier}`."
         )
 
     def validate(self, queries: list[DatapointsQuery], dps_limit_raw: int, dps_limit_agg: int) -> list[DatapointsQuery]:
@@ -294,7 +290,7 @@ class _FullDatapointsQuery:
     def _verify_and_convert_limit(limit: int | None) -> int | None:
         if is_unlimited(limit):
             return None
-        elif isinstance(limit, numbers.Integral) and limit >= 0:  # limit=0 is accepted by the API
+        elif isinstance(limit, int) and limit >= 0:  # limit=0 is accepted by the API
             try:
                 # We don't want weird stuff like numpy dtypes etc:
                 return int(limit)

--- a/cognite/client/_api/datapoint_tasks.py
+++ b/cognite/client/_api/datapoint_tasks.py
@@ -464,7 +464,10 @@ def get_datapoints_from_proto(res: DataPointListItem) -> DatapointsAny:
 
 def get_ts_info_from_proto(res: DataPointListItem) -> dict[str, int | str | bool | NodeId | None]:
     # Note: When 'unit_external_id' is returned, regular 'unit' is ditched
-    instance_id = NodeId(res.instanceId.space, res.instanceId.externalId) if res.instanceId else None
+    if res.instanceId and res.instanceId.space:  # res.instanceId evaluates to True even when empty :eyes:
+        instance_id = NodeId(res.instanceId.space, res.instanceId.externalId)
+    else:
+        instance_id = None
     return {
         "id": res.id,
         "external_id": res.externalId,

--- a/cognite/client/_api/time_series.py
+++ b/cognite/client/_api/time_series.py
@@ -25,7 +25,6 @@ from cognite.client.data_classes.time_series import (
     TimeSeriesSort,
     TimeSeriesWrite,
 )
-from cognite.client.utils._experimental import FeaturePreviewWarning
 from cognite.client.utils._identifier import IdentifierSequence
 from cognite.client.utils._validation import prepare_filter_sort, process_asset_subtree_ids, process_data_set_ids
 from cognite.client.utils.useful_types import SequenceNotStr
@@ -229,17 +228,11 @@ class TimeSeriesAPI(APIClient):
                 >>> client = CogniteClient()
                 >>> res = client.time_series.retrieve(external_id="1")
         """
-        headers: dict | None = None
-        if instance_id is not None:
-            self._warn_alpha()
-            headers = {"cdf-version": "alpha"}
         identifiers = IdentifierSequence.load(ids=id, external_ids=external_id, instance_ids=instance_id).as_singleton()
-
         return self._retrieve_multiple(
             list_cls=TimeSeriesList,
             resource_cls=TimeSeries,
             identifiers=identifiers,
-            headers=headers,
         )
 
     def retrieve_multiple(
@@ -274,17 +267,12 @@ class TimeSeriesAPI(APIClient):
                 >>> client = CogniteClient()
                 >>> res = client.time_series.retrieve_multiple(external_ids=["abc", "def"])
         """
-        header: dict | None = None
-        if instance_ids is not None:
-            self._warn_alpha()
-            header = {"cdf-version": "alpha"}
         identifiers = IdentifierSequence.load(ids=ids, external_ids=external_ids, instance_ids=instance_ids)
         return self._retrieve_multiple(
             list_cls=TimeSeriesList,
             resource_cls=TimeSeries,
             identifiers=identifiers,
             ignore_unknown_ids=ignore_unknown_ids,
-            headers=header,
         )
 
     def aggregate(self, filter: TimeSeriesFilter | dict[str, Any] | None = None) -> list[CountAggregate]:
@@ -563,12 +551,6 @@ class TimeSeriesAPI(APIClient):
             input_resource_cls=TimeSeriesWrite,
         )
 
-    @staticmethod
-    def _warn_alpha() -> None:
-        FeaturePreviewWarning(
-            api_maturity="alpha", feature_name="TimeSeries with Instance ID", sdk_maturity="alpha"
-        ).warn()
-
     def delete(
         self,
         id: int | Sequence[int] | None = None,
@@ -635,19 +617,11 @@ class TimeSeriesAPI(APIClient):
                 >>> my_update = TimeSeriesUpdate(id=1).description.set("New description").metadata.add({"key": "value"})
                 >>> res = client.time_series.update(my_update)
         """
-        headers: dict | None = None
-        if (isinstance(item, Sequence) and any(ts.instance_id for ts in item)) or (
-            not isinstance(item, Sequence) and item.instance_id
-        ):
-            self._warn_alpha()
-            headers = {"cdf-version": "alpha"}
-
         return self._update_multiple(
             list_cls=TimeSeriesList,
             resource_cls=TimeSeries,
             update_cls=TimeSeriesUpdate,
             items=item,
-            headers=headers,
         )
 
     @overload

--- a/cognite/client/_api_client.py
+++ b/cognite/client/_api_client.py
@@ -1225,24 +1225,21 @@ class APIClient:
         update_attributes: list[PropertySpec],
         mode: Literal["replace_ignore_null", "patch", "replace"] = "replace_ignore_null",
     ) -> dict[str, dict[str, dict]]:
-        dumped_resource = resource.dump(camel_case=True)
-        has_id = "id" in dumped_resource
-        has_external_id = "externalId" in dumped_resource
-        has_instance_id = "instanceId" in dumped_resource
+        dumped = resource.dump(camel_case=True)
 
         patch_object: dict[str, dict[str, dict]] = {"update": {}}
-        if has_instance_id:
-            patch_object["instanceId"] = dumped_resource.pop("instanceId")
-            dumped_resource.pop("id", None)
-        elif has_id:
-            patch_object["id"] = dumped_resource.pop("id")
-        elif has_external_id:
-            patch_object["externalId"] = dumped_resource.pop("externalId")
+        if "instanceId" in dumped:
+            patch_object["instanceId"] = dumped.pop("instanceId")
+            dumped.pop("id", None)
+        elif "id" in dumped:
+            patch_object["id"] = dumped.pop("id")
+        elif "externalId" in dumped:
+            patch_object["externalId"] = dumped.pop("externalId")
 
         update: dict[str, dict] = cls._clear_all_attributes(update_attributes) if mode == "replace" else {}
 
         update_attribute_by_name = {prop.name: prop for prop in update_attributes}
-        for key, value in dumped_resource.items():
+        for key, value in dumped.items():
             if (snake := to_snake_case(key)) not in update_attribute_by_name:
                 continue
             prop = update_attribute_by_name[snake]

--- a/cognite/client/_version.py
+++ b/cognite/client/_version.py
@@ -1,4 +1,4 @@
 from __future__ import annotations
 
-__version__ = "7.60.6"
+__version__ = "7.61.0"
 __api_subversion__ = "20230101"

--- a/cognite/client/data_classes/datapoints.py
+++ b/cognite/client/data_classes/datapoints.py
@@ -35,6 +35,7 @@ from cognite.client.utils._pandas_helpers import (
     concat_dps_dataframe_list,
     convert_tz_for_pandas,
     notebook_display_with_fallback,
+    resolve_ts_identifier_as_df_column_name,
 )
 from cognite.client.utils._text import (
     convert_all_keys_to_camel_case,
@@ -803,7 +804,7 @@ class DatapointsArray(CogniteResource):
 
     def to_pandas(  # type: ignore [override]
         self,
-        column_names: Literal["id", "external_id"] = "external_id",
+        column_names: Literal["id", "external_id", "instance_id"] = "instance_id",
         include_aggregate_name: bool = True,
         include_granularity_name: bool = False,
         include_status: bool = True,
@@ -811,7 +812,7 @@ class DatapointsArray(CogniteResource):
         """Convert the DatapointsArray into a pandas DataFrame.
 
         Args:
-            column_names (Literal["id", "external_id"]): Which field to use as column header. Defaults to "external_id", can also be "id". For time series with no external ID, ID will be used instead.
+            column_names (Literal["id", "external_id", "instance_id"]): Which field to use for the columns. Defaults to "instance_id", if it exists, then uses "external_id" if available, and "id" as fallback.
             include_aggregate_name (bool): Include aggregate in the column name
             include_granularity_name (bool): Include granularity in the column name (after aggregate if present)
             include_status (bool): Include status code and status symbol as separate columns, if available.
@@ -820,32 +821,11 @@ class DatapointsArray(CogniteResource):
             pandas.DataFrame: The datapoints as a pandas DataFrame.
         """
         pd = local_import("pandas")
-        if column_names == "id":
-            if self.id is None:
-                raise ValueError("Unable to use `id` as column name(s), not set on object")
-            identifier = str(self.id)
-
-        elif column_names == "external_id":
-            if self.external_id is not None:
-                identifier = self.external_id
-            elif self.id is not None:
-                # Time series are not required to have an external_id unfortunately...
-                identifier = str(self.id)
-                warnings.warn(
-                    f"Time series does not have an external ID, so its ID ({self.id}) was used instead as "
-                    'the column name in the DataFrame. If this is expected, consider passing `column_names="id"` '
-                    "to silence this warning.",
-                    UserWarning,
-                )
-            else:
-                raise ValueError("Object missing both `id` and `external_id` attributes")
-        else:
-            raise ValueError("Argument `column_names` must be either 'external_id' or 'id'")
-
         idx, tz = self.timestamp, self.timezone
         if tz is not None:
             idx = pd.to_datetime(idx, utc=True).tz_convert(convert_tz_for_pandas(tz))
 
+        identifier = resolve_ts_identifier_as_df_column_name(self, column_names)
         if self.value is not None:
             raw_columns: dict[str, npt.NDArray] = {identifier: self.value}
             if include_status:
@@ -857,7 +837,7 @@ class DatapointsArray(CogniteResource):
 
         (_, *agg_names), (_, *arrays) = self._data_fields()
         aggregate_columns = [
-            str(identifier) + include_aggregate_name * f"|{agg}" + include_granularity_name * f"|{self.granularity}"
+            identifier + include_aggregate_name * f"|{agg}" + include_granularity_name * f"|{self.granularity}"
             for agg in agg_names
         ]
         # Since columns might contain duplicates, we can't instantiate from dict as only the
@@ -1045,7 +1025,7 @@ class Datapoints(CogniteResource):
 
     def to_pandas(  # type: ignore [override]
         self,
-        column_names: str = "external_id",
+        column_names: Literal["id", "external_id", "instance_id"] = "instance_id",
         include_aggregate_name: bool = True,
         include_granularity_name: bool = False,
         include_errors: bool = False,
@@ -1054,7 +1034,7 @@ class Datapoints(CogniteResource):
         """Convert the datapoints into a pandas DataFrame.
 
         Args:
-            column_names (str): Which field to use as column header. Defaults to "external_id", can also be "id". For time series with no external ID, ID will be used instead.
+            column_names (Literal["id", "external_id", "instance_id"]): Which field to use for the columns. Defaults to "instance_id", if it exists, then uses "external_id" if available, and "id" as fallback.
             include_aggregate_name (bool): Include aggregate in the column name
             include_granularity_name (bool): Include granularity in the column name (after aggregate if present)
             include_errors (bool): For synthetic datapoint queries, include a column with errors.
@@ -1064,12 +1044,9 @@ class Datapoints(CogniteResource):
             pandas.DataFrame: The dataframe.
         """
         pd = local_import("pandas")
-        if column_names in ["external_id", "externalId"]:  # Camel case for backwards compat
-            identifier = self.external_id if self.external_id is not None else self.id
-        elif column_names == "id":
-            identifier = self.id
-        else:
-            raise ValueError("column_names must be 'external_id' or 'id'")
+        if column_names == "externalId":
+            column_names = "external_id"  # Camel case for backwards compatibility
+        identifier = resolve_ts_identifier_as_df_column_name(self, column_names)
 
         if include_errors and self.error is None:
             raise ValueError("Unable to 'include_errors', only available for data from synthetic datapoint queries")
@@ -1082,7 +1059,7 @@ class Datapoints(CogniteResource):
         for attr, data in data_fields:
             if attr == "timestamp":
                 continue
-            id_col_name = str(identifier)
+            id_col_name = identifier
             if attr == "value":
                 field_names.append(id_col_name)
                 data_lists.append(data)
@@ -1342,7 +1319,7 @@ class DatapointsArrayList(CogniteResourceList[DatapointsArray]):
 
     def to_pandas(  # type: ignore [override]
         self,
-        column_names: Literal["id", "external_id"] = "external_id",
+        column_names: Literal["id", "external_id", "instance_id"] = "instance_id",
         include_aggregate_name: bool = True,
         include_granularity_name: bool = False,
         include_status: bool = True,
@@ -1350,7 +1327,7 @@ class DatapointsArrayList(CogniteResourceList[DatapointsArray]):
         """Convert the DatapointsArrayList into a pandas DataFrame.
 
         Args:
-            column_names (Literal["id", "external_id"]): Which field to use as column header. Defaults to "external_id", can also be "id". For time series with no external ID, ID will be used instead.
+            column_names (Literal["id", "external_id", "instance_id"]): Which field to use for the columns. Defaults to "instance_id", if it exists, then uses "external_id" if available, and "id" as fallback.
             include_aggregate_name (bool): Include aggregate in the column name
             include_granularity_name (bool): Include granularity in the column name (after aggregate if present)
             include_status (bool): Include status code and status symbol as separate columns, if available.
@@ -1429,7 +1406,7 @@ class DatapointsList(CogniteResourceList[Datapoints]):
 
     def to_pandas(  # type: ignore [override]
         self,
-        column_names: Literal["id", "external_id"] = "external_id",
+        column_names: Literal["id", "external_id", "instance_id"] = "instance_id",
         include_aggregate_name: bool = True,
         include_granularity_name: bool = False,
         include_status: bool = True,
@@ -1437,7 +1414,7 @@ class DatapointsList(CogniteResourceList[Datapoints]):
         """Convert the datapoints list into a pandas DataFrame.
 
         Args:
-            column_names (Literal["id", "external_id"]): Which field to use as column header. Defaults to "external_id", can also be "id". For time series with no external ID, ID will be used instead.
+            column_names (Literal["id", "external_id", "instance_id"]): Which field to use for the columns. Defaults to "instance_id", if it exists, then uses "external_id" if available, and "id" as fallback.
             include_aggregate_name (bool): Include aggregate in the column name
             include_granularity_name (bool): Include granularity in the column name (after aggregate if present)
             include_status (bool): Include status code and status symbol as separate columns, if available.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "cognite-sdk"
 
-version = "7.60.6"
+version = "7.61.0"
 description = "Cognite Python SDK"
 readme = "README.md"
 documentation = "https://cognite-sdk-python.readthedocs-hosted.com"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,5 @@
+import platform
+
 import dotenv
 import pytest
 import responses
@@ -21,6 +23,12 @@ def disable_gzip():
     global_config.disable_gzip = True
     yield
     global_config.disable_gzip = old
+
+
+@pytest.fixture
+def os_and_py_version():
+    # Nice to use to create resources that is unique to each test runner
+    return f"{platform.system()}-{platform.python_version()}"
 
 
 def pytest_addoption(parser):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -25,7 +25,7 @@ def disable_gzip():
     global_config.disable_gzip = old
 
 
-@pytest.fixture
+@pytest.fixture(scope="session")
 def os_and_py_version():
     # Nice to use to create resources that is unique to each test runner
     return f"{platform.system()}-{platform.python_version()}"

--- a/tests/tests_integration/conftest.py
+++ b/tests/tests_integration/conftest.py
@@ -34,7 +34,7 @@ def cognite_client_alpha() -> CogniteClient:
 
 @pytest.fixture(scope="session")
 def instance_id_test_space(cognite_client: CogniteClient) -> Space:
-    return cognite_client_alpha.data_modeling.spaces.apply(SpaceApply(space="sp_python_sdk_instance_id_tests"))
+    return cognite_client.data_modeling.spaces.apply(SpaceApply(space="sp_python_sdk_instance_id_tests"))
 
 
 @pytest.fixture(scope="session")

--- a/tests/tests_integration/conftest.py
+++ b/tests/tests_integration/conftest.py
@@ -33,7 +33,7 @@ def cognite_client_alpha() -> CogniteClient:
 
 
 @pytest.fixture(scope="session")
-def alpha_test_space(cognite_client_alpha: CogniteClient) -> Space:
+def instance_id_test_space(cognite_client: CogniteClient) -> Space:
     return cognite_client_alpha.data_modeling.spaces.apply(SpaceApply(space="sp_python_sdk_instance_id_tests"))
 
 

--- a/tests/tests_integration/conftest.py
+++ b/tests/tests_integration/conftest.py
@@ -8,7 +8,7 @@ from dotenv import load_dotenv
 from cognite.client import ClientConfig, CogniteClient
 from cognite.client.credentials import OAuthClientCertificate, OAuthClientCredentials, OAuthInteractive
 from cognite.client.data_classes import DataSet, DataSetWrite
-from cognite.client.data_classes.data_modeling import Space, SpaceApply
+from cognite.client.data_classes.data_modeling import SpaceApply
 from tests.utils import REPO_ROOT
 
 
@@ -33,8 +33,8 @@ def cognite_client_alpha() -> CogniteClient:
 
 
 @pytest.fixture(scope="session")
-def instance_id_test_space(cognite_client: CogniteClient) -> Space:
-    return cognite_client.data_modeling.spaces.apply(SpaceApply(space="sp_python_sdk_instance_id_tests"))
+def instance_id_test_space(cognite_client: CogniteClient) -> str:
+    return cognite_client.data_modeling.spaces.apply(SpaceApply(space="sp_python_sdk_instance_id_tests")).space
 
 
 @pytest.fixture(scope="session")

--- a/tests/tests_integration/test_api/test_datapoint_subscriptions.py
+++ b/tests/tests_integration/test_api/test_datapoint_subscriptions.py
@@ -64,7 +64,7 @@ def time_series_external_ids(all_time_series_external_ids):
 def subscription(
     cognite_client: CogniteClient, all_time_series_external_ids: list[str], os_and_py_version: str
 ) -> DatapointSubscription:
-    external_id = f"PYSDKDataPointSubscriptionTest-{os_and_py_version}"
+    external_id = f"PYSDKDataPointSubscriptionTest-{os_and_py_version.replace('.', '-')}"
     sub = cognite_client.time_series.subscriptions.retrieve(external_id)
     if sub is not None:
         return sub

--- a/tests/tests_integration/test_api/test_datapoint_subscriptions.py
+++ b/tests/tests_integration/test_api/test_datapoint_subscriptions.py
@@ -1,12 +1,10 @@
 from __future__ import annotations
 
 import math
-import platform
 import random
 import time
 from contextlib import contextmanager
 from datetime import datetime
-from sys import version_info
 
 import numpy as np
 import pandas as pd
@@ -63,8 +61,10 @@ def time_series_external_ids(all_time_series_external_ids):
 
 
 @pytest.fixture(scope="session")
-def subscription(cognite_client: CogniteClient, all_time_series_external_ids: list[str]) -> DatapointSubscription:
-    external_id = f"PYSDKDataPointSubscriptionTest-{platform.system()}-{'-'.join(map(str, version_info[:2]))}"
+def subscription(
+    cognite_client: CogniteClient, all_time_series_external_ids: list[str], os_and_py_version: str
+) -> DatapointSubscription:
+    external_id = f"PYSDKDataPointSubscriptionTest-{os_and_py_version}"
     sub = cognite_client.time_series.subscriptions.retrieve(external_id)
     if sub is not None:
         return sub

--- a/tests/tests_integration/test_api/test_datapoints.py
+++ b/tests/tests_integration/test_api/test_datapoints.py
@@ -2275,7 +2275,7 @@ class TestRetrieveDataFrameAPI:
             assert col == name
 
     def test_column_names_fails(self, cognite_client, one_mill_dps_ts):
-        with pytest.raises(ValueError, match=re.escape("must be one of 'id' or 'external_id'")):
+        with pytest.warns(UserWarning, match=re.escape("must be either 'instance_id', 'external_id' or 'id'")):
             cognite_client.time_series.data.retrieve_dataframe(
                 id=one_mill_dps_ts[0].id, limit=5, column_names="bogus_id"
             )

--- a/tests/tests_integration/test_api/test_datapoints.py
+++ b/tests/tests_integration/test_api/test_datapoints.py
@@ -9,13 +9,11 @@ from __future__ import annotations
 
 import itertools
 import math
-import platform
 import random
 import re
 import unittest
 from contextlib import nullcontext as does_not_raise
 from datetime import datetime, timezone
-from sys import version_info
 from typing import Callable, Iterator, Literal
 from unittest.mock import patch
 
@@ -37,12 +35,13 @@ from cognite.client.data_classes import (
     TimeSeries,
     TimeSeriesList,
 )
-from cognite.client.data_classes.data_modeling import NodeApply, NodeOrEdgeData, Space, ViewId
+from cognite.client.data_classes.data_modeling import NodeApply, NodeOrEdgeData, Space
+from cognite.client.data_classes.data_modeling.cdm.v1 import CogniteTimeSeries
+from cognite.client.data_classes.data_modeling.ids import NodeId
 from cognite.client.data_classes.data_modeling.instances import NodeApplyResult
 from cognite.client.data_classes.data_modeling.spaces import SpaceApply
 from cognite.client.data_classes.datapoints import ALL_SORTED_DP_AGGS
 from cognite.client.exceptions import CogniteAPIError, CogniteNotFoundError
-from cognite.client.utils._identifier import InstanceId
 from cognite.client.utils._text import to_camel_case, to_snake_case
 from cognite.client.utils._time import (
     MAX_TIMESTAMP_MS,
@@ -184,13 +183,13 @@ def all_retrieve_endpoints(cognite_client, retrieve_endpoints):
 
 
 @pytest.fixture(scope="session")
-def instance_ts_id(cognite_client: CogniteClient, alpha_test_space: Space) -> InstanceId:
+def instance_ts_id(cognite_client: CogniteClient, instance_id_test_space: str, os_and_py_version: str) -> NodeId:
     my_ts = NodeApply(
-        space=alpha_test_space.space,
-        external_id="ts_python_sdk_instance_id_tests",
+        space=instance_id_test_space,
+        external_id=f"ts_pysdk_instance_id_tests-{os_and_py_version}",
         sources=[
             NodeOrEdgeData(
-                source=ViewId("cdf_cdm_experimental", "CogniteTimeSeries", "v1"),
+                source=CogniteTimeSeries.get_source(),
                 properties={
                     "name": "ts_python_sdk_instance_id_tests",
                     "isStep": False,
@@ -199,9 +198,8 @@ def instance_ts_id(cognite_client: CogniteClient, alpha_test_space: Space) -> In
             )
         ],
     )
-    created_ts = cognite_client.data_modeling.instances.apply(my_ts).nodes
-
-    return created_ts[0].as_id()
+    created_ts = cognite_client.data_modeling.instances.apply(my_ts).nodes[0]
+    return created_ts.as_id()
 
 
 def ts_to_ms(ts, tz=None):
@@ -419,13 +417,13 @@ def space_for_time_series(cognite_client) -> Iterator[Space]:
 
 
 @pytest.fixture(scope="session")
-def ts_create_in_dms(cognite_client, space_for_time_series) -> NodeApplyResult:
+def ts_create_in_dms(cognite_client, space_for_time_series, os_and_py_version) -> NodeApplyResult:
     from cognite.client.data_classes.data_modeling.cdm.v1 import CogniteTimeSeriesApply
 
     dms_ts = CogniteTimeSeriesApply(
         space=space_for_time_series.space,
         # One per test runner, per OS, to avoid conflicts:
-        external_id=f"dms-time-series-{platform.system()}-{'-'.join(map(str, version_info[:2]))}",
+        external_id=f"dms-time-series-{os_and_py_version}",
         is_step=True,
         time_series_type="numeric",
     )
@@ -2764,27 +2762,26 @@ class TestInsertDatapointsAPI:
         assert set(dps_numeric.status_symbol) == {"Good", "Uncertain", "Bad"}
 
     def test_insert_retrieve_delete_datapoints_with_instance_id(
-        self, cognite_client: CogniteClient, instance_ts_id: InstanceId
+        self, cognite_client: CogniteClient, instance_ts_id: NodeId
     ) -> None:
-        cognite_client.time_series.data.insert([(0, 0.0), (1.0, 1.0)], instance_id=instance_ts_id)
-
+        v1, v2 = random_cognite_ids(2)
+        cognite_client.time_series.data.insert([(0, v1), (1.0, v2)], instance_id=instance_ts_id)
         retrieved = cognite_client.time_series.data.retrieve(instance_id=instance_ts_id, start=0, end=2)
 
         assert retrieved.timestamp == [0, 1]
-        assert retrieved.value == [0.0, 1.0]
+        assert retrieved.value == [v1, v2]
 
         cognite_client.time_series.data.delete_range(0, 2, instance_id=instance_ts_id)
-
         retrieved = cognite_client.time_series.data.retrieve(instance_id=instance_ts_id, start=0, end=2)
 
         assert retrieved.timestamp == []
 
-    def test_insert_multiple_with_instance_id(self, cognite_client: CogniteClient, instance_ts_id: InstanceId) -> None:
+    def test_insert_multiple_with_instance_id(self, cognite_client: CogniteClient, instance_ts_id: NodeId) -> None:
+        ts, value = random.choices(range(MIN_TIMESTAMP_MS, MAX_TIMESTAMP_MS + 1), k=2)
         cognite_client.time_series.data.insert_multiple(
-            [{"instance_id": instance_ts_id, "datapoints": [{"timestamp": 4, "value": 42}]}]
+            [{"instance_id": instance_ts_id, "datapoints": [{"timestamp": ts, "value": value}]}]
         )
-
         retrieved = cognite_client.time_series.data.retrieve(instance_id=instance_ts_id, start=3, end=5)
 
-        assert retrieved.timestamp == [4]
-        assert retrieved.value == [42]
+        assert retrieved.timestamp == [ts]
+        assert retrieved.value == [value]

--- a/tests/tests_integration/test_api/test_datapoints.py
+++ b/tests/tests_integration/test_api/test_datapoints.py
@@ -2781,7 +2781,7 @@ class TestInsertDatapointsAPI:
         cognite_client.time_series.data.insert_multiple(
             [{"instance_id": instance_ts_id, "datapoints": [{"timestamp": ts, "value": value}]}]
         )
-        retrieved = cognite_client.time_series.data.retrieve(instance_id=instance_ts_id, start=3, end=5)
+        retrieved = cognite_client.time_series.data.retrieve(instance_id=instance_ts_id, start=ts, end=ts + 1)
 
         assert retrieved.timestamp == [ts]
         assert retrieved.value == [value]

--- a/tests/tests_integration/test_api/test_files.py
+++ b/tests/tests_integration/test_api/test_files.py
@@ -15,7 +15,6 @@ from cognite.client.data_classes import (
     Label,
     LabelDefinition,
 )
-from cognite.client.data_classes.data_modeling import Space
 from cognite.client.data_classes.data_modeling.cdm.v1 import CogniteFileApply
 from cognite.client.utils._text import random_string
 
@@ -251,10 +250,10 @@ class TestFilesAPI:
         cognite_client.files.delete(session.file_metadata.id)
 
     def test_create_retrieve_update_delete_with_instance_id(
-        self, cognite_client: CogniteClient, alpha_test_space: Space
+        self, cognite_client: CogniteClient, instance_id_test_space: str
     ) -> None:
         file = CogniteFileApply(
-            space=alpha_test_space.space,
+            space=instance_id_test_space,
             external_id="file_python_sdk_instance_id_tests",
             name="file_python_sdk_instance_id_tests",
             description="This file was created by the Python SDK",

--- a/tests/tests_integration/test_api/test_hosted_extractors/test_sources.py
+++ b/tests/tests_integration/test_api/test_hosted_extractors/test_sources.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-import platform
-
 import pytest
 
 from cognite.client import CogniteClient
@@ -16,9 +14,9 @@ from cognite.client.utils._text import random_string
 
 
 @pytest.fixture(scope="session")
-def one_event_hub_source(cognite_client: CogniteClient) -> SourceList:
+def one_event_hub_source(cognite_client: CogniteClient, os_and_py_version: str) -> SourceList:
     my_hub = EventHubSourceWrite(
-        external_id=f"myNewHub-{platform.system()}-{platform.python_version()}",
+        external_id=f"myNewHub-{os_and_py_version}",
         host="myHost",
         key_name="myKeyName",
         key_value="myKey",

--- a/tests/tests_integration/test_api/test_time_series.py
+++ b/tests/tests_integration/test_api/test_time_series.py
@@ -5,7 +5,6 @@ import pytest
 
 from cognite.client import CogniteClient
 from cognite.client.data_classes import DataSet, TimeSeries, TimeSeriesFilter, TimeSeriesList, TimeSeriesUpdate, filters
-from cognite.client.data_classes.data_modeling import Space
 from cognite.client.data_classes.data_modeling.cdm.v1 import CogniteTimeSeriesApply
 from cognite.client.data_classes.time_series import TimeSeriesProperty
 from cognite.client.utils._text import random_string
@@ -277,10 +276,10 @@ class TestTimeSeriesAPI:
         }
 
     def test_create_retrieve_update_delete_with_instance_id(
-        self, cognite_client: CogniteClient, alpha_test_space: Space, alpha_test_dataset: DataSet
+        self, cognite_client: CogniteClient, instance_id_test_space: str, alpha_test_dataset: DataSet
     ) -> None:
         my_ts = CogniteTimeSeriesApply(
-            space=alpha_test_space.space,
+            space=instance_id_test_space,
             external_id="ts_python_sdk_instance_id_tests",
             time_series_type="numeric",
             is_step=False,

--- a/tests/tests_unit/test_api/test_datapoints_tasks.py
+++ b/tests/tests_unit/test_api/test_datapoints_tasks.py
@@ -16,18 +16,14 @@ LIMIT_KWS = dict(dps_limit_raw=1234, dps_limit_agg=5678)
 
 
 class TestSingleTSQueryValidator:
-    @pytest.mark.parametrize(
-        "ids, xids",
-        (
-            (None, None),
-            ([], None),
-            (None, []),
-            ([], []),
-        ),
-    )
-    def test_no_identifiers_raises(self, ids, xids):
-        with pytest.raises(ValueError, match=re.escape("Pass at least one time series `id` or `external_id`!")):
-            _FullDatapointsQuery(id=ids, external_id=xids).parse_into_queries()
+    @pytest.mark.parametrize("ids", (None, []))
+    @pytest.mark.parametrize("xids", (None, []))
+    @pytest.mark.parametrize("inst_id", (None, []))
+    def test_no_identifiers_raises(self, ids, xids, inst_id):
+        with pytest.raises(
+            ValueError, match=re.escape("Pass at least one time series `id`, `external_id` or `instance_id`!")
+        ):
+            _FullDatapointsQuery(id=ids, external_id=xids, instance_id=inst_id).parse_into_queries()
 
     @pytest.mark.parametrize(
         "ids, xids, exp_attr_to_fail",

--- a/tests/tests_unit/test_data_classes/test_repr.py
+++ b/tests/tests_unit/test_data_classes/test_repr.py
@@ -32,7 +32,7 @@ class TestRepr:
             Datapoints(id=1),
             DatapointsArray(id=1, timestamp=[]),
             Datapoints(instance_id=NodeId("space", "xid")),
-            DatapointsArray(instance_id=NodeId("space", "xid")),
+            DatapointsArray(instance_id=NodeId("space", "xid"), timestamp=[]),
         ),
     )
     def test_repr_html_dps_classes(self, inst):

--- a/tests/tests_unit/test_data_classes/test_repr.py
+++ b/tests/tests_unit/test_data_classes/test_repr.py
@@ -14,19 +14,39 @@ from cognite.client.data_classes import (
     TableList,
     ThreeDModel,
 )
+from cognite.client.data_classes.data_modeling.ids import NodeId
+from cognite.client.data_classes.datapoints import DatapointsArray
 
 
 @pytest.mark.dsl
 class TestRepr:
     # TODO: We should auto-create these tests for all subclasses impl. _repr_html_:
-    def test_repr_html(self):
-        for cls in [Asset, Datapoints, Sequence, FileMetadata, Row, Table, ThreeDModel]:
-            assert len(cls()._repr_html_()) > 0
+    @pytest.mark.parametrize("cls", (Asset, Sequence, FileMetadata, Row, Table, ThreeDModel))
+    def test_repr_html(self, cls):
+        assert len(cls()._repr_html_()) > 0
 
-    def test_repr_html_datapoint(self):
-        assert len(Datapoint(timestamp=0, value=0)._repr_html_()) > 0
+    @pytest.mark.parametrize(
+        "inst",
+        (
+            Datapoint(timestamp=0, value=0),
+            Datapoints(id=1),
+            DatapointsArray(id=1, timestamp=[]),
+            Datapoints(instance_id=NodeId("space", "xid")),
+            DatapointsArray(instance_id=NodeId("space", "xid")),
+        ),
+    )
+    def test_repr_html_dps_classes(self, inst):
+        assert len(inst._repr_html_()) > 0
 
-    def test_repr_html_list(self):
-        for cls in [AssetList, DatapointsList, TableList]:
-            assert len(cls([cls._RESOURCE()])._repr_html_()) > 0
-        assert len(RowList([RowList._RESOURCE("row", columns={})])._repr_html_()) > 0
+    @pytest.mark.parametrize(
+        "lst",
+        (
+            AssetList([AssetList._RESOURCE()]),
+            DatapointsList([DatapointsList._RESOURCE(id=1)]),
+            DatapointsList([DatapointsList._RESOURCE(instance_id=NodeId("space", "xid"))]),
+            TableList([TableList._RESOURCE()]),
+            RowList([RowList._RESOURCE("row", columns={})]),
+        ),
+    )
+    def test_repr_html_list(self, lst):
+        assert len(lst._repr_html_()) > 0


### PR DESCRIPTION
Incorporate instance_id as an equal to id and external_id in the TimeSeries/Datapoints API.

https://cognitedata.atlassian.net/browse/DM-2128

## TODO
Some more tests, particularly on combining identifiers.