### PR TITLE
DM-2412 fix aggregate property casing + add files tests cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ Changes are grouped as follows
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
-## [7.70.3] - 2024-12-05
+## [7.70.3] - 2024-12-11
 ### Fixed
 - Aggregation requests with custom properties, like a metadata key, are no longer converted to camelCase
   automatically.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,11 +17,14 @@ Changes are grouped as follows
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
+## [7.70.3] - 2024-12-05
+### Fixed
+- Aggregation requests with custom properties, like a metadata key, are no longer converted to camelCase
+  automatically.
+
 ## [7.70.2] - 2024-12-04
 ### Fixed
-- Retrieving `ExtractionPipeline` either with `client.extraction_pipelines.retrieve` or 
-  `client.extraction_pipelines.list` no longer raises a `KeyError` if any of the pipline properties have a contact
-  with a `None` value.
+- Retrieving `ExtractionPipeline` no longer raises a `KeyError` if any of the piplines have a contact with missing fields.
 
 ## [7.70.1] - 2024-12-04
 ### Fixed
@@ -29,7 +32,7 @@ Changes are grouped as follows
 
 ## [7.70.0] - 2024-12-02
 ### Added
-- Workflow support for "simulation" task type. 
+- Workflow support for "simulation" task type.
 
 ## [7.69.4] - 2024-12-02
 ### Added

--- a/cognite/client/_api/documents.py
+++ b/cognite/client/_api/documents.py
@@ -333,7 +333,7 @@ class DocumentsAPI(APIClient):
 
     def aggregate_cardinality_properties(
         self,
-        path: DocumentProperty | SourceFileProperty | list[str] | str,
+        path: SourceFileProperty | list[str] = SourceFileProperty.metadata,
         query: str | None = None,
         filter: Filter | dict[str, Any] | None = None,
         aggregate_filter: AggregationFilter | dict[str, Any] | None = None,
@@ -341,7 +341,7 @@ class DocumentsAPI(APIClient):
         """`Find approximate paths count for documents.  <https://developer.cognite.com/api#tag/Documents/operation/documentsAggregate>`_
 
         Args:
-            path (DocumentProperty | SourceFileProperty | list[str] | str): The scope in every document to aggregate properties. The only value allowed now is ["metadata"]. It means to aggregate only metadata properties (aka keys).
+            path (SourceFileProperty | list[str]): The scope in every document to aggregate properties. The only value allowed now is ["sourceFile", "metadata"]. It means to aggregate only metadata properties (aka keys).
             query (str | None): The free text search query, for details see the documentation referenced above.
             filter (Filter | dict[str, Any] | None): The filter to narrow down the documents to count cardinality.
             aggregate_filter (AggregationFilter | dict[str, Any] | None): The filter to apply to the resulting buckets.
@@ -354,9 +354,8 @@ class DocumentsAPI(APIClient):
             Count the number metadata keys for documents in your CDF project:
 
                 >>> from cognite.client import CogniteClient
-                >>> from cognite.client.data_classes.documents import SourceFileProperty
                 >>> client = CogniteClient()
-                >>> count = client.documents.aggregate_cardinality_properties(SourceFileProperty.metadata)
+                >>> count = client.documents.aggregate_cardinality_properties()
         """
         self._validate_filter(filter)
 

--- a/cognite/client/_api_client.py
+++ b/cognite/client/_api_client.py
@@ -804,7 +804,7 @@ class APIClient:
             elif isinstance(properties, str):
                 dumped_properties = [to_camel_case(properties)]
             elif isinstance(properties, list):
-                dumped_properties = [to_camel_case(p) for p in properties]
+                dumped_properties = [to_camel_case(properties[0])] if len(properties) == 1 else properties
             else:
                 raise ValueError(f"Unknown property format: {properties}")
 
@@ -832,8 +832,6 @@ class APIClient:
                 dumped_filter = filter.dump(camel_case=True)
             elif isinstance(filter, dict):
                 dumped_filter = convert_all_keys_to_camel_case(filter)
-            else:
-                raise ValueError(f"Unknown filter format: {filter}")
             body["filter"] = dumped_filter
 
         if advanced_filter is not None:

--- a/cognite/client/_api_client.py
+++ b/cognite/client/_api_client.py
@@ -72,6 +72,8 @@ logger = logging.getLogger(__name__)
 
 T = TypeVar("T", bound=CogniteObject)
 
+VALID_AGGREGATIONS = {"count", "cardinalityValues", "cardinalityProperties", "uniqueValues", "uniqueProperties"}
+
 
 class APIClient:
     _RESOURCE_PATH: str
@@ -787,11 +789,8 @@ class APIClient:
         api_subversion: str | None = None,
     ) -> int | UniqueResultList:
         verify_limit(limit)
-        if aggregate not in ["count", "cardinalityValues", "cardinalityProperties", "uniqueValues", "uniqueProperties"]:
-            raise ValueError(
-                f"Invalid aggregate '{aggregate}'. Valid aggregates are 'count', 'cardinalityValues', "
-                f"'cardinalityProperties', 'uniqueValues', and 'uniqueProperties'."
-            )
+        if aggregate not in VALID_AGGREGATIONS:
+            raise ValueError(f"Invalid aggregate {aggregate!r}. Valid aggregates are {sorted(VALID_AGGREGATIONS)}.")
 
         body: dict[str, Any] = {"aggregate": aggregate}
         if properties is not None:
@@ -799,6 +798,7 @@ class APIClient:
                 properties, property_aggregation_filter = properties
             else:
                 property_aggregation_filter = None
+
             if isinstance(properties, EnumProperty):
                 dumped_properties = properties.as_reference()
             elif isinstance(properties, str):

--- a/cognite/client/_version.py
+++ b/cognite/client/_version.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
 
-__version__ = "7.70.2"
+__version__ = "7.70.3"
 
 __api_subversion__ = "20230101"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "cognite-sdk"
 
-version = "7.70.2"
+version = "7.70.3"
 
 description = "Cognite Python SDK"
 readme = "README.md"

--- a/tests/tests_integration/test_api/test_documents.py
+++ b/tests/tests_integration/test_api/test_documents.py
@@ -8,7 +8,8 @@ from pathlib import Path
 import pytest
 
 from cognite.client import CogniteClient
-from cognite.client.data_classes import aggregations, filters
+from cognite.client.data_classes import aggregations as agg
+from cognite.client.data_classes import filters as flt
 from cognite.client.data_classes.documents import (
     DocumentProperty,
     SortableDocumentProperty,
@@ -16,6 +17,7 @@ from cognite.client.data_classes.documents import (
     SourceFileProperty,
 )
 from cognite.client.data_classes.files import FileMetadata, FileMetadataList
+from cognite.client.exceptions import CogniteAPIError
 from tests.utils import dict_without
 
 RESOURCES = Path(__file__).resolve().parent / "documents_resources"
@@ -25,23 +27,24 @@ _FILE_PREFIX = "document_api_integration"
 _SYMMETRIC_DIFFERENCE_FILEMETADATA_SOURCEFILE: frozenset[str] = frozenset(
     set(inspect.signature(FileMetadata.__init__).parameters) ^ set(inspect.signature(SourceFile.__init__).parameters)
 )
-
-
-@pytest.fixture(scope="session")
-def text_file_content_pair(cognite_client: CogniteClient) -> tuple[FileMetadata, str]:
-    external_id = f"{_FILE_PREFIX}_test_file"
-    content = """This is a test file for the document API integration test.
+PLAIN_TEXT_CONTENT = """This is a test file for the document API integration test.
 
 Lorem ipsum dolor sit amet, eum an quando noster graecis, nam everti offendit an.
 Quod probo mazim cu pro, pro at pericula ullamcorper, vitae cetero vis ex.
 Error deserunt eu eos, te vix labores suscipiantur, ut quot atomorum comprehensam quo.
 Nam cu appareat officiis, vis et enim vide possit. Dicat bonorum ancillae est at.
-Mei et possim option. An sit ipsum scaevola."""
+Mei et possim option. An sit ipsum scaevola.
+"""
+
+
+@pytest.fixture(scope="session")
+def text_file(cognite_client: CogniteClient) -> FileMetadata:
+    external_id = f"{_FILE_PREFIX}_test_file"
     file = cognite_client.files.retrieve(external_id=external_id)
     if file is not None:
-        return file, content
+        return file
     created_file = cognite_client.files.upload_bytes(
-        content=content,
+        content=PLAIN_TEXT_CONTENT,
         name=external_id,
         external_id=external_id,
         mime_type="text/plain",
@@ -50,7 +53,7 @@ Mei et possim option. An sit ipsum scaevola."""
             "im_a_key": "t-X-t",
         },
     )
-    return created_file, content
+    return created_file
 
 
 @pytest.fixture(scope="session")
@@ -72,8 +75,8 @@ def pdf_file(cognite_client: CogniteClient) -> FileMetadata:
 
 
 @pytest.fixture(scope="session")
-def document_list(text_file_content_pair: tuple[FileMetadata, str], pdf_file: FileMetadata) -> FileMetadataList:
-    return FileMetadataList([text_file_content_pair[0], pdf_file])
+def document_list(text_file: FileMetadata, pdf_file: FileMetadata) -> FileMetadataList:
+    return FileMetadataList([text_file, pdf_file])
 
 
 class TestDocumentsAPI:
@@ -81,18 +84,16 @@ class TestDocumentsAPI:
         self,
         cognite_client: CogniteClient,
         document_list: FileMetadataList,
-        text_file_content_pair: tuple[FileMetadata, str],
+        text_file: FileMetadata,
     ):
-        text_file, _ = text_file_content_pair
-        is_integration_test = filters.Prefix("externalId", _FILE_PREFIX)
+        is_integration_test = flt.Prefix("externalId", _FILE_PREFIX)
 
         documents = cognite_client.documents.list(
             limit=5, filter=is_integration_test, sort=SortableDocumentProperty.mime_type
         )
-
         assert len(documents) >= len(document_list)
         assert [doc.mime_type for doc in documents] == sorted(doc.mime_type for doc in document_list)
-        exclude = set(_SYMMETRIC_DIFFERENCE_FILEMETADATA_SOURCEFILE)
+        exclude = _SYMMETRIC_DIFFERENCE_FILEMETADATA_SOURCEFILE
         retrieved_text = documents.get(id=text_file.id)
         assert retrieved_text is not None, "Expected to retrieve the text file to be the list"
         assert dict_without(retrieved_text.source_file.dump(camel_case=False), exclude) == dict_without(
@@ -105,100 +106,81 @@ class TestDocumentsAPI:
         document_list: FileMetadataList,
         pdf_file: FileMetadata,
     ):
-        is_integration_test = filters.Prefix("externalId", _FILE_PREFIX)
-        is_lorem = filters.Search(DocumentProperty.content, "lorem ipsum")
+        is_integration_test = flt.Prefix("externalId", _FILE_PREFIX)
+        is_lorem = flt.Search(DocumentProperty.content, "lorem ipsum")
 
-        documents = cognite_client.documents.list(filter=filters.And(is_lorem, is_integration_test), limit=5)
+        documents = cognite_client.documents.list(filter=flt.And(is_lorem, is_integration_test), limit=5)
 
         # Both the files in the document list have "lorem ipsum" in the content
         assert len(documents) >= len(document_list)
         retrieved_pdf = documents.get(id=pdf_file.id)
         assert retrieved_pdf is not None, "Expected to retrieve the pdf file to be the list"
-        exclude = set(_SYMMETRIC_DIFFERENCE_FILEMETADATA_SOURCEFILE)
+        exclude = _SYMMETRIC_DIFFERENCE_FILEMETADATA_SOURCEFILE
         assert dict_without(retrieved_pdf.source_file.dump(camel_case=False), exclude) == dict_without(
             pdf_file.dump(camel_case=False), exclude
         )
 
-    def test_retrieve_content(self, cognite_client: CogniteClient, text_file_content_pair):
-        doc, content = text_file_content_pair
-
-        res = cognite_client.documents.retrieve_content(id=doc.id)
-
+    def test_retrieve_content(self, cognite_client: CogniteClient, text_file: FileMetadata):
+        res = cognite_client.documents.retrieve_content(id=text_file.id)
         assert isinstance(res, bytes)
-        res = res.decode("utf-8")
-        if res[-1] == "\n" and content[-1] != "\n":
-            res = res[:-1]
-        assert res == content
+        res = res.decode("utf-8")[:-1]  # remove additional newline added by Files API
+        assert res == PLAIN_TEXT_CONTENT
 
-    def test_retrieve_content_into_buffer(self, cognite_client: CogniteClient, text_file_content_pair):
-        doc, content = text_file_content_pair
+    def test_retrieve_content_into_buffer(self, cognite_client: CogniteClient, text_file: FileMetadata):
         buffer = BytesIO()
-
-        res = cognite_client.documents.retrieve_content_buffer(id=doc.id, buffer=buffer)
-
+        res = cognite_client.documents.retrieve_content_buffer(id=text_file.id, buffer=buffer)
         assert res is None
         result = buffer.getvalue().decode("utf-8")
-        if result[-1] == "\n" and content[-1] != "\n":
-            result = result[:-1]
-        assert result == content
+        result = result[:-1]  # remove additional newline added by Files API
+        assert result == PLAIN_TEXT_CONTENT
 
-    def test_search_no_filters_no_highlight(self, cognite_client: CogniteClient, text_file_content_pair):
-        doc, content = text_file_content_pair
+    def test_search_no_filters_no_highlight(self, cognite_client: CogniteClient, text_file: FileMetadata):
         query = '"pro at pericula ullamcorper"'
-
         result = cognite_client.documents.search(query=query, limit=5, sort=SortableDocumentProperty.title)
-
         assert len(result) == 1, "Expected to retrieve exactly one document."
-        actual = result[0]
-        assert actual.id == doc.id
-        assert actual.source_file.name == doc.name
 
-    def test_search_no_filter_with_highlight(self, cognite_client: CogniteClient, text_file_content_pair):
-        doc, content = text_file_content_pair
+        actual = result[0]
+        assert actual.id == text_file.id
+        assert actual.source_file.name == text_file.name
+
+    def test_search_no_filter_with_highlight(self, cognite_client: CogniteClient, text_file):
         query = '"pro at pericula ullamcorper"'
 
         result = cognite_client.documents.search(query=query, highlight=True, limit=5)
-
         assert len(result) == 1, "Expected to retrieve exactly one document."
+
         actual = result[0]
-        assert actual.document.id == doc.id
-        assert actual.document.source_file.name == doc.name
+        assert actual.document.id == text_file.id
+        assert actual.document.source_file.name == text_file.name
         assert not actual.highlight.name
         assert query[1:-1] in actual.highlight.content[0]
 
     def test_aggregate_count(self, cognite_client: CogniteClient, document_list: FileMetadataList):
-        f = filters
-        is_integration_test = f.Prefix("externalId", _FILE_PREFIX)
+        is_integration_test = flt.Prefix("externalId", _FILE_PREFIX)
 
         count = cognite_client.documents.aggregate_count(filter=is_integration_test)
-
         assert count >= len(document_list)
 
     def test_aggregate_cardinality(self, cognite_client: CogniteClient, document_list: FileMetadataList):
-        f = filters
-        is_integration_test = f.Prefix("externalId", _FILE_PREFIX)
+        is_integration_test = flt.Prefix("externalId", _FILE_PREFIX)
 
         count = cognite_client.documents.aggregate_cardinality_values(
             property=DocumentProperty.mime_type, filter=is_integration_test
         )
-
         assert count >= len({doc.mime_type for doc in document_list if doc.mime_type is not None})
 
     def test_aggregate_cardinality_metadata(self, cognite_client: CogniteClient, document_list: FileMetadataList):
-        f = filters
-        is_integration_test = f.Prefix("externalId", _FILE_PREFIX)
+        is_integration_test = flt.Prefix("externalId", _FILE_PREFIX)
 
         count = cognite_client.documents.aggregate_cardinality_properties(
             path=SourceFileProperty.metadata, filter=is_integration_test
         )
-
         assert count >= len({k for doc in document_list for k in doc.metadata or []})
 
-    def test_aggregate_unique_types(self, cognite_client: CogniteClient, document_list: FileMetadataList):
-        f = filters
-        is_integration_test = f.Prefix("externalId", _FILE_PREFIX)
+    @pytest.mark.usefixtures("document_list")
+    def test_aggregate_unique_types(self, cognite_client: CogniteClient):
+        is_integration_test = flt.Prefix("externalId", _FILE_PREFIX)
 
-        agg = aggregations
         is_not_text = agg.Not(agg.Prefix("text"))
 
         all_buckets = cognite_client.documents.aggregate_unique_values(
@@ -209,7 +191,6 @@ class TestDocumentsAPI:
             aggregate_filter=is_not_text,
             filter=is_integration_test,
         )
-
         assert not_text_buckets
         assert len(all_buckets) > len(not_text_buckets)
 
@@ -217,32 +198,32 @@ class TestDocumentsAPI:
     def test_aggregate_unique_types__property_is_custom(self, cognite_client: CogniteClient):
         # Bug prior to 7.70.3 would convert user given property (list) to camelCase, which would then silently fail
         # and not return any results from the aggregation request.
-        key_count = cognite_client.documents.aggregate_unique_values(property=SourceFileProperty.metadata_key("im_a_key"))
+        key_count = cognite_client.documents.aggregate_unique_values(
+            property=SourceFileProperty.metadata_key("im_a_key")
+        )
         # Note that the agg. API return keys in lowercase:
         assert {"p-duh-f", "t-x-t"} == set(res.values[0] for res in key_count)
 
-        assert SourceFileProperty.mime_type.as_reference() == ['sourceFile', 'mimeType']
+        assert SourceFileProperty.mime_type.as_reference() == ["sourceFile", "mimeType"]
         mime_types = cognite_client.documents.aggregate_unique_values(property=SourceFileProperty.mime_type)
         assert {"text/plain", "application/pdf"} <= set(res.values[0] for res in mime_types)
 
         # When given in snake_case (wrong), we should ensure the agg. request fails (it means we havent converted it to camelCase)
         with pytest.raises(CogniteAPIError, match="Invalid property for the specified aggregate:") as err:
-            cognite_client.documents.aggregate_unique_values(property=['source_file', 'mime_type'])
+            cognite_client.documents.aggregate_unique_values(property=["source_file", "mime_type"])
         assert err.value.code == 400
 
     def test_aggregate_unique_metadata(self, cognite_client: CogniteClient, document_list: FileMetadataList):
-        f = filters
-        is_integration_test = f.Prefix("externalId", _FILE_PREFIX)
+        is_integration_test = flt.Prefix("externalId", _FILE_PREFIX)
 
         result = cognite_client.documents.aggregate_unique_properties(
             path=SourceFileProperty.metadata, filter=is_integration_test
         )
-
         assert result
         assert set(result.unique) >= {key.casefold() for a in document_list for key in a.metadata or []}
 
     def test_iterate_over_text_documents(self, cognite_client: CogniteClient):
-        is_text_doc = filters.Equals(DocumentProperty.mime_type, "text/plain")
+        is_text_doc = flt.Equals(DocumentProperty.mime_type, "text/plain")
 
         for text_doc in cognite_client.documents(filter=is_text_doc):
             assert text_doc.mime_type == "text/plain"
@@ -250,23 +231,14 @@ class TestDocumentsAPI:
 
     def test_retrieve_pdf_link(self, cognite_client: CogniteClient, pdf_file: FileMetadata):
         link = cognite_client.documents.previews.retrieve_pdf_link(id=pdf_file.id)
-
         life = link.expires_at - int(time.time() * 1000)
         assert life > 0
         assert link.url.startswith("http")
 
-    def test_download_image_bytes(
-        self, cognite_client: CogniteClient, text_file_content_pair: tuple[FileMetadata, str]
-    ):
-        doc, _ = text_file_content_pair
-
-        content = cognite_client.documents.previews.download_page_as_png_bytes(id=doc.id)
-
+    def test_download_image_bytes(self, cognite_client: CogniteClient, text_file: FileMetadata):
+        content = cognite_client.documents.previews.download_page_as_png_bytes(id=text_file.id)
         assert content.startswith(b"\x89PNG\r\n\x1a\n")
 
-    def test_download_pdf_bytes(self, cognite_client: CogniteClient, text_file_content_pair: tuple[FileMetadata, str]):
-        doc, _ = text_file_content_pair
-
-        content = cognite_client.documents.previews.download_document_as_pdf_bytes(id=doc.id)
-
+    def test_download_pdf_bytes(self, cognite_client: CogniteClient, text_file: FileMetadata):
+        content = cognite_client.documents.previews.download_document_as_pdf_bytes(id=text_file.id)
         assert content.startswith(b"%PDF")

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -274,7 +274,7 @@ K = TypeVar("K")
 V = TypeVar("V")
 
 
-def dict_without(input_dict: Mapping[K, V], without_keys: set[str]) -> dict[K, V]:
+def dict_without(input_dict: Mapping[K, V], without_keys: collections.abc.Set[str]) -> dict[K, V]:
     """Copy `input_dict`, but exclude the keys in `without_keys`.
 
     >>> a = {"foo": "bar", "bar": "baz", "zip": "zap"}


### PR DESCRIPTION
Raised on slack: https://cognitedata.slack.com/archives/CG10VQPFX/p1733302661860609

1. fix aggregate property casing
2. add files tests cleanup
3. fix wrong type annotations for `aggregate_cardinality_properties`