### PR TITLE
add method `InstancesAPI.inspect`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,12 @@ Changes are grouped as follows
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
+## [7.64.0] - 2024-10-09
+### Added
+- New instance inspection endpoint `client.data_modeling.instances.inspect` enabling easy reverse
+  lookup to find which views and containers they have data in.
+
+## [7.62.8] - 2024-10-08
 ## [7.63.11] - 2024-10-26
 ### Fixed
 - The `/context/diagram/` endpoints are now retried on 5xx and 429 errors.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,6 @@ Changes are grouped as follows
 - New instance inspection endpoint `client.data_modeling.instances.inspect` enabling easy reverse
   lookup to find which views and containers they have data in.
 
-## [7.62.8] - 2024-10-08
 ## [7.63.11] - 2024-10-26
 ### Fixed
 - The `/context/diagram/` endpoints are now retried on 5xx and 429 errors.

--- a/cognite/client/_api/data_modeling/instances.py
+++ b/cognite/client/_api/data_modeling/instances.py
@@ -716,6 +716,31 @@ class InstancesAPI(APIClient):
         return_all_view_versions: bool = False,
         return_all_container_versions: bool = False,
     ) -> InstanceInspectResultList:
+        """`Reverse lookup for instances. <https://developer.cognite.com/api/v1/#tag/Instances/operation/instanceInspect>`_
+
+        This method will return the involved views and containers for the given nodes and edges.
+
+        Args:
+            nodes (NodeId | Sequence[NodeId] | tuple[str, str] | Sequence[tuple[str, str]] | None): Node IDs.
+            edges (EdgeId | Sequence[EdgeId] | tuple[str, str] | Sequence[tuple[str, str]] | None): Edge IDs.
+            return_all_view_versions (bool): Include all view versions in inspection results.
+            return_all_container_versions (bool): Include all container versions in inspection results.
+
+        Returns:
+            InstanceInspectResultList: List of instance inspection results.
+
+        Examples:
+
+            Look up the involved views and containers for a given node and edge:
+
+                >>> from cognite.client import CogniteClient
+                >>> from cognite.client.data_classes.data_modeling import NodeId, EdgeId
+                >>> client = CogniteClient()
+                >>> res = client.data_modeling.instances.inspect(
+                ...     nodes=NodeId("my-space", "foo1"),
+                ...     edges=EdgeId("my-space", "bar2"),
+                ... )
+        """
         identifiers = self._load_node_and_edge_ids(nodes, edges)
         options = {
             "inspectionOperations": {

--- a/cognite/client/_version.py
+++ b/cognite/client/_version.py
@@ -1,4 +1,4 @@
 from __future__ import annotations
 
-__version__ = "7.63.11"
+__version__ = "7.64.0"
 __api_subversion__ = "20230101"

--- a/cognite/client/data_classes/data_modeling/instances.py
+++ b/cognite/client/data_classes/data_modeling/instances.py
@@ -557,20 +557,18 @@ class InspectionResults(DataModelingResource):
         self.involved_containers = involved_containers
 
     @classmethod
-    def load(cls, resource: dict, cognite_client: CogniteClient | None = None) -> Self:
+    def _load(cls, resource: dict, cognite_client: CogniteClient | None = None) -> Self:
         return cls(
             involved_views=[ViewId.load(vid) for vid in resource["involvedViews"]],
-            involved_containers=[ContainerId.load(cid) for cid in resource["involvedViews"]],
+            involved_containers=[ContainerId.load(cid) for cid in resource["involvedContainers"]],
         )
 
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
+        views = [vid.dump(camel_case, include_type=True) for vid in self.involved_views]
+        containers = [cid.dump(camel_case, include_type=True) for cid in self.involved_containers]
         return {
-            "involvedViews" if camel_case else "involved_views": [
-                vid.dump(camel_case, include_type=True) for vid in self.involved_views
-            ],
-            "involvedContainers" if camel_case else "involved_containers": [
-                cid.dump(camel_case, include_type=True) for cid in self.involved_containers
-            ],
+            "involvedViews" if camel_case else "involved_views": views,
+            "involvedContainers" if camel_case else "involved_containers": containers,
         }
 
 

--- a/cognite/client/data_classes/data_modeling/instances.py
+++ b/cognite/client/data_classes/data_modeling/instances.py
@@ -516,15 +516,14 @@ class InstanceAggregationResult(DataModelingResource):
     @classmethod
     def _load(cls, resource: dict, cognite_client: CogniteClient | None = None) -> Self:
         """
-        Loads an instance from a json string or dictionary.
+        Loads an instance aggregation result from a json string or dictionary.
 
         Args:
             resource (dict): No description.
             cognite_client (CogniteClient | None): No description.
 
         Returns:
-            Self: An instance.
-
+            Self: An instance aggregation result.
         """
         return cls(
             aggregates=[AggregatedNumberedValue.load(agg) for agg in resource["aggregates"]],
@@ -550,6 +549,64 @@ class InstanceAggregationResult(DataModelingResource):
 
 class InstanceAggregationResultList(CogniteResourceList[InstanceAggregationResult]):
     _RESOURCE = InstanceAggregationResult
+
+
+class InspectionResults(DataModelingResource):
+    def __init__(self, involved_views: list[ViewId], involved_containers: list[ContainerId]) -> None:
+        self.involved_views = involved_views
+        self.involved_containers = involved_containers
+
+    @classmethod
+    def load(cls, resource: dict, cognite_client: CogniteClient | None = None) -> Self:
+        return cls(
+            involved_views=[ViewId.load(vid) for vid in resource["involvedViews"]],
+            involved_containers=[ContainerId.load(cid) for cid in resource["involvedViews"]],
+        )
+
+    def dump(self, camel_case: bool = True) -> dict[str, Any]:
+        return {
+            "involvedViews" if camel_case else "involved_views": [
+                vid.dump(camel_case, include_type=True) for vid in self.involved_views
+            ],
+            "involvedContainers" if camel_case else "involved_containers": [
+                cid.dump(camel_case, include_type=True) for cid in self.involved_containers
+            ],
+        }
+
+
+class InstanceInspectResult(DataModelingResource):
+    def __init__(
+        self,
+        space: str,
+        external_id: str,
+        instance_type: Literal["node", "edge"],
+        inspection_results: InspectionResults,
+    ) -> None:
+        self.space = space
+        self.external_id = external_id
+        self.instance_type = instance_type
+        self.inspection_results = inspection_results
+
+    @classmethod
+    def _load(cls, resource: dict, cognite_client: CogniteClient | None = None) -> Self:
+        return cls(
+            space=resource["space"],
+            external_id=resource["externalId"],
+            instance_type=resource["instanceType"],
+            inspection_results=InspectionResults.load(resource["inspectionResults"]),
+        )
+
+    def dump(self, camel_case: bool = True) -> dict[str, Any]:
+        return {
+            "space": self.space,
+            "externalId" if camel_case else "external_id": self.external_id,
+            "instanceType" if camel_case else "instance_type": self.instance_type,
+            "inspectionResults" if camel_case else "inspection_results": self.inspection_results.dump(camel_case),
+        }
+
+
+class InstanceInspectResultList(CogniteResourceList[InstanceInspectResult]):
+    _RESOURCE = InstanceInspectResult
 
 
 class NodeApply(InstanceApply["NodeApply"]):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "cognite-sdk"
 
-version = "7.63.11"
+version = "7.64.0"
 description = "Cognite Python SDK"
 readme = "README.md"
 documentation = "https://cognite-sdk-python.readthedocs-hosted.com"

--- a/tests/tests_integration/test_api/test_data_modeling/test_instances.py
+++ b/tests/tests_integration/test_api/test_data_modeling/test_instances.py
@@ -47,7 +47,9 @@ from cognite.client.data_classes.data_modeling import (
 from cognite.client.data_classes.data_modeling.data_types import UnitReference
 from cognite.client.data_classes.data_modeling.instances import (
     InstanceInspectResult,
-    InstanceInspectResultList,
+    InstanceInspectResults,
+    InvolvedContainers,
+    InvolvedViews,
     TargetUnit,
 )
 from cognite.client.data_classes.data_modeling.query import (
@@ -1106,23 +1108,26 @@ class TestInstancesAPI:
     def test_inspecting_instances(
         self, cognite_client: CogniteClient, movie_nodes: NodeList, movie_edges: EdgeList
     ) -> None:
-        all_inspection_results = cognite_client.data_modeling.instances.inspect(
-            nodes=movie_nodes[:5].as_ids(), edges=movie_edges[0].as_id()
+        inspect_result = cognite_client.data_modeling.instances.inspect(
+            nodes=movie_nodes[:5].as_ids(),
+            edges=movie_edges[0].as_id(),
+            involved_views=InvolvedViews(),
+            involved_containers=InvolvedContainers(),
         )
-        assert isinstance(all_inspection_results, InstanceInspectResultList)
-        assert len(all_inspection_results) == 6
-        *node_results, edge_result = all_inspection_results
-        assert isinstance(edge_result, InstanceInspectResult)
+        assert isinstance(inspect_result, InstanceInspectResults)
+        assert len(inspect_result.nodes) == 5
+        assert len(inspect_result.edges) == 1
+        assert isinstance(inspect_result.edges[0], InstanceInspectResult)
 
-        for node_res in node_results:
+        for node_res in inspect_result.nodes:
             res = node_res.inspection_results
             assert res.involved_views and res.involved_views[0].space == "IntegrationTestSpace"
             assert res.involved_views and res.involved_views[0].external_id == "Movie"
             assert res.involved_containers and res.involved_containers[0].space == "IntegrationTestSpace"
             assert res.involved_containers and res.involved_containers[0].external_id == "Movie"
 
-        assert edge_result.inspection_results.involved_views == []
-        assert edge_result.inspection_results.involved_containers == []
+        assert inspect_result.edges[0].inspection_results.involved_views == []
+        assert inspect_result.edges[0].inspection_results.involved_containers == []
 
 
 class TestInstancesSync:


### PR DESCRIPTION
## [7.63.0] - 2024-10-09
### Added
- New instance inspection endpoint `client.data_modeling.instances.inspect` enabling easy reverse
  lookup to find which views and containers they have data in.