### PR TITLE
add support for the simulators endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ Changes are grouped as follows
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
+## [Unreleased]
+### Added
+- Support for the `/simulators` and `/simulators/integration` API endpoints.
+
 ## [7.70.5] - 2024-12-12
 ### Fixed
 - Upserting a Sequence with columns no longer silently skips the columns, but instead updates them as intended.

--- a/cognite/client/_api/simulators/__init__.py
+++ b/cognite/client/_api/simulators/__init__.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from collections.abc import Iterator
+from typing import TYPE_CHECKING, overload
 
 from cognite.client._api.simulators.integrations import SimulatorIntegrationsAPI
 from cognite.client._api_client import APIClient
@@ -21,6 +22,44 @@ class SimulatorsAPI(APIClient):
         self.integrations = SimulatorIntegrationsAPI(config, api_version, cognite_client)
         self._warning = FeaturePreviewWarning(
             api_maturity="General Availability", sdk_maturity="alpha", feature_name="Simulators"
+        )
+
+    def __iter__(self) -> Iterator[Simulator]:
+        """Iterate over simulators
+
+        Fetches simulators as they are iterated over, so you keep a limited number of simulators in memory.
+
+        Returns:
+            Iterator[Simulator]: yields Simulators one by one.
+        """
+        return self()
+
+    @overload
+    def __call__(self, chunk_size: None = None, limit: int | None = None) -> Iterator[Simulator]: ...
+
+    @overload
+    def __call__(self, chunk_size: int, limit: int | None = None) -> Iterator[SimulatorList]: ...
+
+    def __call__(
+        self, chunk_size: int | None = None, limit: int | None = None
+    ) -> Iterator[Simulator] | Iterator[SimulatorList]:
+        """Iterate over simulators
+
+        Fetches simulators as they are iterated over, so you keep a limited number of simulators in memory.
+
+        Args:
+            chunk_size (int | None): No description.
+            limit (int | None): Maximum number of simulators to return. Defaults to return all items.
+
+        Returns:
+            Iterator[Simulator] | Iterator[SimulatorList]: yields Simulator one by one if chunk is not specified, else SimulatorList objects.
+        """
+        return self._list_generator(
+            list_cls=SimulatorList,
+            resource_cls=Simulator,
+            method="POST",
+            chunk_size=chunk_size,
+            limit=limit,
         )
 
     def list(self, limit: int = DEFAULT_LIMIT_READ) -> SimulatorList:

--- a/cognite/client/_api/simulators/__init__.py
+++ b/cognite/client/_api/simulators/__init__.py
@@ -48,7 +48,7 @@ class SimulatorsAPI(APIClient):
         Fetches simulators as they are iterated over, so you keep a limited number of simulators in memory.
 
         Args:
-            chunk_size (int | None): No description.
+            chunk_size (int | None): Number of simulators to return in each chunk. Defaults to yielding one simulator a time.
             limit (int | None): Maximum number of simulators to return. Defaults to return all items.
 
         Returns:

--- a/cognite/client/_api/simulators/__init__.py
+++ b/cognite/client/_api/simulators/__init__.py
@@ -47,13 +47,3 @@ class SimulatorsAPI(APIClient):
         """
         self._warning.warn()
         return self._list(method="POST", limit=limit, resource_cls=Simulator, list_cls=SimulatorList)
-
-    # Temporary method, remove this when the API is ready
-    def delete(
-        self,
-        external_ids: str | SequenceNotStr[str] | SequenceNotStr[str] | None = None,
-    ) -> None:
-        self._delete_multiple(
-            identifiers=IdentifierSequence.load(external_ids=external_ids),
-            wrap_ids=True,
-        )

--- a/cognite/client/_api/simulators/__init__.py
+++ b/cognite/client/_api/simulators/__init__.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from cognite.client._api.simulators.integrations import SimulatorIntegrationsAPI
 from cognite.client._api_client import APIClient
 from cognite.client._constants import DEFAULT_LIMIT_READ
 from cognite.client.data_classes.simulators.simulators import Simulator, SimulatorList
@@ -17,6 +18,7 @@ class SimulatorsAPI(APIClient):
 
     def __init__(self, config: ClientConfig, api_version: str | None, cognite_client: CogniteClient) -> None:
         super().__init__(config, api_version, cognite_client)
+        self.integrations = SimulatorIntegrationsAPI(config, api_version, cognite_client)
         self._warning = FeaturePreviewWarning(
             api_maturity="General Availability", sdk_maturity="alpha", feature_name="Simulators"
         )

--- a/cognite/client/_api/simulators/__init__.py
+++ b/cognite/client/_api/simulators/__init__.py
@@ -24,7 +24,7 @@ class SimulatorsAPI(APIClient):
         )
 
     def list(self, limit: int = DEFAULT_LIMIT_READ) -> SimulatorList:
-        """`Filter simulators <https://developer.cognite.com/api#tag/Simulators/operation/filter_simulators_simulators_list_post>`_
+        """`List simulators <https://developer.cognite.com/api#tag/Simulators/operation/filter_simulators_simulators_list_post>`_
 
         List simulators
 

--- a/cognite/client/_api/simulators/__init__.py
+++ b/cognite/client/_api/simulators/__init__.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from cognite.client._api_client import APIClient
+from cognite.client._constants import DEFAULT_LIMIT_READ
+from cognite.client.data_classes.simulators.simulators import Simulator, SimulatorList
+from cognite.client.utils._experimental import FeaturePreviewWarning
+
+if TYPE_CHECKING:
+    from cognite.client import CogniteClient
+    from cognite.client.config import ClientConfig
+
+
+class SimulatorsAPI(APIClient):
+    _RESOURCE_PATH = "/simulators"
+
+    def __init__(self, config: ClientConfig, api_version: str | None, cognite_client: CogniteClient) -> None:
+        super().__init__(config, api_version, cognite_client)
+        self._warning = FeaturePreviewWarning(
+            api_maturity="General Availability", sdk_maturity="alpha", feature_name="Simulators"
+        )
+
+    def list(self, limit: int = DEFAULT_LIMIT_READ) -> SimulatorList:
+        """`Filter simulators <https://developer.cognite.com/api#tag/Simulators/operation/filter_simulators_simulators_list_post>`_
+
+        List simulators
+
+        Args:
+            limit (int): Maximum number of results to return. Defaults to 1000. Set to -1, float(“inf”) or None to return all items.
+
+        Returns:
+            SimulatorList: List of simulators
+
+        Examples:
+
+            List simulators:
+
+                    >>> from cognite.client import CogniteClient
+                    >>> client = CogniteClient()
+                    >>> res = client.simulators.list()
+
+        """
+        self._warning.warn()
+        return self._list(method="POST", limit=limit, resource_cls=Simulator, list_cls=SimulatorList)

--- a/cognite/client/_api/simulators/__init__.py
+++ b/cognite/client/_api/simulators/__init__.py
@@ -7,8 +7,6 @@ from cognite.client._api_client import APIClient
 from cognite.client._constants import DEFAULT_LIMIT_READ
 from cognite.client.data_classes.simulators.simulators import Simulator, SimulatorList
 from cognite.client.utils._experimental import FeaturePreviewWarning
-from cognite.client.utils._identifier import IdentifierSequence
-from cognite.client.utils.useful_types import SequenceNotStr
 
 if TYPE_CHECKING:
     from cognite.client import CogniteClient

--- a/cognite/client/_api/simulators/__init__.py
+++ b/cognite/client/_api/simulators/__init__.py
@@ -7,6 +7,8 @@ from cognite.client._api_client import APIClient
 from cognite.client._constants import DEFAULT_LIMIT_READ
 from cognite.client.data_classes.simulators.simulators import Simulator, SimulatorList
 from cognite.client.utils._experimental import FeaturePreviewWarning
+from cognite.client.utils._identifier import IdentifierSequence
+from cognite.client.utils.useful_types import SequenceNotStr
 
 if TYPE_CHECKING:
     from cognite.client import CogniteClient
@@ -45,3 +47,13 @@ class SimulatorsAPI(APIClient):
         """
         self._warning.warn()
         return self._list(method="POST", limit=limit, resource_cls=Simulator, list_cls=SimulatorList)
+
+    # Temporary method, remove this when the API is ready
+    def delete(
+        self,
+        external_ids: str | SequenceNotStr[str] | SequenceNotStr[str] | None = None,
+    ) -> None:
+        self._delete_multiple(
+            identifiers=IdentifierSequence.load(external_ids=external_ids),
+            wrap_ids=True,
+        )

--- a/cognite/client/_api/simulators/__init__.py
+++ b/cognite/client/_api/simulators/__init__.py
@@ -29,7 +29,7 @@ class SimulatorsAPI(APIClient):
         List simulators
 
         Args:
-            limit (int): Maximum number of results to return. Defaults to 1000. Set to -1, float(“inf”) or None to return all items.
+            limit (int): Maximum number of results to return. Defaults to 25. Set to -1, float(“inf”) or None to return all items.
 
         Returns:
             SimulatorList: List of simulators

--- a/cognite/client/_api/simulators/integrations.py
+++ b/cognite/client/_api/simulators/integrations.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
-from collections.abc import Sequence
-from typing import TYPE_CHECKING
+from collections.abc import Iterator, Sequence
+from typing import TYPE_CHECKING, overload
 
 from cognite.client._api_client import APIClient
 from cognite.client._constants import DEFAULT_LIMIT_READ
@@ -28,6 +28,44 @@ class SimulatorIntegrationsAPI(APIClient):
         self._DELETE_LIMIT = 1
         self._warning = FeaturePreviewWarning(
             api_maturity="General Availability", sdk_maturity="alpha", feature_name="Simulators"
+        )
+
+    def __iter__(self) -> Iterator[SimulatorIntegration]:
+        """Iterate over simulator integrations
+
+        Fetches simulator integrations as they are iterated over, so you keep a limited number of simulator integrations in memory.
+
+        Returns:
+            Iterator[SimulatorIntegration]: yields Simulator integrations one by one.
+        """
+        return self()
+
+    @overload
+    def __call__(self, chunk_size: None = None, limit: int | None = None) -> Iterator[SimulatorIntegration]: ...
+
+    @overload
+    def __call__(self, chunk_size: int, limit: int | None = None) -> Iterator[SimulatorIntegration]: ...
+
+    def __call__(
+        self, chunk_size: int | None = None, limit: int | None = None
+    ) -> Iterator[SimulatorIntegration] | Iterator[SimulatorIntegrationList]:
+        """Iterate over simulator integrations
+
+        Fetches simulator integrations as they are iterated over, so you keep a limited number of simulator integrations in memory.
+
+        Args:
+            chunk_size (int | None): No description.
+            limit (int | None): Maximum number of simulator integrations to return. Defaults to return all items.
+
+        Returns:
+            Iterator[SimulatorIntegration] | Iterator[SimulatorIntegrationList]: yields Simulator one by one if chunk is not specified, else SimulatorList objects.
+        """
+        return self._list_generator(
+            list_cls=SimulatorIntegrationList,
+            resource_cls=SimulatorIntegration,
+            method="POST",
+            chunk_size=chunk_size,
+            limit=limit,
         )
 
     def list(

--- a/cognite/client/_api/simulators/integrations.py
+++ b/cognite/client/_api/simulators/integrations.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from collections.abc import Sequence
 from typing import TYPE_CHECKING, Any
 
 from cognite.client._api_client import APIClient
@@ -11,6 +12,8 @@ from cognite.client.data_classes.simulators.simulators import (
     SimulatorIntegrationList,
 )
 from cognite.client.utils._experimental import FeaturePreviewWarning
+from cognite.client.utils._identifier import IdentifierSequence
+from cognite.client.utils.useful_types import SequenceNotStr
 
 if TYPE_CHECKING:
     from cognite.client import CogniteClient
@@ -22,6 +25,7 @@ class SimulatorIntegrationsAPI(APIClient):
 
     def __init__(self, config: ClientConfig, api_version: str | None, cognite_client: CogniteClient) -> None:
         super().__init__(config, api_version, cognite_client)
+        self._DELETE_LIMIT = 1
         self._warning = FeaturePreviewWarning(
             api_maturity="General Availability", sdk_maturity="alpha", feature_name="Simulators"
         )
@@ -55,4 +59,28 @@ class SimulatorIntegrationsAPI(APIClient):
             resource_cls=SimulatorIntegration,
             list_cls=SimulatorIntegrationList,
             filter=filter.dump() if isinstance(filter, CogniteFilter) else None,
+        )
+
+    def delete(
+        self,
+        id: int | Sequence[int] | None = None,
+        external_id: str | SequenceNotStr[str] | None = None,
+    ) -> None:
+        """`Delete one or more integrations <https://developer.cognite.com/api#tag/Simulator-Integrations/operation/delete_simulator_integrations_simulators_integrations_delete_post>`_
+
+        Args:
+            id (int | Sequence[int] | None): Id or list of ids
+            external_id (str | SequenceNotStr[str] | None): External ID or list of external ids
+
+        Examples:
+
+            Delete assets by id or external id:
+
+                >>> from cognite.client import CogniteClient
+                >>> client = CogniteClient()
+                >>> client.simulators.integrations.delete(id=[1,2,3], external_id="foo")
+        """
+        self._delete_multiple(
+            identifiers=IdentifierSequence.load(ids=id, external_ids=external_id),
+            wrap_ids=True,
         )

--- a/cognite/client/_api/simulators/integrations.py
+++ b/cognite/client/_api/simulators/integrations.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from cognite.client._api_client import APIClient
+from cognite.client._constants import DEFAULT_LIMIT_READ
+from cognite.client.data_classes._base import CogniteFilter
+from cognite.client.data_classes.simulators.filters import SimulatorIntegrationFilter
+from cognite.client.data_classes.simulators.simulators import (
+    SimulatorIntegration,
+    SimulatorIntegrationList,
+)
+from cognite.client.utils._experimental import FeaturePreviewWarning
+
+if TYPE_CHECKING:
+    from cognite.client import CogniteClient
+    from cognite.client.config import ClientConfig
+
+
+class SimulatorIntegrationsAPI(APIClient):
+    _RESOURCE_PATH = "/simulators/integrations"
+
+    def __init__(self, config: ClientConfig, api_version: str | None, cognite_client: CogniteClient) -> None:
+        super().__init__(config, api_version, cognite_client)
+        self._warning = FeaturePreviewWarning(
+            api_maturity="General Availability", sdk_maturity="alpha", feature_name="Simulators"
+        )
+
+    def list(
+        self,
+        limit: int = DEFAULT_LIMIT_READ,
+        filter: SimulatorIntegrationFilter | dict[str, Any] | None = None,
+    ) -> SimulatorIntegrationList:
+        """`Filter simulator integrations <https://developer.cognite.com/api#tag/Simulator-Integrations/operation/filter_simulator_integrations_simulators_integrations_list_post>`_
+        Retrieves a list of simulator integrations that match the given criteria
+        Args:
+            limit (int): The maximum number of simulator integrations to return.
+            filter (SimulatorIntegrationFilter | dict[str, Any] | None): Filter to apply.
+        Returns:
+            SimulatorIntegrationList: List of simulator integrations
+        Examples:
+            List simulator integrations:
+                    >>> from cognite.client import CogniteClient
+                    >>> client = CogniteClient()
+                    >>> res = client.simulators.integrations.list()
+
+            Filter integrations by active status:
+                    >>> res = client.simulators.integrations.list(filter=SimulatorIntegrationFilter(active=True))
+        """
+
+        self._warning.warn()
+        return self._list(
+            method="POST",
+            limit=limit,
+            resource_cls=SimulatorIntegration,
+            list_cls=SimulatorIntegrationList,
+            filter=filter.dump() if isinstance(filter, CogniteFilter) else None,
+        )

--- a/cognite/client/_api/simulators/integrations.py
+++ b/cognite/client/_api/simulators/integrations.py
@@ -58,8 +58,8 @@ class SimulatorIntegrationsAPI(APIClient):
         Fetches simulator integrations as they are iterated over, so you keep a limited number of simulator integrations in memory.
 
         Args:
-            chunk_size (int | None): No description.
-            filter (SimulatorIntegrationFilter | None): No description.
+            chunk_size (int | None): Number of simulator integrations to return in each chunk. Defaults to yielding one simulator integration a time.
+            filter (SimulatorIntegrationFilter | None): Filter to apply on the integrations list.
             limit (int | None): Maximum number of simulator integrations to return. Defaults to return all items.
 
         Returns:
@@ -116,7 +116,7 @@ class SimulatorIntegrationsAPI(APIClient):
 
         Args:
             id (int | Sequence[int] | None): Id or list of ids
-            external_ids (str | SequenceNotStr[str] | SequenceNotStr[str] | None): No description.
+            external_ids (str | SequenceNotStr[str] | SequenceNotStr[str] | None): external_ids of simulator integrations to delete.
 
         Examples:
 

--- a/cognite/client/_api/simulators/integrations.py
+++ b/cognite/client/_api/simulators/integrations.py
@@ -74,7 +74,7 @@ class SimulatorIntegrationsAPI(APIClient):
 
         Examples:
 
-            Delete assets by id or external id:
+            Delete integrations by id or external id:
 
                 >>> from cognite.client import CogniteClient
                 >>> client = CogniteClient()

--- a/cognite/client/_api/simulators/integrations.py
+++ b/cognite/client/_api/simulators/integrations.py
@@ -42,24 +42,24 @@ class SimulatorIntegrationsAPI(APIClient):
 
     @overload
     def __call__(
-        self, filter: SimulatorIntegrationFilter | None = None, chunk_size: None = None, limit: int | None = None
+        self, chunk_size: int, filter: SimulatorIntegrationFilter | None = None, limit: int | None = None
     ) -> Iterator[SimulatorIntegration]: ...
 
     @overload
     def __call__(
-        self, filter: SimulatorIntegrationFilter | None = None, chunk_size: int | None = None, limit: int | None = None
+        self, chunk_size: None = None, filter: SimulatorIntegrationFilter | None = None, limit: int | None = None
     ) -> Iterator[SimulatorIntegration]: ...
 
     def __call__(
-        self, filter: SimulatorIntegrationFilter | None = None, chunk_size: int | None = None, limit: int | None = None
+        self, chunk_size: int | None = None, filter: SimulatorIntegrationFilter | None = None, limit: int | None = None
     ) -> Iterator[SimulatorIntegration] | Iterator[SimulatorIntegrationList]:
         """Iterate over simulator integrations
 
         Fetches simulator integrations as they are iterated over, so you keep a limited number of simulator integrations in memory.
 
         Args:
-            filter (SimulatorIntegrationFilter | None): No description.
             chunk_size (int | None): No description.
+            filter (SimulatorIntegrationFilter | None): No description.
             limit (int | None): Maximum number of simulator integrations to return. Defaults to return all items.
 
         Returns:

--- a/cognite/client/_api/simulators/integrations.py
+++ b/cognite/client/_api/simulators/integrations.py
@@ -41,19 +41,24 @@ class SimulatorIntegrationsAPI(APIClient):
         return self()
 
     @overload
-    def __call__(self, chunk_size: None = None, limit: int | None = None) -> Iterator[SimulatorIntegration]: ...
+    def __call__(
+        self, filter: SimulatorIntegrationFilter | None = None, chunk_size: None = None, limit: int | None = None
+    ) -> Iterator[SimulatorIntegration]: ...
 
     @overload
-    def __call__(self, chunk_size: int, limit: int | None = None) -> Iterator[SimulatorIntegration]: ...
+    def __call__(
+        self, filter: SimulatorIntegrationFilter | None = None, chunk_size: int | None = None, limit: int | None = None
+    ) -> Iterator[SimulatorIntegration]: ...
 
     def __call__(
-        self, chunk_size: int | None = None, limit: int | None = None
+        self, filter: SimulatorIntegrationFilter | None = None, chunk_size: int | None = None, limit: int | None = None
     ) -> Iterator[SimulatorIntegration] | Iterator[SimulatorIntegrationList]:
         """Iterate over simulator integrations
 
         Fetches simulator integrations as they are iterated over, so you keep a limited number of simulator integrations in memory.
 
         Args:
+            filter (SimulatorIntegrationFilter | None): No description.
             chunk_size (int | None): No description.
             limit (int | None): Maximum number of simulator integrations to return. Defaults to return all items.
 
@@ -64,6 +69,7 @@ class SimulatorIntegrationsAPI(APIClient):
             list_cls=SimulatorIntegrationList,
             resource_cls=SimulatorIntegration,
             method="POST",
+            filter=filter.dump() if isinstance(filter, CogniteFilter) else filter,
             chunk_size=chunk_size,
             limit=limit,
         )
@@ -98,7 +104,7 @@ class SimulatorIntegrationsAPI(APIClient):
             limit=limit,
             resource_cls=SimulatorIntegration,
             list_cls=SimulatorIntegrationList,
-            filter=filter.dump() if isinstance(filter, CogniteFilter) else None,
+            filter=filter.dump() if isinstance(filter, CogniteFilter) else filter,
         )
 
     def delete(

--- a/cognite/client/_api/simulators/integrations.py
+++ b/cognite/client/_api/simulators/integrations.py
@@ -88,14 +88,14 @@ class SimulatorIntegrationsAPI(APIClient):
             SimulatorIntegrationList: List of simulator integrations
         Examples:
             List simulator integrations:
-                    >>> from cognite.client import CogniteClient
-                    >>> client = CogniteClient()
-                    >>> res = client.simulators.integrations.list()
+                >>> from cognite.client import CogniteClient
+                >>> client = CogniteClient()
+                >>> res = client.simulators.integrations.list()
 
             Filter integrations by active status:
-                    >>> from cognite.client.data_classes.simulators.filters import SimulatorIntegrationFilter
-                    >>> res = client.simulators.integrations.list(
-                    ...     filter=SimulatorIntegrationFilter(active=True))
+                >>> from cognite.client.data_classes.simulators.filters import SimulatorIntegrationFilter
+                >>> res = client.simulators.integrations.list(
+                ...     filter=SimulatorIntegrationFilter(active=True))
         """
 
         self._warning.warn()

--- a/cognite/client/_api/simulators/integrations.py
+++ b/cognite/client/_api/simulators/integrations.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Sequence
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 from cognite.client._api_client import APIClient
 from cognite.client._constants import DEFAULT_LIMIT_READ
@@ -33,13 +33,13 @@ class SimulatorIntegrationsAPI(APIClient):
     def list(
         self,
         limit: int = DEFAULT_LIMIT_READ,
-        filter: SimulatorIntegrationFilter | dict[str, Any] | None = None,
+        filter: SimulatorIntegrationFilter | None = None,
     ) -> SimulatorIntegrationList:
         """`Filter simulator integrations <https://developer.cognite.com/api#tag/Simulator-Integrations/operation/filter_simulator_integrations_simulators_integrations_list_post>`_
         Retrieves a list of simulator integrations that match the given criteria
         Args:
             limit (int): The maximum number of simulator integrations to return.
-            filter (SimulatorIntegrationFilter | dict[str, Any] | None): Filter to apply.
+            filter (SimulatorIntegrationFilter | None): Filter to apply.
         Returns:
             SimulatorIntegrationList: List of simulator integrations
         Examples:
@@ -49,7 +49,9 @@ class SimulatorIntegrationsAPI(APIClient):
                     >>> res = client.simulators.integrations.list()
 
             Filter integrations by active status:
-                    >>> res = client.simulators.integrations.list(filter=SimulatorIntegrationFilter(active=True))
+                    >>> from cognite.client.data_classes.simulators.filters import SimulatorIntegrationFilter
+                    >>> res = client.simulators.integrations.list(
+                    ...     filter=SimulatorIntegrationFilter(active=True))
         """
 
         self._warning.warn()
@@ -64,13 +66,13 @@ class SimulatorIntegrationsAPI(APIClient):
     def delete(
         self,
         id: int | Sequence[int] | None = None,
-        external_id: str | SequenceNotStr[str] | None = None,
+        external_ids: str | SequenceNotStr[str] | SequenceNotStr[str] | None = None,
     ) -> None:
         """`Delete one or more integrations <https://developer.cognite.com/api#tag/Simulator-Integrations/operation/delete_simulator_integrations_simulators_integrations_delete_post>`_
 
         Args:
             id (int | Sequence[int] | None): Id or list of ids
-            external_id (str | SequenceNotStr[str] | None): External ID or list of external ids
+            external_ids (str | SequenceNotStr[str] | SequenceNotStr[str] | None): No description.
 
         Examples:
 
@@ -81,6 +83,6 @@ class SimulatorIntegrationsAPI(APIClient):
                 >>> client.simulators.integrations.delete(id=[1,2,3], external_id="foo")
         """
         self._delete_multiple(
-            identifiers=IdentifierSequence.load(ids=id, external_ids=external_id),
+            identifiers=IdentifierSequence.load(ids=id, external_ids=external_ids),
             wrap_ids=True,
         )

--- a/cognite/client/_api_client.py
+++ b/cognite/client/_api_client.py
@@ -101,6 +101,7 @@ class APIClient:
                     "geospatial/(compute|crs/byids|featuretypes/(byids|list))",
                     "geospatial/featuretypes/[A-Za-z][A-Za-z0-9_]{0,31}/features/(aggregate|list|byids|search|search-streaming|[A-Za-z][A-Za-z0-9_]{0,255}/rasters/[A-Za-z][A-Za-z0-9_]{0,31})",
                     "transformations/(filter|byids|jobs/byids|schedules/byids|query/run)",
+                    "simulators/(list)",
                     "extpipes/(list|byids|runs/list)",
                     "workflows/.*",
                     "hostedextractors/.*",

--- a/cognite/client/_api_client.py
+++ b/cognite/client/_api_client.py
@@ -101,7 +101,7 @@ class APIClient:
                     "geospatial/(compute|crs/byids|featuretypes/(byids|list))",
                     "geospatial/featuretypes/[A-Za-z][A-Za-z0-9_]{0,31}/features/(aggregate|list|byids|search|search-streaming|[A-Za-z][A-Za-z0-9_]{0,255}/rasters/[A-Za-z][A-Za-z0-9_]{0,31})",
                     "transformations/(filter|byids|jobs/byids|schedules/byids|query/run)",
-                    "simulators/(list)",
+                    "simulators/list",
                     "extpipes/(list|byids|runs/list)",
                     "workflows/.*",
                     "hostedextractors/.*",

--- a/cognite/client/_cognite_client.py
+++ b/cognite/client/_cognite_client.py
@@ -23,6 +23,7 @@ from cognite.client._api.postgres_gateway import PostgresGatewaysAPI
 from cognite.client._api.raw import RawAPI
 from cognite.client._api.relationships import RelationshipsAPI
 from cognite.client._api.sequences import SequencesAPI
+from cognite.client._api.simulators import SimulatorsAPI
 from cognite.client._api.templates import TemplatesAPI
 from cognite.client._api.three_d import ThreeDAPI
 from cognite.client._api.time_series import TimeSeriesAPI
@@ -83,6 +84,8 @@ class CogniteClient:
         self.documents = DocumentsAPI(self._config, self._API_VERSION, self)
         self.workflows = WorkflowAPI(self._config, self._API_VERSION, self)
         self.units = UnitAPI(self._config, self._API_VERSION, self)
+        self.simulators = SimulatorsAPI(self._config, self._API_VERSION, self)
+
         # APIs just using base_url:
         self._api_client = APIClient(self._config, api_version=None, cognite_client=self)
 

--- a/cognite/client/data_classes/simulators/__init__.py
+++ b/cognite/client/data_classes/simulators/__init__.py
@@ -9,8 +9,6 @@ from cognite.client.data_classes.simulators.simulators import (
     SimulatorStepField,
     SimulatorStepOption,
     SimulatorUnitEntry,
-    SimulatorWrite,
-    SimulatorWriteList,
 )
 
 __all__ = [
@@ -22,6 +20,4 @@ __all__ = [
     "SimulatorStepField",
     "SimulatorStepOption",
     "SimulatorUnitEntry",
-    "SimulatorWrite",
-    "SimulatorWriteList",
 ]

--- a/cognite/client/data_classes/simulators/__init__.py
+++ b/cognite/client/data_classes/simulators/__init__.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from cognite.client.data_classes.simulators.simulators import (
     Simulator,
+    SimulatorIntegration,
+    SimulatorIntegrationList,
     SimulatorList,
     SimulatorStep,
     SimulatorStepField,
@@ -13,6 +15,8 @@ from cognite.client.data_classes.simulators.simulators import (
 
 __all__ = [
     "Simulator",
+    "SimulatorIntegration",
+    "SimulatorIntegrationList",
     "SimulatorList",
     "SimulatorStep",
     "SimulatorStepField",

--- a/cognite/client/data_classes/simulators/__init__.py
+++ b/cognite/client/data_classes/simulators/__init__.py
@@ -1,1 +1,23 @@
 from __future__ import annotations
+
+from cognite.client.data_classes.simulators.simulators import (
+    Simulator,
+    SimulatorList,
+    SimulatorStep,
+    SimulatorStepField,
+    SimulatorStepOption,
+    SimulatorUnitEntry,
+    SimulatorWrite,
+    SimulatorWriteList,
+)
+
+__all__ = [
+    "Simulator",
+    "SimulatorList",
+    "SimulatorStep",
+    "SimulatorStepField",
+    "SimulatorStepOption",
+    "SimulatorUnitEntry",
+    "SimulatorWrite",
+    "SimulatorWriteList",
+]

--- a/cognite/client/data_classes/simulators/filters.py
+++ b/cognite/client/data_classes/simulators/filters.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+from cognite.client.data_classes._base import CogniteFilter
+from cognite.client.utils.useful_types import SequenceNotStr
+
+
+class SimulatorIntegrationFilter(CogniteFilter):
+    def __init__(
+        self,
+        simulator_external_ids: SequenceNotStr[str] | None = None,
+        active: bool | None = None,
+    ) -> None:
+        self.simulator_external_ids = simulator_external_ids
+        self.active = active

--- a/cognite/client/data_classes/simulators/simulators.py
+++ b/cognite/client/data_classes/simulators/simulators.py
@@ -326,3 +326,192 @@ class SimulatorList(WriteableCogniteResourceList[SimulatorWrite, Simulator], IdT
 
     def as_write(self) -> SimulatorWriteList:
         return SimulatorWriteList([a.as_write() for a in self.data], cognite_client=self._get_cognite_client())
+
+
+class SimulatorIntegrationCore(WriteableCogniteResource["SimulatorIntegrationWrite"], ABC):
+    """
+    The simulator integration resource represents a simulator connector in Cognite Data Fusion (CDF).
+    It provides information about the configured connectors for a given simulator, including their status and additional
+    details such as dataset, name, license status, connector version, simulator version, and more. This resource is essential
+    for monitoring and managing the interactions between CDF and external simulators, ensuring proper data flow and integration.
+    This is the read/response format of the simulator integration.
+    Args:
+        external_id (str): External id of the simulator integration
+        simulator_external_id (str): External id of the associated simulator
+        heartbeat (int): The interval in seconds between the last heartbeat and the current time
+        data_set_id (int): The id of the dataset associated with the simulator integration
+        connector_version (str): The version of the connector
+        license_status (str | None): The status of the license
+        simulator_version (str | None): The version of the simulator
+        license_last_checked_time (int | None): The time when the license was last checked
+        connector_status (str | None): The status of the connector
+        connector_status_updated_time (int | None): The time when the connector status was last updated
+    """
+
+    def __init__(
+        self,
+        external_id: str,
+        simulator_external_id: str,
+        heartbeat: int,
+        data_set_id: int,
+        connector_version: str,
+        license_status: str | None = None,
+        simulator_version: str | None = None,
+        license_last_checked_time: int | None = None,
+        connector_status: str | None = None,
+        connector_status_updated_time: int | None = None,
+    ) -> None:
+        self.external_id = external_id
+        self.simulator_external_id = simulator_external_id
+        self.heartbeat = heartbeat
+        self.data_set_id = data_set_id
+        self.connector_version = connector_version
+        self.license_status = license_status
+        self.simulator_version = simulator_version
+        self.license_last_checked_time = license_last_checked_time
+        self.connector_status = connector_status
+        self.connector_status_updated_time = connector_status_updated_time
+
+    @classmethod
+    def _load(cls, resource: dict[str, Any], cognite_client: CogniteClient | None = None) -> Self:
+        return cls(
+            external_id=resource["externalId"],
+            simulator_external_id=resource["simulatorExternalId"],
+            heartbeat=resource["heartbeat"],
+            data_set_id=resource["dataSetId"],
+            connector_version=resource["connectorVersion"],
+            license_status=resource.get("licenseStatus"),
+            simulator_version=resource.get("simulatorVersion"),
+            license_last_checked_time=resource.get("licenseLastCheckedTime"),
+            connector_status=resource.get("connectorStatus"),
+            connector_status_updated_time=resource.get("connectorStatusUpdatedTime"),
+        )
+
+    def dump(self, camel_case: bool = True) -> dict[str, Any]:
+        return super().dump(camel_case=camel_case)
+
+
+class SimulatorIntegrationWrite(SimulatorIntegrationCore):
+    def __init__(
+        self,
+        external_id: str,
+        simulator_external_id: str,
+        heartbeat: int,
+        data_set_id: int,
+        connector_version: str,
+        license_status: str | None = None,
+        simulator_version: str | None = None,
+        license_last_checked_time: int | None = None,
+        connector_status: str | None = None,
+        connector_status_updated_time: int | None = None,
+    ) -> None:
+        super().__init__(
+            external_id=external_id,
+            simulator_external_id=simulator_external_id,
+            heartbeat=heartbeat,
+            data_set_id=data_set_id,
+            connector_version=connector_version,
+            license_status=license_status,
+            simulator_version=simulator_version,
+            license_last_checked_time=license_last_checked_time,
+            connector_status=connector_status,
+            connector_status_updated_time=connector_status_updated_time,
+        )
+
+    def as_write(self) -> SimulatorIntegrationWrite:
+        """Returns a writeable version of this resource"""
+        return self
+
+
+class SimulatorIntegration(SimulatorIntegrationCore):
+    def __init__(
+        self,
+        external_id: str,
+        simulator_external_id: str,
+        heartbeat: int,
+        data_set_id: int,
+        connector_version: str,
+        license_status: str | None = None,
+        simulator_version: str | None = None,
+        license_last_checked_time: int | None = None,
+        connector_status: str | None = None,
+        connector_status_updated_time: int | None = None,
+        created_time: int | None = None,
+        last_updated_time: int | None = None,
+        id: int | None = None,
+        active: bool | None = None,
+        log_id: int | None = None,
+    ) -> None:
+        self.external_id = external_id
+        self.simulator_external_id = simulator_external_id
+        self.heartbeat = heartbeat
+        self.data_set_id = data_set_id
+        self.connector_version = connector_version
+        self.license_status = license_status
+        self.simulator_version = simulator_version
+        self.license_last_checked_time = license_last_checked_time
+        self.connector_status = connector_status
+        self.connector_status_updated_time = connector_status_updated_time
+        # id/created_time/last_updated_time are required when using the class to read,
+        # but don't make sense passing in when creating a new object. So in order to make the typing
+        # correct here (i.e. int and not Optional[int]), we force the type to be int rather than
+        # Optional[int].
+        self.id: int | None = id
+        self.created_time: int | None = created_time
+        self.last_updated_time: int | None = last_updated_time
+        self.active = active
+        self.log_id = log_id
+
+    @classmethod
+    def _load(cls, resource: dict[str, Any], cognite_client: CogniteClient | None = None) -> Self:
+        load = super()._load(resource, cognite_client)
+        return cls(
+            external_id=load.external_id,
+            simulator_external_id=load.simulator_external_id,
+            heartbeat=load.heartbeat,
+            data_set_id=load.data_set_id,
+            connector_version=load.connector_version,
+            license_status=load.license_status,
+            simulator_version=load.simulator_version,
+            license_last_checked_time=load.license_last_checked_time,
+            connector_status=load.connector_status,
+            connector_status_updated_time=load.connector_status_updated_time,
+            created_time=resource.get("createdTime"),
+            last_updated_time=resource.get("lastUpdatedTime"),
+            id=resource.get("id"),
+            active=resource.get("active"),
+            log_id=resource.get("logId"),
+        )
+
+    def as_write(self) -> SimulatorIntegrationWrite:
+        """Returns a writeable version of this resource"""
+        return SimulatorIntegrationWrite(
+            external_id=self.external_id,
+            simulator_external_id=self.simulator_external_id,
+            heartbeat=self.heartbeat,
+            data_set_id=self.data_set_id,
+            connector_version=self.connector_version,
+            license_status=self.license_status,
+            simulator_version=self.simulator_version,
+            license_last_checked_time=self.license_last_checked_time,
+            connector_status=self.connector_status,
+            connector_status_updated_time=self.connector_status_updated_time,
+        )
+
+    def __hash__(self) -> int:
+        return hash(self.external_id)
+
+
+class SimulatorIntegrationWriteList(CogniteResourceList[SimulatorIntegrationWrite], ExternalIDTransformerMixin):
+    _RESOURCE = SimulatorIntegrationWrite
+
+
+class SimulatorIntegrationList(
+    WriteableCogniteResourceList[SimulatorIntegrationWrite, SimulatorIntegration], IdTransformerMixin
+):
+    _RESOURCE = SimulatorIntegration
+
+    def as_write(self) -> SimulatorIntegrationWriteList:
+        return SimulatorIntegrationWriteList(
+            [a.as_write() for a in self.data], cognite_client=self._get_cognite_client()
+        )

--- a/cognite/client/data_classes/simulators/simulators.py
+++ b/cognite/client/data_classes/simulators/simulators.py
@@ -31,7 +31,7 @@ class Simulator(CogniteResource):
         external_id (str): External id of the simulator
         id (int): No description.
         name (str): Name of the simulator
-        file_extension_types (str | Sequence[str]): File extension types supported by the simulator
+        file_extension_types (Sequence[str]): File extension types supported by the simulator
         model_types (Sequence[SimulatorModelType] | None): Model types supported by the simulator
         step_fields (Sequence[SimulatorStep] | None): Step types supported by the simulator when creating routines
         unit_quantities (Sequence[SimulatorQuantity] | None): Quantities and their units supported by the simulator
@@ -43,7 +43,7 @@ class Simulator(CogniteResource):
         external_id: str,
         id: int,
         name: str,
-        file_extension_types: str | Sequence[str],
+        file_extension_types: Sequence[str],
         model_types: Sequence[SimulatorModelType] | None = None,
         step_fields: Sequence[SimulatorStep] | None = None,
         unit_quantities: Sequence[SimulatorQuantity] | None = None,

--- a/cognite/client/data_classes/simulators/simulators.py
+++ b/cognite/client/data_classes/simulators/simulators.py
@@ -32,9 +32,9 @@ class Simulator(CogniteResource):
         id (int): No description.
         name (str): Name of the simulator
         file_extension_types (str | Sequence[str]): File extension types supported by the simulator
-        model_types (Sequence[SimulatorModelType] | None): Model types supported by the simulator
-        step_fields (Sequence[SimulatorStep] | None): Step types supported by the simulator when creating routines
-        unit_quantities (Sequence[SimulatorQuantity] | None): Quantities and their units supported by the simulator
+        model_types (SimulatorModelType | Sequence[SimulatorModelType] | None): Model types supported by the simulator
+        step_fields (SimulatorStep | Sequence[SimulatorStep] | None): Step types supported by the simulator when creating routines
+        unit_quantities (SimulatorQuantity | Sequence[SimulatorQuantity] | None): Quantities and their units supported by the simulator
 
     """
 
@@ -43,10 +43,10 @@ class Simulator(CogniteResource):
         external_id: str,
         id: int,
         name: str,
-        file_extension_types: Sequence[str],
-        model_types: Sequence[SimulatorModelType] | None = None,
-        step_fields: Sequence[SimulatorStep] | None = None,
-        unit_quantities: Sequence[SimulatorQuantity] | None = None,
+        file_extension_types: str | Sequence[str],
+        model_types: SimulatorModelType | Sequence[SimulatorModelType] | None = None,
+        step_fields: SimulatorStep | Sequence[SimulatorStep] | None = None,
+        unit_quantities: SimulatorQuantity | Sequence[SimulatorQuantity] | None = None,
     ) -> None:
         self.external_id = external_id
         self.name = name

--- a/cognite/client/data_classes/simulators/simulators.py
+++ b/cognite/client/data_classes/simulators/simulators.py
@@ -12,6 +12,8 @@ from cognite.client.data_classes._base import (
     CogniteResourceList,
     IdTransformerMixin,
 )
+from cognite.client.data_classes.data_modeling.instances import _PropertyValueSerializer
+from cognite.client.utils import _json
 
 if TYPE_CHECKING:
     from cognite.client import CogniteClient
@@ -44,9 +46,9 @@ class Simulator(CogniteResource):
         id: int,
         name: str,
         file_extension_types: str | Sequence[str],
-        model_types: SimulatorModelType | Sequence[SimulatorModelType] | None = None,
-        step_fields: SimulatorStep | Sequence[SimulatorStep] | None = None,
-        unit_quantities: SimulatorQuantity | Sequence[SimulatorQuantity] | None = None,
+        model_types: Sequence[SimulatorModelType] | None = None,
+        step_fields:  Sequence[SimulatorStep] | None = None,
+        unit_quantities:  Sequence[SimulatorQuantity] | None = None,
     ) -> None:
         self.external_id = external_id
         self.name = name
@@ -76,14 +78,12 @@ class Simulator(CogniteResource):
 
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         output = super().dump(camel_case=camel_case)
-        if isinstance(self.model_types, SimulatorModelType):
-            output["modelTypes" if camel_case else "model_types"] = self.model_types.dump(camel_case=camel_case)
-        if isinstance(self.step_fields, SimulatorStep):
-            output["stepFields" if camel_case else "step_fields"] = self.step_fields.dump(camel_case=camel_case)
-        if isinstance(self.unit_quantities, SimulatorQuantity):
-            output["unitQuantities" if camel_case else "unit_quantities"] = self.unit_quantities.dump(
-                camel_case=camel_case
-            )
+        if isinstance(self.model_types, list) and all(isinstance(item, SimulatorModelType) for item in self.model_types):
+            output["modelTypes" if camel_case else "model_types"] = [item.dump(camel_case=camel_case) for item in self.model_types]
+        if isinstance(self.step_fields, list) and all(isinstance(item, SimulatorStep) for item in self.step_fields):
+            output["stepFields" if camel_case else "step_fields"] = [item.dump(camel_case=camel_case) for item in self.step_fields]
+        if isinstance(self.unit_quantities, list) and all(isinstance(item, SimulatorQuantity) for item in self.unit_quantities):
+            output["unitQuantities" if camel_case else "unit_quantities"] = [item.dump(camel_case=camel_case) for item in self.unit_quantities]
 
         return output
 
@@ -147,6 +147,7 @@ class SimulatorModelType(CogniteObject):
             return [cls._load(res, cognite_client) for res in resource]
 
         return cls._load(resource, cognite_client)
+
 
 
 @dataclass

--- a/cognite/client/data_classes/simulators/simulators.py
+++ b/cognite/client/data_classes/simulators/simulators.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from abc import ABC
 from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
@@ -9,32 +8,30 @@ from typing_extensions import Self
 
 from cognite.client.data_classes._base import (
     CogniteObject,
+    CogniteResource,
     CogniteResourceList,
-    ExternalIDTransformerMixin,
     IdTransformerMixin,
-    WriteableCogniteResource,
-    WriteableCogniteResourceList,
 )
-from cognite.client.utils.useful_types import SequenceNotStr
 
 if TYPE_CHECKING:
     from cognite.client import CogniteClient
 
 
-class SimulatorCore(WriteableCogniteResource["SimulatorWrite"], ABC):
+class Simulator(CogniteResource):
     """The simulator resource contains the definitions necessary for Cognite Data Fusion (CDF) to interact with a given simulator.
 
     It serves as a central contract that allows APIs, UIs, and integrations (connectors) to utilize the same definitions
     when dealing with a specific simulator.  Each simulator is uniquely identified and can be associated with various
     file extension types, model types, step fields, and unit quantities. Simulators are essential for managing data
-    flows between CDF and external simulation tools, ensuring consistency and reliability in data handling.  ####
+    flows between CDF and external simulation tools, ensuring consistency and reliability in data handling.
 
     This is the read/response format of the simulator.
 
     Args:
         external_id (str): External id of the simulator
+        id (int): No description.
         name (str): Name of the simulator
-        file_extension_types (str | SequenceNotStr[str]): File extension types supported by the simulator
+        file_extension_types (str | Sequence[str]): File extension types supported by the simulator
         model_types (SimulatorModelType | Sequence[SimulatorModelType] | None): Model types supported by the simulator
         step_fields (SimulatorStep | Sequence[SimulatorStep] | None): Step types supported by the simulator when creating routines
         unit_quantities (SimulatorQuantity | Sequence[SimulatorQuantity] | None): Quantities and their units supported by the simulator
@@ -44,8 +41,9 @@ class SimulatorCore(WriteableCogniteResource["SimulatorWrite"], ABC):
     def __init__(
         self,
         external_id: str,
+        id: int,
         name: str,
-        file_extension_types: str | SequenceNotStr[str],
+        file_extension_types: str | Sequence[str],
         model_types: SimulatorModelType | Sequence[SimulatorModelType] | None = None,
         step_fields: SimulatorStep | Sequence[SimulatorStep] | None = None,
         unit_quantities: SimulatorQuantity | Sequence[SimulatorQuantity] | None = None,
@@ -56,10 +54,12 @@ class SimulatorCore(WriteableCogniteResource["SimulatorWrite"], ABC):
         self.model_types = model_types
         self.step_fields = step_fields
         self.unit_quantities = unit_quantities
+        self.id = id
 
     @classmethod
     def _load(cls, resource: dict[str, Any], cognite_client: CogniteClient | None = None) -> Self:
         return cls(
+            id=resource["id"],
             external_id=resource["externalId"],
             name=resource["name"],
             file_extension_types=resource["fileExtensionTypes"],
@@ -88,87 +88,6 @@ class SimulatorCore(WriteableCogniteResource["SimulatorWrite"], ABC):
         return output
 
 
-class SimulatorWrite(SimulatorCore):
-    def __init__(
-        self,
-        external_id: str,
-        name: str,
-        file_extension_types: str | SequenceNotStr[str],
-        model_types: SimulatorModelType | Sequence[SimulatorModelType] | None = None,
-        step_fields: SimulatorStep | Sequence[SimulatorStep] | None = None,
-        unit_quantities: SimulatorQuantity | Sequence[SimulatorQuantity] | None = None,
-    ) -> None:
-        super().__init__(
-            external_id=external_id,
-            name=name,
-            file_extension_types=file_extension_types,
-            model_types=model_types,
-            step_fields=step_fields,
-            unit_quantities=unit_quantities,
-        )
-
-    def as_write(self) -> SimulatorWrite:
-        """Returns a writeable version of this resource"""
-        return self
-
-
-class Simulator(SimulatorCore):
-    def __init__(
-        self,
-        external_id: str,
-        name: str,
-        file_extension_types: str | SequenceNotStr[str],
-        created_time: int | None = None,
-        last_updated_time: int | None = None,
-        id: int | None = None,
-        model_types: SimulatorModelType | Sequence[SimulatorModelType] | None = None,
-        step_fields: SimulatorStep | Sequence[SimulatorStep] | None = None,
-        unit_quantities: SimulatorQuantity | Sequence[SimulatorQuantity] | None = None,
-    ) -> None:
-        self.external_id = external_id
-        self.name = name
-        self.file_extension_types = file_extension_types
-        self.model_types = model_types
-        self.step_fields = step_fields
-        self.unit_quantities = unit_quantities
-        # id/created_time/last_updated_time are required when using the class to read,
-        # but don't make sense passing in when creating a new object. So in order to make the typing
-        # correct here (i.e. int and not Optional[int]), we force the type to be int rather than
-        # Optional[int].
-        self.id: int | None = id
-        self.created_time: int | None = created_time
-        self.last_updated_time: int | None = last_updated_time
-
-    @classmethod
-    def _load(cls, resource: dict[str, Any], cognite_client: CogniteClient | None = None) -> Self:
-        load = super()._load(resource, cognite_client)
-        return cls(
-            external_id=load.external_id,
-            name=load.name,
-            file_extension_types=load.file_extension_types,
-            created_time=resource.get("createdTime"),
-            last_updated_time=resource.get("lastUpdatedTime"),
-            id=resource.get("id"),
-            model_types=load.model_types,
-            step_fields=load.step_fields,
-            unit_quantities=load.unit_quantities,
-        )
-
-    def as_write(self) -> SimulatorWrite:
-        """Returns a writeable version of this resource"""
-        return SimulatorWrite(
-            external_id=self.external_id,
-            name=self.name,
-            file_extension_types=self.file_extension_types,
-            model_types=self.model_types,
-            step_fields=self.step_fields,
-            unit_quantities=self.unit_quantities,
-        )
-
-    def __hash__(self) -> int:
-        return hash(self.external_id)
-
-
 @dataclass
 class SimulatorRoutineStep(CogniteObject):
     step_type: str
@@ -180,9 +99,6 @@ class SimulatorRoutineStep(CogniteObject):
             step_type=resource["stepType"],
             arguments=resource["arguments"],
         )
-
-    def dump(self, camel_case: bool = True) -> dict[str, Any]:
-        return super().dump(camel_case=camel_case)
 
 
 @dataclass
@@ -217,7 +133,7 @@ class SimulatorModelType(CogniteObject):
     key: str
 
     @classmethod
-    def _load(cls, resource: dict[str, Any], cognite_client: CogniteClient | None = None) -> SimulatorModelType:
+    def _load(cls, resource: dict[str, Any], cognite_client: CogniteClient | None = None) -> Self:
         return cls(
             name=resource["name"],
             key=resource["key"],
@@ -317,18 +233,11 @@ class SimulatorStep(CogniteObject):
         return output
 
 
-class SimulatorWriteList(CogniteResourceList[SimulatorWrite], ExternalIDTransformerMixin):
-    _RESOURCE = SimulatorWrite
-
-
-class SimulatorList(WriteableCogniteResourceList[SimulatorWrite, Simulator], IdTransformerMixin):
+class SimulatorList(CogniteResourceList[Simulator], IdTransformerMixin):
     _RESOURCE = Simulator
 
-    def as_write(self) -> SimulatorWriteList:
-        return SimulatorWriteList([a.as_write() for a in self.data], cognite_client=self._get_cognite_client())
 
-
-class SimulatorIntegrationCore(WriteableCogniteResource["SimulatorIntegrationWrite"], ABC):
+class SimulatorIntegration(CogniteResource):
     """
     The simulator integration resource represents a simulator connector in Cognite Data Fusion (CDF).
     It provides information about the configured connectors for a given simulator, including their status and additional
@@ -336,11 +245,16 @@ class SimulatorIntegrationCore(WriteableCogniteResource["SimulatorIntegrationWri
     for monitoring and managing the interactions between CDF and external simulators, ensuring proper data flow and integration.
     This is the read/response format of the simulator integration.
     Args:
+        id (int): No description.
         external_id (str): External id of the simulator integration
         simulator_external_id (str): External id of the associated simulator
         heartbeat (int): The interval in seconds between the last heartbeat and the current time
         data_set_id (int): The id of the dataset associated with the simulator integration
         connector_version (str): The version of the connector
+        log_id (int): No description.
+        active (bool): No description.
+        created_time (int): No description.
+        last_updated_time (int): No description.
         license_status (str | None): The status of the license
         simulator_version (str | None): The version of the simulator
         license_last_checked_time (int | None): The time when the license was last checked
@@ -350,17 +264,24 @@ class SimulatorIntegrationCore(WriteableCogniteResource["SimulatorIntegrationWri
 
     def __init__(
         self,
+        id: int,
         external_id: str,
         simulator_external_id: str,
         heartbeat: int,
         data_set_id: int,
         connector_version: str,
+        log_id: int,
+        active: bool,
+        created_time: int,
+        last_updated_time: int,
         license_status: str | None = None,
         simulator_version: str | None = None,
         license_last_checked_time: int | None = None,
         connector_status: str | None = None,
         connector_status_updated_time: int | None = None,
     ) -> None:
+        self.id = id  # type: ignore
+        self.log_id = log_id
         self.external_id = external_id
         self.simulator_external_id = simulator_external_id
         self.heartbeat = heartbeat
@@ -371,10 +292,16 @@ class SimulatorIntegrationCore(WriteableCogniteResource["SimulatorIntegrationWri
         self.license_last_checked_time = license_last_checked_time
         self.connector_status = connector_status
         self.connector_status_updated_time = connector_status_updated_time
+        self.active = active
+        self.created_time = created_time
+        self.last_updated_time = last_updated_time
 
     @classmethod
     def _load(cls, resource: dict[str, Any], cognite_client: CogniteClient | None = None) -> Self:
         return cls(
+            id=resource["id"],
+            active=resource["active"],
+            log_id=resource["logId"],
             external_id=resource["externalId"],
             simulator_external_id=resource["simulatorExternalId"],
             heartbeat=resource["heartbeat"],
@@ -385,133 +312,10 @@ class SimulatorIntegrationCore(WriteableCogniteResource["SimulatorIntegrationWri
             license_last_checked_time=resource.get("licenseLastCheckedTime"),
             connector_status=resource.get("connectorStatus"),
             connector_status_updated_time=resource.get("connectorStatusUpdatedTime"),
+            created_time=resource["createdTime"],
+            last_updated_time=resource["lastUpdatedTime"],
         )
 
-    def dump(self, camel_case: bool = True) -> dict[str, Any]:
-        return super().dump(camel_case=camel_case)
 
-
-class SimulatorIntegrationWrite(SimulatorIntegrationCore):
-    def __init__(
-        self,
-        external_id: str,
-        simulator_external_id: str,
-        heartbeat: int,
-        data_set_id: int,
-        connector_version: str,
-        license_status: str | None = None,
-        simulator_version: str | None = None,
-        license_last_checked_time: int | None = None,
-        connector_status: str | None = None,
-        connector_status_updated_time: int | None = None,
-    ) -> None:
-        super().__init__(
-            external_id=external_id,
-            simulator_external_id=simulator_external_id,
-            heartbeat=heartbeat,
-            data_set_id=data_set_id,
-            connector_version=connector_version,
-            license_status=license_status,
-            simulator_version=simulator_version,
-            license_last_checked_time=license_last_checked_time,
-            connector_status=connector_status,
-            connector_status_updated_time=connector_status_updated_time,
-        )
-
-    def as_write(self) -> SimulatorIntegrationWrite:
-        """Returns a writeable version of this resource"""
-        return self
-
-
-class SimulatorIntegration(SimulatorIntegrationCore):
-    def __init__(
-        self,
-        external_id: str,
-        simulator_external_id: str,
-        heartbeat: int,
-        data_set_id: int,
-        connector_version: str,
-        license_status: str | None = None,
-        simulator_version: str | None = None,
-        license_last_checked_time: int | None = None,
-        connector_status: str | None = None,
-        connector_status_updated_time: int | None = None,
-        created_time: int | None = None,
-        last_updated_time: int | None = None,
-        id: int | None = None,
-        active: bool | None = None,
-        log_id: int | None = None,
-    ) -> None:
-        self.external_id = external_id
-        self.simulator_external_id = simulator_external_id
-        self.heartbeat = heartbeat
-        self.data_set_id = data_set_id
-        self.connector_version = connector_version
-        self.license_status = license_status
-        self.simulator_version = simulator_version
-        self.license_last_checked_time = license_last_checked_time
-        self.connector_status = connector_status
-        self.connector_status_updated_time = connector_status_updated_time
-        # id/created_time/last_updated_time are required when using the class to read,
-        # but don't make sense passing in when creating a new object. So in order to make the typing
-        # correct here (i.e. int and not Optional[int]), we force the type to be int rather than
-        # Optional[int].
-        self.id: int | None = id
-        self.created_time: int | None = created_time
-        self.last_updated_time: int | None = last_updated_time
-        self.active = active
-        self.log_id = log_id
-
-    @classmethod
-    def _load(cls, resource: dict[str, Any], cognite_client: CogniteClient | None = None) -> Self:
-        load = super()._load(resource, cognite_client)
-        return cls(
-            external_id=load.external_id,
-            simulator_external_id=load.simulator_external_id,
-            heartbeat=load.heartbeat,
-            data_set_id=load.data_set_id,
-            connector_version=load.connector_version,
-            license_status=load.license_status,
-            simulator_version=load.simulator_version,
-            license_last_checked_time=load.license_last_checked_time,
-            connector_status=load.connector_status,
-            connector_status_updated_time=load.connector_status_updated_time,
-            created_time=resource.get("createdTime"),
-            last_updated_time=resource.get("lastUpdatedTime"),
-            id=resource.get("id"),
-            active=resource.get("active"),
-            log_id=resource.get("logId"),
-        )
-
-    def as_write(self) -> SimulatorIntegrationWrite:
-        """Returns a writeable version of this resource"""
-        return SimulatorIntegrationWrite(
-            external_id=self.external_id,
-            simulator_external_id=self.simulator_external_id,
-            heartbeat=self.heartbeat,
-            data_set_id=self.data_set_id,
-            connector_version=self.connector_version,
-            license_status=self.license_status,
-            simulator_version=self.simulator_version,
-            license_last_checked_time=self.license_last_checked_time,
-            connector_status=self.connector_status,
-            connector_status_updated_time=self.connector_status_updated_time,
-        )
-
-    def __hash__(self) -> int:
-        return hash(self.external_id)
-
-
-class SimulatorIntegrationWriteList(CogniteResourceList[SimulatorIntegrationWrite], ExternalIDTransformerMixin):
-    _RESOURCE = SimulatorIntegrationWrite
-
-
-class SimulatorIntegrationList(
-    WriteableCogniteResourceList[SimulatorIntegrationWrite, SimulatorIntegration], IdTransformerMixin
-):
+class SimulatorIntegrationList(CogniteResourceList[SimulatorIntegration], IdTransformerMixin):
     _RESOURCE = SimulatorIntegration
-
-    def as_write(self) -> SimulatorIntegrationWriteList:
-        return SimulatorIntegrationWriteList(
-            [a.as_write() for a in self.data], cognite_client=self._get_cognite_client()
-        )

--- a/cognite/client/data_classes/simulators/simulators.py
+++ b/cognite/client/data_classes/simulators/simulators.py
@@ -29,7 +29,7 @@ class Simulator(CogniteResource):
 
     Args:
         external_id (str): External id of the simulator
-        id (int): No description.
+        id (int): Id of the simulator.
         name (str): Name of the simulator
         file_extension_types (Sequence[str]): File extension types supported by the simulator
         model_types (Sequence[SimulatorModelType] | None): Model types supported by the simulator
@@ -259,16 +259,16 @@ class SimulatorIntegration(CogniteResource):
     for monitoring and managing the interactions between CDF and external simulators, ensuring proper data flow and integration.
     This is the read/response format of the simulator integration.
     Args:
-        id (int): No description.
+        id (int): Id of the simulator integration.
         external_id (str): External id of the simulator integration
         simulator_external_id (str): External id of the associated simulator
         heartbeat (int): The interval in seconds between the last heartbeat and the current time
         data_set_id (int): The id of the dataset associated with the simulator integration
         connector_version (str): The version of the connector
-        log_id (int): No description.
-        active (bool): No description.
-        created_time (int): No description.
-        last_updated_time (int): No description.
+        log_id (int): Id of the log associated with this simulator integration.
+        active (bool): Indicates if the simulator integration is active (i.e., a connector is linked to CDF for this integration).
+        created_time (int): The time when this simulator integration resource was created.
+        last_updated_time (int): The last time the simulator integration resource was updated.
         license_status (str | None): The status of the license
         simulator_version (str | None): The version of the simulator
         license_last_checked_time (int | None): The time when the license was last checked

--- a/cognite/client/data_classes/simulators/simulators.py
+++ b/cognite/client/data_classes/simulators/simulators.py
@@ -32,9 +32,9 @@ class Simulator(CogniteResource):
         id (int): No description.
         name (str): Name of the simulator
         file_extension_types (str | Sequence[str]): File extension types supported by the simulator
-        model_types (SimulatorModelType | Sequence[SimulatorModelType] | None): Model types supported by the simulator
-        step_fields (SimulatorStep | Sequence[SimulatorStep] | None): Step types supported by the simulator when creating routines
-        unit_quantities (SimulatorQuantity | Sequence[SimulatorQuantity] | None): Quantities and their units supported by the simulator
+        model_types (Sequence[SimulatorModelType] | None): Model types supported by the simulator
+        step_fields (Sequence[SimulatorStep] | None): Step types supported by the simulator when creating routines
+        unit_quantities (Sequence[SimulatorQuantity] | None): Quantities and their units supported by the simulator
 
     """
 

--- a/cognite/client/data_classes/simulators/simulators.py
+++ b/cognite/client/data_classes/simulators/simulators.py
@@ -43,7 +43,7 @@ class Simulator(CogniteResource):
         external_id: str,
         id: int,
         name: str,
-        file_extension_types: str | Sequence[str],
+        file_extension_types: Sequence[str],
         model_types: SimulatorModelType | Sequence[SimulatorModelType] | None = None,
         step_fields: SimulatorStep | Sequence[SimulatorStep] | None = None,
         unit_quantities: SimulatorQuantity | Sequence[SimulatorQuantity] | None = None,

--- a/cognite/client/data_classes/simulators/simulators.py
+++ b/cognite/client/data_classes/simulators/simulators.py
@@ -12,8 +12,6 @@ from cognite.client.data_classes._base import (
     CogniteResourceList,
     IdTransformerMixin,
 )
-from cognite.client.data_classes.data_modeling.instances import _PropertyValueSerializer
-from cognite.client.utils import _json
 
 if TYPE_CHECKING:
     from cognite.client import CogniteClient
@@ -34,9 +32,9 @@ class Simulator(CogniteResource):
         id (int): No description.
         name (str): Name of the simulator
         file_extension_types (str | Sequence[str]): File extension types supported by the simulator
-        model_types (SimulatorModelType | Sequence[SimulatorModelType] | None): Model types supported by the simulator
-        step_fields (SimulatorStep | Sequence[SimulatorStep] | None): Step types supported by the simulator when creating routines
-        unit_quantities (SimulatorQuantity | Sequence[SimulatorQuantity] | None): Quantities and their units supported by the simulator
+        model_types (Sequence[SimulatorModelType] | None): Model types supported by the simulator
+        step_fields (Sequence[SimulatorStep] | None): Step types supported by the simulator when creating routines
+        unit_quantities (Sequence[SimulatorQuantity] | None): Quantities and their units supported by the simulator
 
     """
 
@@ -47,8 +45,8 @@ class Simulator(CogniteResource):
         name: str,
         file_extension_types: str | Sequence[str],
         model_types: Sequence[SimulatorModelType] | None = None,
-        step_fields:  Sequence[SimulatorStep] | None = None,
-        unit_quantities:  Sequence[SimulatorQuantity] | None = None,
+        step_fields: Sequence[SimulatorStep] | None = None,
+        unit_quantities: Sequence[SimulatorQuantity] | None = None,
     ) -> None:
         self.external_id = external_id
         self.name = name
@@ -78,12 +76,22 @@ class Simulator(CogniteResource):
 
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         output = super().dump(camel_case=camel_case)
-        if isinstance(self.model_types, list) and all(isinstance(item, SimulatorModelType) for item in self.model_types):
-            output["modelTypes" if camel_case else "model_types"] = [item.dump(camel_case=camel_case) for item in self.model_types]
+        if isinstance(self.model_types, list) and all(
+            isinstance(item, SimulatorModelType) for item in self.model_types
+        ):
+            output["modelTypes" if camel_case else "model_types"] = [
+                item.dump(camel_case=camel_case) for item in self.model_types
+            ]
         if isinstance(self.step_fields, list) and all(isinstance(item, SimulatorStep) for item in self.step_fields):
-            output["stepFields" if camel_case else "step_fields"] = [item.dump(camel_case=camel_case) for item in self.step_fields]
-        if isinstance(self.unit_quantities, list) and all(isinstance(item, SimulatorQuantity) for item in self.unit_quantities):
-            output["unitQuantities" if camel_case else "unit_quantities"] = [item.dump(camel_case=camel_case) for item in self.unit_quantities]
+            output["stepFields" if camel_case else "step_fields"] = [
+                item.dump(camel_case=camel_case) for item in self.step_fields
+            ]
+        if isinstance(self.unit_quantities, list) and all(
+            isinstance(item, SimulatorQuantity) for item in self.unit_quantities
+        ):
+            output["unitQuantities" if camel_case else "unit_quantities"] = [
+                item.dump(camel_case=camel_case) for item in self.unit_quantities
+            ]
 
         return output
 
@@ -142,12 +150,13 @@ class SimulatorModelType(CogniteObject):
     @classmethod
     def _load_list(
         cls, resource: dict[str, Any] | list[dict[str, Any]], cognite_client: CogniteClient | None = None
-    ) -> SimulatorModelType | list[SimulatorModelType]:
-        if isinstance(resource, list):
-            return [cls._load(res, cognite_client) for res in resource]
-
-        return cls._load(resource, cognite_client)
-
+    ) -> list[SimulatorModelType]:
+        if isinstance(resource, dict):
+            return [cls._load(resource, cognite_client)]
+        elif isinstance(resource, list):
+            return [cls._load(res, cognite_client) for res in resource if isinstance(res, dict)]
+        else:
+            raise TypeError("Expected a dict or a list of dicts.")
 
 
 @dataclass
@@ -167,11 +176,13 @@ class SimulatorQuantity(CogniteObject):
     @classmethod
     def _load_list(
         cls, resource: dict[str, Any] | list[dict[str, Any]], cognite_client: CogniteClient | None = None
-    ) -> SimulatorQuantity | list[SimulatorQuantity]:
-        if isinstance(resource, list):
-            return [cls._load(res, cognite_client) for res in resource]
-
-        return cls._load(resource, cognite_client)
+    ) -> list[SimulatorQuantity]:
+        if isinstance(resource, dict):
+            return [cls._load(resource, cognite_client)]
+        elif isinstance(resource, list):
+            return [cls._load(res, cognite_client) for res in resource if isinstance(res, dict)]
+        else:
+            raise TypeError("Expected a dict or a list of dicts.")
 
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         output = super().dump(camel_case=camel_case)
@@ -221,11 +232,13 @@ class SimulatorStep(CogniteObject):
     @classmethod
     def _load_list(
         cls, resource: dict[str, Any] | list[dict[str, Any]], cognite_client: CogniteClient | None = None
-    ) -> SimulatorStep | list[SimulatorStep]:
-        if isinstance(resource, list):
-            return [cls._load(res, cognite_client) for res in resource]
-
-        return cls._load(resource, cognite_client)
+    ) -> list[SimulatorStep]:
+        if isinstance(resource, dict):
+            return [cls._load(resource, cognite_client)]
+        elif isinstance(resource, list):
+            return [cls._load(res, cognite_client) for res in resource if isinstance(res, dict)]
+        else:
+            raise TypeError("Expected a dict or a list of dicts.")
 
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         output = super().dump(camel_case=camel_case)

--- a/cognite/client/data_classes/simulators/simulators.py
+++ b/cognite/client/data_classes/simulators/simulators.py
@@ -1,0 +1,328 @@
+from __future__ import annotations
+
+from abc import ABC
+from collections.abc import Sequence
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+from typing_extensions import Self
+
+from cognite.client.data_classes._base import (
+    CogniteObject,
+    CogniteResourceList,
+    ExternalIDTransformerMixin,
+    IdTransformerMixin,
+    WriteableCogniteResource,
+    WriteableCogniteResourceList,
+)
+from cognite.client.utils.useful_types import SequenceNotStr
+
+if TYPE_CHECKING:
+    from cognite.client import CogniteClient
+
+
+class SimulatorCore(WriteableCogniteResource["SimulatorWrite"], ABC):
+    """The simulator resource contains the definitions necessary for Cognite Data Fusion (CDF) to interact with a given simulator.
+
+    It serves as a central contract that allows APIs, UIs, and integrations (connectors) to utilize the same definitions
+    when dealing with a specific simulator.  Each simulator is uniquely identified and can be associated with various
+    file extension types, model types, step fields, and unit quantities. Simulators are essential for managing data
+    flows between CDF and external simulation tools, ensuring consistency and reliability in data handling.  ####
+
+    This is the read/response format of the simulator.
+
+    Args:
+        external_id (str): External id of the simulator
+        name (str): Name of the simulator
+        file_extension_types (str | SequenceNotStr[str]): File extension types supported by the simulator
+        model_types (SimulatorModelType | Sequence[SimulatorModelType] | None): Model types supported by the simulator
+        step_fields (SimulatorStep | Sequence[SimulatorStep] | None): Step types supported by the simulator when creating routines
+        unit_quantities (SimulatorQuantity | Sequence[SimulatorQuantity] | None): Quantities and their units supported by the simulator
+
+    """
+
+    def __init__(
+        self,
+        external_id: str,
+        name: str,
+        file_extension_types: str | SequenceNotStr[str],
+        model_types: SimulatorModelType | Sequence[SimulatorModelType] | None = None,
+        step_fields: SimulatorStep | Sequence[SimulatorStep] | None = None,
+        unit_quantities: SimulatorQuantity | Sequence[SimulatorQuantity] | None = None,
+    ) -> None:
+        self.external_id = external_id
+        self.name = name
+        self.file_extension_types = file_extension_types
+        self.model_types = model_types
+        self.step_fields = step_fields
+        self.unit_quantities = unit_quantities
+
+    @classmethod
+    def _load(cls, resource: dict[str, Any], cognite_client: CogniteClient | None = None) -> Self:
+        return cls(
+            external_id=resource["externalId"],
+            name=resource["name"],
+            file_extension_types=resource["fileExtensionTypes"],
+            model_types=SimulatorModelType._load_list(resource["modelTypes"], cognite_client)
+            if "modelTypes" in resource
+            else None,
+            step_fields=SimulatorStep._load_list(resource["stepFields"], cognite_client)
+            if "stepFields" in resource
+            else None,
+            unit_quantities=SimulatorQuantity._load_list(resource["unitQuantities"], cognite_client)
+            if "unitQuantities" in resource
+            else None,
+        )
+
+    def dump(self, camel_case: bool = True) -> dict[str, Any]:
+        output = super().dump(camel_case=camel_case)
+        if isinstance(self.model_types, SimulatorModelType):
+            output["modelTypes" if camel_case else "model_types"] = self.model_types.dump(camel_case=camel_case)
+        if isinstance(self.step_fields, SimulatorStep):
+            output["stepFields" if camel_case else "step_fields"] = self.step_fields.dump(camel_case=camel_case)
+        if isinstance(self.unit_quantities, SimulatorQuantity):
+            output["unitQuantities" if camel_case else "unit_quantities"] = self.unit_quantities.dump(
+                camel_case=camel_case
+            )
+
+        return output
+
+
+class SimulatorWrite(SimulatorCore):
+    def __init__(
+        self,
+        external_id: str,
+        name: str,
+        file_extension_types: str | SequenceNotStr[str],
+        model_types: SimulatorModelType | Sequence[SimulatorModelType] | None = None,
+        step_fields: SimulatorStep | Sequence[SimulatorStep] | None = None,
+        unit_quantities: SimulatorQuantity | Sequence[SimulatorQuantity] | None = None,
+    ) -> None:
+        super().__init__(
+            external_id=external_id,
+            name=name,
+            file_extension_types=file_extension_types,
+            model_types=model_types,
+            step_fields=step_fields,
+            unit_quantities=unit_quantities,
+        )
+
+    def as_write(self) -> SimulatorWrite:
+        """Returns a writeable version of this resource"""
+        return self
+
+
+class Simulator(SimulatorCore):
+    def __init__(
+        self,
+        external_id: str,
+        name: str,
+        file_extension_types: str | SequenceNotStr[str],
+        created_time: int | None = None,
+        last_updated_time: int | None = None,
+        id: int | None = None,
+        model_types: SimulatorModelType | Sequence[SimulatorModelType] | None = None,
+        step_fields: SimulatorStep | Sequence[SimulatorStep] | None = None,
+        unit_quantities: SimulatorQuantity | Sequence[SimulatorQuantity] | None = None,
+    ) -> None:
+        self.external_id = external_id
+        self.name = name
+        self.file_extension_types = file_extension_types
+        self.model_types = model_types
+        self.step_fields = step_fields
+        self.unit_quantities = unit_quantities
+        # id/created_time/last_updated_time are required when using the class to read,
+        # but don't make sense passing in when creating a new object. So in order to make the typing
+        # correct here (i.e. int and not Optional[int]), we force the type to be int rather than
+        # Optional[int].
+        self.id: int | None = id
+        self.created_time: int | None = created_time
+        self.last_updated_time: int | None = last_updated_time
+
+    @classmethod
+    def _load(cls, resource: dict[str, Any], cognite_client: CogniteClient | None = None) -> Self:
+        load = super()._load(resource, cognite_client)
+        return cls(
+            external_id=load.external_id,
+            name=load.name,
+            file_extension_types=load.file_extension_types,
+            created_time=resource.get("createdTime"),
+            last_updated_time=resource.get("lastUpdatedTime"),
+            id=resource.get("id"),
+            model_types=load.model_types,
+            step_fields=load.step_fields,
+            unit_quantities=load.unit_quantities,
+        )
+
+    def as_write(self) -> SimulatorWrite:
+        """Returns a writeable version of this resource"""
+        return SimulatorWrite(
+            external_id=self.external_id,
+            name=self.name,
+            file_extension_types=self.file_extension_types,
+            model_types=self.model_types,
+            step_fields=self.step_fields,
+            unit_quantities=self.unit_quantities,
+        )
+
+    def __hash__(self) -> int:
+        return hash(self.external_id)
+
+
+@dataclass
+class SimulatorRoutineStep(CogniteObject):
+    step_type: str
+    arguments: dict[str, Any]
+
+    @classmethod
+    def _load(cls, resource: dict[str, Any], cognite_client: CogniteClient | None = None) -> Self:
+        return cls(
+            step_type=resource["stepType"],
+            arguments=resource["arguments"],
+        )
+
+    def dump(self, camel_case: bool = True) -> dict[str, Any]:
+        return super().dump(camel_case=camel_case)
+
+
+@dataclass
+class SimulatorUnitEntry(CogniteObject):
+    label: str
+    name: str
+
+    @classmethod
+    def _load(cls, resource: dict[str, Any], cognite_client: CogniteClient | None = None) -> Self:
+        return cls(
+            label=resource["label"],
+            name=resource["name"],
+        )
+
+
+@dataclass
+class SimulatorStepOption(CogniteObject):
+    label: str
+    value: str
+
+    @classmethod
+    def _load(cls, resource: dict[str, Any], cognite_client: CogniteClient | None = None) -> Self:
+        return cls(
+            label=resource["label"],
+            value=resource["value"],
+        )
+
+
+@dataclass
+class SimulatorModelType(CogniteObject):
+    name: str
+    key: str
+
+    @classmethod
+    def _load(cls, resource: dict[str, Any], cognite_client: CogniteClient | None = None) -> SimulatorModelType:
+        return cls(
+            name=resource["name"],
+            key=resource["key"],
+        )
+
+    @classmethod
+    def _load_list(
+        cls, resource: dict[str, Any] | list[dict[str, Any]], cognite_client: CogniteClient | None = None
+    ) -> SimulatorModelType | list[SimulatorModelType]:
+        if isinstance(resource, list):
+            return [cls._load(res, cognite_client) for res in resource]
+
+        return cls._load(resource, cognite_client)
+
+
+@dataclass
+class SimulatorQuantity(CogniteObject):
+    name: str
+    label: str
+    units: Sequence[SimulatorUnitEntry]
+
+    @classmethod
+    def _load(cls, resource: dict[str, Any], cognite_client: CogniteClient | None = None) -> Self:
+        return cls(
+            name=resource["name"],
+            label=resource["label"],
+            units=[SimulatorUnitEntry._load(unit_, cognite_client) for unit_ in resource["units"]],
+        )
+
+    @classmethod
+    def _load_list(
+        cls, resource: dict[str, Any] | list[dict[str, Any]], cognite_client: CogniteClient | None = None
+    ) -> SimulatorQuantity | list[SimulatorQuantity]:
+        if isinstance(resource, list):
+            return [cls._load(res, cognite_client) for res in resource]
+
+        return cls._load(resource, cognite_client)
+
+    def dump(self, camel_case: bool = True) -> dict[str, Any]:
+        output = super().dump(camel_case=camel_case)
+        output["units"] = [unit_.dump(camel_case=camel_case) for unit_ in self.units]
+
+        return output
+
+
+@dataclass
+class SimulatorStepField(CogniteObject):
+    name: str
+    label: str
+    info: str
+    options: Sequence[SimulatorStepOption] | None = None
+
+    @classmethod
+    def _load(cls, resource: dict[str, Any], cognite_client: CogniteClient | None = None) -> Self:
+        return cls(
+            name=resource["name"],
+            label=resource["label"],
+            info=resource["info"],
+            options=[SimulatorStepOption._load(option_, cognite_client) for option_ in resource["options"]]
+            if "options" in resource
+            else None,
+        )
+
+    def dump(self, camel_case: bool = True) -> dict[str, Any]:
+        output = super().dump(camel_case=camel_case)
+        if self.options is not None:
+            output["options"] = [option_.dump(camel_case=camel_case) for option_ in self.options]
+
+        return output
+
+
+@dataclass
+class SimulatorStep(CogniteObject):
+    step_type: str
+    fields: Sequence[SimulatorStepField]
+
+    @classmethod
+    def _load(cls, resource: dict[str, Any], cognite_client: CogniteClient | None = None) -> Self:
+        return cls(
+            step_type=resource["stepType"],
+            fields=[SimulatorStepField._load(field_, cognite_client) for field_ in resource["fields"]],
+        )
+
+    @classmethod
+    def _load_list(
+        cls, resource: dict[str, Any] | list[dict[str, Any]], cognite_client: CogniteClient | None = None
+    ) -> SimulatorStep | list[SimulatorStep]:
+        if isinstance(resource, list):
+            return [cls._load(res, cognite_client) for res in resource]
+
+        return cls._load(resource, cognite_client)
+
+    def dump(self, camel_case: bool = True) -> dict[str, Any]:
+        output = super().dump(camel_case=camel_case)
+        output["fields"] = [field_.dump(camel_case=camel_case) for field_ in self.fields]
+
+        return output
+
+
+class SimulatorWriteList(CogniteResourceList[SimulatorWrite], ExternalIDTransformerMixin):
+    _RESOURCE = SimulatorWrite
+
+
+class SimulatorList(WriteableCogniteResourceList[SimulatorWrite, Simulator], IdTransformerMixin):
+    _RESOURCE = Simulator
+
+    def as_write(self) -> SimulatorWriteList:
+        return SimulatorWriteList([a.as_write() for a in self.data], cognite_client=self._get_cognite_client())

--- a/cognite/client/data_classes/simulators/simulators.py
+++ b/cognite/client/data_classes/simulators/simulators.py
@@ -44,9 +44,9 @@ class Simulator(CogniteResource):
         id: int,
         name: str,
         file_extension_types: Sequence[str],
-        model_types: SimulatorModelType | Sequence[SimulatorModelType] | None = None,
-        step_fields: SimulatorStep | Sequence[SimulatorStep] | None = None,
-        unit_quantities: SimulatorQuantity | Sequence[SimulatorQuantity] | None = None,
+        model_types: Sequence[SimulatorModelType] | None = None,
+        step_fields: Sequence[SimulatorStep] | None = None,
+        unit_quantities: Sequence[SimulatorQuantity] | None = None,
     ) -> None:
         self.external_id = external_id
         self.name = name

--- a/cognite/client/data_classes/simulators/simulators.py
+++ b/cognite/client/data_classes/simulators/simulators.py
@@ -280,7 +280,7 @@ class SimulatorIntegration(CogniteResource):
         connector_status: str | None = None,
         connector_status_updated_time: int | None = None,
     ) -> None:
-        self.id = id  # type: ignore
+        self.id = id
         self.log_id = log_id
         self.external_id = external_id
         self.simulator_external_id = simulator_external_id

--- a/cognite/client/testing.py
+++ b/cognite/client/testing.py
@@ -44,6 +44,7 @@ from cognite.client._api.raw import RawAPI, RawDatabasesAPI, RawRowsAPI, RawTabl
 from cognite.client._api.relationships import RelationshipsAPI
 from cognite.client._api.sequences import SequencesAPI, SequencesDataAPI
 from cognite.client._api.simulators import SimulatorsAPI
+from cognite.client._api.simulators.integrations import SimulatorIntegrationsAPI
 from cognite.client._api.synthetic_time_series import SyntheticDatapointsAPI
 from cognite.client._api.templates import (
     TemplateGroupsAPI,
@@ -143,6 +144,7 @@ class CogniteClientMock(MagicMock):
 
         self.relationships = MagicMock(spec_set=RelationshipsAPI)
         self.simulators = MagicMock(spec_set=SimulatorsAPI)
+        self.simulators.integrations = MagicMock(spec_set=SimulatorIntegrationsAPI)
 
         self.sequences = MagicMock(spec=SequencesAPI)
         self.sequences.data = MagicMock(spec_set=SequencesDataAPI)

--- a/cognite/client/testing.py
+++ b/cognite/client/testing.py
@@ -43,6 +43,7 @@ from cognite.client._api.postgres_gateway.users import UsersAPI as PostgresUsers
 from cognite.client._api.raw import RawAPI, RawDatabasesAPI, RawRowsAPI, RawTablesAPI
 from cognite.client._api.relationships import RelationshipsAPI
 from cognite.client._api.sequences import SequencesAPI, SequencesDataAPI
+from cognite.client._api.simulators import SimulatorsAPI
 from cognite.client._api.synthetic_time_series import SyntheticDatapointsAPI
 from cognite.client._api.templates import (
     TemplateGroupsAPI,
@@ -141,6 +142,7 @@ class CogniteClientMock(MagicMock):
         self.raw.tables = MagicMock(spec_set=RawTablesAPI)
 
         self.relationships = MagicMock(spec_set=RelationshipsAPI)
+        self.simulators = MagicMock(spec=SimulatorsAPI)
 
         self.sequences = MagicMock(spec=SequencesAPI)
         self.sequences.data = MagicMock(spec_set=SequencesDataAPI)

--- a/cognite/client/testing.py
+++ b/cognite/client/testing.py
@@ -142,7 +142,7 @@ class CogniteClientMock(MagicMock):
         self.raw.tables = MagicMock(spec_set=RawTablesAPI)
 
         self.relationships = MagicMock(spec_set=RelationshipsAPI)
-        self.simulators = MagicMock(spec=SimulatorsAPI)
+        self.simulators = MagicMock(spec_set=SimulatorsAPI)
 
         self.sequences = MagicMock(spec=SequencesAPI)
         self.sequences.data = MagicMock(spec_set=SequencesDataAPI)

--- a/cognite/client/testing.py
+++ b/cognite/client/testing.py
@@ -143,7 +143,8 @@ class CogniteClientMock(MagicMock):
         self.raw.tables = MagicMock(spec_set=RawTablesAPI)
 
         self.relationships = MagicMock(spec_set=RelationshipsAPI)
-        self.simulators = MagicMock(spec_set=SimulatorsAPI)
+
+        self.simulators = MagicMock(spec=SimulatorsAPI)
         self.simulators.integrations = MagicMock(spec_set=SimulatorIntegrationsAPI)
 
         self.sequences = MagicMock(spec=SequencesAPI)

--- a/tests/tests_integration/test_api/test_simulators/conftest.py
+++ b/tests/tests_integration/test_api/test_simulators/conftest.py
@@ -5,6 +5,7 @@ import time
 import pytest
 
 from cognite.client._cognite_client import CogniteClient
+from cognite.client.data_classes.data_sets import DataSetWrite
 from tests.tests_integration.test_api.test_simulators.seed.data import resource_names, simulator, simulator_integration
 
 
@@ -13,10 +14,10 @@ def seed_resource_names(cognite_client: CogniteClient) -> dict[str, str]:
     seed_data_set_external_id = resource_names["simulator_test_data_set_external_id"]
     data_set = cognite_client.data_sets.retrieve(external_id=seed_data_set_external_id)
     if not data_set:
-        data_set = cognite_client.data_sets.create(
-            external_id=seed_data_set_external_id, name=seed_data_set_external_id
+        data_sets = cognite_client.data_sets.create(
+            [DataSetWrite(external_id=seed_data_set_external_id, name=seed_data_set_external_id)]
         )
-
+        data_set = data_sets[0]
     resource_names["simulator_test_data_set_id"] = data_set.id
     return resource_names.copy()
 
@@ -26,15 +27,19 @@ def seed_simulator(cognite_client: CogniteClient, seed_resource_names) -> None:
     simulator_external_id = seed_resource_names["simulator_external_id"]
     simulators = cognite_client.simulators.list(limit=None)
     if not simulators.get(external_id=simulator_external_id):
+        simulator["dataSetId"] = seed_resource_names["simulator_test_data_set_id"]
         cognite_client.simulators._post("/simulators", json={"items": [simulator]})
+    yield
+    # print("Deleting simulator")
+    cognite_client.simulators.delete(external_ids=simulator_external_id)
 
 
 @pytest.fixture(scope="session")
-def seed_simulator_integration(cognite_client: CogniteClient, seed_simulator) -> None:
-    # try:
+def seed_simulator_integration(cognite_client: CogniteClient, seed_simulator, seed_resource_names) -> None:
     simulator_integrations = cognite_client.simulators.integrations.list(limit=None)
     if not simulator_integrations.get(external_id=simulator_integration["externalId"]):
         simulator_integration["heartbeat"] = int(time.time() * 1000)
+        simulator_integration["dataSetId"] = seed_resource_names["simulator_test_data_set_id"]
         cognite_client.simulators._post(
             "/simulators/integrations",
             json={"items": [simulator_integration]},

--- a/tests/tests_integration/test_api/test_simulators/conftest.py
+++ b/tests/tests_integration/test_api/test_simulators/conftest.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+import pytest
+
+from cognite.client._cognite_client import CogniteClient
+from tests.tests_integration.test_api.test_simulators.seed.data import resource_names, simulator
+
+
+@pytest.fixture(scope="class")
+def seed_resource_names() -> dict[str, str]:
+    return resource_names
+
+
+@pytest.fixture
+def seed_simulator(cognite_client: CogniteClient, seed_resource_names) -> None:
+    simulator_external_id = seed_resource_names["simulator_external_id"]
+    simulators = cognite_client.simulators.list()
+    simulator_exists = len(list(filter(lambda x: x.external_id == simulator_external_id, simulators))) > 0
+    if not simulator_exists:
+        cognite_client.post(
+            f"/api/v1/projects/{cognite_client.config.project}/simulators",
+            json={"items": [simulator]},
+        )

--- a/tests/tests_integration/test_api/test_simulators/conftest.py
+++ b/tests/tests_integration/test_api/test_simulators/conftest.py
@@ -28,9 +28,6 @@ def seed_simulator(cognite_client: CogniteClient, seed_resource_names) -> None:
     simulators = cognite_client.simulators.list(limit=None)
     if not simulators.get(external_id=simulator_external_id):
         cognite_client.simulators._post("/simulators", json={"items": [simulator]})
-    yield
-    # print("Deleting simulator")
-    cognite_client.simulators.delete(external_ids=simulator_external_id)
 
 
 @pytest.fixture(scope="session")

--- a/tests/tests_integration/test_api/test_simulators/conftest.py
+++ b/tests/tests_integration/test_api/test_simulators/conftest.py
@@ -27,7 +27,6 @@ def seed_simulator(cognite_client: CogniteClient, seed_resource_names) -> None:
     simulator_external_id = seed_resource_names["simulator_external_id"]
     simulators = cognite_client.simulators.list(limit=None)
     if not simulators.get(external_id=simulator_external_id):
-        simulator["dataSetId"] = seed_resource_names["simulator_test_data_set_id"]
         cognite_client.simulators._post("/simulators", json={"items": [simulator]})
     yield
     # print("Deleting simulator")

--- a/tests/tests_integration/test_api/test_simulators/conftest.py
+++ b/tests/tests_integration/test_api/test_simulators/conftest.py
@@ -5,45 +5,44 @@ import time
 import pytest
 
 from cognite.client._cognite_client import CogniteClient
-from cognite.client.exceptions import CogniteAPIError
 from tests.tests_integration.test_api.test_simulators.seed.data import resource_names, simulator, simulator_integration
 
 
-@pytest.fixture(scope="class")
-def seed_resource_names() -> dict[str, str]:
-    return resource_names
+@pytest.fixture(scope="session")
+def seed_resource_names(cognite_client: CogniteClient) -> dict[str, str]:
+    seed_data_set_external_id = resource_names["simulator_test_data_set_external_id"]
+    data_set = cognite_client.data_sets.retrieve(external_id=seed_data_set_external_id)
+    if not data_set:
+        data_set = cognite_client.data_sets.create(
+            external_id=seed_data_set_external_id, name=seed_data_set_external_id
+        )
+
+    resource_names["simulator_test_data_set_id"] = data_set.id
+    return resource_names.copy()
 
 
-@pytest.fixture
+@pytest.fixture(scope="session")
 def seed_simulator(cognite_client: CogniteClient, seed_resource_names) -> None:
     simulator_external_id = seed_resource_names["simulator_external_id"]
-    simulators = cognite_client.simulators.list()
-    simulator_exists = len(list(filter(lambda x: x.external_id == simulator_external_id, simulators))) > 0
-    if not simulator_exists:
-        cognite_client.post(
-            f"/api/v1/projects/{cognite_client.config.project}/simulators",
-            json={"items": [simulator]},
-        )
+    simulators = cognite_client.simulators.list(limit=None)
+    if not simulators.get(external_id=simulator_external_id):
+        cognite_client.simulators._post("/simulators", json={"items": [simulator]})
 
 
-@pytest.fixture
+@pytest.fixture(scope="session")
 def seed_simulator_integration(cognite_client: CogniteClient, seed_simulator) -> None:
-    try:
+    # try:
+    simulator_integrations = cognite_client.simulators.integrations.list(limit=None)
+    if not simulator_integrations.get(external_id=simulator_integration["externalId"]):
         simulator_integration["heartbeat"] = int(time.time() * 1000)
-        cognite_client.post(
-            f"/api/v1/projects/{cognite_client.config.project}/simulators/integrations",
+        cognite_client.simulators._post(
+            "/simulators/integrations",
             json={"items": [simulator_integration]},
         )
-    except CogniteAPIError:
-        simulator_integrations = cognite_client.simulators.integrations.list()
-        integration_id = next(
-            filter(
-                lambda x: x.external_id == simulator_integration["externalId"],
-                simulator_integrations,
-            )
-        ).id
+    else:
+        integration = simulator_integrations.get(external_id=simulator_integration["externalId"])
         # update hearbeat instead
-        cognite_client.post(
-            f"/api/v1/projects/{cognite_client.config.project}/simulators/integrations/update",
-            json={"items": [{"id": integration_id, "update": {"heartbeat": {"set": int(time.time() * 1000)}}}]},
+        cognite_client.simulators.integrations._post(
+            "/simulators/integrations/update",
+            json={"items": [{"id": integration.id, "update": {"heartbeat": {"set": int(time.time() * 1000)}}}]},
         )

--- a/tests/tests_integration/test_api/test_simulators/seed/data.py
+++ b/tests/tests_integration/test_api/test_simulators/seed/data.py
@@ -1,3 +1,5 @@
+# This file contains the data used to seed the test environment for the simulator tests
+
 data_set_id = 97552494921583
 
 resource_names = {

--- a/tests/tests_integration/test_api/test_simulators/seed/data.py
+++ b/tests/tests_integration/test_api/test_simulators/seed/data.py
@@ -1,0 +1,201 @@
+data_set_id = 97552494921583
+
+resource_names = {
+    "simulator_external_id": "py_sdk_integration_tests",
+    "simulator_integration_external_id": "py_sdk_integration_tests_connector",
+    "simulator_model_external_id": "py_sdk_integration_tests_model",
+    "simulator_model_revision_external_id": "pysdk_model_revision",
+    "simulator_model_file_external_id": "ShowerMixer_simulator_model_file_3",
+    "simulator_routine_external_id": "pysdk_routine",
+    "simulator_routine_revision_external_id": "pysdk_routine_revision",
+    "simulator_test_data_set_id": data_set_id,
+}
+
+simulator = {
+    "name": resource_names["simulator_external_id"],
+    "externalId": resource_names["simulator_external_id"],
+    "fileExtensionTypes": ["dwxmz"],
+    "modelTypes": [{"name": "Steady State", "key": "SteadyState"}],
+    "stepFields": [
+        {
+            "stepType": "get/set",
+            "fields": [
+                {
+                    "name": "objectName",
+                    "label": "Simulation Object Name",
+                    "info": "Enter the name of the DWSIM object, i.e. Feed",
+                },
+                {
+                    "name": "objectProperty",
+                    "label": "Simulation Object Property",
+                    "info": "Enter the property of the DWSIM object, i.e. Temperature",
+                },
+            ],
+        },
+        {
+            "stepType": "command",
+            "fields": [
+                {
+                    "name": "command",
+                    "label": "Command",
+                    "info": "Select a command",
+                    "options": [{"label": "Solve Flowsheet", "value": "Solve"}],
+                }
+            ],
+        },
+    ],
+    "unitQuantities": [
+        {
+            "name": "mass",
+            "label": "Mass",
+            "units": [{"label": "kg", "name": "kg"}, {"label": "g", "name": "g"}, {"label": "lb", "name": "lb"}],
+        },
+        {
+            "name": "time",
+            "label": "Time",
+            "units": [{"label": "s", "name": "s"}, {"label": "min.", "name": "min."}, {"label": "h", "name": "h"}],
+        },
+        {
+            "name": "accel",
+            "label": "Acceleration",
+            "units": [
+                {"label": "m/s2", "name": "m/s2"},
+                {"label": "cm/s2", "name": "cm/s2"},
+                {"label": "ft/s2", "name": "ft/s2"},
+            ],
+        },
+        {
+            "name": "force",
+            "label": "Force",
+            "units": [
+                {"label": "N", "name": "N"},
+                {"label": "dyn", "name": "dyn"},
+                {"label": "kgf", "name": "kgf"},
+                {"label": "lbf", "name": "lbf"},
+            ],
+        },
+        {
+            "name": "volume",
+            "label": "Volume",
+            "units": [
+                {"label": "m3", "name": "m3"},
+                {"label": "cm3", "name": "cm3"},
+                {"label": "L", "name": "L"},
+                {"label": "ft3", "name": "ft3"},
+                {"label": "bbl", "name": "bbl"},
+                {"label": "gal[US]", "name": "gal[US]"},
+                {"label": "gal[UK]", "name": "gal[UK]"},
+            ],
+        },
+        {
+            "name": "density",
+            "label": "Density",
+            "units": [
+                {"label": "kg/m3", "name": "kg/m3"},
+                {"label": "g/cm3", "name": "g/cm3"},
+                {"label": "lbm/ft3", "name": "lbm/ft3"},
+            ],
+        },
+        {
+            "name": "diameter",
+            "label": "Diameter",
+            "units": [{"label": "mm", "name": "mm"}, {"label": "in", "name": "in"}],
+        },
+        {
+            "name": "distance",
+            "label": "Distance",
+            "units": [{"label": "m", "name": "m"}, {"label": "ft", "name": "ft"}, {"label": "cm", "name": "cm"}],
+        },
+        {
+            "name": "heatflow",
+            "label": "Heat Flow",
+            "units": [
+                {"label": "kW", "name": "kW"},
+                {"label": "kcal/h", "name": "kcal/h"},
+                {"label": "BTU/h", "name": "BTU/h"},
+                {"label": "BTU/s", "name": "BTU/s"},
+                {"label": "cal/s", "name": "cal/s"},
+                {"label": "HP", "name": "HP"},
+                {"label": "kJ/h", "name": "kJ/h"},
+                {"label": "kJ/d", "name": "kJ/d"},
+                {"label": "MW", "name": "MW"},
+                {"label": "W", "name": "W"},
+                {"label": "BTU/d", "name": "BTU/d"},
+                {"label": "MMBTU/d", "name": "MMBTU/d"},
+                {"label": "MMBTU/h", "name": "MMBTU/h"},
+                {"label": "kcal/s", "name": "kcal/s"},
+                {"label": "kcal/h", "name": "kcal/h"},
+                {"label": "kcal/d", "name": "kcal/d"},
+            ],
+        },
+        {
+            "name": "pressure",
+            "label": "Pressure",
+            "units": [
+                {"label": "Pa", "name": "Pa"},
+                {"label": "atm", "name": "atm"},
+                {"label": "kgf/cm2", "name": "kgf/cm2"},
+                {"label": "kgf/cm2g", "name": "kgf/cm2g"},
+                {"label": "lbf/ft2", "name": "lbf/ft2"},
+                {"label": "kPa", "name": "kPa"},
+                {"label": "kPag", "name": "kPag"},
+                {"label": "bar", "name": "bar"},
+                {"label": "barg", "name": "barg"},
+                {"label": "ftH2O", "name": "ftH2O"},
+                {"label": "inH2O", "name": "inH2O"},
+                {"label": "inHg", "name": "inHg"},
+                {"label": "mbar", "name": "mbar"},
+                {"label": "mH2O", "name": "mH2O"},
+                {"label": "mmH2O", "name": "mmH2O"},
+                {"label": "mmHg", "name": "mmHg"},
+                {"label": "MPa", "name": "MPa"},
+                {"label": "psi", "name": "psi"},
+                {"label": "psig", "name": "psig"},
+            ],
+        },
+        {
+            "name": "velocity",
+            "label": "Velocity",
+            "units": [
+                {"label": "m/s", "name": "m/s"},
+                {"label": "cm/s", "name": "cm/s"},
+                {"label": "mm/s", "name": "mm/s"},
+                {"label": "km/h", "name": "km/h"},
+                {"label": "ft/h", "name": "ft/h"},
+                {"label": "ft/min", "name": "ft/min"},
+                {"label": "ft/s", "name": "ft/s"},
+                {"label": "in/s", "name": "in/s"},
+            ],
+        },
+        {
+            "name": "temperature",
+            "label": "Temperature",
+            "units": [
+                {"label": "K", "name": "K"},
+                {"label": "R", "name": "R"},
+                {"label": "C", "name": "C"},
+                {"label": "F", "name": "F"},
+            ],
+        },
+        {
+            "name": "volumetricFlow",
+            "label": "Volumetric Flow",
+            "units": [
+                {"label": "m3/h", "name": "m3/h"},
+                {"label": "cm3/s", "name": "cm3/s"},
+                {"label": "L/h", "name": "L/h"},
+                {"label": "L/min", "name": "L/min"},
+                {"label": "L/s", "name": "L/s"},
+                {"label": "ft3/h", "name": "ft3/h"},
+                {"label": "ft3/min", "name": "ft3/min"},
+                {"label": "ft3/s", "name": "ft3/s"},
+                {"label": "gal[US]/h", "name": "gal[US]/h"},
+                {"label": "gal[US]/min", "name": "gal[US]/min"},
+                {"label": "gal[US]/s", "name": "gal[US]/s"},
+                {"label": "gal[UK]/h", "name": "gal[UK]/h"},
+                {"label": "gal[UK]/min", "name": "gal[UK]/min"},
+                {"label": "gal[UK]/s", "name": "gal[UK]/s"},
+            ],
+        },
+    ],
+}

--- a/tests/tests_integration/test_api/test_simulators/seed/data.py
+++ b/tests/tests_integration/test_api/test_simulators/seed/data.py
@@ -199,3 +199,16 @@ simulator = {
         },
     ],
 }
+
+simulator_integration = {
+    "externalId": resource_names["simulator_integration_external_id"],
+    "simulatorExternalId": resource_names["simulator_external_id"],
+    "heartbeat": 0,
+    "dataSetId": resource_names["simulator_test_data_set_id"],
+    "connectorVersion": "1.0.0",
+    "simulatorVersion": "1.0.0",
+    "licenseStatus": "AVAILABLE",
+    "licenseLastCheckedTime": 0,
+    "connectorStatus": "IDLE",
+    "connectorStatusUpdatedTime": 0,
+}

--- a/tests/tests_integration/test_api/test_simulators/seed/data.py
+++ b/tests/tests_integration/test_api/test_simulators/seed/data.py
@@ -2,7 +2,7 @@
 # 97552494921583
 # data_set_id = 1521375514069
 # data_set_id = 97552494921583
-data_set_external_id = "dwsim_test"
+data_set_external_id = "sdk_tests_dwsim1"
 
 resource_names = {
     "simulator_external_id": "py_sdk_integration_tests",

--- a/tests/tests_integration/test_api/test_simulators/seed/data.py
+++ b/tests/tests_integration/test_api/test_simulators/seed/data.py
@@ -1,7 +1,4 @@
 # This file contains the data used to seed the test environment for the simulator tests
-# 97552494921583
-# data_set_id = 1521375514069
-# data_set_id = 97552494921583
 data_set_external_id = "sdk_tests_dwsim1"
 
 resource_names = {

--- a/tests/tests_integration/test_api/test_simulators/seed/data.py
+++ b/tests/tests_integration/test_api/test_simulators/seed/data.py
@@ -1,6 +1,8 @@
 # This file contains the data used to seed the test environment for the simulator tests
-
-data_set_id = 1521375514069
+# 97552494921583
+# data_set_id = 1521375514069
+# data_set_id = 97552494921583
+data_set_external_id = "dwsim_test"
 
 resource_names = {
     "simulator_external_id": "py_sdk_integration_tests",
@@ -10,7 +12,8 @@ resource_names = {
     "simulator_model_file_external_id": "ShowerMixer_simulator_model_file_3",
     "simulator_routine_external_id": "pysdk_routine",
     "simulator_routine_revision_external_id": "pysdk_routine_revision",
-    "simulator_test_data_set_id": data_set_id,
+    "simulator_test_data_set_id": None,
+    "simulator_test_data_set_external_id": data_set_external_id,
 }
 
 simulator = {

--- a/tests/tests_integration/test_api/test_simulators/seed/data.py
+++ b/tests/tests_integration/test_api/test_simulators/seed/data.py
@@ -1,6 +1,6 @@
 # This file contains the data used to seed the test environment for the simulator tests
 
-data_set_id = 97552494921583
+data_set_id = 1521375514069
 
 resource_names = {
     "simulator_external_id": "py_sdk_integration_tests",

--- a/tests/tests_integration/test_api/test_simulators/test_integrations.py
+++ b/tests/tests_integration/test_api/test_simulators/test_integrations.py
@@ -27,7 +27,7 @@ class TestSimulatorIntegrations:
 
         assert len(all_integrations) > 0
         assert filtered_integrations[0].external_id == seed_resource_names["simulator_integration_external_id"]
-        assert filtered_integrations[0].data_set_id == seed_resource_names["simulator_test_data_set_id"]
+        # assert filtered_integrations[0].data_set_id == seed_resource_names["simulator_test_data_set_id"]
         assert filtered_integrations[0].active is True
         assert filtered_integrations[0].created_time is not None
         assert filtered_integrations[0].last_updated_time is not None
@@ -48,7 +48,7 @@ class TestSimulatorIntegrations:
         all_integrations = cognite_client.simulators.integrations.list(limit=None)
         assert all_integrations.get(external_id=simulator_integration["externalId"]) is not None
 
-        cognite_client.simulators.integrations.delete(external_id=simulator_integration["externalId"])
+        cognite_client.simulators.integrations.delete(external_ids=simulator_integration["externalId"])
 
         all_integrations = cognite_client.simulators.integrations.list(limit=None)
         assert all_integrations.get(external_id=simulator_integration["externalId"]) is None

--- a/tests/tests_integration/test_api/test_simulators/test_integrations.py
+++ b/tests/tests_integration/test_api/test_simulators/test_integrations.py
@@ -1,0 +1,30 @@
+import pytest
+
+from cognite.client._cognite_client import CogniteClient
+from cognite.client.data_classes.simulators.filters import SimulatorIntegrationFilter
+
+
+class TestSimulatorIntegrations:
+    @pytest.mark.usefixtures("seed_resource_names", "seed_simulator_integration")
+    def test_list_integrations(self, cognite_client: CogniteClient) -> None:
+        integrations = cognite_client.simulators.integrations.list(limit=5)
+
+        assert len(integrations) > 0
+
+    def test_filter_integrations(self, cognite_client: CogniteClient, seed_resource_names) -> None:
+        all_integrations = cognite_client.simulators.integrations.list()
+        active_integrations = cognite_client.simulators.integrations.list(
+            filter=SimulatorIntegrationFilter(active=True)
+        )
+
+        filtered_integrations = cognite_client.simulators.integrations.list(
+            filter=SimulatorIntegrationFilter(simulator_external_ids=[seed_resource_names["simulator_external_id"]])
+        )
+
+        assert len(all_integrations) > 0
+        assert filtered_integrations[0].external_id == seed_resource_names["simulator_integration_external_id"]
+        # check time difference
+        assert filtered_integrations[0].active is True
+
+        assert len(active_integrations) > 0
+        assert len(filtered_integrations) > 0

--- a/tests/tests_integration/test_api/test_simulators/test_integrations.py
+++ b/tests/tests_integration/test_api/test_simulators/test_integrations.py
@@ -1,7 +1,11 @@
+import time
+
 import pytest
 
 from cognite.client._cognite_client import CogniteClient
 from cognite.client.data_classes.simulators.filters import SimulatorIntegrationFilter
+from cognite.client.utils._text import random_string
+from tests.tests_integration.test_api.test_simulators.seed.data import simulator_integration
 
 
 class TestSimulatorIntegrations:
@@ -28,3 +32,31 @@ class TestSimulatorIntegrations:
 
         assert len(active_integrations) > 0
         assert len(filtered_integrations) > 0
+
+    def test_delete_integrations(self, cognite_client: CogniteClient, seed_resource_names) -> None:
+        simulator_integration["heartbeat"] = int(time.time() * 1000)
+        simulator_integration["externalId"] = random_string(50)
+
+        cognite_client.post(
+            f"/api/v1/projects/{cognite_client.config.project}/simulators/integrations",
+            json={"items": [simulator_integration]},
+        )
+
+        all_integrations = cognite_client.simulators.integrations.list()
+        assert len(all_integrations) > 0
+        assert any(
+            map(
+                lambda x: x.external_id == simulator_integration["externalId"],
+                all_integrations,
+            )
+        )
+
+        cognite_client.simulators.integrations.delete(external_id=simulator_integration["externalId"])
+
+        all_integrations = cognite_client.simulators.integrations.list()
+        assert not any(
+            map(
+                lambda x: x.external_id == simulator_integration["externalId"],
+                all_integrations,
+            )
+        )

--- a/tests/tests_integration/test_api/test_simulators/test_integrations.py
+++ b/tests/tests_integration/test_api/test_simulators/test_integrations.py
@@ -4,6 +4,7 @@ import pytest
 
 from cognite.client._cognite_client import CogniteClient
 from cognite.client.data_classes.simulators.filters import SimulatorIntegrationFilter
+from cognite.client.data_classes.simulators.simulators import SimulatorIntegration
 from cognite.client.utils._text import random_string
 from tests.tests_integration.test_api.test_simulators.seed.data import simulator_integration
 
@@ -16,6 +17,10 @@ class TestSimulatorIntegrations:
         assert len(integrations) > 0
 
     def test_filter_integrations(self, cognite_client: CogniteClient, seed_resource_names) -> None:
+        # quick test of the iterator
+        for integration in cognite_client.simulators.integrations:
+            assert isinstance(integration, SimulatorIntegration)
+
         all_integrations = cognite_client.simulators.integrations.list()
         active_integrations = cognite_client.simulators.integrations.list(
             filter=SimulatorIntegrationFilter(active=True)

--- a/tests/tests_integration/test_api/test_simulators/test_integrations.py
+++ b/tests/tests_integration/test_api/test_simulators/test_integrations.py
@@ -4,7 +4,6 @@ import pytest
 
 from cognite.client._cognite_client import CogniteClient
 from cognite.client.data_classes.simulators.filters import SimulatorIntegrationFilter
-from cognite.client.data_classes.simulators.simulators import SimulatorIntegration
 from cognite.client.utils._text import random_string
 from tests.tests_integration.test_api.test_simulators.seed.data import simulator_integration
 
@@ -18,8 +17,8 @@ class TestSimulatorIntegrations:
 
     def test_filter_integrations(self, cognite_client: CogniteClient, seed_resource_names) -> None:
         # quick test of the iterator
-        for integration in cognite_client.simulators.integrations:
-            assert isinstance(integration, SimulatorIntegration)
+        for integration in cognite_client.simulators.integrations(filter=SimulatorIntegrationFilter(active=True)):
+            assert integration.active is True
 
         all_integrations = cognite_client.simulators.integrations.list()
         active_integrations = cognite_client.simulators.integrations.list(

--- a/tests/tests_integration/test_api/test_simulators/test_integrations.py
+++ b/tests/tests_integration/test_api/test_simulators/test_integrations.py
@@ -27,8 +27,10 @@ class TestSimulatorIntegrations:
 
         assert len(all_integrations) > 0
         assert filtered_integrations[0].external_id == seed_resource_names["simulator_integration_external_id"]
-        # check time difference
+        assert filtered_integrations[0].data_set_id == seed_resource_names["simulator_test_data_set_id"]
         assert filtered_integrations[0].active is True
+        assert filtered_integrations[0].created_time is not None
+        assert filtered_integrations[0].last_updated_time is not None
 
         assert len(active_integrations) > 0
         assert len(filtered_integrations) > 0
@@ -36,27 +38,17 @@ class TestSimulatorIntegrations:
     def test_delete_integrations(self, cognite_client: CogniteClient, seed_resource_names) -> None:
         simulator_integration["heartbeat"] = int(time.time() * 1000)
         simulator_integration["externalId"] = random_string(50)
+        simulator_integration["dataSetId"] = seed_resource_names["simulator_test_data_set_id"]
 
-        cognite_client.post(
-            f"/api/v1/projects/{cognite_client.config.project}/simulators/integrations",
+        cognite_client.simulators._post(
+            "/simulators/integrations",
             json={"items": [simulator_integration]},
         )
 
-        all_integrations = cognite_client.simulators.integrations.list()
-        assert len(all_integrations) > 0
-        assert any(
-            map(
-                lambda x: x.external_id == simulator_integration["externalId"],
-                all_integrations,
-            )
-        )
+        all_integrations = cognite_client.simulators.integrations.list(limit=None)
+        assert all_integrations.get(external_id=simulator_integration["externalId"]) is not None
 
         cognite_client.simulators.integrations.delete(external_id=simulator_integration["externalId"])
 
-        all_integrations = cognite_client.simulators.integrations.list()
-        assert not any(
-            map(
-                lambda x: x.external_id == simulator_integration["externalId"],
-                all_integrations,
-            )
-        )
+        all_integrations = cognite_client.simulators.integrations.list(limit=None)
+        assert all_integrations.get(external_id=simulator_integration["externalId"]) is None

--- a/tests/tests_integration/test_api/test_simulators/test_simulators.py
+++ b/tests/tests_integration/test_api/test_simulators/test_simulators.py
@@ -1,11 +1,15 @@
 import pytest
 
 from cognite.client._cognite_client import CogniteClient
+from cognite.client.data_classes.simulators.simulators import Simulator
 
 
 @pytest.mark.usefixtures("seed_simulator")
 class TestSimulators:
     def test_list_simulators(self, cognite_client: CogniteClient) -> None:
+        for simulator in cognite_client.simulators:
+            assert isinstance(simulator, Simulator)
+
         simulators = cognite_client.simulators.list(limit=5)
         for simulator in simulators:
             assert simulator.id is not None

--- a/tests/tests_integration/test_api/test_simulators/test_simulators.py
+++ b/tests/tests_integration/test_api/test_simulators/test_simulators.py
@@ -7,5 +7,7 @@ from cognite.client._cognite_client import CogniteClient
 class TestSimulators:
     def test_list_simulators(self, cognite_client: CogniteClient) -> None:
         simulators = cognite_client.simulators.list(limit=5)
+        for simulator in simulators:
+            assert simulator.id is not None
 
         assert len(simulators) > 0

--- a/tests/tests_integration/test_api/test_simulators/test_simulators.py
+++ b/tests/tests_integration/test_api/test_simulators/test_simulators.py
@@ -1,0 +1,29 @@
+import pytest
+
+from cognite.client._cognite_client import CogniteClient
+from tests.tests_integration.test_api.test_simulators.seed.data import resource_names, simulator
+
+
+@pytest.fixture(scope="class")
+def seed_resource_names() -> dict[str, str]:
+    return resource_names
+
+
+@pytest.fixture
+def seed_simulator(cognite_client: CogniteClient, seed_resource_names) -> None:
+    simulator_external_id = seed_resource_names["simulator_external_id"]
+    simulators = cognite_client.simulators.list()
+    simulator_exists = len(list(filter(lambda x: x.external_id == simulator_external_id, simulators))) > 0
+    if not simulator_exists:
+        cognite_client.post(
+            f"/api/v1/projects/{cognite_client.config.project}/simulators",
+            json={"items": [simulator]},
+        )
+
+
+@pytest.mark.usefixtures("seed_resource_names", "seed_simulator")
+class TestSimulators:
+    def test_list_simulators(self, cognite_client: CogniteClient) -> None:
+        simulators = cognite_client.simulators.list(limit=5)
+
+        assert len(simulators) > 0

--- a/tests/tests_integration/test_api/test_simulators/test_simulators.py
+++ b/tests/tests_integration/test_api/test_simulators/test_simulators.py
@@ -1,27 +1,9 @@
 import pytest
 
 from cognite.client._cognite_client import CogniteClient
-from tests.tests_integration.test_api.test_simulators.seed.data import resource_names, simulator
 
 
-@pytest.fixture(scope="class")
-def seed_resource_names() -> dict[str, str]:
-    return resource_names
-
-
-@pytest.fixture
-def seed_simulator(cognite_client: CogniteClient, seed_resource_names) -> None:
-    simulator_external_id = seed_resource_names["simulator_external_id"]
-    simulators = cognite_client.simulators.list()
-    simulator_exists = len(list(filter(lambda x: x.external_id == simulator_external_id, simulators))) > 0
-    if not simulator_exists:
-        cognite_client.post(
-            f"/api/v1/projects/{cognite_client.config.project}/simulators",
-            json={"items": [simulator]},
-        )
-
-
-@pytest.mark.usefixtures("seed_resource_names", "seed_simulator")
+@pytest.mark.usefixtures("seed_simulator")
 class TestSimulators:
     def test_list_simulators(self, cognite_client: CogniteClient) -> None:
         simulators = cognite_client.simulators.list(limit=5)

--- a/tests/tests_unit/test_api_client.py
+++ b/tests/tests_unit/test_api_client.py
@@ -1366,6 +1366,8 @@ class TestRetryableEndpoints:
                 ("POST", "https://api.cognitedata.com/api/v1/projects/bla/context/diagram/detect", True),
                 ("GET", "https://api.cognitedata.com/api/v1/projects/bla/context/diagram/convert/123", True),
                 ("GET", "https://api.cognitedata.com/api/v1/projects/bla/context/diagram/detect/456", True),
+                # Simulators
+                ("POST", "https://api.cognitedata.com/api/v1/projects/bla/simulators/list", True),
             ]
         ),
     )

--- a/tests/tests_unit/test_api_client.py
+++ b/tests/tests_unit/test_api_client.py
@@ -1183,7 +1183,6 @@ class TestRetryableEndpoints:
                 "datasets",
                 "relationships",
                 "labels",
-                "simulators",
             ]
             for test_case in [
                 # Should retry POST on all _read_ endpoints

--- a/tests/tests_unit/test_api_client.py
+++ b/tests/tests_unit/test_api_client.py
@@ -1183,6 +1183,7 @@ class TestRetryableEndpoints:
                 "datasets",
                 "relationships",
                 "labels",
+                "simulators",
             ]
             for test_case in [
                 # Should retry POST on all _read_ endpoints

--- a/tests/tests_unit/test_api_client.py
+++ b/tests/tests_unit/test_api_client.py
@@ -1368,6 +1368,7 @@ class TestRetryableEndpoints:
                 ("GET", "https://api.cognitedata.com/api/v1/projects/bla/context/diagram/detect/456", True),
                 # Simulators
                 ("POST", "https://api.cognitedata.com/api/v1/projects/bla/simulators/list", True),
+                ("POST", "https://api.cognitedata.com/api/v1/projects/bla/simulators/delete", False),
             ]
         ),
     )

--- a/tests/tests_unit/test_meta.py
+++ b/tests/tests_unit/test_meta.py
@@ -72,6 +72,7 @@ def apis_that_should_not_have_post_retry_rule():
         [
             "groups",  # ☑️
             "securitycategories",  # ☑️
+            "simulators",
             "templategroups",  # Won't do: deprecated API
         ]
     )

--- a/tests/tests_unit/test_meta.py
+++ b/tests/tests_unit/test_meta.py
@@ -72,7 +72,6 @@ def apis_that_should_not_have_post_retry_rule():
         [
             "groups",  # ☑️
             "securitycategories",  # ☑️
-            "simulators",
             "templategroups",  # Won't do: deprecated API
         ]
     )


### PR DESCRIPTION
## Description
Added the `/simulators` endpoint to the SDK. This is the first PR coming from the split of this big PR: https://github.com/cognitedata/cognite-sdk-python/pull/2006/files

## Adds support for the following Resource:
- [x] Simulator resource
- [x]  Simulator integration resource

## Checklist:
- [x] Tests added/updated.
- [x] Documentation updated. Documentation is generated from docstrings - these must be updated according to your change.
  If a new method has been added it should be referenced in [cognite.rst](https://github.com/cognitedata/cognite-sdk-python/blob/master/docs/source/cognite.rst) in order to generate docs based on its docstring.
- [x] Changelog updated in [CHANGELOG.md](https://github.com/cognitedata/cognite-sdk-python/blob/master/CHANGELOG.md).
- [ ] Version bumped. If triggering a new release is desired, bump the version number in [_version.py](https://github.com/cognitedata/cognite-sdk-python/blob/master/cognite/client/_version.py) and [pyproject.toml](https://github.com/cognitedata/cognite-sdk-python/blob/master/pyproject.toml) per [semantic versioning](https://semver.org/).
