### PR TITLE
add support for `instance_id` in synth. dps query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,12 @@ Changes are grouped as follows
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
+## [7.69.0] - 2024-11-23
+### Added
+- Synthetic Datapoints API has better support for `instance_id`. Previously you had to specify these directly
+  in the expression(s), but now you can use the `variables` parameter to more easily substitute the time series
+  identifiers directly into the expression(s).
+
 ## [7.68.0] - 2024-11-22
 ### Added
 - New methods: `WorkflowTriggerAPI.[list, list_runs]`

--- a/cognite/client/_version.py
+++ b/cognite/client/_version.py
@@ -1,4 +1,4 @@
 from __future__ import annotations
 
-__version__ = "7.68.0"
+__version__ = "7.69.0"
 __api_subversion__ = "20230101"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "cognite-sdk"
 
-version = "7.68.0"
+version = "7.69.0"
 description = "Cognite Python SDK"
 readme = "README.md"
 documentation = "https://cognite-sdk-python.readthedocs-hosted.com"


### PR DESCRIPTION
## [7.69.0] - 2024-11-23
### Added
- Synthetic Datapoints API has better support for `instance_id`. Previously you had to specify these directly
  in the expression(s), but now you can use the `variables` parameter to more easily substitute the time series
  identifiers directly into the expression(s).