### PR TITLE
Fix compund filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,11 @@ Changes are grouped as follows
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
+## [7.63.10] - 2024-10-22
+### Fixed
+- The Not() filter now only accepts a single filter (and no longer silently ignores the rest).
+- The And(), Or() and Not() filter now requires at least one argument.
+
 ## [7.63.9] - 2024-10-21
 ### Added
 - Filters can now be combined using `And` and `Or` by using the operators `&` and `|`.

--- a/cognite/client/_version.py
+++ b/cognite/client/_version.py
@@ -1,4 +1,4 @@
 from __future__ import annotations
 
-__version__ = "7.63.9"
+__version__ = "7.63.10"
 __api_subversion__ = "20230101"

--- a/cognite/client/data_classes/filters.py
+++ b/cognite/client/data_classes/filters.py
@@ -273,6 +273,8 @@ class CompoundFilter(Filter, ABC):
     def __init__(self, *filters: Filter) -> None:
         if not_flt := [flt for flt in filters if not isinstance(flt, Filter)]:
             raise TypeError(f"One or more invalid filters, expected Filter, got: {not_flt}")
+        if not filters:
+            raise TypeError("At least one filter must be provided")
         self._filters = filters
 
     def _filter_body(self, camel_case_property: bool) -> list | dict:

--- a/cognite/client/data_classes/filters.py
+++ b/cognite/client/data_classes/filters.py
@@ -405,6 +405,9 @@ class Not(CompoundFilter):
 
     _filter_name = "not"
 
+    def __init__(self, filter: Filter) -> None:
+        super().__init__(filter)
+
     def _filter_body(self, camel_case_property: bool) -> dict:
         return self._filters[0].dump(camel_case_property)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "cognite-sdk"
 
-version = "7.63.9"
+version = "7.63.10"
 description = "Cognite Python SDK"
 readme = "README.md"
 documentation = "https://cognite-sdk-python.readthedocs-hosted.com"

--- a/tests/tests_unit/test_data_classes/test_data_models/test_filters.py
+++ b/tests/tests_unit/test_data_classes/test_data_models/test_filters.py
@@ -309,6 +309,17 @@ def test_not_filter_only_accepts_a_single_filter() -> None:
         f.Not(f.Exists("foo"), f.Exists("bar"))  # type: ignore [call-arg]
 
 
+@pytest.mark.parametrize("compound_flt", [f.And, f.Or, f.Not])
+def test_compound_filters_require_at_least_one_filter(compound_flt: type[f.CompoundFilter]) -> None:
+    # Bug prior to 7.63.10: CompoundFilters (and/or/not) would accept no filters given:
+    if compound_flt is f.Not:
+        err_msg = re.escape("Not.__init__() missing 1 required positional argument: 'filter'")
+    else:
+        err_msg = "^At least one filter must be provided$"
+    with pytest.raises(TypeError, match=err_msg):
+        compound_flt()
+
+
 class TestSpaceFilter:
     @pytest.mark.parametrize(
         "inst_type, space, expected",

--- a/tests/tests_unit/test_data_classes/test_data_models/test_filters.py
+++ b/tests/tests_unit/test_data_classes/test_data_models/test_filters.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import re
 from collections.abc import Iterator
 from typing import TYPE_CHECKING, Any, Literal
 
@@ -299,6 +300,13 @@ def test_user_given_metadata_keys_are_not_camel_cased(property_cls: type) -> Non
     # property may contain more (static) values, so we just verify the end:
     assert dumped["property"][-2:] == ["metadata", "key_foo_Bar_baz"]
     assert dumped["value"] == "value_foo Bar_baz"
+
+
+def test_not_filter_only_accepts_a_single_filter() -> None:
+    # Bug prior to 7.63.10: Not-filter would accept and ignore all-but-the-first filter given:
+    err_msg = re.escape("Not.__init__() takes 2 positional arguments but 3 were given")
+    with pytest.raises(TypeError, match=f"^{err_msg}$"):
+        f.Not(f.Exists("foo"), f.Exists("bar"))  # type: ignore [call-arg]
 
 
 class TestSpaceFilter:


### PR DESCRIPTION
To be merged after #1986

## [7.63.10] - 2024-10-22
### Fixed
- The Not() filter now only accepts a single filter (and no longer silently ignores the rest).
- The And(), Or() and Not() filter now requires at least one argument.

