### PR TITLE
Fix instance to pandas prop name conflict

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,13 @@ Changes are grouped as follows
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
-## [7.69.1] - 2024-11-25
+## [7.69.2] - 2024-11-28
+### Improved
+- Handle conversion of instance lists like NodeList to pandas DataFrame in scenarios where: a) properties are expanded
+  into columns, b) the view ID prefix has be removed and c) one or more user properties have a naming conflict with
+  base properties. This no longer raises a documented error by pandas, but gives a warning instead.
+
+## [7.69.1] - 2024-11-27
 ### Fixed
 - Convenience methods for `TimeSeries` (defined through Data Modeling with `instance_id`) now works as
   intended: `count`, `latest` and `first`.

--- a/cognite/client/_version.py
+++ b/cognite/client/_version.py
@@ -1,4 +1,4 @@
 from __future__ import annotations
 
-__version__ = "7.69.1"
+__version__ = "7.69.2"
 __api_subversion__ = "20230101"

--- a/cognite/client/data_classes/data_modeling/instances.py
+++ b/cognite/client/data_classes/data_modeling/instances.py
@@ -457,6 +457,11 @@ class Instance(WritableInstanceCore[T_CogniteResource], ABC):
             if not extra:
                 prefix = "{}.{}/{}.".format(*view_id.as_tuple())
                 prop_df.columns = prop_df.columns.str.removeprefix(prefix)
+
+                if isinstance(self, TypedInstance):
+                    attr_name_mapping = self._get_descriptor_property_name_mapping()
+                    prop_df = prop_df.rename(columns=attr_name_mapping)
+
                 if any(overlapping := col.index.intersection(prop_df.columns)):
                     warnings.warn(
                         "One or more expanded property names overlapped with base properties. "
@@ -464,10 +469,6 @@ class Instance(WritableInstanceCore[T_CogniteResource], ABC):
                         RuntimeWarning,
                     )
                     prop_df = prop_df.rename(columns={col: f"{prefix}{col}" for col in overlapping})
-
-                if isinstance(self, TypedInstance):
-                    attr_name_mapping = self._get_descriptor_property_name_mapping()
-                    prop_df = prop_df.rename(columns=attr_name_mapping)
             else:
                 warnings.warn(
                     "Can't remove view ID prefix from expanded property rows as source was not unique",
@@ -1125,6 +1126,11 @@ class DataModelingInstancesList(WriteableCogniteResourceList[T_WriteClass, T_Ins
             if not extra:
                 prefix = "{}.{}/{}.".format(*view_id.as_tuple())
                 prop_df.columns = prop_df.columns.str.removeprefix(prefix)
+
+                if len(self) > 0 and isinstance(self[0], TypedInstance):
+                    attr_name_mapping = self[0]._get_descriptor_property_name_mapping()
+                    prop_df = prop_df.rename(columns=attr_name_mapping)
+
                 if any(overlapping := df.columns.intersection(prop_df.columns)):
                     warnings.warn(
                         "One or more expanded property names overlapped with base properties. "
@@ -1132,10 +1138,6 @@ class DataModelingInstancesList(WriteableCogniteResourceList[T_WriteClass, T_Ins
                         RuntimeWarning,
                     )
                     prop_df = prop_df.rename(columns={col: f"{prefix}{col}" for col in overlapping})
-
-                if len(self) > 0 and isinstance(self[0], TypedInstance):
-                    attr_name_mapping = self[0]._get_descriptor_property_name_mapping()
-                    prop_df = prop_df.rename(columns=attr_name_mapping)
             else:
                 warnings.warn(
                     "Can't remove view ID prefix from expanded property columns as multiple sources exist",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "cognite-sdk"
 
-version = "7.69.1"
+version = "7.69.2"
 description = "Cognite Python SDK"
 readme = "README.md"
 documentation = "https://cognite-sdk-python.readthedocs-hosted.com"


### PR DESCRIPTION
https://cognitedata.atlassian.net/browse/DM-2388

Handle:

`ValueError: columns overlap but no suffix specified: Index(['type'], dtype='object')`

...even though we already did cover for this scenario:

> Convert the instance into a pandas DataFrame. Note that if the properties column is expanded and there are
keys in the metadata that already exist in the DataFrame, then an error will be raised by pandas during joining.

raised through slack: https://cognitedata.slack.com/archives/CG10VQPFX/p1732631517180759