### PR TITLE
Overload boolean operators to work with filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ Changes are grouped as follows
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
+## [7.63.8] - 2024-10-21
+### Added
+- The filters `And`, `Or` and `Not` can now be applied by using the operators `&`, `|` and `~` .
+
 ## [7.63.7] - 2024-10-18
 ### Fixed
 - Calling `cognite_client.data_modeling.instances(..., chunk_size=False, include_typing=False)` no longer raises a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,8 @@ Changes are grouped as follows
 
 ## [7.63.8] - 2024-10-21
 ### Added
-- The filters `And`, `Or` and `Not` can now be applied by using the operators `&`, `|` and `~` .
+- Filters can now be combined using `And` and `Or` by using the operators `&` and `|`.
+- Filters can now be negated by using the `~` operator (instead of using the `Not` filter)
 
 ## [7.63.7] - 2024-10-18
 ### Fixed

--- a/cognite/client/_version.py
+++ b/cognite/client/_version.py
@@ -1,4 +1,4 @@
 from __future__ import annotations
 
-__version__ = "7.63.7"
+__version__ = "7.63.8"
 __api_subversion__ = "20230101"

--- a/cognite/client/_version.py
+++ b/cognite/client/_version.py
@@ -1,4 +1,4 @@
 from __future__ import annotations
 
-__version__ = "7.63.8"
+__version__ = "7.63.9"
 __api_subversion__ = "20230101"

--- a/cognite/client/data_classes/filters.py
+++ b/cognite/client/data_classes/filters.py
@@ -340,7 +340,6 @@ class And(CompoundFilter):
 
         Using the "&" operator:
 
-            >>> from cognite.client.data_classes.filters import And
             >>> flt = Equals("age", 42) & Equals("name", "Alice")
     """
 
@@ -372,7 +371,6 @@ class Or(CompoundFilter):
 
         Using the "|" operator:
 
-            >>> from cognite.client.data_classes.filters import And
             >>> flt = Equals("name", "Bob") | Equals("name", "Alice")
     """
 

--- a/cognite/client/data_classes/filters.py
+++ b/cognite/client/data_classes/filters.py
@@ -204,10 +204,10 @@ class Filter(ABC):
 
     def __and__(self, other: Filter) -> And:
         return And(self, other)
-    
+
     def __or__(self, other: Filter) -> Or:
         return Or(self, other)
-    
+
     def __invert__(self) -> Not:
         return Not(self)
 
@@ -331,6 +331,11 @@ class And(CompoundFilter):
             >>> flt = And(
             ...     Equals(my_view.as_property_ref("some_property"), 42),
             ...     In(my_view.as_property_ref("another_property"), ["a", "b", "c"]))
+
+        Usint the "&" operator:
+
+            >>> from cognite.client.data_classes.filters import And
+            >>> flt = Equals("age", 42) & Equals("name", "Alice")
     """
 
     _filter_name = "and"
@@ -358,6 +363,11 @@ class Or(CompoundFilter):
             >>> flt = Or(
             ...     Equals(my_view.as_property_ref("some_property"), 42),
             ...     In(my_view.as_property_ref("another_property"), ["a", "b", "c"]))
+
+        Usint the "|" operator:
+
+            >>> from cognite.client.data_classes.filters import And
+            >>> flt = Equals("name", "Bob") | Equals("name", "Alice")
     """
 
     _filter_name = "or"
@@ -383,6 +393,11 @@ class Not(CompoundFilter):
 
             >>> is_42 = Equals(my_view.as_property_ref("some_property"), 42)
             >>> flt = Not(is_42)
+
+        Usint the "~" operator:
+
+            >>> from cognite.client.data_classes.filters import And
+            >>> flt = ~Equals("name", "Bob")
     """
 
     _filter_name = "not"

--- a/cognite/client/data_classes/filters.py
+++ b/cognite/client/data_classes/filters.py
@@ -202,17 +202,17 @@ class Filter(ABC):
                 output.update(filter_._involved_filter_types())
         return output
 
-    def __list_filters_without_nesting(self, right_flt: Filter, operator: type[CompoundFilter]) -> list[Filter]:
+    def _list_filters_without_nesting(self, other: Filter, operator: type[CompoundFilter]) -> list[Filter]:
         filters: list[Filter] = []
         filters.extend(self._filters) if isinstance(self, operator) else filters.append(self)
-        filters.extend(right_flt._filters) if isinstance(right_flt, operator) else filters.append(right_flt)
+        filters.extend(other._filters) if isinstance(other, operator) else filters.append(other)
         return filters
 
     def __and__(self, other: Filter) -> And:
-        return And(*self.__list_filters_without_nesting(other, And))
+        return And(*self._list_filters_without_nesting(other, And))
 
     def __or__(self, other: Filter) -> Or:
-        return Or(*self.__list_filters_without_nesting(other, Or))
+        return Or(*self._list_filters_without_nesting(other, Or))
 
     def __invert__(self) -> Not:
         return Not(self)

--- a/cognite/client/data_classes/filters.py
+++ b/cognite/client/data_classes/filters.py
@@ -202,11 +202,17 @@ class Filter(ABC):
                 output.update(filter_._involved_filter_types())
         return output
 
+    def __list_filters_without_nesting(self, right_flt: Filter, operator: type[CompoundFilter]) -> list[Filter]:
+        filters: list[Filter] = []
+        filters.extend(self._filters) if isinstance(self, operator) else filters.append(self)
+        filters.extend(right_flt._filters) if isinstance(right_flt, operator) else filters.append(right_flt)
+        return filters
+
     def __and__(self, other: Filter) -> And:
-        return And(self, other)
+        return And(*self.__list_filters_without_nesting(other, And))
 
     def __or__(self, other: Filter) -> Or:
-        return Or(self, other)
+        return Or(*self.__list_filters_without_nesting(other, Or))
 
     def __invert__(self) -> Not:
         return Not(self)

--- a/cognite/client/data_classes/filters.py
+++ b/cognite/client/data_classes/filters.py
@@ -402,7 +402,6 @@ class Not(CompoundFilter):
 
         Using the "~" operator:
 
-            >>> from cognite.client.data_classes.filters import And
             >>> flt = ~Equals("name", "Bob")
     """
 

--- a/cognite/client/data_classes/filters.py
+++ b/cognite/client/data_classes/filters.py
@@ -332,7 +332,7 @@ class And(CompoundFilter):
             ...     Equals(my_view.as_property_ref("some_property"), 42),
             ...     In(my_view.as_property_ref("another_property"), ["a", "b", "c"]))
 
-        Usint the "&" operator:
+        Using the "&" operator:
 
             >>> from cognite.client.data_classes.filters import And
             >>> flt = Equals("age", 42) & Equals("name", "Alice")
@@ -364,7 +364,7 @@ class Or(CompoundFilter):
             ...     Equals(my_view.as_property_ref("some_property"), 42),
             ...     In(my_view.as_property_ref("another_property"), ["a", "b", "c"]))
 
-        Usint the "|" operator:
+        Using the "|" operator:
 
             >>> from cognite.client.data_classes.filters import And
             >>> flt = Equals("name", "Bob") | Equals("name", "Alice")
@@ -394,7 +394,7 @@ class Not(CompoundFilter):
             >>> is_42 = Equals(my_view.as_property_ref("some_property"), 42)
             >>> flt = Not(is_42)
 
-        Usint the "~" operator:
+        Using the "~" operator:
 
             >>> from cognite.client.data_classes.filters import And
             >>> flt = ~Equals("name", "Bob")

--- a/cognite/client/data_classes/filters.py
+++ b/cognite/client/data_classes/filters.py
@@ -202,6 +202,15 @@ class Filter(ABC):
                 output.update(filter_._involved_filter_types())
         return output
 
+    def __and__(self, other: Filter) -> And:
+        return And(self, other)
+    
+    def __or__(self, other: Filter) -> Or:
+        return Or(self, other)
+    
+    def __invert__(self) -> Not:
+        return Not(self)
+
 
 class UnknownFilter(Filter):
     def __init__(self, filter_name: str, filter_body: dict[str, Any]) -> None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "cognite-sdk"
 
-version = "7.63.8"
+version = "7.63.9"
 description = "Cognite Python SDK"
 readme = "README.md"
 documentation = "https://cognite-sdk-python.readthedocs-hosted.com"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "cognite-sdk"
 
-version = "7.63.7"
+version = "7.63.8"
 description = "Cognite Python SDK"
 readme = "README.md"
 documentation = "https://cognite-sdk-python.readthedocs-hosted.com"

--- a/tests/tests_unit/test_data_classes/test_data_models/test_filters.py
+++ b/tests/tests_unit/test_data_classes/test_data_models/test_filters.py
@@ -250,12 +250,20 @@ def dump_filter_test_data() -> Iterator[ParameterSet]:
     )
     yield pytest.param(prop_list1, expected, id="Prefix filter with list property of objects")
     yield pytest.param(prop_list2, expected, id="Prefix filter with list property of dicts")
-    overloaded_filter = f.Equals(property="name", value="bob") & f.HasData(containers=[("space", "container")]) | ~ f.Range(property="size", gt=0)
-    expected = {'or': [{'and': [{'equals': {'property': ['name'], 'value': 'bob'}},
-    {'hasData': [{'type': 'container',
-       'space': 'space',
-       'externalId': 'container'}]}]},
-  {'not': {'range': {'property': ['size'], 'gt': 0}}}]}
+    overloaded_filter = f.Equals(property="name", value="bob") & f.HasData(
+        containers=[("space", "container")]
+    ) | ~f.Range(property="size", gt=0)
+    expected = {
+        "or": [
+            {
+                "and": [
+                    {"equals": {"property": ["name"], "value": "bob"}},
+                    {"hasData": [{"type": "container", "space": "space", "externalId": "container"}]},
+                ]
+            },
+            {"not": {"range": {"property": ["size"], "gt": 0}}},
+        ]
+    }
     yield pytest.param(overloaded_filter, expected, id="Compound filter with overloaded")
 
 

--- a/tests/tests_unit/test_data_classes/test_data_models/test_filters.py
+++ b/tests/tests_unit/test_data_classes/test_data_models/test_filters.py
@@ -264,7 +264,17 @@ def dump_filter_test_data() -> Iterator[ParameterSet]:
             {"not": {"range": {"property": ["size"], "gt": 0}}},
         ]
     }
-    yield pytest.param(overloaded_filter, expected, id="Compound filter with overloaded")
+    yield pytest.param(overloaded_filter, expected, id="Compound filter with overloaded operators")
+    nested_overloaded_filter = (f.Equals("a", "b") & f.Equals("c", "d")) & (f.Equals("e", "f") & f.Equals("g", "h"))
+    expected = {
+        "and": [
+            {"equals": {"property": ["a"], "value": "b"}},
+            {"equals": {"property": ["c"], "value": "d"}},
+            {"equals": {"property": ["e"], "value": "f"}},
+            {"equals": {"property": ["g"], "value": "h"}},
+        ]
+    }
+    yield pytest.param(nested_overloaded_filter, expected, id="Compound filter with nested overloaded and")
 
 
 @pytest.mark.parametrize("user_filter, expected", list(dump_filter_test_data()))

--- a/tests/tests_unit/test_data_classes/test_data_models/test_filters.py
+++ b/tests/tests_unit/test_data_classes/test_data_models/test_filters.py
@@ -250,6 +250,13 @@ def dump_filter_test_data() -> Iterator[ParameterSet]:
     )
     yield pytest.param(prop_list1, expected, id="Prefix filter with list property of objects")
     yield pytest.param(prop_list2, expected, id="Prefix filter with list property of dicts")
+    overloaded_filter = f.Equals(property="name", value="bob") & f.HasData(containers=[("space", "container")]) | ~ f.Range(property="size", gt=0)
+    expected = {'or': [{'and': [{'equals': {'property': ['name'], 'value': 'bob'}},
+    {'hasData': [{'type': 'container',
+       'space': 'space',
+       'externalId': 'container'}]}]},
+  {'not': {'range': {'property': ['size'], 'gt': 0}}}]}
+    yield pytest.param(overloaded_filter, expected, id="Compound filter with overloaded")
 
 
 @pytest.mark.parametrize("user_filter, expected", list(dump_filter_test_data()))


### PR DESCRIPTION
## Description
Overload the boolean operators when used with filters.

## Checklist:
- [x] Tests added/updated.
- [x] Documentation updated. Documentation is generated from docstrings - these must be updated according to your change.
  If a new method has been added it should be referenced in [cognite.rst](https://github.com/cognitedata/cognite-sdk-python/blob/master/docs/source/cognite.rst) in order to generate docs based on its docstring.
- [x] Changelog updated in [CHANGELOG.md](https://github.com/cognitedata/cognite-sdk-python/blob/master/CHANGELOG.md).
- [x] Version bumped. If triggering a new release is desired, bump the version number in [_version.py](https://github.com/cognitedata/cognite-sdk-python/blob/master/cognite/client/_version.py) and [pyproject.toml](https://github.com/cognitedata/cognite-sdk-python/blob/master/pyproject.toml) per [semantic versioning](https://semver.org/).
