### PR TITLE
fix: Passing empty string to external_id in datapoints.retrieve_dataframe raises error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ Changes are grouped as follows
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
+## [7.70.7] - 2024-12-19
+### Fixed
+- Passing an empty string to external_id in `datapoints.retrieve_dataframe` no longer raises an error.
+
 ## [7.70.6] - 2024-12-14
 ### Fixed
 - Updating a Sequence and repeating existing columns no longer raises a `CogniteDuplicatedError`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,9 +17,9 @@ Changes are grouped as follows
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
-## [7.70.7] - 2024-12-19
+## [7.70.7] - 2024-12-20
 ### Fixed
-- Passing an empty string to external_id in `datapoints.retrieve_dataframe` no longer raises an error.
+- Passing a valid but empty string as external_id no longer raises an error for certain SDK methods
 
 ## [7.70.6] - 2024-12-14
 ### Fixed

--- a/cognite/client/_version.py
+++ b/cognite/client/_version.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
 
-__version__ = "7.70.6"
+__version__ = "7.70.7"
 
 __api_subversion__ = "20230101"

--- a/cognite/client/data_classes/datapoints.py
+++ b/cognite/client/data_classes/datapoints.py
@@ -179,10 +179,10 @@ class DatapointsQuery:
     treat_uncertain_as_bad: bool = _NOT_SET  # type: ignore [assignment]
 
     def __post_init__(
-        self, id_: int | None, external_id: str | None, instance_id: NodeId | tuple[str, str] | None
+        self, id: int | None, external_id: str | None, instance_id: NodeId | tuple[str, str] | None
     ) -> None:
         # Ensure user have just specified one of id/xid:
-        self._identifier = Identifier.of_either(id_, external_id, instance_id)
+        self._identifier = Identifier.of_either(id, external_id, instance_id)
         if instance_id is not None:
             # dump/load is used in parsing and it loses info of this being a NodeId (loads back as InstanceId). We need
             # to lookup by identifier to sort (match user queries), and then InstanceId won't compare equal to NodeId:

--- a/cognite/client/data_classes/datapoints.py
+++ b/cognite/client/data_classes/datapoints.py
@@ -179,10 +179,10 @@ class DatapointsQuery:
     treat_uncertain_as_bad: bool = _NOT_SET  # type: ignore [assignment]
 
     def __post_init__(
-        self, id: int | None, external_id: str | None, instance_id: NodeId | tuple[str, str] | None
+        self, id_: int | None, external_id: str | None, instance_id: NodeId | tuple[str, str] | None
     ) -> None:
         # Ensure user have just specified one of id/xid:
-        self._identifier = Identifier.of_either(id, external_id, instance_id)
+        self._identifier = Identifier.of_either(id_, external_id, instance_id)
         if instance_id is not None:
             # dump/load is used in parsing and it loses info of this being a NodeId (loads back as InstanceId). We need
             # to lookup by identifier to sort (match user queries), and then InstanceId won't compare equal to NodeId:

--- a/cognite/client/utils/_identifier.py
+++ b/cognite/client/utils/_identifier.py
@@ -70,7 +70,7 @@ class IdentifierCore(Protocol):
 class Identifier(Generic[T_ID]):
     def __init__(self, value: T_ID) -> None:
         if not isinstance(value, (int, str, InstanceId)):
-            raise TypeError(f"Expected id/external_id to be of type int or str, got {value} of type {type(id)}")
+            raise TypeError(f"Expected id/external_id to be of type int or str, got {value} of type {type(value)}")
         self.__value: T_ID = value
 
     def __eq__(self, other: Any) -> bool:

--- a/cognite/client/utils/_identifier.py
+++ b/cognite/client/utils/_identifier.py
@@ -86,16 +86,16 @@ class Identifier(Generic[T_ID]):
 
     @classmethod
     def of_either(
-        cls, id: int | None, external_id: str | None, instance_id: InstanceId | tuple[str, str] | None = None
+        cls, id_: int | None, external_id: str | None, instance_id: InstanceId | tuple[str, str] | None = None
     ) -> Identifier:
-        if id is external_id is instance_id is None:
+        if id_ is external_id is instance_id is None:
             raise ValueError("Exactly one of id, external id, or instance_id must be specified, got neither")
-        elif id is not None:
+        elif id_ is not None:
             if external_id is not None or instance_id is not None:
                 raise ValueError("Exactly one of id, external id, or instance_id must be specified, got multiple")
-            elif not isinstance(id, int):
-                raise TypeError(f"Invalid id, expected int, got {type(id)}")
-            elif not 1 <= id <= MAX_VALID_INTERNAL_ID:
+            elif not isinstance(id_, int):
+                raise TypeError(f"Invalid id, expected int, got {type(id_)}")
+            elif not 1 <= id_ <= MAX_VALID_INTERNAL_ID:
                 raise ValueError(f"Invalid id, must satisfy: 1 <= id <= {MAX_VALID_INTERNAL_ID}")
         elif external_id is not None:
             if instance_id is not None:
@@ -107,14 +107,14 @@ class Identifier(Generic[T_ID]):
                 instance_id = InstanceId.load(instance_id)
             if not isinstance(instance_id, InstanceId):
                 raise TypeError(f"Invalid instance_id, expected InstanceId, got {type(instance_id)}")
-        return Identifier(id or external_id or instance_id)
+        return Identifier(id_ or external_id or instance_id)
 
     @classmethod
     def load(
-        cls, id: int | None = None, external_id: str | None = None, instance_id: InstanceId | None = None
+        cls, id_: int | None = None, external_id: str | None = None, instance_id: InstanceId | None = None
     ) -> Identifier:
-        if id is not None:
-            return Identifier(id)
+        if id_ is not None:
+            return Identifier(id_)
         if external_id is not None:
             return Identifier(external_id)
         if instance_id is not None:

--- a/cognite/client/utils/_identifier.py
+++ b/cognite/client/utils/_identifier.py
@@ -111,10 +111,10 @@ class Identifier(Generic[T_ID]):
 
     @classmethod
     def load(
-        cls, id_: int | None = None, external_id: str | None = None, instance_id: InstanceId | None = None
+        cls, id: int | None = None, external_id: str | None = None, instance_id: InstanceId | None = None
     ) -> Identifier:
-        if id_ is not None:
-            return Identifier(id_)
+        if id is not None:
+            return Identifier(id)
         if external_id is not None:
             return Identifier(external_id)
         if instance_id is not None:

--- a/cognite/client/utils/_identifier.py
+++ b/cognite/client/utils/_identifier.py
@@ -107,7 +107,7 @@ class Identifier(Generic[T_ID]):
                 instance_id = InstanceId.load(instance_id)
             if not isinstance(instance_id, InstanceId):
                 raise TypeError(f"Invalid instance_id, expected InstanceId, got {type(instance_id)}")
-        return Identifier(id_ or external_id or instance_id)
+        return Identifier(next(idx for idx in (id_, external_id, instance_id) if idx is not None))
 
     @classmethod
     def load(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "cognite-sdk"
 
-version = "7.70.6"
+version = "7.70.7"
 
 description = "Cognite Python SDK"
 readme = "README.md"

--- a/tests/tests_unit/test_utils/test_identifier.py
+++ b/tests/tests_unit/test_utils/test_identifier.py
@@ -23,6 +23,8 @@ class TestIdentifier:
             (1, None, None, ("id", 1)),
             (MAX_VALID_INTERNAL_ID, None, None, ("id", MAX_VALID_INTERNAL_ID)),
             (None, "foo", None, ("external_id", "foo")),
+            # Bug prior to 7.70.7, empty string external ID would fail with wrong error message
+            (None, "", None, ("external_id", "")),
             (None, None, InstanceId("s", "extid"), ("instance_id", InstanceId("s", "extid"))),
         ),
     )


### PR DESCRIPTION
## Description
If passing an empty string "" external_id to `datapoints.retrieve_dataframe` you get the following error:

`TypeError: Expected id/external_id to be of type int or str, got None of type <class 'builtin_function_or_method'>`

This is caused by two issues:
* empty string evaluates to false in boolean expression 
* typo in error message

## Checklist:
- [x] Tests added/updated.
- [ ] Documentation updated. Documentation is generated from docstrings - these must be updated according to your change.
  If a new method has been added it should be referenced in [cognite.rst](https://github.com/cognitedata/cognite-sdk-python/blob/master/docs/source/cognite.rst) in order to generate docs based on its docstring.
- [x] Changelog updated in [CHANGELOG.md](https://github.com/cognitedata/cognite-sdk-python/blob/master/CHANGELOG.md).
- [x] Version bumped. If triggering a new release is desired, bump the version number in [_version.py](https://github.com/cognitedata/cognite-sdk-python/blob/master/cognite/client/_version.py) and [pyproject.toml](https://github.com/cognitedata/cognite-sdk-python/blob/master/pyproject.toml) per [semantic versioning](https://semver.org/).
