### PR TITLE
In filter with node ids

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ Changes are grouped as follows
 
 ## [7.63.10] - 2024-10-22
 ### Added
-- Data modeling: When using the `In` filter to filter on direct relations, `NodeId`s can now be used directly as values.
+- Data modeling filters now support the use of `NodeId` (and `EdgeId`) directly.
 
 ## [7.63.9] - 2024-10-21
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ Changes are grouped as follows
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
+## [7.63.10] - 2024-10-22
+### Added
+- Data modeling: When using the `In` filter to filter on direct relations, `NodeId`s can now be used directly as values.
+
 ## [7.63.9] - 2024-10-21
 ### Added
 - Filters can now be combined using `And` and `Or` by using the operators `&` and `|`.

--- a/cognite/client/_version.py
+++ b/cognite/client/_version.py
@@ -1,4 +1,4 @@
 from __future__ import annotations
 
-__version__ = "7.63.9"
+__version__ = "7.63.10"
 __api_subversion__ = "20230101"

--- a/cognite/client/data_classes/filters.py
+++ b/cognite/client/data_classes/filters.py
@@ -17,7 +17,7 @@ if TYPE_CHECKING:
 
 PropertyReference: TypeAlias = str | tuple[str, ...] | list[str] | EnumProperty
 
-RawValue: TypeAlias = str | float | bool | Sequence | Mapping[str, Any] | Label
+RawValue: TypeAlias = str | float | bool | Sequence | Mapping[str, Any] | Label | InstanceId
 
 
 @dataclass
@@ -31,7 +31,7 @@ class ParameterValue:
 
 
 FilterValue: TypeAlias = RawValue | PropertyReferenceValue | ParameterValue
-FilterValueList: TypeAlias = Sequence[RawValue | InstanceId] | PropertyReferenceValue | ParameterValue
+FilterValueList: TypeAlias = Sequence[RawValue] | PropertyReferenceValue | ParameterValue
 
 
 def _dump_filter_value(value: FilterValueList | FilterValue) -> Any:

--- a/cognite/client/data_classes/filters.py
+++ b/cognite/client/data_classes/filters.py
@@ -31,7 +31,7 @@ class ParameterValue:
 
 
 FilterValue: TypeAlias = RawValue | PropertyReferenceValue | ParameterValue
-FilterValueList: TypeAlias = Sequence[RawValue] | PropertyReferenceValue | ParameterValue | Sequence[InstanceId]
+FilterValueList: TypeAlias = Sequence[RawValue | InstanceId] | PropertyReferenceValue | ParameterValue
 
 
 def _dump_filter_value(value: FilterValueList | FilterValue) -> Any:

--- a/cognite/client/data_classes/filters.py
+++ b/cognite/client/data_classes/filters.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING, Any, Literal, NoReturn, TypeAlias, cast, final
 
 from cognite.client.data_classes._base import EnumProperty, Geometry
 from cognite.client.data_classes.labels import Label
+from cognite.client.utils._identifier import InstanceId
 from cognite.client.utils._text import convert_all_keys_to_camel_case, to_camel_case
 from cognite.client.utils.useful_types import SequenceNotStr
 
@@ -30,7 +31,7 @@ class ParameterValue:
 
 
 FilterValue: TypeAlias = RawValue | PropertyReferenceValue | ParameterValue
-FilterValueList: TypeAlias = Sequence[RawValue] | PropertyReferenceValue | ParameterValue
+FilterValueList: TypeAlias = Sequence[RawValue] | PropertyReferenceValue | ParameterValue | Sequence[InstanceId]
 
 
 def _dump_filter_value(value: FilterValueList | FilterValue) -> Any:
@@ -41,6 +42,9 @@ def _dump_filter_value(value: FilterValueList | FilterValue) -> Any:
 
     elif isinstance(value, ParameterValue):
         return {"parameter": value.parameter}
+
+    elif isinstance(value, InstanceId):
+        return value.dump(include_instance_type=False)
 
     elif hasattr(value, "dump"):
         return value.dump()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "cognite-sdk"
 
-version = "7.63.9"
+version = "7.63.10"
 description = "Cognite Python SDK"
 readme = "README.md"
 documentation = "https://cognite-sdk-python.readthedocs-hosted.com"

--- a/tests/tests_unit/test_data_classes/test_data_models/test_filters.py
+++ b/tests/tests_unit/test_data_classes/test_data_models/test_filters.py
@@ -8,7 +8,7 @@ from _pytest.mark import ParameterSet
 
 import cognite.client.data_classes.filters as f
 from cognite.client.data_classes._base import EnumProperty
-from cognite.client.data_classes.data_modeling import ViewId
+from cognite.client.data_classes.data_modeling import NodeId, ViewId
 from cognite.client.data_classes.data_modeling.data_types import DirectRelationReference
 from cognite.client.data_classes.filters import Filter, UnknownFilter
 from tests.utils import all_subclasses
@@ -275,6 +275,19 @@ def dump_filter_test_data() -> Iterator[ParameterSet]:
         ]
     }
     yield pytest.param(nested_overloaded_filter, expected, id="Compound filter with nested overloaded and")
+    in_filter_with_node_id = f.In("name", [NodeId(space="space", external_id="ex_id")])
+    expected = {
+        "in": {
+            "property": ["name"],
+            "values": [
+                {
+                    "externalId": "ex_id",
+                    "space": "space",
+                },
+            ],
+        },
+    }
+    yield pytest.param(in_filter_with_node_id, expected, id="In filter with node ID")
 
 
 @pytest.mark.parametrize("user_filter, expected", list(dump_filter_test_data()))


### PR DESCRIPTION
## Description
If you pass a list of NodeIds as values to the In filter and use this to filter instances in a data model, you get the following error:
`Invalid value for direct relation property 'property'. The value must be a json object with space and externalId fields. |  code: 400`
The same happens if you try to use the `dump` method on the NodeIds. You have to relalize that `include_instance_type` has to be set to False, which is not obvious by reading the error message.

## Checklist:
- [x] Tests added/updated.
- [ ] Documentation updated. Documentation is generated from docstrings - these must be updated according to your change.
  If a new method has been added it should be referenced in [cognite.rst](https://github.com/cognitedata/cognite-sdk-python/blob/master/docs/source/cognite.rst) in order to generate docs based on its docstring.
- [x] Changelog updated in [CHANGELOG.md](https://github.com/cognitedata/cognite-sdk-python/blob/master/CHANGELOG.md).
- [x] Version bumped. If triggering a new release is desired, bump the version number in [_version.py](https://github.com/cognitedata/cognite-sdk-python/blob/master/cognite/client/_version.py) and [pyproject.toml](https://github.com/cognitedata/cognite-sdk-python/blob/master/pyproject.toml) per [semantic versioning](https://semver.org/).
