### PR TITLE
feature: iterate datapoints using `DatapointsAPI.__call__`

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,5 +1,7 @@
 [run]
 source=cognite
+omit =
+    cognite/client/_proto/*
 
 [report]
 exclude_lines =

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ Changes are grouped as follows
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
+## [7.65.0] - 2024-11-08
+### Added
+- DatapointsAPI now support iteration like most other APIs: `for dps in client.time_series.data(...)`.
+
 ## [7.64.13] - 2024-11-12
 ### Added
 - Added new `SAPWriteback` and `SAPWritebackRequests` capabilities.
@@ -24,7 +28,7 @@ Changes are grouped as follows
 ## [7.64.12] - 2024-11-11
 ### Fixed
 - `FunctionSchedulesAPI.__call__()` calls `FunctionSchedulesAPI.list()` instead of `APIClient._list_generator()`.
-  (The latter relied on pagination, which was not implemented by `/schedules/list`). 
+  (The latter relied on pagination, which was not implemented by `/schedules/list`).
 
 ## [7.64.11] - 2024-11-10
 ### Added
@@ -44,7 +48,8 @@ Changes are grouped as follows
 
 ## [7.64.7] - 2024-11-04
 ### Fixed
-- Set batch size to 10 for `create` and `update` of hosted extractor jobs, destinations, sources and mappings to avoid hitting the API limits.
+- Set batch size to 10 for `create` and `update` of hosted extractor jobs, destinations, sources and mappings
+  to avoid hitting the API limits.
 
 ## [7.64.6] - 2024-10-22
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,9 +17,11 @@ Changes are grouped as follows
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
-## [7.65.0] - 2024-11-08
+## [7.65.0] - 2024-11-12
 ### Added
 - DatapointsAPI now support iteration like most other APIs: `for dps in client.time_series.data(...)`.
+  You may control memory usage by specifying how many time series to fetch in parallel with the
+  `chunk_size_time_series` parameter, and datapoints with `chunk_size_datapoints`.
 
 ## [7.64.13] - 2024-11-12
 ### Added

--- a/cognite/client/_api/datapoint_tasks.py
+++ b/cognite/client/_api/datapoint_tasks.py
@@ -38,7 +38,7 @@ from cognite.client.data_classes.datapoints import (
     DatapointsQuery,
     _DatapointsPayloadItem,
 )
-from cognite.client.utils._auxiliary import exactly_one_is_not_none, is_unlimited
+from cognite.client.utils._auxiliary import exactly_one_is_not_none, is_finite, is_unlimited
 from cognite.client.utils._text import convert_all_keys_to_snake_case, to_snake_case
 from cognite.client.utils._time import (
     ZoneInfo,
@@ -290,7 +290,7 @@ class _DpsQueryValidator:
     def _verify_and_convert_limit(limit: int | None) -> int | None:
         if is_unlimited(limit):
             return None
-        elif isinstance(limit, int) and limit >= 0:  # limit=0 is accepted by the API
+        elif is_finite(limit):  # limit=0 is accepted by the API
             try:
                 # We don't want weird stuff like numpy dtypes etc:
                 return int(limit)

--- a/cognite/client/_api/datapoint_tasks.py
+++ b/cognite/client/_api/datapoint_tasks.py
@@ -6,7 +6,7 @@ import operator as op
 import warnings
 from abc import ABC, abstractmethod
 from collections import defaultdict
-from collections.abc import Callable, Iterator, Sequence
+from collections.abc import Callable, Iterable, Iterator, Sequence
 from dataclasses import dataclass
 from functools import cached_property
 from itertools import chain, pairwise
@@ -200,7 +200,7 @@ class _DpsQueryValidator:
     dps_limit_raw: int
     dps_limit_agg: int
 
-    def __call__(self, queries: list[DatapointsQuery]) -> list[DatapointsQuery]:
+    def __call__(self, queries: Iterable[DatapointsQuery]) -> Iterable[DatapointsQuery]:
         # We want all start/end = "now" (and those using the same relative time specifiers, like "4d-ago")
         # queries to get the same time domain to fetch. This also -guarantees- that we correctly raise
         # exception 'end not after start' if both are set to the same value.

--- a/cognite/client/_api/datapoints.py
+++ b/cognite/client/_api/datapoints.py
@@ -727,13 +727,13 @@ class DatapointsAPI(APIClient):
                 break
 
             if chunk_size_datapoints == request_limit:
-                yield dps_lst[0] if is_single else dps_lst  # type: ignore [return-value]
+                yield dps_lst[0] if is_single else dps_lst
             elif is_single:
                 yield from chunk_fn(dps_lst[0])  # type: ignore [misc]
             else:
                 for all_chunks in itertools.zip_longest(*map(chunk_fn, dps_lst)):
                     # Filter out dps as ts get exhausted, then rebuild the Dps(Array)List container and yield chunk:
-                    yield dps_lst_cls(list(filter(None, all_chunks)), cognite_client=self._cognite_client)  # type: ignore [return-value]
+                    yield dps_lst_cls(list(filter(None, all_chunks)), cognite_client=self._cognite_client)
 
     def retrieve(
         self,

--- a/cognite/client/_api/datapoints.py
+++ b/cognite/client/_api/datapoints.py
@@ -590,7 +590,7 @@ class DatapointsAPI(APIClient):
                 >>> from cognite.client.data_classes import DatapointsQuery
                 >>> client = CogniteClient()
                 >>> query = DatapointsQuery(external_id="foo", start="2w-ago")
-                >>> for chunk in client.time_series.data(query, chunk_size=25_000):
+                >>> for chunk in client.time_series.data(query, chunk_size_datapoints=25_000):
                 ...     pass  # do something with the datapoints chunk
 
             Iterate through datapoints from multiple time series, and do not return them as numpy arrays. As one or more time
@@ -606,8 +606,8 @@ class DatapointsAPI(APIClient):
                 ...     DatapointsQuery(instance_id=NodeId("my-space", "my-ts-xid"))
                 ... ]
                 >>> for chunk_lst in client.time_series.data(query, return_arrays=False):
-                ...     if chunk_lst.get(id=2) is None:
-                ...         print("Time series with id=2 has no more datapoints!")
+                ...     if chunk_lst.get(id=123) is None:
+                ...         print("Time series with id=123 has no more datapoints!")
 
             A likely use case for iterating datapoints is to clone data from one project to another, while keeping a low memory
             footprint and without having to write very custom logic involving count aggregates (which won't work for string data)
@@ -712,7 +712,7 @@ class DatapointsAPI(APIClient):
                 dps = dps_lst.get(**ident.as_dict(camel_case=False))
                 if isinstance(dps, list):
                     raise RuntimeError(
-                        "When iterating datapoints, identifiers must be unique! You can not get around this by passing "
+                        "When iterating datapoints, identifiers must be unique! You cannot get around this by passing "
                         "several of [id, external_id, instance_id] for the same underlying time series."
                     )
                 # Update query.start for next iteration if ts is not yet exhausted:

--- a/cognite/client/_api/datapoints.py
+++ b/cognite/client/_api/datapoints.py
@@ -20,6 +20,7 @@ from typing import (
     TypeGuard,
     TypeVar,
     cast,
+    overload,
 )
 
 from typing_extensions import Self
@@ -27,6 +28,7 @@ from typing_extensions import Self
 from cognite.client._api.datapoint_tasks import (
     BaseDpsFetchSubtask,
     BaseTaskOrchestrator,
+    _DpsQueryValidator,
     _FullDatapointsQuery,
 )
 from cognite.client._api.synthetic_time_series import SyntheticDatapointsAPI
@@ -47,6 +49,7 @@ from cognite.client.utils import _json
 from cognite.client.utils._auxiliary import (
     exactly_one_is_not_none,
     find_duplicates,
+    is_finite,
     split_into_chunks,
     split_into_n_parts,
     unpack_items_in_payload,
@@ -77,49 +80,26 @@ if TYPE_CHECKING:
 
 as_completed = import_as_completed()
 
-_TSQueryList = list[DatapointsQuery]
 PoolSubtaskType = tuple[float, int, BaseDpsFetchSubtask]
 
 _T = TypeVar("_T")
 _TResLst = TypeVar("_TResLst", DatapointsList, DatapointsArrayList)
 
 
-def select_dps_fetch_strategy(dps_client: DatapointsAPI, full_query: _FullDatapointsQuery) -> DpsFetchStrategy:
-    all_queries = full_query.parse_into_queries()
-    full_query.validate(all_queries, dps_limit_raw=dps_client._DPS_LIMIT_RAW, dps_limit_agg=dps_client._DPS_LIMIT_AGG)
-    agg_queries, raw_queries = split_queries_into_raw_and_aggs(all_queries)
-
-    # Running mode is decided based on how many time series are requested VS. number of workers:
-    if len(all_queries) <= (max_workers := dps_client._config.max_workers):
-        # Start shooting requests from the hip immediately:
-        return EagerDpsFetcher(dps_client, all_queries, agg_queries, raw_queries, max_workers)
-    # Fetch a smaller, chunked batch of dps from all time series - which allows us to do some rudimentary
-    # guesstimation of dps density - then chunk away:
-    return ChunkingDpsFetcher(dps_client, all_queries, agg_queries, raw_queries, max_workers)
-
-
-def split_queries_into_raw_and_aggs(all_queries: _TSQueryList) -> tuple[_TSQueryList, _TSQueryList]:
-    split_qs: tuple[_TSQueryList, _TSQueryList] = [], []
-    for query in all_queries:
-        split_qs[query.is_raw_query].append(query)
-    return split_qs
-
-
 class DpsFetchStrategy(ABC):
-    def __init__(
-        self,
-        dps_client: DatapointsAPI,
-        all_queries: _TSQueryList,
-        agg_queries: _TSQueryList,
-        raw_queries: _TSQueryList,
-        max_workers: int,
-    ) -> None:
+    def __init__(self, dps_client: DatapointsAPI, all_queries: list[DatapointsQuery], max_workers: int) -> None:
         self.dps_client = dps_client
         self.all_queries = all_queries
-        self.agg_queries = agg_queries
-        self.raw_queries = raw_queries
+        self.agg_queries, self.raw_queries = self.split_queries(all_queries)
         self.max_workers = max_workers
         self.n_queries = len(all_queries)
+
+    @staticmethod
+    def split_queries(all_queries: list[DatapointsQuery]) -> tuple[list[DatapointsQuery], list[DatapointsQuery]]:
+        split_qs: tuple[list[DatapointsQuery], list[DatapointsQuery]] = [], []
+        for query in all_queries:
+            split_qs[query.is_raw_query].append(query)
+        return split_qs
 
     def fetch_all_datapoints(self) -> DatapointsList:
         pool = ConcurrencySettings.get_executor(max_workers=self.max_workers)
@@ -324,9 +304,9 @@ class ChunkingDpsFetcher(DpsFetchStrategy):
 
     def _create_initial_tasks(
         self, pool: ThreadPoolExecutor
-    ) -> tuple[dict[DatapointsQuery, int], dict[Future, tuple[_TSQueryList, _TSQueryList]]]:
+    ) -> tuple[dict[DatapointsQuery, int], dict[Future, tuple[list[DatapointsQuery], list[DatapointsQuery]]]]:
         initial_query_limits: dict[DatapointsQuery, int] = {}
-        initial_futures_dct: dict[Future, tuple[_TSQueryList, _TSQueryList]] = {}
+        initial_futures_dct: dict[Future, tuple[list[DatapointsQuery], list[DatapointsQuery]]] = {}
         # Optimal queries uses the entire worker pool. We may be forced to use more (queue) when we
         # can't fit all individual time series (maxes out at `_FETCH_TS_LIMIT * max_workers`):
         n_queries = max(self.max_workers, math.ceil(self.n_queries / self.dps_client._FETCH_TS_LIMIT))
@@ -351,7 +331,7 @@ class ChunkingDpsFetcher(DpsFetchStrategy):
     def _create_ts_tasks_and_handle_missing(
         self,
         res: Sequence[DataPointListItem],
-        chunk_queues: tuple[_TSQueryList, _TSQueryList],
+        chunk_queues: tuple[list[DatapointsQuery], list[DatapointsQuery]],
         initial_query_limits: dict[DatapointsQuery, int],
         use_numpy: bool,
     ) -> tuple[dict[DatapointsQuery, BaseTaskOrchestrator], set[DatapointsQuery]]:
@@ -489,9 +469,9 @@ class ChunkingDpsFetcher(DpsFetchStrategy):
     @staticmethod
     def _handle_missing_ts(
         res: Sequence[DataPointListItem],
-        agg_queries: _TSQueryList,
-        raw_queries: _TSQueryList,
-    ) -> tuple[tuple[_TSQueryList, _TSQueryList], set[DatapointsQuery]]:
+        agg_queries: list[DatapointsQuery],
+        raw_queries: list[DatapointsQuery],
+    ) -> tuple[tuple[list[DatapointsQuery], list[DatapointsQuery]], set[DatapointsQuery]]:
         to_raise = set()
         not_missing = {("id", r.id) for r in res}.union(("externalId", r.externalId) for r in res)
         for query in chain(agg_queries, raw_queries):
@@ -516,6 +496,244 @@ class DatapointsAPI(APIClient):
         self._DPS_INSERT_LIMIT = 100_000
         self._RETRIEVE_LATEST_LIMIT = 100
         self._POST_DPS_OBJECTS_LIMIT = 10_000
+
+        self.query_validator = _DpsQueryValidator(dps_limit_raw=self._DPS_LIMIT_RAW, dps_limit_agg=self._DPS_LIMIT_AGG)
+
+    @overload
+    def __call__(
+        self,
+        queries: DatapointsQuery,
+        *,
+        return_arrays: Literal[True],
+    ) -> Iterator[DatapointsArray]: ...
+
+    @overload
+    def __call__(
+        self,
+        queries: Sequence[DatapointsQuery],
+        *,
+        return_arrays: Literal[True],
+    ) -> Iterator[DatapointsArrayList]: ...
+
+    @overload
+    def __call__(
+        self,
+        queries: DatapointsQuery,
+        *,
+        return_arrays: Literal[False],
+    ) -> Iterator[Datapoints]: ...
+
+    @overload
+    def __call__(
+        self,
+        queries: Sequence[DatapointsQuery],
+        *,
+        return_arrays: Literal[False],
+    ) -> Iterator[DatapointsList]: ...
+
+    def __call__(
+        self,
+        queries: DatapointsQuery | Sequence[DatapointsQuery],
+        *,
+        start: int | str | datetime.datetime | None = None,
+        end: int | str | datetime.datetime | None = None,
+        aggregates: Aggregate | str | list[Aggregate | str] | None = None,
+        granularity: str | None = None,
+        timezone: str | datetime.timezone | ZoneInfo | None = None,
+        target_unit: str | None = None,
+        target_unit_system: str | None = None,
+        ignore_unknown_ids: bool = False,
+        include_status: bool = False,
+        ignore_bad_datapoints: bool = True,
+        treat_uncertain_as_bad: bool = True,
+        chunk_size_datapoints: int = 100_000,
+        chunk_size_time_series: int | None = None,
+        return_arrays: bool = True,
+    ) -> Iterator[DatapointsArray | DatapointsArrayList | Datapoints | DatapointsList]:
+        """`Iterate through datapoints in chunks, for one or more time series. <https://developer.cognite.com/api#tag/Time-series/operation/getMultiTimeSeriesDatapoints>`_
+
+        Note:
+            Control memory usage by specifying ``chunk_size_time_series``, how many time series to iterate simultaneously and ``chunk_size_datapoints``,
+            how many datapoints to yield per iteration. Note that in order to make efficient use of the API request limits, this method will never hold
+            less than 100k datapoints in memory at a time, per time series.
+
+            If you run with memory constraints, use ``return_arrays=True`` (the default).
+
+            No empty chunk will ever be returned.
+
+        Args:
+            queries (DatapointsQuery | Sequence[DatapointsQuery]): Query, or queries, using id, external_id or instance_id for time series to fetch data for. Individual settings in the DatapointsQuery take precedence over top-level settings. The options 'limit' and 'include_outside_points' are not supported.
+            start (int | str | datetime.datetime | None): Inclusive start. Default: 1970-01-01 UTC.
+            end (int | str | datetime.datetime | None): Exclusive end. Default: "now"
+            aggregates (Aggregate | str | list[Aggregate | str] | None): Single aggregate or list of aggregates to retrieve. Available options: ``average``, ``continuous_variance``, ``count``, ``count_bad``, ``count_good``, ``count_uncertain``, ``discrete_variance``, ``duration_bad``, ``duration_good``, ``duration_uncertain``, ``interpolation``, ``max``, ``min``, ``step_interpolation``, ``sum`` and ``total_variation``. Default: None (raw datapoints returned)
+            granularity (str | None): The granularity to fetch aggregates at. Can be given as an abbreviation or spelled out for clarity: ``s/second(s)``, ``m/minute(s)``, ``h/hour(s)``, ``d/day(s)``, ``w/week(s)``, ``mo/month(s)``, ``q/quarter(s)``, or ``y/year(s)``. Examples: ``30s``, ``5m``, ``1day``, ``2weeks``. Default: None.
+            timezone (str | datetime.timezone | ZoneInfo | None): For raw datapoints, which timezone to use when displaying (will not affect what is retrieved). For aggregates, which timezone to align to for granularity 'hour' and longer. Align to the start of the hour, day or month. For timezones of type Region/Location, like 'Europe/Oslo', pass a string or ``ZoneInfo`` instance. The aggregate duration will then vary, typically due to daylight saving time. You can also use a fixed offset from UTC by passing a string like '+04:00', 'UTC-7' or 'UTC-02:30' or an instance of ``datetime.timezone``. Note: Historical timezones with second offset are not supported, and timezones with minute offsets (e.g. UTC+05:30 or Asia/Kolkata) may take longer to execute.
+            target_unit (str | None): The unit_external_id of the datapoints returned. If the time series does not have a unit_external_id that can be converted to the target_unit, an error will be returned. Cannot be used with target_unit_system.
+            target_unit_system (str | None): The unit system of the datapoints returned. Cannot be used with target_unit.
+            ignore_unknown_ids (bool): Whether to ignore missing time series rather than raising an exception. Default: False
+            include_status (bool): Also return the status code, an integer, for each datapoint in the response. Only relevant for raw datapoint queries, not aggregates.
+            ignore_bad_datapoints (bool): Treat datapoints with a bad status code as if they do not exist. If set to false, raw queries will include bad datapoints in the response, and aggregates will in general omit the time period between a bad datapoint and the next good datapoint. Also, the period between a bad datapoint and the previous good datapoint will be considered constant. Default: True.
+            treat_uncertain_as_bad (bool): Treat datapoints with uncertain status codes as bad. If false, treat datapoints with uncertain status codes as good. Used for both raw queries and aggregates. Default: True.
+            chunk_size_datapoints (int): The number of datapoints per time series to yield per iteration. Must evenly divide 100k OR be an integer multiple of 100k. Default: 100_000.
+            chunk_size_time_series (int | None): The max number of time series to yield per iteration (varies as time series get exhausted, but is always at least 1). Default: None (all given queries are returned).
+            return_arrays (bool): Whether to return the datapoints as numpy arrays. Default: True.
+
+        Yields:
+            DatapointsArray | DatapointsArrayList | Datapoints | DatapointsList: If return_arrays=True, a ``DatapointsArray`` object containing the datapoints chunk, or a ``DatapointsArrayList`` if multiple time series were asked for. When False, a ``Datapoints`` object containing the datapoints chunk, or a ``DatapointsList`` if multiple time series were asked for. If `ignore_unknown_ids` is `True`, a single time series is requested and it is not found, iteration will quit.
+
+        Examples:
+
+            BACKUP: DatapointsArray | DatapointsArrayList | Datapoints | DatapointsList:
+            Iterate through the datapoints of a single time series with external_id="foo", in chunks of 25k:
+
+                >>> from cognite.client import CogniteClient
+                >>> from cognite.client.data_classes import DatapointsQuery
+                >>> client = CogniteClient()
+                >>> query = DatapointsQuery(external_id="foo", start="2w-ago")
+                >>> for chunk in client.time_series.data(query, chunk_size=25_000)
+                ...     pass  # do something with the datapoints chunk
+
+            Iterate through datapoints from multiple time series, and do not return them as numpy arrays. As one or more time
+            series get exhausted (no more data), they are no longer part of the returned "chunk list", but the order is
+            still preserved (for the remaining).
+
+            If you run with ``chunk_size_time_series=None``, an easy way to check is to use the ``.get`` method, as illustrated below:
+
+                >>> from cognite.client.data_classes.data_modeling import NodeId
+                >>> queries = [
+                ...     DatapointsQuery(id=123),
+                ...     DatapointsQuery(external_id="foo"),
+                ...     DatapointsQuery(instance_id=NodeId("my-space", "my-ts-xid"))
+                ... ]
+                >>> for chunk_lst in client.time_series.data(query, return_arrays=False):
+                ...     if chunk_lst.get(id=2) is None:
+                ...         print("Time series with id=2 has no more datapoints!")
+
+            A likely use case for iterating datapoints is to clone data from one project to another, while keeping a low memory
+            footprint and without having to write very custom logic involving count aggregates (which won't work for string data)
+            and time domain splitting.
+
+            Here's an example of how to do so efficiently, while not ignoring bad and uncertain data (``ignore_bad_datapoints=False``)
+            and copying status codes (automatically taken care of when requested, ``include_status=True``). The only assumption is that
+            the time series are already created in the target project.
+
+                >>> from cognite.client.utils import MIN_TIMESTAMP_MS, MAX_TIMESTAMP_MS
+                >>> target_client = CogniteClient(...)
+                >>> to_copy = client.time_series.list(data_set_external_ids="my-use-case")
+                >>> queries = [DatapointsQuery(external_id=ts.external_id) for ts in to_copy]
+                >>> for dps_chunk in client.time_series.data(
+                ...     queries,  # may be several thousand time series...
+                ...     chunk_size_time_series=20,  # control memory usage by specifying how many to iterate at a time
+                ...     chunk_size_datapoints=100_000,
+                ...     include_status=True,
+                ...     ignore_bad_datapoints=False,
+                ...     start=MIN_TIMESTAMP_MS,
+                ...     end=MAX_TIMESTAMP_MS + 1,  # end is exclusive
+                ... ):
+                ...     target_client.time_series.data.insert_multiple(
+                ...         [{"external_id": dps.external_id, "datapoints": dps} for dps in dps_chunk]
+                ...     )
+
+        """
+        # To make efficient usage of the API, we don't want a chunk size like 10 to send a million API requests when we can
+        # get 10k/100k datapoints per request. Thus, we round up the given chunk size to the nearest integer multiple of 100k,
+        # then subdivide and yield client-side (we use the raw limit also when dealing with aggregates):
+        request_limit = self._DPS_LIMIT_RAW * math.ceil(chunk_size_datapoints / self._DPS_LIMIT_RAW)
+        if (
+            not is_finite(chunk_size_datapoints)
+            or chunk_size_datapoints != request_limit
+            and request_limit % chunk_size_datapoints
+        ):
+            raise ValueError(
+                "The 'chunk_size_datapoints' must be a positive integer that evenly divides 100k OR an integer multiple of 100k "
+                f"(to ensure efficient API usage), not {chunk_size_datapoints}."
+            )
+        chunk_fn = functools.partial(split_into_chunks, chunk_size=chunk_size_datapoints)
+
+        if not (chunk_size_time_series is None or is_finite(chunk_size_time_series)):
+            raise ValueError(
+                f"'chunk_size_time_series' must be a positive integer or None, not {chunk_size_time_series}"
+            )
+
+        user_queries = [queries] if (is_single := isinstance(queries, DatapointsQuery)) else queries
+        dps_lst_cls: type[DatapointsArrayList | DatapointsList] = (
+            DatapointsArrayList if return_arrays else DatapointsList
+        )
+
+        # Note: Next major we should remove id/xid/instance_id from the other retrieve methods and just accept queries:
+        qs_per_id_type = defaultdict(list)
+        for q in user_queries:
+            qs_per_id_type[q.identifier.name()].append(q)
+
+            if q.include_outside_points is True or q.limit is not DatapointsQuery._NOT_SET:
+                raise ValueError(
+                    "When iterating datapoints, the options 'include_outside_points' and 'limit' are not supported."
+                )
+
+        for ident_type, queries in qs_per_id_type.items():
+            if dupes := find_duplicates(q.identifier.as_primitive() for q in queries):
+                raise ValueError(
+                    f"When iterating datapoints, identifiers must be unique! Duplicates found for {ident_type}: {dupes}"
+                )
+        original_order = [q.identifier for q in user_queries]
+
+        parsed_queries = _FullDatapointsQuery(
+            start=start,
+            end=end,
+            id=qs_per_id_type["id"],
+            external_id=qs_per_id_type["external_id"],
+            instance_id=qs_per_id_type["instance_id"],
+            aggregates=aggregates,
+            granularity=granularity,
+            timezone=timezone,
+            target_unit=target_unit,
+            target_unit_system=target_unit_system,
+            limit=request_limit,
+            include_outside_points=False,
+            ignore_unknown_ids=ignore_unknown_ids,
+            include_status=include_status,
+            ignore_bad_datapoints=ignore_bad_datapoints,
+            treat_uncertain_as_bad=treat_uncertain_as_bad,
+        ).parse_into_queries()
+        self.query_validator(parsed_queries)
+        alive_queries = {q.identifier: q for q in parsed_queries}
+        alive_queries = {ident: alive_queries[ident] for ident in original_order}  # ..and sort
+
+        while alive_queries:
+            to_fetch_queries = list(itertools.islice(alive_queries.values(), chunk_size_time_series))
+            fetcher = self._select_dps_fetch_strategy(to_fetch_queries)(
+                self, to_fetch_queries, self._config.max_workers
+            )
+            dps_lst: DatapointsArrayList | DatapointsList = (
+                fetcher.fetch_all_datapoints_numpy() if return_arrays else fetcher.fetch_all_datapoints()
+            )
+            for query in to_fetch_queries:
+                ident = query.identifier
+                dps = dps_lst.get(**ident.as_dict(camel_case=False))
+                # Update query.start for next iteration if ts is not yet exhausted:
+                if dps and len(dps) == request_limit:
+                    new_start = cast(int, dps[-1].timestamp) + 1
+                    if query.end_ms > new_start:
+                        query.start = new_start  # manual cursoring ftw
+                        continue
+                alive_queries.pop(ident)
+
+            # We should never yield an empty chunk, so we filter out empty or exhausted time series from result
+            # (need to rebuild to not keep references to those empty in various private "id lookups")
+            dps_lst = dps_lst_cls(list(filter(None, dps_lst)), cognite_client=self._cognite_client)
+            if not any(dps_lst):
+                if alive_queries:
+                    continue
+                break
+
+            if chunk_size_datapoints == request_limit:
+                yield dps_lst[0] if is_single else dps_lst  # type: ignore [return-value]
+            elif is_single:
+                yield from chunk_fn(dps_lst[0])  # type: ignore [misc]
+            else:
+                for all_chunks in itertools.zip_longest(*map(chunk_fn, dps_lst)):
+                    # Filter out dps as ts get exhausted, then rebuild the Dps(Array)List container and yield chunk:
+                    yield dps_lst_cls(list(filter(None, all_chunks)), cognite_client=self._cognite_client)  # type: ignore [return-value]
 
     def retrieve(
         self,
@@ -744,8 +962,10 @@ class DatapointsAPI(APIClient):
             ignore_bad_datapoints=ignore_bad_datapoints,
             treat_uncertain_as_bad=treat_uncertain_as_bad,
         )
-        fetcher = select_dps_fetch_strategy(self, full_query=query)
-        dps_lst = fetcher.fetch_all_datapoints()
+        self.query_validator(parsed_queries := query.parse_into_queries())
+        dps_lst = self._select_dps_fetch_strategy(parsed_queries)(
+            self, parsed_queries, self._config.max_workers
+        ).fetch_all_datapoints()
 
         if not query.is_single_identifier:
             return dps_lst
@@ -872,9 +1092,11 @@ class DatapointsAPI(APIClient):
             ignore_bad_datapoints=ignore_bad_datapoints,
             treat_uncertain_as_bad=treat_uncertain_as_bad,
         )
-        fetcher = select_dps_fetch_strategy(self, full_query=query)
+        self.query_validator(parsed_queries := query.parse_into_queries())
+        dps_lst = self._select_dps_fetch_strategy(parsed_queries)(
+            self, parsed_queries, self._config.max_workers
+        ).fetch_all_datapoints_numpy()
 
-        dps_lst = fetcher.fetch_all_datapoints_numpy()
         if not query.is_single_identifier:
             return dps_lst
         elif not dps_lst:
@@ -1008,7 +1230,8 @@ class DatapointsAPI(APIClient):
             ignore_bad_datapoints=ignore_bad_datapoints,
             treat_uncertain_as_bad=treat_uncertain_as_bad,
         )
-        fetcher = select_dps_fetch_strategy(self, full_query=query)
+        self.query_validator(parsed_queries := query.parse_into_queries())
+        fetcher = self._select_dps_fetch_strategy(parsed_queries)(self, parsed_queries, self._config.max_workers)
 
         if not uniform_index:
             return fetcher.fetch_all_datapoints_numpy().to_pandas(
@@ -1544,6 +1767,15 @@ class DatapointsAPI(APIClient):
             else:
                 dps.append({"datapoints": datapoints, "id": int(column_id)})
         self.insert_multiple(dps)
+
+    def _select_dps_fetch_strategy(self, queries: list[DatapointsQuery]) -> type[DpsFetchStrategy]:
+        # Running mode is decided based on how many time series are requested VS. number of workers:
+        if len(queries) <= self._config.max_workers:
+            # Start shooting requests from the hip immediately:
+            return EagerDpsFetcher
+        # Fetch a smaller, chunked batch of dps from all time series - which allows us to do some rudimentary
+        # guesstimation of dps density - then chunk away:
+        return ChunkingDpsFetcher
 
 
 class _InsertDatapoint(NamedTuple):

--- a/cognite/client/_api/datapoints.py
+++ b/cognite/client/_api/datapoints.py
@@ -583,7 +583,6 @@ class DatapointsAPI(APIClient):
 
         Examples:
 
-            BACKUP: DatapointsArray | DatapointsArrayList | Datapoints | DatapointsList:
             Iterate through the datapoints of a single time series with external_id="foo", in chunks of 25k:
 
                 >>> from cognite.client import CogniteClient

--- a/cognite/client/_api/datapoints.py
+++ b/cognite/client/_api/datapoints.py
@@ -590,7 +590,7 @@ class DatapointsAPI(APIClient):
                 >>> from cognite.client.data_classes import DatapointsQuery
                 >>> client = CogniteClient()
                 >>> query = DatapointsQuery(external_id="foo", start="2w-ago")
-                >>> for chunk in client.time_series.data(query, chunk_size=25_000)
+                >>> for chunk in client.time_series.data(query, chunk_size=25_000):
                 ...     pass  # do something with the datapoints chunk
 
             Iterate through datapoints from multiple time series, and do not return them as numpy arrays. As one or more time
@@ -618,7 +618,7 @@ class DatapointsAPI(APIClient):
             the time series are already created in the target project.
 
                 >>> from cognite.client.utils import MIN_TIMESTAMP_MS, MAX_TIMESTAMP_MS
-                >>> target_client = CogniteClient(...)
+                >>> target_client = CogniteClient()
                 >>> to_copy = client.time_series.list(data_set_external_ids="my-use-case")
                 >>> queries = [DatapointsQuery(external_id=ts.external_id) for ts in to_copy]
                 >>> for dps_chunk in client.time_series.data(

--- a/cognite/client/_version.py
+++ b/cognite/client/_version.py
@@ -1,4 +1,4 @@
 from __future__ import annotations
 
-__version__ = "7.64.13"
+__version__ = "7.65.0"
 __api_subversion__ = "20230101"

--- a/cognite/client/data_classes/_base.py
+++ b/cognite/client/data_classes/_base.py
@@ -26,7 +26,7 @@ from typing_extensions import Self
 from cognite.client.exceptions import CogniteMissingClientError
 from cognite.client.utils import _json
 from cognite.client.utils._auxiliary import fast_dict_load, load_resource_to_dict, load_yaml_or_json
-from cognite.client.utils._identifier import IdentifierSequence
+from cognite.client.utils._identifier import IdentifierSequence, InstanceId
 from cognite.client.utils._importing import local_import
 from cognite.client.utils._pandas_helpers import (
     convert_nullable_int_cols,
@@ -264,13 +264,15 @@ class CogniteResourceList(UserList, Generic[T_CogniteResource], _WithClientMixin
         self._build_id_mappings()
 
     def _build_id_mappings(self) -> None:
-        self._id_to_item, self._external_id_to_item = {}, {}
+        self._id_to_item, self._external_id_to_item, self._instance_id_to_item = {}, {}, {}
         if not self.data:
             return
         if hasattr(self.data[0], "external_id"):
             self._external_id_to_item = {item.external_id: item for item in self.data if item.external_id is not None}
         if hasattr(self.data[0], "id"):
             self._id_to_item = {item.id: item for item in self.data if item.id is not None}
+        if hasattr(self.data[0], "instance_id"):
+            self._instance_id_to_item = {item.instance_id: item for item in self.data if item.instance_id is not None}
 
     def pop(self, i: int = -1) -> T_CogniteResource:
         return super().pop(i)
@@ -303,6 +305,7 @@ class CogniteResourceList(UserList, Generic[T_CogniteResource], _WithClientMixin
             super().extend(other)
             self._external_id_to_item.update(other_res_list._external_id_to_item)
             self._id_to_item.update(other_res_list._id_to_item)
+            self._instance_id_to_item.update(other_res_list._instance_id_to_item)
         else:
             raise ValueError("Unable to extend as this would introduce duplicates")
 
@@ -326,20 +329,28 @@ class CogniteResourceList(UserList, Generic[T_CogniteResource], _WithClientMixin
         yaml = local_import("yaml")
         return yaml.safe_dump(self.dump(camel_case=True), sort_keys=False)
 
-    def get(self, id: int | None = None, external_id: str | None = None) -> T_CogniteResource | None:
-        """Get an item from this list by id or external_id.
+    def get(
+        self,
+        id: int | None = None,
+        external_id: str | None = None,
+        instance_id: InstanceId | tuple[str, str] | None = None,
+    ) -> T_CogniteResource | None:
+        """Get an item from this list by id, external_id or instance_id.
 
         Args:
             id (int | None): The id of the item to get.
             external_id (str | None): The external_id of the item to get.
+            instance_id (InstanceId | tuple[str, str] | None): The instance_id of the item to get.
 
         Returns:
-            T_CogniteResource | None: The requested item
+            T_CogniteResource | None: The requested item if present, otherwise None.
         """
-        IdentifierSequence.load(id, external_id).assert_singleton()
+        (ident := IdentifierSequence.load(id, external_id, instance_id)).assert_singleton()
         if id:
             return self._id_to_item.get(id)
-        return self._external_id_to_item.get(external_id)
+        elif external_id:
+            return self._external_id_to_item.get(external_id)
+        return self._instance_id_to_item.get(ident.as_primitives()[0])
 
     def to_pandas(
         self,

--- a/cognite/client/data_classes/data_modeling/instances.py
+++ b/cognite/client/data_classes/data_modeling/instances.py
@@ -1064,7 +1064,7 @@ class DataModelingInstancesList(WriteableCogniteResourceList[T_WriteClass, T_Ins
 
         if isinstance(instance_id, InstanceId):
             instance_id = instance_id.as_tuple()
-        return self._instance_id_to_item.get(instance_id)  # type: ignore [arg-type]
+        return self._instance_id_to_item.get(instance_id)
 
     def extend(self, other: Iterable[Any]) -> None:
         other_res_list = type(self)(other)  # See if we can accept the types

--- a/cognite/client/data_classes/datapoints.py
+++ b/cognite/client/data_classes/datapoints.py
@@ -532,7 +532,7 @@ class DatapointsArray(CogniteResource):
         self.granularity = granularity
         self.timestamp: NumpyDatetime64NSArray = (
             timestamp if timestamp is not None else np.array([], dtype="datetime64[ns]")
-        )  # type: ignore
+        )
         self.value = value
         self.average = average
         self.max = max

--- a/cognite/client/data_classes/datapoints.py
+++ b/cognite/client/data_classes/datapoints.py
@@ -5,7 +5,7 @@ import datetime
 import json
 import typing
 import warnings
-from collections import defaultdict
+from collections import ChainMap, defaultdict
 from collections.abc import Collection, Iterator, Sequence
 from dataclasses import InitVar, dataclass, fields
 from enum import IntEnum
@@ -199,6 +199,10 @@ class DatapointsQuery:
 
     def __hash__(self) -> int:
         return hash(id(self))  # See note on __eq__
+
+    @classmethod
+    def valid_from_user_query(cls, query: Self, **settings: Any) -> Self:
+        return cls(**ChainMap(query.dump(), settings, dict.fromkeys(cls.OPTIONAL_DICT_KEYS)))
 
     @classmethod
     # TODO: Remove in next major version (require use of DatapointsQuery directly)

--- a/cognite/client/data_classes/datapoints.py
+++ b/cognite/client/data_classes/datapoints.py
@@ -1256,7 +1256,7 @@ class DatapointsArrayList(CogniteResourceList[DatapointsArray]):
                 id_dct[id_].append(dps)
             if (xid := dps.external_id) is not None and xid in dupe_xids:
                 xid_dct[xid].append(dps)
-            if (inst_id := dps.external_id) is not None and inst_id in dupe_inst_ids:
+            if (inst_id := dps.instance_id) is not None and inst_id in dupe_inst_ids:
                 inst_id_dct[xid].append(dps)
 
         self._id_to_item.update(id_dct)
@@ -1385,7 +1385,7 @@ class DatapointsList(CogniteResourceList[Datapoints]):
                 id_dct[id_].append(dps)
             if (xid := dps.external_id) is not None and xid in dupe_xids:
                 xid_dct[xid].append(dps)
-            if (inst_id := dps.external_id) is not None and inst_id in dupe_inst_ids:
+            if (inst_id := dps.instance_id) is not None and inst_id in dupe_inst_ids:
                 inst_id_dct[xid].append(dps)
 
         self._id_to_item.update(id_dct)

--- a/cognite/client/data_classes/datapoints.py
+++ b/cognite/client/data_classes/datapoints.py
@@ -16,7 +16,6 @@ from typing import (
     ClassVar,
     Literal,
     TypedDict,
-    cast,
     overload,
 )
 
@@ -424,7 +423,7 @@ class Datapoint(CogniteResource):
         status_symbol: str | None = None,
         timezone: datetime.timezone | ZoneInfo | None = None,
     ) -> None:
-        self.timestamp = timestamp
+        self.timestamp: int = timestamp  # type: ignore
         self.value = value
         self.average = average
         self.max = max
@@ -448,7 +447,7 @@ class Datapoint(CogniteResource):
 
     def __str__(self) -> str:
         item = self.dump(camel_case=False)
-        item["timestamp"] = convert_and_isoformat_timestamp(cast(int, self.timestamp), self.timezone)
+        item["timestamp"] = convert_and_isoformat_timestamp(self.timestamp, self.timezone)
         return _json.dumps(item, indent=4)
 
     def to_pandas(self, camel_case: bool = False) -> pandas.DataFrame:  # type: ignore[override]
@@ -531,7 +530,9 @@ class DatapointsArray(CogniteResource):
         self.unit = unit
         self.unit_external_id = unit_external_id
         self.granularity = granularity
-        self.timestamp = timestamp if timestamp is not None else np.array([], dtype="datetime64[ns]")
+        self.timestamp: NumpyDatetime64NSArray = (
+            timestamp if timestamp is not None else np.array([], dtype="datetime64[ns]")
+        )  # type: ignore
         self.value = value
         self.average = average
         self.max = max
@@ -926,7 +927,7 @@ class Datapoints(CogniteResource):
         self.unit = unit
         self.unit_external_id = unit_external_id
         self.granularity = granularity
-        self.timestamp = timestamp or []  # Needed in __len__
+        self.timestamp: list[int] = timestamp or []  # type: ignore
         self.value = value
         self.average = average
         self.max = max

--- a/cognite/client/utils/_auxiliary.py
+++ b/cognite/client/utils/_auxiliary.py
@@ -206,6 +206,11 @@ def split_into_chunks(
         collection = list(collection.items())
         return [dict(collection[i : i + chunk_size]) for i in range(0, len(collection), chunk_size)]
 
+    from cognite.client.data_classes.datapoints import Datapoints, DatapointsArray
+
+    if isinstance(collection, (DatapointsArray, Datapoints)):
+        return [collection[i : i + chunk_size] for i in range(0, len(collection), chunk_size)]
+
     raise TypeError(f"Can only split list or dict, not {type(collection)}")
 
 

--- a/cognite/client/utils/_auxiliary.py
+++ b/cognite/client/utils/_auxiliary.py
@@ -43,6 +43,10 @@ def is_finite(limit: Any) -> TypeGuard[int]:
     return isinstance(limit, int) and limit >= 0
 
 
+def is_positive(limit: Any) -> TypeGuard[int]:
+    return isinstance(limit, int) and limit > 0
+
+
 def is_unlimited(limit: float | int | None) -> bool:
     return limit in {None, -1, math.inf}
 

--- a/docs/source/time_series.rst
+++ b/docs/source/time_series.rst
@@ -98,6 +98,10 @@ Retrieve datapoints in time zone in pandas dataframe
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. automethod:: cognite.client._api.datapoints.DatapointsAPI.retrieve_dataframe_in_tz
 
+Iterate through datapoints in chunks
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+.. automethod:: cognite.client._api.datapoints.DatapointsAPI.__call__
+
 Retrieve latest datapoint
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 .. automethod:: cognite.client._api.datapoints.DatapointsAPI.retrieve_latest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "cognite-sdk"
 
-version = "7.64.13"
+version = "7.65.0"
 description = "Cognite Python SDK"
 readme = "README.md"
 documentation = "https://cognite-sdk-python.readthedocs-hosted.com"

--- a/scripts/create_ts_for_integration_tests.py
+++ b/scripts/create_ts_for_integration_tests.py
@@ -1,3 +1,4 @@
+import math
 import random
 import time
 
@@ -7,6 +8,9 @@ import pandas as pd
 from cognite.client import CogniteClient
 from cognite.client._api.time_series import TimeSeriesAPI
 from cognite.client.data_classes import DatapointsList, TimeSeries, TimeSeriesList
+from cognite.client.data_classes.data_modeling.cdm.v1 import CogniteTimeSeriesApply
+from cognite.client.data_classes.data_modeling.ids import NodeId
+from cognite.client.data_classes.datapoints import DatapointsQuery
 from cognite.client.utils._time import MAX_TIMESTAMP_MS, MIN_TIMESTAMP_MS, UNIT_IN_MS
 
 NAMES = [
@@ -43,10 +47,50 @@ SPARSE_NAMES = [
 ]
 
 NAMES_USING_INSTANCE_ID = [
-    "125: same as 114",
-    "126: same as 121",
-    "127: only bad status codes, daily values, 2023-2024, string",
+    NodeId(space="PySDK-DMS-time-series-integration-test", external_id="PYSDK integration test 125: clone of 109"),
+    NodeId(space="PySDK-DMS-time-series-integration-test", external_id="PYSDK integration test 126: clone of 114"),
+    NodeId(space="PySDK-DMS-time-series-integration-test", external_id="PYSDK integration test 127: clone of 121"),
 ]
+
+
+def create_instance_id_ts(client):
+    client.dm.instances.apply(
+        [
+            CogniteTimeSeriesApply(
+                space="PySDK-DMS-time-series-integration-test",
+                external_id=NAMES_USING_INSTANCE_ID[0].external_id,
+                name=NAMES_USING_INSTANCE_ID[0].external_id,
+                is_step=True,
+                time_series_type="numeric",
+            ),
+            CogniteTimeSeriesApply(
+                space="PySDK-DMS-time-series-integration-test",
+                external_id=NAMES_USING_INSTANCE_ID[1].external_id,
+                name=NAMES_USING_INSTANCE_ID[1].external_id,
+                is_step=False,
+                time_series_type="numeric",
+            ),
+            CogniteTimeSeriesApply(
+                space="PySDK-DMS-time-series-integration-test",
+                external_id=NAMES_USING_INSTANCE_ID[2].external_id,
+                name=NAMES_USING_INSTANCE_ID[2].external_id,
+                is_step=False,
+                time_series_type="numeric",
+            ),
+        ]
+    )
+
+
+def clone_datapoints_to_dms_ts(client):
+    dps_lst = client.time_series.data.retrieve(
+        instance_id=[DatapointsQuery(instance_id=node_id) for node_id in NAMES_USING_INSTANCE_ID],
+        include_status=True,
+        ignore_bad_datapoints=False,
+        start=MIN_TIMESTAMP_MS,
+        end=MAX_TIMESTAMP_MS,
+    )
+    to_insert = [{"instance_id": node_id, "datapoints": dps} for node_id, dps in zip(dps_lst, NAMES_USING_INSTANCE_ID)]
+    client.time_series.data.insert_multiple(to_insert)
 
 
 def create_dense_rand_dist_ts(xid, seed, n=1_000_000):
@@ -285,8 +329,7 @@ def create_status_code_ts(client: CogniteClient) -> None:
 
     def get_bad():
         options = [None, "NaN", "Infinity", "-Infinity", -1e100, 2.71, 3.14, 420, 1e100]
-        # TODO: Need PY39 for math.nextafter
-        options.extend((np.nextafter(0, -np.inf).item(), np.nextafter(0, np.inf).item()))
+        options.extend((math.nextafter(0, -math.inf), math.nextafter(0, math.inf)))
         v = random.choice(options)
         c = random.choice(BAD_STATUS_CODES_COMPRESSED)
         return v, c << 16
@@ -316,18 +359,13 @@ def create_status_code_ts(client: CogniteClient) -> None:
             TimeSeries(name=bad_ts_str, external_id=bad_ts_str, is_string=True, metadata={"delta": UNIT_IN_MS["d"]}),
         ]
     )
-    # TODO: Insert normally when supported by SDK
-    client.post(
-        f"/api/v1/projects/{client.config.project}/timeseries/data",
-        json={
-            "items": [
-                {"externalId": mixed_ts, "datapoints": dps},
-                {"externalId": mixed_ts_str, "datapoints": dps_str},
-                {"externalId": bad_ts, "datapoints": dps_all_bad},
-                {"externalId": bad_ts_str, "datapoints": dps_all_bad_str},
-            ]
-        },
-        headers={"cdf-version": "20230101-beta"},
+    client.time_series.data.insert_multiple(
+        [
+            {"externalId": mixed_ts, "datapoints": dps},
+            {"externalId": mixed_ts_str, "datapoints": dps_str},
+            {"externalId": bad_ts, "datapoints": dps_all_bad},
+            {"externalId": bad_ts_str, "datapoints": dps_all_bad_str},
+        ]
     )
 
 
@@ -382,3 +420,5 @@ if __name__ == "__main__":
     create_if_not_exists(client.time_series, ts_lst, df_lst)
     create_edge_case_if_not_exists(client.time_series)
     create_status_code_ts(client)
+    create_instance_id_ts(client)
+    clone_datapoints_to_dms_ts(client)

--- a/scripts/create_ts_for_integration_tests.py
+++ b/scripts/create_ts_for_integration_tests.py
@@ -42,6 +42,12 @@ SPARSE_NAMES = [
     "PYSDK integration test 118: single dp at 2099-12-31 23:59:59.999, numeric",
 ]
 
+NAMES_USING_INSTANCE_ID = [
+    "125: same as 114",
+    "126: same as 121",
+    "127: only bad status codes, daily values, 2023-2024, string",
+]
+
 
 def create_dense_rand_dist_ts(xid, seed, n=1_000_000):
     np.random.seed(seed)

--- a/scripts/custom_checks/docstrings.py
+++ b/scripts/custom_checks/docstrings.py
@@ -115,6 +115,11 @@ class DocstrFormatter:
         # TODO: With 3.9 this gets much easier: get_args(get_type_hints(method)["return"])[0]
 
         if string.startswith("Iterator["):
+            if string.count("Iterator[") > 1:
+                raise ValueError(
+                    "pydoclint doesn't allow unions between Iterators in 'Yields:' annotation. Example: instead of "
+                    "`Iterator[int] | Iterator[str]`, use `Iterator[int | str]`. Please fix manually."
+                )
             return string[9:-1]
 
         if not string.startswith("Generator["):

--- a/tests/tests_integration/test_api/test_datapoints.py
+++ b/tests/tests_integration/test_api/test_datapoints.py
@@ -611,9 +611,13 @@ class TestIterateDatapoints:
             assert False, "No iteration should happen"
 
     def test_no_data_due_to_missing_is_noop(self, cognite_client):
-        xid = random_cognite_external_ids(1, str_len=80)[0]
-        query = DatapointsQuery(external_id=xid, ignore_unknown_ids=True)
-        for _ in cognite_client.time_series.data(query, ignore_unknown_ids=False):  # query should take precedence
+        xid1, xid2 = random_cognite_external_ids(2, str_len=60)
+        query1 = DatapointsQuery(external_id=xid1, ignore_unknown_ids=True)
+        for _ in cognite_client.time_series.data(query1):
+            assert False, "No iteration should happen"
+
+        query2 = DatapointsQuery(external_id=xid2, ignore_unknown_ids=True)
+        for _ in cognite_client.time_series.data([query1, query2]):
             assert False, "No iteration should happen"
 
     def test_iterate_exhausted_but_queue_not_empty(self, cognite_client, weekly_dps_ts, all_test_time_series):

--- a/tests/tests_integration/test_api/test_datapoints.py
+++ b/tests/tests_integration/test_api/test_datapoints.py
@@ -581,7 +581,7 @@ class TestIterateDatapoints:
         id_ = cognite_client.time_series.retrieve(instance_id=instance_id).id
         qs_with_hidden_duplicates = [DatapointsQuery(id=id_), DatapointsQuery(instance_id=instance_id)]
 
-        with pytest.raises(RuntimeError, match="must be unique! You can not get around this"):
+        with pytest.raises(RuntimeError, match="must be unique! You cannot get around this"):
             next(cognite_client.time_series.data(qs_with_hidden_duplicates))
 
     @pytest.mark.parametrize(


### PR DESCRIPTION
https://cognitedata.atlassian.net/browse/DM-2319

```
`Iterate through datapoints in chunks, for one or more time series. <https://developer.cognite.com/api#tag/Time-series/operation/getMultiTimeSeriesDatapoints>`_

Note:
    Control memory usage by specifying ``chunk_size_time_series``, how many time series to iterate simultaneously and ``chunk_size_datapoints``,
    how many datapoints to yield per iteration. Note that in order to make efficient use of the API request limits, this method will never hold
    less than 100k datapoints in memory at a time, per time series.

    If you run with memory constraints, use ``return_arrays=True`` (the default).

    No empty chunk will ever be returned.

Args:
    queries (DatapointsQuery | Sequence[DatapointsQuery]): Query, or queries, using id, external_id or instance_id for time series to fetch data for. Individual settings in the DatapointsQuery take precedence over top-level settings. The options 'limit' and 'include_outside_points' are not supported.
    start (int | str | datetime.datetime | None): Inclusive start. Default: 1970-01-01 UTC.
    end (int | str | datetime.datetime | None): Exclusive end. Default: "now"
    aggregates (Aggregate | str | list[Aggregate | str] | None): Single aggregate or list of aggregates to retrieve. Available options: ``average``, ``continuous_variance``, ``count``, ``count_bad``, ``count_good``, ``count_uncertain``, ``discrete_variance``, ``duration_bad``, ``duration_good``, ``duration_uncertain``, ``interpolation``, ``max``, ``min``, ``step_interpolation``, ``sum`` and ``total_variation``. Default: None (raw datapoints returned)
    granularity (str | None): The granularity to fetch aggregates at. Can be given as an abbreviation or spelled out for clarity: ``s/second(s)``, ``m/minute(s)``, ``h/hour(s)``, ``d/day(s)``, ``w/week(s)``, ``mo/month(s)``, ``q/quarter(s)``, or ``y/year(s)``. Examples: ``30s``, ``5m``, ``1day``, ``2weeks``. Default: None.
    timezone (str | datetime.timezone | ZoneInfo | None): For raw datapoints, which timezone to use when displaying (will not affect what is retrieved). For aggregates, which timezone to align to for granularity 'hour' and longer. Align to the start of the hour, day or month. For timezones of type Region/Location, like 'Europe/Oslo', pass a string or ``ZoneInfo`` instance. The aggregate duration will then vary, typically due to daylight saving time. You can also use a fixed offset from UTC by passing a string like '+04:00', 'UTC-7' or 'UTC-02:30' or an instance of ``datetime.timezone``. Note: Historical timezones with second offset are not supported, and timezones with minute offsets (e.g. UTC+05:30 or Asia/Kolkata) may take longer to execute.
    target_unit (str | None): The unit_external_id of the datapoints returned. If the time series does not have a unit_external_id that can be converted to the target_unit, an error will be returned. Cannot be used with target_unit_system.
    target_unit_system (str | None): The unit system of the datapoints returned. Cannot be used with target_unit.
    ignore_unknown_ids (bool): Whether to ignore missing time series rather than raising an exception. Default: False
    include_status (bool): Also return the status code, an integer, for each datapoint in the response. Only relevant for raw datapoint queries, not aggregates.
    ignore_bad_datapoints (bool): Treat datapoints with a bad status code as if they do not exist. If set to false, raw queries will include bad datapoints in the response, and aggregates will in general omit the time period between a bad datapoint and the next good datapoint. Also, the period between a bad datapoint and the previous good datapoint will be considered constant. Default: True.
    treat_uncertain_as_bad (bool): Treat datapoints with uncertain status codes as bad. If false, treat datapoints with uncertain status codes as good. Used for both raw queries and aggregates. Default: True.
    chunk_size_datapoints (int): The number of datapoints per time series to yield per iteration. Must evenly divide 100k OR be an integer multiple of 100k. Default: 100_000.
    chunk_size_time_series (int | None): The max number of time series to yield per iteration (varies as time series get exhausted, but is always at least 1). Default: None (all given queries are returned).
    return_arrays (bool): Whether to return the datapoints as numpy arrays. Default: True.

Yields:
    DatapointsArray | DatapointsArrayList | Datapoints | DatapointsList: If return_arrays=True, a ``DatapointsArray`` object containing the datapoints chunk, or a ``DatapointsArrayList`` if multiple time series were asked for. When False, a ``Datapoints`` object containing the datapoints chunk, or a ``DatapointsList`` if multiple time series were asked for. If `ignore_unknown_ids` is `True`, a single time series is requested and it is not found, iteration will quit.

Examples:

    Iterate through the datapoints of a single time series with external_id="foo", in chunks of 25k:

        >>> from cognite.client import CogniteClient
        >>> from cognite.client.data_classes import DatapointsQuery
        >>> client = CogniteClient()
        >>> query = DatapointsQuery(external_id="foo", start="2w-ago")
        >>> for chunk in client.time_series.data(query, chunk_size=25_000):
        ...     pass  # do something with the datapoints chunk

    Iterate through datapoints from multiple time series, and do not return them as numpy arrays. As one or more time
    series get exhausted (no more data), they are no longer part of the returned "chunk list", but the order is
    still preserved (for the remaining).

    If you run with ``chunk_size_time_series=None``, an easy way to check is to use the ``.get`` method, as illustrated below:

        >>> from cognite.client.data_classes.data_modeling import NodeId
        >>> queries = [
        ...     DatapointsQuery(id=123),
        ...     DatapointsQuery(external_id="foo"),
        ...     DatapointsQuery(instance_id=NodeId("my-space", "my-ts-xid"))
        ... ]
        >>> for chunk_lst in client.time_series.data(query, return_arrays=False):
        ...     if chunk_lst.get(id=2) is None:
        ...         print("Time series with id=2 has no more datapoints!")

    A likely use case for iterating datapoints is to clone data from one project to another, while keeping a low memory
    footprint and without having to write very custom logic involving count aggregates (which won't work for string data)
    and time domain splitting.

    Here's an example of how to do so efficiently, while not ignoring bad and uncertain data (``ignore_bad_datapoints=False``)
    and copying status codes (automatically taken care of when requested, ``include_status=True``). The only assumption is that
    the time series are already created in the target project.

        >>> from cognite.client.utils import MIN_TIMESTAMP_MS, MAX_TIMESTAMP_MS
        >>> target_client = CogniteClient(...)
        >>> to_copy = client.time_series.list(data_set_external_ids="my-use-case")
        >>> queries = [DatapointsQuery(external_id=ts.external_id) for ts in to_copy]
        >>> for dps_chunk in client.time_series.data(
        ...     queries,  # may be several thousand time series...
        ...     chunk_size_time_series=20,  # control memory usage by specifying how many to iterate at a time
        ...     chunk_size_datapoints=100_000,
        ...     include_status=True,
        ...     ignore_bad_datapoints=False,
        ...     start=MIN_TIMESTAMP_MS,
        ...     end=MAX_TIMESTAMP_MS + 1,  # end is exclusive
        ... ):
        ...     target_client.time_series.data.insert_multiple(
        ...         [{"external_id": dps.external_id, "datapoints": dps} for dps in dps_chunk]
        ...     )
```