### PR TITLE
Fix FunctionSchedulesAPI.__call__()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ Changes are grouped as follows
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
-## [7.64.12] - 2024-11-10
+## [7.64.12] - 2024-11-11
 ### Fixed
 - `FunctionSchedulesAPI.__call__()` calls `FunctionSchedulesAPI.list()` instead of `APIClient._list_generator()`.
   (The latter relied on pagination, which was not implemented by `/schedules/list`). 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,11 @@ Changes are grouped as follows
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
+## [7.64.12] - 2024-11-10
+### Fixed
+- `FunctionSchedulesAPI.__call__()` calls `FunctionSchedulesAPI.list()` instead of `APIClient._list_generator()`.
+  (The latter relied on pagination, which was not implemented by `/schedules/list`). 
+
 ## [7.64.11] - 2024-11-10
 ### Added
 - [Feature Preview - alpha] Support for `PostgresGateway` `Tables` `client.postegres_gateway.tables`.

--- a/cognite/client/_api/functions.py
+++ b/cognite/client/_api/functions.py
@@ -40,11 +40,7 @@ from cognite.client.data_classes.functions import (
     FunctionWrite,
     RunTime,
 )
-from cognite.client.utils._auxiliary import (
-    at_most_one_is_not_none,
-    is_unlimited,
-    split_into_chunks,
-)
+from cognite.client.utils._auxiliary import at_most_one_is_not_none, is_unlimited, split_into_chunks
 from cognite.client.utils._identifier import Identifier, IdentifierSequence
 from cognite.client.utils._importing import local_import
 from cognite.client.utils._session import create_session_and_return_nonce
@@ -1106,22 +1102,20 @@ class FunctionSchedulesAPI(APIClient):
         """
         _ensure_at_most_one_id_given(function_id, function_external_id)
 
-        filter_ = FunctionSchedulesFilter(
+        schedules = self.list(
             name=name,
             function_id=function_id,
             function_external_id=function_external_id,
             created_time=created_time,
             cron_expression=cron_expression,
-        ).dump(camel_case=True)
-
-        return self._list_generator(
-            method="POST",
-            url_path=f"{self._RESOURCE_PATH}/list",
-            filter=filter_,
-            resource_cls=FunctionSchedule,
-            list_cls=FunctionSchedulesList,
-            chunk_size=chunk_size,
             limit=limit,
+        )
+
+        if chunk_size is None:
+            return iter(schedules)
+        return (
+            FunctionSchedulesList(chunk, cognite_client=self._cognite_client)
+            for chunk in split_into_chunks(schedules.data, chunk_size)
         )
 
     def __iter__(self) -> Iterator[FunctionSchedule]:

--- a/cognite/client/_version.py
+++ b/cognite/client/_version.py
@@ -1,4 +1,4 @@
 from __future__ import annotations
 
-__version__ = "7.64.11"
+__version__ = "7.64.12"
 __api_subversion__ = "20230101"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "cognite-sdk"
 
-version = "7.64.11"
+version = "7.64.12"
 description = "Cognite Python SDK"
 readme = "README.md"
 documentation = "https://cognite-sdk-python.readthedocs-hosted.com"


### PR DESCRIPTION
## Description
`FunctionSchedulesAPI.__call__()` currently calls `APIClient._list_generator()`, which relies on `/schedules/list` supporting pagination. However, `/schedules/list` does not support pagination. Fix so that `FunctionSchedulesAPI.__call__()` instead calls `FunctionSchedulesAPI.list()`.

## Checklist:
- [x] Changelog updated in [CHANGELOG.md](https://github.com/cognitedata/cognite-sdk-python/blob/master/CHANGELOG.md).
- [x] Version bumped. If triggering a new release is desired, bump the version number in [_version.py](https://github.com/cognitedata/cognite-sdk-python/blob/master/cognite/client/_version.py) and [pyproject.toml](https://github.com/cognitedata/cognite-sdk-python/blob/master/pyproject.toml) per [semantic versioning](https://semver.org/).
