### PR TITLE
fix(workflows): support None value for simulation input unit override

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ Changes are grouped as follows
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
+## [7.70.1] - 2024-12-04
+### Fixed
+- Fix `workflows.executions.retrieve_detailed` type for `SimulationInputOverride` to allow for `None` value for `unit`.
 
 ## [7.70.0] - 2024-12-02
 ### Added

--- a/cognite/client/_version.py
+++ b/cognite/client/_version.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
 
-__version__ = "7.70.0"
+__version__ = "7.70.1"
 
 __api_subversion__ = "20230101"

--- a/cognite/client/data_classes/simulators/runs.py
+++ b/cognite/client/data_classes/simulators/runs.py
@@ -44,7 +44,7 @@ class SimulationInputOverride(CogniteObject):
         return cls(
             reference_id=resource["referenceId"],
             value=resource["value"],
-            unit=SimulationValueUnitName._load(resource["unit"], cognite_client) if "unit" in resource else None,
+            unit=SimulationValueUnitName._load(resource["unit"], cognite_client) if resource.get("unit") else None,
         )
 
     def __post_init__(self) -> None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "cognite-sdk"
 
-version = "7.70.0"
+version = "7.70.1"
 
 description = "Cognite Python SDK"
 readme = "README.md"

--- a/tests/tests_integration/test_api/test_simulators/seed/resources.py
+++ b/tests/tests_integration/test_api/test_simulators/seed/resources.py
@@ -97,6 +97,13 @@ def get_workflow_seed_data(data_set_id: int, file_id: int):
                     "valueType": "DOUBLE",
                     "unit": {"name": "C", "quantity": "temperature"},
                 },
+                {
+                    "name": "Hot Water Temperature",
+                    "referenceId": "HWT",
+                    "value": 1.0,
+                    "valueType": "DOUBLE",
+                    "unit": {"name": "C", "quantity": "temperature"},
+                },
             ],
             "outputs": [
                 {

--- a/tests/tests_integration/test_api/test_workflows.py
+++ b/tests/tests_integration/test_api/test_workflows.py
@@ -382,9 +382,7 @@ class TestWorkflowVersions:
                                 SimulationInputOverride(
                                     reference_id="CWT", value=11, unit=SimulationValueUnitName(name="F")
                                 ),
-                                SimulationInputOverride(
-                                    reference_id="HWT", value=0.1
-                                )
+                                SimulationInputOverride(reference_id="HWT", value=0.1),
                             ],
                         ),
                         timeout=100,

--- a/tests/tests_integration/test_api/test_workflows.py
+++ b/tests/tests_integration/test_api/test_workflows.py
@@ -381,6 +381,9 @@ class TestWorkflowVersions:
                             inputs=[
                                 SimulationInputOverride(
                                     reference_id="CWT", value=11, unit=SimulationValueUnitName(name="F")
+                                ),
+                                SimulationInputOverride(
+                                    reference_id="HWT", value=0.1
                                 )
                             ],
                         ),


### PR DESCRIPTION
## Description
introduced a small bug my recent PR when adding simulation workflows.
basically, a null pointer exception, fixed now