### PR TITLE
Don't use deprecated endpoint for documents.retrieve_content

### DIFF
--- a/cognite/client/_api/documents.py
+++ b/cognite/client/_api/documents.py
@@ -491,7 +491,9 @@ class DocumentsAPI(APIClient):
                 >>> client = CogniteClient()
                 >>> content = client.documents.retrieve_content(id=123)
         """
-        response = self._do_request("GET", f"{self._RESOURCE_PATH}/{id}/content", accept="text/plain")
+
+        body = {"id": id}
+        response = self._do_request("POST", f"{self._RESOURCE_PATH}/content", accept="text/plain", json=body)
         return response.content
 
     def retrieve_content_buffer(self, id: int, buffer: BinaryIO) -> None:


### PR DESCRIPTION
## Description
Please describe the change you have made.

## Checklist:
- [ ] Tests added/updated.
- [ ] Documentation updated. Documentation is generated from docstrings - these must be updated according to your change.
  If a new method has been added it should be referenced in [cognite.rst](https://github.com/cognitedata/cognite-sdk-python/blob/master/docs/source/cognite.rst) in order to generate docs based on its docstring.
- [ ] Changelog updated in [CHANGELOG.md](https://github.com/cognitedata/cognite-sdk-python/blob/master/CHANGELOG.md).
- [ ] Version bumped. If triggering a new release is desired, bump the version number in [_version.py](https://github.com/cognitedata/cognite-sdk-python/blob/master/cognite/client/_version.py) and [pyproject.toml](https://github.com/cognitedata/cognite-sdk-python/blob/master/pyproject.toml) per [semantic versioning](https://semver.org/).
