### PR TITLE
fix 3.13 test runners

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
         with:
           extras: "-E pandas"
       - name: Linting and static code checks
-        run: pre-commit run --all-files
+        run: pre-commit run --all-files --show-diff-on-failure
 
   build_docs:
     runs-on: ubuntu-latest

--- a/tests/tests_unit/test_data_classes/test_capabilities.py
+++ b/tests/tests_unit/test_data_classes/test_capabilities.py
@@ -598,5 +598,5 @@ def test_show_example_usage(capability):
         pytest.skip("LegacyCapability is abstract")
     else:
         cmd = capability.show_example_usage().removeprefix("Example usage: ")
-        exec(f"{capability.__name__} = capabilities_module.{capability.__name__}", globals=globals())
+        exec(f"{capability.__name__} = capabilities_module.{capability.__name__}", globals())
         exec(cmd)

--- a/tests/tests_unit/test_data_classes/test_capabilities.py
+++ b/tests/tests_unit/test_data_classes/test_capabilities.py
@@ -591,11 +591,12 @@ def test_idscopes_camel_case():
 
 @pytest.mark.parametrize("capability", Capability.__subclasses__())
 def test_show_example_usage(capability):
+    # This test ensures that the example usage given in error messages etc. works by executing it.
     if capability is UnknownAcl:
         assert not capability.show_example_usage()
     elif capability is capabilities_module.LegacyCapability:
         pytest.skip("LegacyCapability is abstract")
     else:
-        cmd = capability.show_example_usage()[15:]  # TODO PY39: .removeprefix
-        exec(f"{capability.__name__} = capabilities_module.{capability.__name__}")
+        cmd = capability.show_example_usage().removeprefix("Example usage: ")
+        exec(f"{capability.__name__} = capabilities_module.{capability.__name__}", globals=globals())
         exec(cmd)


### PR DESCRIPTION
Python 3.13 ships with some safety improvements to exec/eval that caused some tests to fail:

> This change to the semantics of locals() in optimized scopes also affects the default behavior of code execution functions that implicitly target locals() if no explicit namespace is provided (such as exec() and eval()). 