### PR TITLE
Undeprecate instance lst get method with external_id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,12 @@ Changes are grouped as follows
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
+## [7.62.9] - 2024-10-09
+### Fixed
+- NodeList and EdgeList (and subclasses) now support using `.get` with an `external_id` as a shortcut over
+  using `instance_id`. When the `external_id` is ambiguous (non-unique, multiple spaces), a ValueError
+  is raised. Thus, using `external_id` is no longer deprecated.
+
 ## [7.62.8] - 2024-10-07
 ### Added
 - [Feature Preview - alpha] Support for `PostgresGateway` `Users` `client.postegres_gateway.users`.

--- a/cognite/client/_version.py
+++ b/cognite/client/_version.py
@@ -1,4 +1,4 @@
 from __future__ import annotations
 
-__version__ = "7.62.8"
+__version__ = "7.62.9"
 __api_subversion__ = "20230101"

--- a/cognite/client/data_classes/data_modeling/instances.py
+++ b/cognite/client/data_classes/data_modeling/instances.py
@@ -959,8 +959,8 @@ class DataModelingInstancesList(WriteableCogniteResourceList[T_WriteClass, T_Ins
 
         Args:
             instance_id (InstanceId | tuple[str, str] | None): The instance ID to get. A tuple on the form (space, external_id) is also accepted.
-            external_id (str | None): DEPRECATED (reason: ambiguous). The external ID of the instance to return.
-            id (InstanceId | tuple[str, str] | None): Backwards-compatible alias for instance_id. Will be removed in the next major version.
+            external_id (str | None): The external ID of the instance to return. Will raise ValueError when ambiguous (in presence of multiple spaces).
+            id (InstanceId | tuple[str, str] | None): (DEPRECATED) Backwards-compatible alias for instance_id. Will be removed in the next major version.
 
         Returns:
             T_Instance | None: The requested instance if present, else None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "cognite-sdk"
 
-version = "7.62.8"
+version = "7.62.9"
 description = "Cognite Python SDK"
 readme = "README.md"
 documentation = "https://cognite-sdk-python.readthedocs-hosted.com"

--- a/tests/tests_integration/test_api/test_data_modeling/test_instances.py
+++ b/tests/tests_integration/test_api/test_data_modeling/test_instances.py
@@ -813,8 +813,8 @@ class TestInstancesAPI:
         assert "One or more views do not exist: " in error.value.message
         assert view_id.as_source_identifier() in error.value.message
 
-    def test_dump_json_serialize_load_node(self, movie_nodes: NodeList) -> None:
-        node = movie_nodes.get(external_id="movie:pulp_fiction")
+    def test_dump_json_serialize_load_node(self, movie_nodes: NodeList, integration_test_space: Space) -> None:
+        node = movie_nodes.get((integration_test_space.space, "movie:pulp_fiction"))
         assert node is not None, "Pulp fiction movie not found, please recreate it"
 
         node_dumped = node.dump(camel_case=True)
@@ -823,8 +823,8 @@ class TestInstancesAPI:
 
         assert node == node_loaded
 
-    def test_dump_json_serialize_load_edge(self, movie_edges: EdgeList) -> None:
-        edge = movie_edges.get(external_id="person:quentin_tarantino:director:quentin_tarantino")
+    def test_dump_json_serialize_load_edge(self, movie_edges: EdgeList, integration_test_space: Space) -> None:
+        edge = movie_edges.get((integration_test_space.space, "person:quentin_tarantino:director:quentin_tarantino"))
         assert edge is not None, "Relation between Quentin Tarantino person and director not found, please recreate it"
 
         edge_dumped = edge.dump(camel_case=True)


### PR DESCRIPTION
## [7.62.9] - 2024-10-09
### Fixed
- NodeList and EdgeList (and subclasses) now support using `.get` with an `external_id` as a shortcut over
  using `instance_id`. When the `external_id` is ambiguous (non-unique, multiple spaces), a ValueError
  is raised. Thus, using `external_id` is no longer deprecated.