### PR TITLE
improve convenience space filter merge logic

### DIFF
--- a/cognite/client/_api/data_modeling/instances.py
+++ b/cognite/client/_api/data_modeling/instances.py
@@ -1605,7 +1605,9 @@ class InstancesAPI(APIClient):
         space_filter = filters.SpaceFilter(space, instance_type)
         if filter is None:
             return space_filter
-        return filters.And(space_filter, Filter.load(filter) if isinstance(filter, dict) else filter)
+        filter = Filter.load(filter) if isinstance(filter, dict) else filter
+        # 'And' the space filter with the user filter (will merge if user filter is 'And')
+        return space_filter & filter
 
     @staticmethod
     def _to_instance_type_str(


### PR DESCRIPTION
With the addition of #1986, we can now way more easily combine the space filter with the user filter. This also makes it so that we don't end up with nested `And`, which is a nice bonus.