### PR TITLE
feat(ai): add document qa and document summary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@ Changes are grouped as follows
 ### Added
 - Support for the `/simulators` and `/simulators/integration` API endpoints.
 
+## [7.72.0] - 2025-01-14
+### Added
+- Document Summary and Document Question Answering endpoints from the AI API.
+
 ## [7.71.4] - 2025-01-09
 ### Changed
 - Update classes accepting insance_id now raise when id/external_id are also given.

--- a/cognite/client/_api/ai/__init__.py
+++ b/cognite/client/_api/ai/__init__.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from cognite.client._api.ai.tools import ToolsAPI
+from cognite.client._api_client import APIClient
+
+if TYPE_CHECKING:
+    from cognite.client import ClientConfig, CogniteClient
+
+
+class AIAPI(APIClient):
+    def __init__(self, config: ClientConfig, api_version: str | None, cognite_client: CogniteClient) -> None:
+        super().__init__(config, api_version, cognite_client)
+        self.tools = ToolsAPI(config, api_version, cognite_client)

--- a/cognite/client/_api/ai/__init__.py
+++ b/cognite/client/_api/ai/__init__.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from cognite.client._api.ai.tools import ToolsAPI
+from cognite.client._api.ai.tools import AIToolsAPI
 from cognite.client._api_client import APIClient
 
 if TYPE_CHECKING:
@@ -12,4 +12,4 @@ if TYPE_CHECKING:
 class AIAPI(APIClient):
     def __init__(self, config: ClientConfig, api_version: str | None, cognite_client: CogniteClient) -> None:
         super().__init__(config, api_version, cognite_client)
-        self.tools = ToolsAPI(config, api_version, cognite_client)
+        self.tools = AIToolsAPI(config, api_version, cognite_client)

--- a/cognite/client/_api/ai/tools/__init__.py
+++ b/cognite/client/_api/ai/tools/__init__.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from cognite.client._api.ai.tools.documents import DocumentsAPI
+from cognite.client._api_client import APIClient
+
+if TYPE_CHECKING:
+    from cognite.client import ClientConfig, CogniteClient
+
+
+class ToolsAPI(APIClient):
+    def __init__(self, config: ClientConfig, api_version: str | None, cognite_client: CogniteClient) -> None:
+        super().__init__(config, api_version, cognite_client)
+        self.documents = DocumentsAPI(config, api_version, cognite_client)

--- a/cognite/client/_api/ai/tools/__init__.py
+++ b/cognite/client/_api/ai/tools/__init__.py
@@ -2,14 +2,14 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from cognite.client._api.ai.tools.documents import DocumentsAPI
+from cognite.client._api.ai.tools.documents import AIDocumentsAPI
 from cognite.client._api_client import APIClient
 
 if TYPE_CHECKING:
     from cognite.client import ClientConfig, CogniteClient
 
 
-class ToolsAPI(APIClient):
+class AIToolsAPI(APIClient):
     def __init__(self, config: ClientConfig, api_version: str | None, cognite_client: CogniteClient) -> None:
         super().__init__(config, api_version, cognite_client)
-        self.documents = DocumentsAPI(config, api_version, cognite_client)
+        self.documents = AIDocumentsAPI(config, api_version, cognite_client)

--- a/cognite/client/_api/ai/tools/documents.py
+++ b/cognite/client/_api/ai/tools/documents.py
@@ -19,16 +19,16 @@ class AIDocumentsAPI(APIClient):
         external_id: str | None = None,
         instance_id: NodeId | None = None,
     ) -> Summary | None:
-        """Summarize a document using a Large Language Model.
+        """`Summarize a document using a Large Language Model. <https://developer.cognite.com/api#tag/Document-AI/operation/document_questioning_api_v1_projects__projectName__ai_tools_documents_ask_post>`_
 
         Note:
             Currently only supports summarizing a single document at a time, but
             this may be extended in the future.
 
         Args:
-            id (int | None): No description.
-            external_id (str | None): No description.
-            instance_id (NodeId | None): No description.
+            id (int | None): The ID of the document
+            external_id (str | None): The external ID of the document
+            instance_id (NodeId | None): The instance ID of the document
 
         Returns:
             Summary | None: A summary of the document if the document exists else None.
@@ -83,15 +83,15 @@ class AIDocumentsAPI(APIClient):
         additional_context: str | None = None,
         ignore_unknown_ids: bool = False,
     ) -> Answer:
-        """Ask a question about one or more documents using a Large Language Model.
+        """`Ask a question about one or more documents using a Large Language Model. <https://developer.cognite.com/api#tag/Document-AI/operation/documents_summary_api_v1_projects__projectName__ai_tools_documents_summarize_post>`_
 
         Supports up to 100 documents at a time.
 
         Args:
             question (str): The question.
-            id (int | None): No description.
-            external_id (str | Sequence[str] | None): No description.
-            instance_id (NodeId | Sequence[NodeId] | None): No description.
+            id (int | None): The ID(s) of the document(s)
+            external_id (str | Sequence[str] | None): The external ID(s) of the document(s)
+            instance_id (NodeId | Sequence[NodeId] | None): The instance ID(s) of the document(s)
             language (AnswerLanguage | Literal['Chinese', 'Dutch', 'English', 'French', 'German', 'Italian', 'Japanese', 'Korean', 'Latvian', 'Norwegian', 'Portuguese', 'Spanish', 'Swedish']): The desired language of the answer, defaults to English.
             additional_context (str | None): Additional context that you want the LLM to take into account.
             ignore_unknown_ids (bool): Whether to skip documents that do not exists or that are not fully processed, instead of throwing an error

--- a/cognite/client/_api/ai/tools/documents.py
+++ b/cognite/client/_api/ai/tools/documents.py
@@ -4,7 +4,7 @@ from collections.abc import Sequence
 
 from cognite.client._api_client import APIClient
 from cognite.client.data_classes.ai import Answer, AnswerLanguage, Summary
-from cognite.client.utils._identifier import InstanceId
+from cognite.client.data_classes.data_modeling import NodeId
 from cognite.client.utils.useful_types import SequenceNotStr
 
 
@@ -15,7 +15,7 @@ class AIDocumentsAPI(APIClient):
         self,
         ids: Sequence[int] | None = None,
         external_ids: SequenceNotStr[str] | None = None,
-        instance_ids: Sequence[InstanceId] | None = None,
+        instance_ids: Sequence[NodeId] | None = None,
         ignore_unknown_ids: bool = False,
     ) -> list[Summary]:
         """Summarize a document using a Large Language Model.
@@ -26,7 +26,7 @@ class AIDocumentsAPI(APIClient):
         Args:
             ids (Sequence[int] | None): Internal ids of documents to summarize.
             external_ids (SequenceNotStr[str] | None): External ids of documents to summarize.
-            instance_ids (Sequence[InstanceId] | None): Instance ids of documents to summarize.
+            instance_ids (Sequence[NodeId] | None): Instance ids of documents to summarize.
             ignore_unknown_ids (bool): Whether to skip documents that can't be summarized, without throwing an error
 
         Returns:
@@ -43,7 +43,7 @@ class AIDocumentsAPI(APIClient):
             "items": (
                 [{"id": id} for id in ids or []]
                 + [{"externalId": external_id} for external_id in external_ids or []]
-                + [{"instanceId": instance_id.dump()} for instance_id in instance_ids or []]
+                + [{"instanceId": instance_id.dump(include_instance_type=False)} for instance_id in instance_ids or []]
             ),
             "ignoreUnknownIds": ignore_unknown_ids,
         }
@@ -53,7 +53,7 @@ class AIDocumentsAPI(APIClient):
 
         summaries = []
         for item in response_json["items"]:
-            instance_id = InstanceId.load(item["instanceId"]) if "instanceId" in item else None
+            instance_id = NodeId.load(item["instanceId"]) if "instanceId" in item else None
             summaries.append(
                 Summary(
                     id=item.get("id"),
@@ -70,7 +70,7 @@ class AIDocumentsAPI(APIClient):
         question: str,
         ids: Sequence[int] | None = None,
         external_ids: SequenceNotStr[str] | None = None,
-        instance_ids: Sequence[InstanceId] | None = None,
+        instance_ids: Sequence[NodeId] | None = None,
         language: AnswerLanguage = AnswerLanguage.English,
         ignore_unknown_ids: bool = False,
         additional_context: str | None = None,
@@ -83,7 +83,7 @@ class AIDocumentsAPI(APIClient):
             question (str): The question.
             ids (Sequence[int] | None): Internal ids of documents to find the answer in.
             external_ids (SequenceNotStr[str] | None): External ids of documents to find the answer in.
-            instance_ids (Sequence[InstanceId] | None): Instance ids of documents to find the answer in.
+            instance_ids (Sequence[NodeId] | None): Instance ids of documents to find the answer in.
             language (AnswerLanguage): The desired language of the answer
             ignore_unknown_ids (bool): Whether to skip documents that are not fully processed, without throwing an error
             additional_context (str | None): Additional context that you want the LLM to take into account.
@@ -103,7 +103,7 @@ class AIDocumentsAPI(APIClient):
             "fileIds": (
                 [{"id": id} for id in ids or []]
                 + [{"externalId": external_id} for external_id in external_ids or []]
-                + [{"instanceId": instance_id.dump()} for instance_id in instance_ids or []]
+                + [{"instanceId": instance_id.dump(include_instance_type=False)} for instance_id in instance_ids or []]
             ),
             "language": language.value,
             "ignoreUnknownIds": ignore_unknown_ids,

--- a/cognite/client/_api/ai/tools/documents.py
+++ b/cognite/client/_api/ai/tools/documents.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
 
 from collections.abc import Sequence
+from typing import Literal
 
 from cognite.client._api_client import APIClient
 from cognite.client.data_classes.ai import Answer, AnswerLanguage, Summary
 from cognite.client.data_classes.data_modeling import NodeId
-from cognite.client.utils.useful_types import SequenceNotStr
+from cognite.client.exceptions import CogniteAPIError
+from cognite.client.utils._identifier import IdentifierSequenceWithInstanceId
 
 
 class AIDocumentsAPI(APIClient):
@@ -13,67 +15,73 @@ class AIDocumentsAPI(APIClient):
 
     def summarize(
         self,
-        ids: Sequence[int] | None = None,
-        external_ids: SequenceNotStr[str] | None = None,
-        instance_ids: Sequence[NodeId] | None = None,
-        ignore_unknown_ids: bool = False,
-    ) -> list[Summary]:
+        id: int | None = None,
+        external_id: str | None = None,
+        instance_id: NodeId | None = None,
+    ) -> Summary | None:
         """Summarize a document using a Large Language Model.
 
-        Currently only supports summarizing a single document at a time, but
-        this may be extended in the future.
+        Note:
+            Currently only supports summarizing a single document at a time, but
+            this may be extended in the future.
 
         Args:
-            ids (Sequence[int] | None): Internal ids of documents to summarize.
-            external_ids (SequenceNotStr[str] | None): External ids of documents to summarize.
-            instance_ids (Sequence[NodeId] | None): Instance ids of documents to summarize.
-            ignore_unknown_ids (bool): Whether to skip documents that can't be summarized, without throwing an error
+            id (int | None): No description.
+            external_id (str | None): No description.
+            instance_id (NodeId | None): No description.
 
         Returns:
-            list[Summary]: No description.
+            Summary | None: A summary of the document if the document exists else None.
+
         Examples:
 
-            Summarize a single document with internal id 123
+            Summarize a single document with id:
 
                 >>> from cognite.client import CogniteClient
                 >>> client = CogniteClient()
-                >>> client.ai.tools.documents.summarize(ids=[123])
+                >>> client.ai.tools.documents.summarize(id=123)
+
+            You can also use external ID or instance ID:
+
+                >>> from cognite.client.data_classes.data_modeling import NodeId
+                >>> client.ai.tools.documents.summarize(
+                ...     instance_id=NodeId("my-space", "my-xid")
+                ... )
         """
-        body = {
-            "items": (
-                [{"id": id} for id in ids or []]
-                + [{"externalId": external_id} for external_id in external_ids or []]
-                + [{"instanceId": instance_id.dump(include_instance_type=False)} for instance_id in instance_ids or []]
-            ),
-            "ignoreUnknownIds": ignore_unknown_ids,
-        }
-
-        response = self._post(self._RESOURCE_PATH + "/summarize", json=body)
-        response_json = response.json()
-
-        summaries = []
-        for item in response_json["items"]:
-            instance_id = NodeId.load(item["instanceId"]) if "instanceId" in item else None
-            summaries.append(
-                Summary(
-                    id=item.get("id"),
-                    external_id=item.get("externalId"),
-                    instance_id=instance_id,
-                    summary=item["summary"],
-                )
-            )
-
-        return summaries
+        ident = IdentifierSequenceWithInstanceId.load(id, external_id, instance_id).as_singleton()
+        try:
+            res = self._post(self._RESOURCE_PATH + "/summarize", json={"items": ident.as_dicts()})
+            return Summary._load(res.json()["items"][0])
+        except CogniteAPIError as e:
+            if e.code != 404:
+                raise
+            return None
 
     def ask_question(
         self,
         question: str,
-        ids: Sequence[int] | None = None,
-        external_ids: SequenceNotStr[str] | None = None,
-        instance_ids: Sequence[NodeId] | None = None,
-        language: AnswerLanguage = AnswerLanguage.English,
-        ignore_unknown_ids: bool = False,
+        *,
+        id: int | None = None,
+        external_id: str | Sequence[str] | None = None,
+        instance_id: NodeId | Sequence[NodeId] | None = None,
+        language: AnswerLanguage
+        | Literal[
+            "Chinese",
+            "Dutch",
+            "English",
+            "French",
+            "German",
+            "Italian",
+            "Japanese",
+            "Korean",
+            "Latvian",
+            "Norwegian",
+            "Portuguese",
+            "Spanish",
+            "Swedish",
+        ] = AnswerLanguage.English,
         additional_context: str | None = None,
+        ignore_unknown_ids: bool = False,
     ) -> Answer:
         """Ask a question about one or more documents using a Large Language Model.
 
@@ -81,34 +89,58 @@ class AIDocumentsAPI(APIClient):
 
         Args:
             question (str): The question.
-            ids (Sequence[int] | None): Internal ids of documents to find the answer in.
-            external_ids (SequenceNotStr[str] | None): External ids of documents to find the answer in.
-            instance_ids (Sequence[NodeId] | None): Instance ids of documents to find the answer in.
-            language (AnswerLanguage): The desired language of the answer
-            ignore_unknown_ids (bool): Whether to skip documents that are not fully processed, without throwing an error
+            id (int | None): No description.
+            external_id (str | Sequence[str] | None): No description.
+            instance_id (NodeId | Sequence[NodeId] | None): No description.
+            language (AnswerLanguage | Literal['Chinese', 'Dutch', 'English', 'French', 'German', 'Italian', 'Japanese', 'Korean', 'Latvian', 'Norwegian', 'Portuguese', 'Spanish', 'Swedish']): The desired language of the answer, defaults to English.
             additional_context (str | None): Additional context that you want the LLM to take into account.
+            ignore_unknown_ids (bool): Whether to skip documents that do not exists or that are not fully processed, instead of throwing an error
 
         Returns:
-            Answer: No description.
+            Answer: The answer to the question in the form of a list of multiple content objects, each consisting of a chunk of text along with a set of references.
+
         Examples:
 
-            Ask a question about a single document with internal id 123
+            Ask a question about a single document with id=123 and get the answer in English (default):
 
                 >>> from cognite.client import CogniteClient
                 >>> client = CogniteClient()
-                >>> client.ai.tools.documents.ask(question="What model pump was used?", ids=[123])
+                >>> client.ai.tools.documents.ask(
+                ...     question="What model pump was used?",
+                ...     ids=123,
+                ... )
+
+            Ask a question about multiple documents referenced using external IDs, and instance ID
+            and get the answer in German:
+
+                >>> from cognite.client.data_classes.data_modeling import NodeId
+                >>> from cognite.client.data_classes.ai import AnswerLanguage
+                >>> client.ai.tools.documents.ask_question(
+                ...     question="What other pumps are available?",
+                ...     external_ids=["foo", "bar"],
+                ...     instance_id=NodeId("my-space", "my-xid"),
+                ...     language=AnswerLanguage.German,
+                ... )
         """
+        identifiers = IdentifierSequenceWithInstanceId.load(id, external_id, instance_id)
+        if len(identifiers) > 100:
+            raise ValueError(f"Maximum number of documents is 100 (was {len(identifiers)})")
+
         body = {
             "question": question,
-            "fileIds": (
-                [{"id": id} for id in ids or []]
-                + [{"externalId": external_id} for external_id in external_ids or []]
-                + [{"instanceId": instance_id.dump(include_instance_type=False)} for instance_id in instance_ids or []]
-            ),
-            "language": language.value,
+            "fileIds": identifiers.as_dicts(),
             "ignoreUnknownIds": ignore_unknown_ids,
             "additionalContext": additional_context,
         }
+        match language:
+            case AnswerLanguage():
+                body["language"] = language.value
+            case str():
+                try:
+                    body["language"] = AnswerLanguage(language.capitalize()).value
+                except ValueError:
+                    # Probably an unknown language, but we let the API handle it (future-proofing)
+                    body["language"] = language
 
         response = self._post(self._RESOURCE_PATH + "/ask", json=body)
-        return Answer.load(response.json())
+        return Answer._load(response.json()["content"])

--- a/cognite/client/_api/ai/tools/documents.py
+++ b/cognite/client/_api/ai/tools/documents.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from collections.abc import Sequence
 
 from cognite.client._api_client import APIClient
-from cognite.client.data_classes.ai import Answer, Language, Summary
+from cognite.client.data_classes.ai import Answer, AnswerLanguage, Summary
 from cognite.client.utils._identifier import InstanceId
 from cognite.client.utils.useful_types import SequenceNotStr
 
@@ -71,7 +71,7 @@ class DocumentsAPI(APIClient):
         ids: Sequence[int] | None = None,
         external_ids: SequenceNotStr[str] | None = None,
         instance_ids: Sequence[InstanceId] | None = None,
-        language: Language = Language.English,
+        language: AnswerLanguage = AnswerLanguage.English,
         ignore_unknown_ids: bool = False,
         additional_context: str | None = None,
     ) -> Answer:
@@ -84,7 +84,7 @@ class DocumentsAPI(APIClient):
             ids (Sequence[int] | None): Internal ids of documents to find the answer in.
             external_ids (SequenceNotStr[str] | None): External ids of documents to find the answer in.
             instance_ids (Sequence[InstanceId] | None): Instance ids of documents to find the answer in.
-            language (Language): The desired language of the answer
+            language (AnswerLanguage): The desired language of the answer
             ignore_unknown_ids (bool): Whether to skip documents that can't be summarized, without throwing an error
             additional_context (str | None): Additional context that you want the LLM to take into account.
 

--- a/cognite/client/_api/ai/tools/documents.py
+++ b/cognite/client/_api/ai/tools/documents.py
@@ -8,7 +8,7 @@ from cognite.client.utils._identifier import InstanceId
 from cognite.client.utils.useful_types import SequenceNotStr
 
 
-class DocumentsAPI(APIClient):
+class AIDocumentsAPI(APIClient):
     _RESOURCE_PATH = "/ai/tools/documents"
 
     def summarize(

--- a/cognite/client/_api/ai/tools/documents.py
+++ b/cognite/client/_api/ai/tools/documents.py
@@ -85,7 +85,7 @@ class AIDocumentsAPI(APIClient):
             external_ids (SequenceNotStr[str] | None): External ids of documents to find the answer in.
             instance_ids (Sequence[InstanceId] | None): Instance ids of documents to find the answer in.
             language (AnswerLanguage): The desired language of the answer
-            ignore_unknown_ids (bool): Whether to skip documents that can't be summarized, without throwing an error
+            ignore_unknown_ids (bool): Whether to skip documents that are not fully processed, without throwing an error
             additional_context (str | None): Additional context that you want the LLM to take into account.
 
         Returns:

--- a/cognite/client/_api/ai/tools/documents.py
+++ b/cognite/client/_api/ai/tools/documents.py
@@ -1,0 +1,114 @@
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from cognite.client._api_client import APIClient
+from cognite.client.data_classes.ai import Answer, Language, Summary
+from cognite.client.utils._identifier import InstanceId
+from cognite.client.utils.useful_types import SequenceNotStr
+
+
+class DocumentsAPI(APIClient):
+    _RESOURCE_PATH = "/ai/tools/documents"
+
+    def summarize(
+        self,
+        ids: Sequence[int] | None = None,
+        external_ids: SequenceNotStr[str] | None = None,
+        instance_ids: Sequence[InstanceId] | None = None,
+        ignore_unknown_ids: bool = False,
+    ) -> list[Summary]:
+        """Summarize a document using a Large Language Model.
+
+        Currently only supports summarizing a single document at a time, but
+        this may be extended in the future.
+
+        Args:
+            ids (Sequence[int] | None): Internal ids of documents to summarize.
+            external_ids (SequenceNotStr[str] | None): External ids of documents to summarize.
+            instance_ids (Sequence[InstanceId] | None): Instance ids of documents to summarize.
+            ignore_unknown_ids (bool): Whether to skip documents that can't be summarized, without throwing an error
+
+        Returns:
+            list[Summary]: No description.
+        Examples:
+
+            Summarize a single document with internal id 123
+
+                >>> from cognite.client import CogniteClient
+                >>> client = CogniteClient()
+                >>> client.ai.tools.documents.summarize(ids=[123])
+        """
+        body = {
+            "items": (
+                [{"id": id} for id in ids or []]
+                + [{"externalId": external_id} for external_id in external_ids or []]
+                + [{"instanceId": instance_id.dump()} for instance_id in instance_ids or []]
+            ),
+            "ignoreUnknownIds": ignore_unknown_ids,
+        }
+
+        response = self._post(self._RESOURCE_PATH + "/summarize", json=body)
+        response_json = response.json()
+
+        summaries = []
+        for item in response_json["items"]:
+            instance_id = InstanceId.load(item["instanceId"]) if "instanceId" in item else None
+            summaries.append(
+                Summary(
+                    id=item.get("id"),
+                    external_id=item.get("externalId"),
+                    instance_id=instance_id,
+                    summary=item["summary"],
+                )
+            )
+
+        return summaries
+
+    def ask_question(
+        self,
+        question: str,
+        ids: Sequence[int] | None = None,
+        external_ids: SequenceNotStr[str] | None = None,
+        instance_ids: Sequence[InstanceId] | None = None,
+        language: Language = Language.English,
+        ignore_unknown_ids: bool = False,
+        additional_context: str | None = None,
+    ) -> Answer:
+        """Ask a question about one or more documents using a Large Language Model.
+
+        Supports up to 100 documents at a time.
+
+        Args:
+            question (str): The question.
+            ids (Sequence[int] | None): Internal ids of documents to find the answer in.
+            external_ids (SequenceNotStr[str] | None): External ids of documents to find the answer in.
+            instance_ids (Sequence[InstanceId] | None): Instance ids of documents to find the answer in.
+            language (Language): The desired language of the answer
+            ignore_unknown_ids (bool): Whether to skip documents that can't be summarized, without throwing an error
+            additional_context (str | None): Additional context that you want the LLM to take into account.
+
+        Returns:
+            Answer: No description.
+        Examples:
+
+            Ask a question about a single document with internal id 123
+
+                >>> from cognite.client import CogniteClient
+                >>> client = CogniteClient()
+                >>> client.ai.tools.documents.ask(question="What model pump was used?", ids=[123])
+        """
+        body = {
+            "question": question,
+            "fileIds": (
+                [{"id": id} for id in ids or []]
+                + [{"externalId": external_id} for external_id in external_ids or []]
+                + [{"instanceId": instance_id.dump()} for instance_id in instance_ids or []]
+            ),
+            "language": language.value,
+            "ignoreUnknownIds": ignore_unknown_ids,
+            "additionalContext": additional_context,
+        }
+
+        response = self._post(self._RESOURCE_PATH + "/ask", json=body)
+        return Answer.load(response.json())

--- a/cognite/client/_api_client.py
+++ b/cognite/client/_api_client.py
@@ -107,6 +107,7 @@ class APIClient:
                     "hostedextractors/.*",
                     "postgresgateway/.*",
                     "context/diagram/.*",
+                    "ai/tools/documents/(summarize|ask)",
                 )
             )
         ]

--- a/cognite/client/_cognite_client.py
+++ b/cognite/client/_cognite_client.py
@@ -4,6 +4,7 @@ from typing import Any
 
 from requests import Response
 
+from cognite.client._api.ai import AIAPI
 from cognite.client._api.annotations import AnnotationsAPI
 from cognite.client._api.assets import AssetsAPI
 from cognite.client._api.data_modeling import DataModelingAPI
@@ -58,6 +59,7 @@ class CogniteClient:
             self._config = client_config
 
         # APIs using base_url / resource path:
+        self.ai = AIAPI(self._config, self._API_VERSION, self)
         self.assets = AssetsAPI(self._config, self._API_VERSION, self)
         self.events = EventsAPI(self._config, self._API_VERSION, self)
         self.files = FilesAPI(self._config, self._API_VERSION, self)

--- a/cognite/client/_version.py
+++ b/cognite/client/_version.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
 
-__version__ = "7.71.4"
+__version__ = "7.72.0"
 
 __api_subversion__ = "20230101"

--- a/cognite/client/data_classes/__init__.py
+++ b/cognite/client/data_classes/__init__.py
@@ -2,14 +2,6 @@ from __future__ import annotations
 
 from cognite.client.data_classes._base import Geometry, HasExternalAndInternalId, HasExternalId, HasInternalId, HasName
 from cognite.client.data_classes.aggregations import CountAggregate
-from cognite.client.data_classes.ai import (
-    Answer,
-    AnswerContent,
-    AnswerLanguage,
-    AnswerLocation,
-    AnswerReference,
-    Summary,
-)
 from cognite.client.data_classes.annotations import (
     Annotation,
     AnnotationFilter,
@@ -341,11 +333,6 @@ __all__ = [
     "AnnotationUpdate",
     "AnnotationWrite",
     "AnnotationWriteList",
-    "Answer",
-    "AnswerContent",
-    "AnswerLanguage",
-    "AnswerLocation",
-    "AnswerReference",
     "Asset",
     "AssetFilter",
     "AssetHierarchy",
@@ -520,7 +507,6 @@ __all__ = [
     "SourceFile",
     "StatusCode",
     "SubworkflowTaskParameters",
-    "Summary",
     "Table",
     "TableList",
     "TableWrite",

--- a/cognite/client/data_classes/__init__.py
+++ b/cognite/client/data_classes/__init__.py
@@ -2,6 +2,14 @@ from __future__ import annotations
 
 from cognite.client.data_classes._base import Geometry, HasExternalAndInternalId, HasExternalId, HasInternalId, HasName
 from cognite.client.data_classes.aggregations import CountAggregate
+from cognite.client.data_classes.ai import (
+    Answer,
+    AnswerContent,
+    AnswerLanguage,
+    AnswerLocation,
+    AnswerReference,
+    Summary,
+)
 from cognite.client.data_classes.annotations import (
     Annotation,
     AnnotationFilter,
@@ -333,6 +341,11 @@ __all__ = [
     "AnnotationUpdate",
     "AnnotationWrite",
     "AnnotationWriteList",
+    "Answer",
+    "AnswerContent",
+    "AnswerLanguage",
+    "AnswerLocation",
+    "AnswerReference",
     "Asset",
     "AssetFilter",
     "AssetHierarchy",
@@ -452,8 +465,12 @@ __all__ = [
     "GroupWrite",
     "GroupWriteList",
     "HasExternalAndInternalId",
+    "HasExternalAndInternalId",
+    "HasExternalId",
     "HasExternalId",
     "HasInternalId",
+    "HasInternalId",
+    "HasName",
     "HasName",
     "JobStatus",
     "Label",
@@ -503,6 +520,7 @@ __all__ = [
     "SourceFile",
     "StatusCode",
     "SubworkflowTaskParameters",
+    "Summary",
     "Table",
     "TableList",
     "TableWrite",

--- a/cognite/client/data_classes/ai.py
+++ b/cognite/client/data_classes/ai.py
@@ -1,0 +1,155 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any
+
+from cognite.client.utils._identifier import InstanceId
+
+
+class Language(Enum):
+    Chinese = "Chinese"
+    Dutch = "Dutch"
+    English = "English"
+    French = "French"
+    German = "German"
+    Italian = "Italian"
+    Japanese = "Japanese"
+    Korean = "Korean"
+    Latvian = "Latvian"
+    Norwegian = "Norwegian"
+    Portuguese = "Portuguese"
+    Spanish = "Spanish"
+    Swedish = "Swedish"
+
+
+@dataclass
+class Summary:
+    """
+    A summary object consisting of a textual summary plus the id of the summarized document
+
+    Args:
+        summary (str): The textual summary of the document
+        id (int | None): The internal id of the document
+        external_id (str | None): The external id of the document
+        instance_id (InstanceId | None): The instance id of the document
+    """
+
+    summary: str
+    id: int | None = None
+    external_id: str | None = None
+    instance_id: InstanceId | None = None
+
+
+@dataclass
+class AnswerLocation:
+    """
+    A location object
+
+    The location object consists of a page number and a bounding box. This
+    specifies exactly where inside a document an answer can be found.
+
+    Args:
+        page_number (int): Page number, starting with 1
+        left (float): Leftmost edge of the bounding box
+        right (float): Rightmost edge of the bounding box
+        top (float): Topmost edge of the bounding box
+        bottom (float): Bottommost edge of the bounding box
+    """
+
+    page_number: int
+    left: float
+    right: float
+    top: float
+    bottom: float
+
+    @classmethod
+    def load(cls, data: dict[str, Any]) -> AnswerLocation:
+        return AnswerLocation(
+            page_number=data["pageNumber"],
+            left=data["left"],
+            right=data["right"],
+            top=data["top"],
+            bottom=data["bottom"],
+        )
+
+
+@dataclass
+class AnswerReference:
+    """
+    A single reference object.
+
+    The reference object specifies which file an answer is based on, and
+    has a list of locations pointing to the specific pages and bounding boxes
+    where the answer was found.
+
+    Args:
+        file_id (int): The internal id of the document
+        external_id (str | None): The external id of the document
+        instance_id (InstanceId | None): The instance id of the document
+        file_name (str): The name of the document
+        locations (list[AnswerLocation]): A list of locations within the document, where the answer was found
+    """
+
+    file_id: int
+    external_id: str | None
+    instance_id: InstanceId | None
+    file_name: str
+    locations: list[AnswerLocation]
+
+    @classmethod
+    def load(cls, data: dict[str, Any]) -> AnswerReference:
+        return AnswerReference(
+            file_id=data["fileId"],
+            external_id=data.get("externalId"),
+            instance_id=InstanceId.load(data["instanceId"]) if "instanceId" in data else None,
+            file_name=data["fileName"],
+            locations=[AnswerLocation.load(d) for d in data.get("locations", [])],
+        )
+
+
+@dataclass
+class AnswerContent:
+    """
+    A single content object.
+
+    It consists of part of the answer from the LLM along with references to
+    the documents containing the source material for the answer.
+
+    Args:
+        text (str): The extracted plain text
+        content (list[AnswerReference]): The list of references
+    """
+
+    text: str
+    references: list[AnswerReference]
+
+    @classmethod
+    def load(cls, data: dict[str, Any]) -> AnswerContent:
+        return AnswerContent(
+            text=data["text"],
+            references=[AnswerReference.load(d) for d in data.get("references", [])],
+        )
+
+
+@dataclass
+class Answer:
+    """
+    An answer returned from the Document Question Answering API.
+
+    The answer contains of multiple content objects. Each content object
+    consists of a chunk of text along with a set of references.
+
+    Each reference contains information about which document this part
+    of the answer was found in, and gives the bounding box and page number
+    of the piece of text the answer was constructed from.
+
+    Args:
+        content (list[AnswerContent]): The list of content objects.
+    """
+
+    content: list[AnswerContent]
+
+    @classmethod
+    def load(cls, data: dict[str, Any]) -> Answer:
+        return Answer(content=[AnswerContent.load(c) for c in data["content"]])

--- a/cognite/client/data_classes/ai.py
+++ b/cognite/client/data_classes/ai.py
@@ -73,6 +73,9 @@ class AnswerLocation:
             bottom=data["bottom"],
         )
 
+    def __hash__(self) -> int:
+        return hash((self.page_number, self.left, self.right, self.top, self.bottom))
+
 
 @dataclass
 class AnswerReference:
@@ -106,6 +109,9 @@ class AnswerReference:
             file_name=data["fileName"],
             locations=[AnswerLocation.load(d) for d in data.get("locations", [])],
         )
+
+    def __hash__(self) -> int:
+        return hash((self.file_id, self.external_id, self.instance_id, self.file_name, tuple(self.locations)))
 
 
 @dataclass
@@ -149,6 +155,24 @@ class Answer:
     """
 
     content: list[AnswerContent]
+
+    def get_full_answer_text(self) -> str:
+        """
+        Get the full answer text. This is the concatenation of the texts from
+        all the content objects.
+        """
+        return "".join([content.text for content in self.content])
+
+    def get_all_references(self) -> list[AnswerReference]:
+        """
+        Get all the references. This is the full list of references from
+        all the content objects.
+        """
+        all_references = set()
+        for content in self.content:
+            all_references |= set(content.references)
+
+        return list(all_references)
 
     @classmethod
     def load(cls, data: dict[str, Any]) -> Answer:

--- a/cognite/client/data_classes/ai.py
+++ b/cognite/client/data_classes/ai.py
@@ -2,9 +2,14 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from enum import Enum
-from typing import Any
+from typing import TYPE_CHECKING, Any
+
+from typing_extensions import Self
 
 from cognite.client.data_classes.data_modeling import NodeId
+
+if TYPE_CHECKING:
+    pass
 
 
 class AnswerLanguage(Enum):
@@ -30,7 +35,7 @@ class Summary:
 
     Args:
         summary (str): The textual summary of the document
-        id (int | None): The internal id of the document
+        id (int | None): The id of the document
         external_id (str | None): The external id of the document
         instance_id (NodeId| None): The instance id of the document
     """
@@ -39,6 +44,15 @@ class Summary:
     id: int | None = None
     external_id: str | None = None
     instance_id: NodeId | None = None
+
+    @classmethod
+    def _load(cls, data: dict[str, Any]) -> Self:
+        return cls(
+            summary=data["summary"],
+            id=data.get("id"),
+            external_id=data.get("externalId"),
+            instance_id=NodeId.load(data["instanceId"]) if "instanceId" in data else None,
+        )
 
 
 @dataclass
@@ -64,8 +78,8 @@ class AnswerLocation:
     bottom: float
 
     @classmethod
-    def load(cls, data: dict[str, Any]) -> AnswerLocation:
-        return AnswerLocation(
+    def _load(cls, data: dict[str, Any]) -> Self:
+        return cls(
             page_number=data["pageNumber"],
             left=data["left"],
             right=data["right"],
@@ -74,6 +88,7 @@ class AnswerLocation:
         )
 
     def __hash__(self) -> int:
+        # Hashing floats, what can go wrong? :)
         return hash((self.page_number, self.left, self.right, self.top, self.bottom))
 
 
@@ -101,13 +116,13 @@ class AnswerReference:
     locations: list[AnswerLocation]
 
     @classmethod
-    def load(cls, data: dict[str, Any]) -> AnswerReference:
-        return AnswerReference(
+    def _load(cls, data: dict[str, Any]) -> Self:
+        return cls(
             file_id=data["fileId"],
             external_id=data.get("externalId"),
             instance_id=NodeId.load(data["instanceId"]) if "instanceId" in data else None,
             file_name=data["fileName"],
-            locations=[AnswerLocation.load(d) for d in data.get("locations", [])],
+            locations=[AnswerLocation._load(d) for d in data.get("locations", [])],
         )
 
     def __hash__(self) -> int:
@@ -131,10 +146,10 @@ class AnswerContent:
     references: list[AnswerReference]
 
     @classmethod
-    def load(cls, data: dict[str, Any]) -> AnswerContent:
-        return AnswerContent(
+    def _load(cls, data: dict[str, Any]) -> Self:
+        return cls(
             text=data["text"],
-            references=[AnswerReference.load(d) for d in data.get("references", [])],
+            references=[AnswerReference._load(ref) for ref in data.get("references", [])],
         )
 
 
@@ -143,7 +158,7 @@ class Answer:
     """
     An answer returned from the Document Question Answering API.
 
-    The answer contains of multiple content objects. Each content object
+    The answer is essentially a list of content objects. Each content object
     consists of a chunk of text along with a set of references.
 
     Each reference contains information about which document this part
@@ -156,24 +171,28 @@ class Answer:
 
     content: list[AnswerContent]
 
-    def get_full_answer_text(self) -> str:
+    def __str__(self) -> str:
+        return f"Answer({self.full_answer!r})"
+
+    def _repr_html_(self) -> str:
+        return str(self)
+
+    @property
+    def full_answer(self) -> str:
         """
         Get the full answer text. This is the concatenation of the texts from
         all the content objects.
         """
-        return "".join([content.text for content in self.content])
+        return "".join(cnt.text for cnt in self.content)
 
-    def get_all_references(self) -> list[AnswerReference]:
+    @property
+    def all_references(self) -> set[AnswerReference]:
         """
-        Get all the references. This is the full list of references from
+        Get all unique references. This is the full set of references from
         all the content objects.
         """
-        all_references = set()
-        for content in self.content:
-            all_references |= set(content.references)
-
-        return list(all_references)
+        return set().union(*(cnt.references for cnt in self.content))
 
     @classmethod
-    def load(cls, data: dict[str, Any]) -> Answer:
-        return Answer(content=[AnswerContent.load(c) for c in data["content"]])
+    def _load(cls, data: list[dict[str, Any]]) -> Self:
+        return cls(content=[AnswerContent._load(cnt) for cnt in data])

--- a/cognite/client/data_classes/ai.py
+++ b/cognite/client/data_classes/ai.py
@@ -7,7 +7,7 @@ from typing import Any
 from cognite.client.utils._identifier import InstanceId
 
 
-class Language(Enum):
+class AnswerLanguage(Enum):
     Chinese = "Chinese"
     Dutch = "Dutch"
     English = "English"

--- a/cognite/client/data_classes/ai.py
+++ b/cognite/client/data_classes/ai.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass
 from enum import Enum
 from typing import Any
 
-from cognite.client.utils._identifier import InstanceId
+from cognite.client.data_classes.data_modeling import NodeId
 
 
 class AnswerLanguage(Enum):
@@ -32,13 +32,13 @@ class Summary:
         summary (str): The textual summary of the document
         id (int | None): The internal id of the document
         external_id (str | None): The external id of the document
-        instance_id (InstanceId | None): The instance id of the document
+        instance_id (NodeId| None): The instance id of the document
     """
 
     summary: str
     id: int | None = None
     external_id: str | None = None
-    instance_id: InstanceId | None = None
+    instance_id: NodeId | None = None
 
 
 @dataclass
@@ -86,14 +86,14 @@ class AnswerReference:
     Args:
         file_id (int): The internal id of the document
         external_id (str | None): The external id of the document
-        instance_id (InstanceId | None): The instance id of the document
+        instance_id (NodeId | None): The instance id of the document
         file_name (str): The name of the document
         locations (list[AnswerLocation]): A list of locations within the document, where the answer was found
     """
 
     file_id: int
     external_id: str | None
-    instance_id: InstanceId | None
+    instance_id: NodeId | None
     file_name: str
     locations: list[AnswerLocation]
 
@@ -102,7 +102,7 @@ class AnswerReference:
         return AnswerReference(
             file_id=data["fileId"],
             external_id=data.get("externalId"),
-            instance_id=InstanceId.load(data["instanceId"]) if "instanceId" in data else None,
+            instance_id=NodeId.load(data["instanceId"]) if "instanceId" in data else None,
             file_name=data["fileName"],
             locations=[AnswerLocation.load(d) for d in data.get("locations", [])],
         )

--- a/cognite/client/testing.py
+++ b/cognite/client/testing.py
@@ -103,6 +103,7 @@ class CogniteClientMock(MagicMock):
         self.ai = MagicMock(spec=AIAPI)
         self.ai.tools = MagicMock(spec=AIToolsAPI)
         self.ai.tools.documents = MagicMock(spec_set=AIDocumentsAPI)
+
         self.annotations = MagicMock(spec_set=AnnotationsAPI)
         self.assets = MagicMock(spec_set=AssetsAPI)
 

--- a/cognite/client/testing.py
+++ b/cognite/client/testing.py
@@ -6,6 +6,9 @@ from typing import Any
 from unittest.mock import MagicMock
 
 from cognite.client import CogniteClient
+from cognite.client._api.ai import AIAPI
+from cognite.client._api.ai.tools import AIToolsAPI
+from cognite.client._api.ai.tools.documents import AIDocumentsAPI
 from cognite.client._api.annotations import AnnotationsAPI
 from cognite.client._api.assets import AssetsAPI
 from cognite.client._api.data_modeling import DataModelingAPI
@@ -97,6 +100,9 @@ class CogniteClientMock(MagicMock):
         #   - Add spacing above and below
         #   - Use `spec=MyAPI` only for "top level"
         #   - Use `spec_set=MyNestedAPI` for all nested APIs
+        self.ai = MagicMock(spec=AIAPI)
+        self.ai.tools = MagicMock(spec=AIToolsAPI)
+        self.ai.tools.documents = MagicMock(spec_set=AIDocumentsAPI)
         self.annotations = MagicMock(spec_set=AnnotationsAPI)
         self.assets = MagicMock(spec_set=AssetsAPI)
 

--- a/cognite/client/utils/_identifier.py
+++ b/cognite/client/utils/_identifier.py
@@ -328,7 +328,7 @@ class IdentifierSequence(IdentifierSequenceCore[Identifier]):
     def load(
         cls,
         ids: int | Sequence[int] | None = None,
-        external_ids: str | SequenceNotStr[str] | SequenceNotStr[str] | None = None,
+        external_ids: str | Sequence[str] | SequenceNotStr[str] | None = None,
         instance_ids: InstanceId
         | Sequence[InstanceId | tuple[str, str] | dict[str, str]]
         | tuple[str, str]
@@ -376,6 +376,16 @@ class IdentifierSequence(IdentifierSequenceCore[Identifier]):
 
         is_singleton = value_passed_as_primitive and len(all_identifiers) == 1
         return cls(identifiers=[Identifier(val) for val in all_identifiers], is_singleton=is_singleton)
+
+
+class IdentifierSequenceWithInstanceId(IdentifierSequence):
+    # TODO: Remove 'instanceId' above and move here instead (and update usage where appropriate...)
+    #       to avoid error messages mentioning instance ID where it's not relevant, and be more
+    #       helpful where needed.
+
+    def assert_singleton(self) -> None:
+        if not self.is_singleton():
+            raise ValueError("Exactly one of id or external_id or instance_id must be specified")
 
 
 class SingletonIdentifierSequence(IdentifierSequenceCore[Identifier]): ...

--- a/docs/source/ai.rst
+++ b/docs/source/ai.rst
@@ -4,8 +4,8 @@ AI API
 ---------------
 Document Summarization
 ^^^^^^^^^^^^^^^^^^^^^^
-.. automethod:: cognite.client._api.ai.tools.documents.DocumentsAPI.summarize
+.. automethod:: cognite.client._api.ai.tools.documents.AIDocumentsAPI.summarize
 
 Document Question Answering
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. automethod:: cognite.client._api.ai.tools.documents.DocumentsAPI.ask_question
+.. automethod:: cognite.client._api.ai.tools.documents.AIDocumentsAPI.ask_question

--- a/docs/source/ai.rst
+++ b/docs/source/ai.rst
@@ -1,0 +1,11 @@
+AI
+===============
+AI API
+---------------
+Document Summarization
+^^^^^^^^^^^^^^^^^^^^^^
+.. automethod:: cognite.client._api.ai.tools.documents.DocumentsAPI.summarize
+
+Document Question Answering
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+.. automethod:: cognite.client._api.ai.tools.documents.DocumentsAPI.ask_question

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -40,6 +40,7 @@ Contents
    extensions_and_optional_dependencies
    identity_and_access_management
    data_modeling
+   ai
    assets
    events
    files

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "cognite-sdk"
 
-version = "7.71.4"
+version = "7.72.0"
 
 description = "Cognite Python SDK"
 readme = "README.md"

--- a/tests/tests_integration/test_api/test_vision_extract.py
+++ b/tests/tests_integration/test_api/test_vision_extract.py
@@ -1,3 +1,5 @@
+from collections.abc import Iterator
+
 import pytest
 
 from cognite.client import CogniteClient
@@ -13,9 +15,9 @@ from cognite.client.data_classes.contextualization import (
 
 # TODO(VIS-986): replace this file generator with a hard-coded ID of an actual image
 @pytest.fixture(scope="class")
-def file_id(cognite_client: CogniteClient) -> int:
+def file_id(cognite_client: CogniteClient, os_and_py_version: str) -> Iterator[int]:
     # Create a test file
-    name = "vision_extract_test_file"
+    name = "vision_extract_test_file" + os_and_py_version
     file = cognite_client.files.create(FileMetadata(external_id=name, name=name), overwrite=True)[0]
     yield file.id
 

--- a/tests/tests_integration/test_api/test_workflows.py
+++ b/tests/tests_integration/test_api/test_workflows.py
@@ -289,7 +289,7 @@ def workflow_scheduled_trigger(cognite_client: CogniteClient, workflow_setup_pre
     )
     # have to sleep until workflow is triggered because it's the only way to properly test get_trigger_run_history
     now = datetime.now()
-    seconds_til_next_minute = 60 - now.second + 5
+    seconds_til_next_minute = 60 - now.second + 15  # 15 seconds buffer, needed from experience...
     time.sleep(seconds_til_next_minute)
 
     yield trigger

--- a/tests/tests_integration/test_api/test_workflows.py
+++ b/tests/tests_integration/test_api/test_workflows.py
@@ -289,7 +289,7 @@ def workflow_scheduled_trigger(cognite_client: CogniteClient, workflow_setup_pre
     )
     # have to sleep until workflow is triggered because it's the only way to properly test get_trigger_run_history
     now = datetime.now()
-    seconds_til_next_minute = 60 - now.second + 15  # 15 seconds buffer, needed from experience...
+    seconds_til_next_minute = 60 - now.second + 30  # 30 seconds buffer, needed from experience...
     time.sleep(seconds_til_next_minute)
 
     yield trigger

--- a/tests/tests_unit/test_api/test_ai.py
+++ b/tests/tests_unit/test_api/test_ai.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+import re
+
+import pytest
+
+from cognite.client.data_classes import AnswerContent, AnswerLocation, AnswerReference, Summary
+
+
+@pytest.fixture
+def mock_summarize_response(rsps, cognite_client):
+    response_body = {
+        "items": [
+            {
+                "id": 1234,
+                "summary": "Summary",
+            }
+        ]
+    }
+
+    url_pattern = re.compile(re.escape(cognite_client.ai.tools.documents._get_base_url_with_base_path()) + "/.+")
+    rsps.assert_all_requests_are_fired = False
+
+    rsps.add(rsps.POST, url_pattern, status=200, json=response_body)
+    yield rsps
+
+
+@pytest.fixture
+def mock_ask_response(rsps, cognite_client):
+    response_body = {
+        "content": [
+            {
+                "text": "Content",
+                "references": [
+                    {
+                        "fileId": 1234,
+                        "fileName": "foo.pdf",
+                        "locations": [
+                            {
+                                "pageNumber": 1,
+                                "left": 0.0,
+                                "right": 1.0,
+                                "top": 0.0,
+                                "bottom": 1.0,
+                            }
+                        ],
+                    }
+                ],
+            }
+        ]
+    }
+
+    url_pattern = re.compile(re.escape(cognite_client.ai.tools.documents._get_base_url_with_base_path()) + "/.+")
+    rsps.assert_all_requests_are_fired = False
+
+    rsps.add(rsps.POST, url_pattern, status=200, json=response_body)
+    yield rsps
+
+
+class TestAIAPI:
+    def test_summarize(self, cognite_client, mock_summarize_response):
+        summaries = cognite_client.ai.tools.documents.summarize(ids=[1234])
+        assert len(summaries) == 1
+        summary = summaries[0]
+        assert isinstance(summary, Summary)
+        assert summary.id == 1234
+        assert summary.summary == "Summary"
+
+    def test_ask_question(self, cognite_client, mock_ask_response):
+        answer = cognite_client.ai.tools.documents.ask_question(question="How is the weather?", ids=[1234])
+        assert len(answer.content) == 1
+        content = answer.content[0]
+        assert isinstance(content, AnswerContent)
+        assert len(content.references) == 1
+        reference = content.references[0]
+        assert isinstance(reference, AnswerReference)
+        assert reference.file_id == 1234
+        assert reference.file_name == "foo.pdf"
+        assert len(reference.locations) == 1
+        location = reference.locations[0]
+        assert isinstance(location, AnswerLocation)
+        assert location.page_number == 1
+        assert location.left == 0.0
+        assert location.right == 1.0
+        assert location.top == 0.0
+        assert location.bottom == 1.0

--- a/tests/tests_unit/test_api_client.py
+++ b/tests/tests_unit/test_api_client.py
@@ -1369,6 +1369,11 @@ class TestRetryableEndpoints:
                 # Simulators
                 ("POST", "https://api.cognitedata.com/api/v1/projects/bla/simulators/list", True),
                 ("POST", "https://api.cognitedata.com/api/v1/projects/bla/simulators/delete", False),
+                # AI API
+                # "ai/tools/documents/(summarize|ask)",
+                ("POST", "https://api.cognitedata.com/api/v1/projects/bla/ai/tools/documents/summarize", True),
+                ("POST", "https://api.cognitedata.com/api/v1/projects/bla/ai/tools/documents/ask", True),
+                ("POST", "https://api.cognitedata.com/api/v1/projects/bla/ai/tools/documents/task", False),
             ]
         ),
     )


### PR DESCRIPTION
## Description
This commit adds sdk support for the newly GA endpoints Document Question Answering and Document Summary, which are part of the AI API.

## Checklist:
- [x] Tests added/updated.
- [x] Documentation updated. Documentation is generated from docstrings - these must be updated according to your change.
  If a new method has been added it should be referenced in [cognite.rst](https://github.com/cognitedata/cognite-sdk-python/blob/master/docs/source/cognite.rst) in order to generate docs based on its docstring.
- [x] Changelog updated in [CHANGELOG.md](https://github.com/cognitedata/cognite-sdk-python/blob/master/CHANGELOG.md).
- [x] Version bumped. If triggering a new release is desired, bump the version number in [_version.py](https://github.com/cognitedata/cognite-sdk-python/blob/master/cognite/client/_version.py) and [pyproject.toml](https://github.com/cognitedata/cognite-sdk-python/blob/master/pyproject.toml) per [semantic versioning](https://semver.org/).
