### PR TITLE
Add more examples for time series with instance_id

### DIFF
--- a/cognite/client/_api/datapoints.py
+++ b/cognite/client/_api/datapoints.py
@@ -588,7 +588,7 @@ class DatapointsAPI(APIClient):
                 >>> client = CogniteClient()
                 >>> dps = client.time_series.data.retrieve(id=42, start="2w-ago")
                 >>> # You can also use instance_id:
-                >>> from cognite.client.data_classes.data_modeling.ids import NodeId
+                >>> from cognite.client.data_classes.data_modeling import NodeId
                 >>> dps = client.time_series.data.retrieve(instance_id=NodeId("ts-space", "foo"))
 
             Although raw datapoints are returned by default, you can also get aggregated values, such as `max` or `average`. You may also fetch more than one time series simultaneously. Here we are

--- a/cognite/client/_api/time_series.py
+++ b/cognite/client/_api/time_series.py
@@ -631,6 +631,20 @@ class TimeSeriesAPI(APIClient):
                 >>> client = CogniteClient()
                 >>> my_update = TimeSeriesUpdate(id=1).description.set("New description").metadata.add({"key": "value"})
                 >>> res = client.time_series.update(my_update)
+
+            Perform a partial update on a time series by instance id::
+
+                >>> from cognite.client import CogniteClient
+                >>> from cognite.client.data_classes import TimeSeriesUpdate
+                >>> from cognite.client.data_classes.data_modeling import NodeId
+
+                >>> client = CogniteClient()
+                >>> my_update = (
+                ...     TimeSeriesUpdate(instance_id=NodeId("test", "hello"))
+                ...     .external_id.set("test:hello")
+                ...     .metadata.add({"test": "hello"})
+                ... )
+                >>> client.time_series.update(my_update)
         """
         return self._update_multiple(
             list_cls=TimeSeriesList,


### PR DESCRIPTION
Minor improvement of the documentation for time series with instance id.