### PR TITLE
Add cluster info to CogniteAPIError

### DIFF
--- a/cognite/client/_api/assets.py
+++ b/cognite/client/_api/assets.py
@@ -53,7 +53,7 @@ from cognite.client.data_classes.assets import (
 )
 from cognite.client.data_classes.filters import _BASIC_FILTERS, Filter, _validate_filter
 from cognite.client.exceptions import CogniteAPIError
-from cognite.client.utils._auxiliary import get_cdf_cluster, split_into_chunks, split_into_n_parts
+from cognite.client.utils._auxiliary import split_into_chunks, split_into_n_parts
 from cognite.client.utils._concurrency import ConcurrencySettings, classify_error, execute_tasks
 from cognite.client.utils._identifier import IdentifierSequence
 from cognite.client.utils._importing import import_as_completed
@@ -1483,7 +1483,7 @@ class _AssetHierarchyCreator:
             unknown=AssetList(self.unknown),
             failed=AssetList(self.failed),
             unwrap_fn=op.attrgetter("external_id"),
-            cluster=get_cdf_cluster(self.assets_api._config),
+            cluster=self.assets_api._config.cdf_cluster,
         )
         err_message = "One or more errors happened during asset creation. Latest error:"
         if isinstance(latest_exception, CogniteAPIError):

--- a/cognite/client/_api/assets.py
+++ b/cognite/client/_api/assets.py
@@ -53,7 +53,7 @@ from cognite.client.data_classes.assets import (
 )
 from cognite.client.data_classes.filters import _BASIC_FILTERS, Filter, _validate_filter
 from cognite.client.exceptions import CogniteAPIError
-from cognite.client.utils._auxiliary import split_into_chunks, split_into_n_parts
+from cognite.client.utils._auxiliary import get_cdf_cluster, split_into_chunks, split_into_n_parts
 from cognite.client.utils._concurrency import ConcurrencySettings, classify_error, execute_tasks
 from cognite.client.utils._identifier import IdentifierSequence
 from cognite.client.utils._importing import import_as_completed
@@ -1483,6 +1483,7 @@ class _AssetHierarchyCreator:
             unknown=AssetList(self.unknown),
             failed=AssetList(self.failed),
             unwrap_fn=op.attrgetter("external_id"),
+            cluster=get_cdf_cluster(self.assets_api._config),
         )
         err_message = "One or more errors happened during asset creation. Latest error:"
         if isinstance(latest_exception, CogniteAPIError):

--- a/cognite/client/_api_client.py
+++ b/cognite/client/_api_client.py
@@ -48,7 +48,6 @@ from cognite.client.data_classes.filters import Filter
 from cognite.client.exceptions import CogniteAPIError, CogniteNotFoundError
 from cognite.client.utils import _json
 from cognite.client.utils._auxiliary import (
-    get_cdf_cluster,
     get_current_sdk_version,
     get_user_agent,
     interpolate_and_url_encode,
@@ -1153,7 +1152,7 @@ class APIClient:
                     successful=successful,
                     failed=failed,
                     unknown=unknown,
-                    cluster=get_cdf_cluster(self._config),
+                    cluster=self._config.cdf_cluster,
                 )
             # Need to retrieve the successful updated items from the first call.
             successful_resources: T_CogniteResourceList | None = None
@@ -1325,7 +1324,7 @@ class APIClient:
             missing=missing,
             duplicated=duplicated,
             extra=extra,
-            cluster=get_cdf_cluster(self._config),
+            cluster=self._config.cdf_cluster,
         )
 
     def _log_request(self, res: Response, **kwargs: Any) -> None:

--- a/cognite/client/_api_client.py
+++ b/cognite/client/_api_client.py
@@ -48,6 +48,7 @@ from cognite.client.data_classes.filters import Filter
 from cognite.client.exceptions import CogniteAPIError, CogniteNotFoundError
 from cognite.client.utils import _json
 from cognite.client.utils._auxiliary import (
+    get_cdf_cluster,
     get_current_sdk_version,
     get_user_agent,
     interpolate_and_url_encode,
@@ -1147,7 +1148,12 @@ class APIClient:
                     # The created call failed
                     failed.extend(item.external_id if item.external_id is not None else item.id for item in to_update)  # type: ignore [attr-defined]
                 raise CogniteAPIError(
-                    api_error.message, code=api_error.code, successful=successful, failed=failed, unknown=unknown
+                    api_error.message,
+                    code=api_error.code,
+                    successful=successful,
+                    failed=failed,
+                    unknown=unknown,
+                    cluster=get_cdf_cluster(self._config),
                 )
             # Need to retrieve the successful updated items from the first call.
             successful_resources: T_CogniteResourceList | None = None
@@ -1272,8 +1278,7 @@ class APIClient:
     def _status_ok(status_code: int) -> bool:
         return status_code in {200, 201, 202, 204}
 
-    @classmethod
-    def _raise_api_error(cls, res: Response, payload: dict) -> NoReturn:
+    def _raise_api_error(self, res: Response, payload: dict) -> NoReturn:
         x_request_id = res.headers.get("X-Request-Id")
         code = res.status_code
         missing = None
@@ -1303,8 +1308,8 @@ class APIClient:
         if duplicated:
             error_details["duplicated"] = duplicated
         error_details["headers"] = res.request.headers.copy()
-        cls._sanitize_headers(error_details["headers"])
-        error_details["response_payload"] = shorten(cls._get_response_content_safe(res), 500)
+        self._sanitize_headers(error_details["headers"])
+        error_details["response_payload"] = shorten(self._get_response_content_safe(res), 500)
         error_details["response_headers"] = res.headers
 
         if res.history:
@@ -1313,7 +1318,15 @@ class APIClient:
                     f"REDIRECT AFTER HTTP Error {res_hist.status_code} {res_hist.request.method} {res_hist.request.url}: {res_hist.content.decode()}"
                 )
         logger.debug(f"HTTP Error {code} {res.request.method} {res.request.url}: {msg}", extra=error_details)
-        raise CogniteAPIError(msg, code, x_request_id, missing=missing, duplicated=duplicated, extra=extra)
+        raise CogniteAPIError(
+            msg,
+            code,
+            x_request_id,
+            missing=missing,
+            duplicated=duplicated,
+            extra=extra,
+            cluster=get_cdf_cluster(self._config),
+        )
 
     def _log_request(self, res: Response, **kwargs: Any) -> None:
         method = res.request.method

--- a/cognite/client/exceptions.py
+++ b/cognite/client/exceptions.py
@@ -136,6 +136,7 @@ class CogniteAPIError(CogniteMultiException):
         unknown (list | None): List of items which may or may not have been successfully processed.
         skipped (list | None): List of items that were skipped due to "fail fast" mode.
         unwrap_fn (Callable): Function to extract identifier from the Cognite resource.
+        cluster (str | None): Which Cognite cluster the user's project is on.
         extra (dict | None): A dict of any additional information.
 
     Examples:
@@ -170,6 +171,7 @@ class CogniteAPIError(CogniteMultiException):
         unknown: list | None = None,
         skipped: list | None = None,
         unwrap_fn: Callable = no_op,
+        cluster: str | None = None,
         extra: dict | None = None,
     ) -> None:
         self.message = message
@@ -177,11 +179,14 @@ class CogniteAPIError(CogniteMultiException):
         self.x_request_id = x_request_id
         self.missing = missing
         self.duplicated = duplicated
+        self.cluster = cluster
         self.extra = extra
         super().__init__(successful, failed, unknown, skipped, unwrap_fn)
 
     def __str__(self) -> str:
         msg = f"{self.message} | code: {self.code} | X-Request-ID: {self.x_request_id}"
+        if self.cluster:
+            msg += f" | cluster: {self.cluster}"
         if self.missing:
             msg += f"\nMissing: {self._truncate_elements(self.missing)}"
         if self.duplicated:

--- a/cognite/client/utils/_auxiliary.py
+++ b/cognite/client/utils/_auxiliary.py
@@ -4,7 +4,6 @@ import functools
 import math
 import platform
 import warnings
-from contextlib import suppress
 from threading import Thread
 from typing import (
     TYPE_CHECKING,
@@ -32,7 +31,6 @@ from cognite.client.utils.useful_types import SequenceNotStr
 
 if TYPE_CHECKING:
     from cognite.client import CogniteClient
-    from cognite.client.config import ClientConfig
     from cognite.client.data_classes._base import T_CogniteObject, T_CogniteResource
 
 T = TypeVar("T")
@@ -143,13 +141,6 @@ def get_current_sdk_version() -> str:
     from cognite.client import __version__
 
     return __version__
-
-
-def get_cdf_cluster(config: ClientConfig) -> str | None:
-    # A best effort attempt to extract the cluster from the base url
-    with suppress(Exception):
-        return config.base_url.split("//")[1].split(".cognitedata")[0]
-    return None
 
 
 @functools.lru_cache(maxsize=1)

--- a/cognite/client/utils/_auxiliary.py
+++ b/cognite/client/utils/_auxiliary.py
@@ -4,6 +4,7 @@ import functools
 import math
 import platform
 import warnings
+from contextlib import suppress
 from threading import Thread
 from typing import (
     TYPE_CHECKING,
@@ -31,6 +32,7 @@ from cognite.client.utils.useful_types import SequenceNotStr
 
 if TYPE_CHECKING:
     from cognite.client import CogniteClient
+    from cognite.client.config import ClientConfig
     from cognite.client.data_classes._base import T_CogniteObject, T_CogniteResource
 
 T = TypeVar("T")
@@ -141,6 +143,13 @@ def get_current_sdk_version() -> str:
     from cognite.client import __version__
 
     return __version__
+
+
+def get_cdf_cluster(config: ClientConfig) -> str | None:
+    # A best effort attempt to extract the cluster from the base url
+    with suppress(Exception):
+        return config.base_url.split("//")[1].split(".cognitedata")[0]
+    return None
 
 
 @functools.lru_cache(maxsize=1)

--- a/tests/tests_unit/test_exceptions.py
+++ b/tests/tests_unit/test_exceptions.py
@@ -1,4 +1,16 @@
+import pytest
+
 from cognite.client.exceptions import CogniteAPIError
+
+
+@pytest.fixture
+def mock_get_400_error(rsps, cognite_client):
+    rsps.add(
+        rsps.GET,
+        cognite_client.assets._get_base_url_with_base_path() + "/any",
+        status=400,
+        json={"error": {"message": "bla", "extra": {"haha": "blabla"}, "other": "yup"}},
+    )
 
 
 class TestAPIError:
@@ -19,15 +31,16 @@ class TestAPIError:
 
         assert "bla" in str(e)
 
-    def test_unknown_fields_in_api_error(self, rsps, cognite_client):
-        rsps.add(
-            rsps.GET,
-            cognite_client.assets._get_base_url_with_base_path() + "/any",
-            status=400,
-            json={"error": {"message": "bla", "extra": {"haha": "blabla"}, "other": "yup"}},
-        )
+    def test_unknown_fields_in_api_error(self, mock_get_400_error, cognite_client):
         try:
             cognite_client.get(url=f"/api/v1/projects/{cognite_client.config.project}/any")
             assert False, "Call did not raise exception"
         except CogniteAPIError as e:
             assert {"extra": {"haha": "blabla"}, "other": "yup"} == e.extra
+
+    def test_api_errors_contain_cluster_info(self, mock_get_400_error, cognite_client):
+        try:
+            cognite_client.get(url=f"/api/v1/projects/{cognite_client.config.project}/any")
+            assert False, "Call did not raise exception"
+        except CogniteAPIError as e:
+            assert e.cluster == "api"


### PR DESCRIPTION
## Description
Every thread starts with
- I got this error when trying to do...
- Which cluster?
- ...the story unfolds

This PR tries to short-cut this 🤓 

```py
>>> client.assets.create(Asset(external_id="x"*256, name="no"))
CogniteAPIError: Request had 1 constraint violations. Please fix the request and try again. [externalId size must be between 0 and 255]
| code: 400
| X-Request-ID: 969147f9-487c-9425-b3d4-8a2bb81d3100
| cluster: greenfield
The API Failed to process some items.
Successful (2xx): []
Unknown (5xx): []
Failed (4xx): [xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx, ...]
```