### PR TITLE
fix type error on inst to pd with single prop and expand True

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ Changes are grouped as follows
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
+## [7.62.6] - 2024-09-27
+### Fixed
+- Instances with a single property no longer fail `to_pandas()` with `TypeError`, when using expand_properties=True.
+
 ## [7.62.5] - 2024-09-26
 ### Added
 - Add new `client.workflows.triggers.upsert`, this allows upserts of triggers.
@@ -26,7 +30,7 @@ Changes are grouped as follows
 ## [7.62.4] - 2024-09-25
 ### Fixed
 - In the CoreModel, `client.data_classes.data_modeling.cdm` the fields `isUploaded` and `uploadedTime` in
-  `CogniteFile` are  now considered read-only 
+  `CogniteFile` are  now considered read-only
 
 ## [7.62.3] - 2024-09-24
 ### Added
@@ -38,7 +42,7 @@ Changes are grouped as follows
 
 ## [7.62.1] - 2024-09-23
 ### Changed
-- Support for `OAuthDeviceCode` now supports non Entra IdPs 
+- Support for `OAuthDeviceCode` now supports non Entra IdPs
 
 ## [7.62.0] - 2024-09-19
 ### Added

--- a/cognite/client/_version.py
+++ b/cognite/client/_version.py
@@ -1,4 +1,4 @@
 from __future__ import annotations
 
-__version__ = "7.62.5"
+__version__ = "7.62.6"
 __api_subversion__ = "20230101"

--- a/cognite/client/data_classes/data_modeling/instances.py
+++ b/cognite/client/data_classes/data_modeling/instances.py
@@ -472,7 +472,7 @@ class Instance(WritableInstanceCore[T_CogniteResource], ABC):
                     "Can't remove view ID prefix from expanded property rows as source was not unique",
                     RuntimeWarning,
                 )
-        return pd.concat((col, prop_df.T.squeeze())).to_frame(name="value")
+        return pd.concat((col, prop_df.T.squeeze(axis=1))).to_frame(name="value")
 
     @abstractmethod
     def as_apply(self) -> InstanceApply:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "cognite-sdk"
 
-version = "7.62.5"
+version = "7.62.6"
 description = "Cognite Python SDK"
 readme = "README.md"
 documentation = "https://cognite-sdk-python.readthedocs-hosted.com"

--- a/tests/tests_unit/test_data_classes/test_data_models/test_instances.py
+++ b/tests/tests_unit/test_data_classes/test_data_models/test_instances.py
@@ -481,6 +481,30 @@ class TestInstancesToPandas:
 
         assert "properties" not in expanded_with_empty_properties.columns
 
+    def test_node_with_single_property_to_pandas_with_expand_props(self) -> None:
+        # Bug prior to 7.62.5 made to_pandas(expand_properties=True) fail on nodes with a single property
+        # due to how squeeze works in pandas, even a DataFrame will be forced into a scalar (to be fair,
+        # the documentation is very clear on this).
+        node = Node.load(
+            {
+                "space": "DEMO_AppData",
+                "externalId": "15777214-1234-4321-1234-02f7b4cd349d",
+                "version": 888,
+                "lastUpdatedTime": 1694611301244,
+                "createdTime": 1685430260401,
+                "instanceType": "node",
+                "properties": {"DEMO_AppData": {"APM_User/15": {"name": "Foo Bar"}}},
+            }
+        )
+        # This has always worked, and should continue to work after the fix
+        node_df1 = node.to_pandas(expand_properties=False)
+        assert node_df1.at["properties", "value"] == {"DEMO_AppData": {"APM_User/15": {"name": "Foo Bar"}}}
+
+        # This failed prior to 7.62.5:
+        node_df2 = node.to_pandas(expand_properties=True)
+        assert "properties" not in node_df2.index
+        assert node_df2.at["name", "value"] == "Foo Bar"
+
 
 class TestTypeInformation:
     @pytest.mark.dsl

--- a/tests/tests_unit/test_data_classes/test_data_models/test_instances.py
+++ b/tests/tests_unit/test_data_classes/test_data_models/test_instances.py
@@ -482,7 +482,7 @@ class TestInstancesToPandas:
         assert "properties" not in expanded_with_empty_properties.columns
 
     def test_node_with_single_property_to_pandas_with_expand_props(self) -> None:
-        # Bug prior to 7.62.5 made to_pandas(expand_properties=True) fail on nodes with a single property
+        # Bug prior to 7.62.6 made to_pandas(expand_properties=True) fail on nodes with a single property
         # due to how squeeze works in pandas, even a DataFrame will be forced into a scalar (to be fair,
         # the documentation is very clear on this).
         node = Node.load(
@@ -500,7 +500,7 @@ class TestInstancesToPandas:
         node_df1 = node.to_pandas(expand_properties=False)
         assert node_df1.at["properties", "value"] == {"DEMO_AppData": {"APM_User/15": {"name": "Foo Bar"}}}
 
-        # This failed prior to 7.62.5:
+        # This failed prior to 7.62.6:
         node_df2 = node.to_pandas(expand_properties=True)
         assert "properties" not in node_df2.index
         assert node_df2.at["name", "value"] == "Foo Bar"


### PR DESCRIPTION
```
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
File /lib/python3.12/site-packages/IPython/core/formatters.py:347, in BaseFormatter.__call__(self, obj)
    345     method = get_real_method(obj, self.print_method)
    346     if method is not None:
--> 347         return method()
    348     return None
    349 else:

File /lib/python3.12/site-packages/cognite/client/data_classes/_base.py:239, in CogniteResource._repr_html_(self)
    238 def _repr_html_(self) -> str:
--> 239     return notebook_display_with_fallback(self)

File /lib/python3.12/site-packages/cognite/client/utils/_pandas_helpers.py:99, in notebook_display_with_fallback(inst, **kwargs)
     97     kwargs["expand_properties"] = True
     98 try:
---> 99     return inst.to_pandas(**kwargs)._repr_html_()
    100 except CogniteImportError:
    101     warnings.warn(
    102         "The 'cognite-sdk' depends on 'pandas' for pretty-printing objects like 'Asset' or 'DatapointsList' in "
    103         "(Jupyter) notebooks and similar environments. Consider installing it! Using fallback method.",
    104         UserWarning,
    105     )

File /lib/python3.12/site-packages/cognite/client/data_classes/data_modeling/instances.py:475, in Instance.to_pandas(self, ignore, camel_case, convert_timestamps, expand_properties, remove_property_prefix, **kwargs)
    470     else:
    471         warnings.warn(
    472             "Can't remove view ID prefix from expanded property rows as source was not unique",
    473             RuntimeWarning,
    474         )
--> 475 return pd.concat((col, prop_df.T.squeeze())).to_frame(name="value")

File /lib/python3.12/site-packages/pandas/core/reshape/concat.py:380, in concat(objs, axis, join, ignore_index, keys, levels, names, verify_integrity, sort, copy)
    377 elif copy and using_copy_on_write():
    378     copy = False
--> 380 op = _Concatenator(
    381     objs,
    382     axis=axis,
    383     ignore_index=ignore_index,
    384     join=join,
    385     keys=keys,
    386     levels=levels,
    387     names=names,
    388     verify_integrity=verify_integrity,
    389     copy=copy,
    390     sort=sort,
    391 )
    393 return op.get_result()

File /lib/python3.12/site-packages/pandas/core/reshape/concat.py:446, in _Concatenator.__init__(self, objs, axis, join, keys, levels, names, ignore_index, verify_integrity, copy, sort)
    443 objs, keys = self._clean_keys_and_objs(objs, keys)
    445 # figure out what our result ndim is going to be
--> 446 ndims = self._get_ndims(objs)
    447 sample, objs = self._get_sample_object(objs, ndims, keys, names, levels)
    449 # Standardize axis parameter to int

File /lib/python3.12/site-packages/pandas/core/reshape/concat.py:487, in _Concatenator._get_ndims(self, objs)
    482     if not isinstance(obj, (ABCSeries, ABCDataFrame)):
    483         msg = (
    484             f"cannot concatenate object of type '{type(obj)}'; "
    485             "only Series and DataFrame objs are valid"
    486         )
--> 487         raise TypeError(msg)
    489     ndims.add(obj.ndim)
    490 return ndims

TypeError: cannot concatenate object of type '<class 'str'>'; only Series and DataFrame objs are valid
```