### PR TITLE
Fix version checker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,11 @@ Changes are grouped as follows
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
+
+## [7.71.1] - 2025-01-07
+### Fixed
+- Version checker (stopped working after 5.3.1 due to subtle package naming change)
+
 ## [7.71.0] - 2025-01-06
 ### Added
 - Support for InstanceReferences filter for Data Modeling

--- a/cognite/client/_version.py
+++ b/cognite/client/_version.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
 
-__version__ = "7.71.0"
+__version__ = "7.71.1"
 
 __api_subversion__ = "20230101"

--- a/cognite/client/config.py
+++ b/cognite/client/config.py
@@ -4,7 +4,6 @@ import getpass
 import pprint
 import re
 import warnings
-from contextlib import suppress
 from typing import Any
 
 from cognite.client._version import __api_subversion__
@@ -142,16 +141,14 @@ class ClientConfig:
         self.headers = headers or {}
         self.timeout = timeout or 30
         self.file_transfer_timeout = file_transfer_timeout or 600
-
         if debug:
             self.debug = True
+        self._validate_config()
 
         if not global_config.disable_pypi_version_check:
-            with suppress(Exception):  # PyPI might be unreachable, if so, skip version check
-                from cognite.client.utils._auxiliary import _check_client_has_newest_major_version
+            from cognite.client.utils._version_checker import check_client_is_running_latest_version
 
-                _check_client_has_newest_major_version()
-        self._validate_config()
+            check_client_is_running_latest_version()
 
     @property
     def max_workers(self) -> int:

--- a/cognite/client/utils/_auxiliary.py
+++ b/cognite/client/utils/_auxiliary.py
@@ -5,7 +5,6 @@ import math
 import platform
 import warnings
 from collections.abc import Hashable, Iterable, Iterator, Sequence
-from threading import Thread
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -23,7 +22,6 @@ from cognite.client.utils._text import (
     to_camel_case,
     to_snake_case,
 )
-from cognite.client.utils._version_checker import get_newest_version_in_major_release
 from cognite.client.utils.useful_types import SequenceNotStr
 
 if TYPE_CHECKING:
@@ -156,24 +154,6 @@ def get_user_agent() -> str:
     operating_system = f"{platform.system()}/{os_version_info_str}"
 
     return f"{sdk_version} {python_version} {operating_system}"
-
-
-# Wrap in a cache to ensure we only ever run the version check once.
-@functools.lru_cache(1)
-def _check_client_has_newest_major_version() -> None:
-    def run() -> None:
-        version = get_current_sdk_version()
-        newest_version = get_newest_version_in_major_release("cognite-sdk", version)
-        if newest_version != version:
-            warnings.warn(
-                f"You are using {version=} of the SDK, however version='{newest_version}' is available. "
-                "To suppress this warning, either upgrade or do the following:\n"
-                ">>> from cognite.client.config import global_config\n"
-                ">>> global_config.disable_pypi_version_check = True",
-                stacklevel=3,
-            )
-
-    Thread(target=run, daemon=True).start()
 
 
 @overload

--- a/cognite/client/utils/_version_checker.py
+++ b/cognite/client/utils/_version_checker.py
@@ -1,89 +1,45 @@
 from __future__ import annotations
 
-import argparse
 import functools
 import re
+import warnings
+from contextlib import suppress
+from threading import Thread
 
 import requests
+from packaging import version
 
 
-def check_if_version_exists(package_name: str, version: str) -> bool:
-    versions = get_all_versions(package_name=package_name)
-    return version in versions
-
-
-@functools.lru_cache(maxsize=1)
-def get_newest_version_in_major_release(package_name: str, version: str) -> str:
-    major, minor, micro, pr_cycle, pr_version = _parse_version(version)
-    versions = get_all_versions(package_name)
-    for v in versions:
-        if _is_newer_major(v, version):
-            major, minor, micro, pr_cycle, pr_version = _parse_version(v)
-    return _format_version(major, minor, micro, pr_cycle, pr_version)
-
-
-def get_all_versions(package_name: str) -> list[str]:
+def get_all_sdk_versions() -> list[version.Version]:
     from cognite.client.config import global_config
 
     verify_ssl = not global_config.disable_ssl
-    res = requests.get(f"https://pypi.org/simple/{package_name}/", verify=verify_ssl, timeout=5)
-    return re.findall(r"cognite[_-]sdk-(\d+\.\d+.[\dabrc]+)", res.content.decode())
+    res = requests.get("https://pypi.org/simple/cognite-sdk/", verify=verify_ssl, timeout=5)
+    return list(map(version.parse, re.findall(r"cognite[_-]sdk-(\d+\.\d+.[\dabrc]+)", res.text)))
 
 
-def _is_newer_major(version_a: str, version_b: str) -> bool:
-    major_a, minor_a, micro_a, pr_cycle_a, pr_version_a = _parse_version(version_a)
-    major_b, minor_b, micro_b, pr_cycle_b, pr_version_b = _parse_version(version_b)
-    is_newer = False
-    if major_a == major_b and minor_a >= minor_b and micro_a >= micro_b:
-        if minor_a > minor_b:
-            is_newer = True
-        else:
-            if micro_a > micro_b:
-                is_newer = True
-            else:
-                is_newer = _is_newer_pre_release(pr_cycle_a, pr_version_a, pr_cycle_b, pr_version_b)
-    return is_newer
+def get_latest_released_stable_version() -> version.Version:
+    # Filter only stable versions (no pre-releases or dev releases, but post-releases are ok)
+    return max(v for v in get_all_sdk_versions() if not v.is_prerelease)
 
 
-def _is_newer_pre_release(
-    pr_cycle_a: str | None, pr_v_a: int | None, pr_cycle_b: str | None, pr_v_b: int | None
-) -> bool:
-    cycles = ["a", "b", "rc", None]
-    if pr_cycle_a not in cycles:
-        raise RuntimeError(f"pr_cycle_a must be one of '{pr_cycle_a}', not '{cycles}'.")
-    if pr_cycle_b not in cycles:
-        raise RuntimeError(f"pr_cycle_a must be one of '{pr_cycle_b}', not '{cycles}'.")
-    is_newer = False
-    if cycles.index(pr_cycle_a) > cycles.index(pr_cycle_b):
-        is_newer = True
-    elif cycles.index(pr_cycle_a) == cycles.index(pr_cycle_b):
-        if pr_v_a is not None and pr_v_b is not None and pr_v_a > pr_v_b:
-            is_newer = True
-    return is_newer
+# Wrap in a cache to ensure we only ever run the version check once.
+@functools.cache
+def check_client_is_running_latest_version() -> None:
+    def run() -> None:
+        from packaging import version
 
+        from cognite.client import __version__
 
-def _parse_version(version: str) -> tuple[int, int, int, str, int | None]:
-    pattern = r"(\d+)\.(\d+)\.(\d+)(?:([abrc]+)(\d+))?"
-    match = re.match(pattern, version)
-    if not match:
-        raise ValueError(f"Could not parse version {version}")
-    major, minor, micro, pr_cycle, pr_version = match.groups()
-    return int(major), int(minor), int(micro), pr_cycle, int(pr_version) if pr_version else None
+        with suppress(Exception):  # PyPI might be unreachable, if so, skip version check
+            newest_version = get_latest_released_stable_version()
+            if version.parse(__version__) < newest_version:
+                warnings.warn(
+                    f"You are using version={__version__!r} of the SDK, however version={newest_version.public!r} is "
+                    "available. To suppress this warning, either upgrade or do the following:\n"
+                    ">>> from cognite.client.config import global_config\n"
+                    ">>> global_config.disable_pypi_version_check = True",
+                    stacklevel=3,
+                )
 
-
-def _format_version(major: int, minor: int, micro: int, pr_cycle: str | None, pr_version: int | None) -> str:
-    return f"{major}.{minor}.{micro}{pr_cycle or ''}{pr_version or ''}"
-
-
-if __name__ == "__main__":
-    parser = argparse.ArgumentParser()
-    parser.add_argument("-p", "--package", required=True)
-    parser.add_argument("-v", "--version", required=True)
-    args = parser.parse_args()
-
-    version_exists = check_if_version_exists(args.package, args.version)
-
-    if version_exists:
-        print("yes")  # noqa: T201
-    else:
-        print("no")  # noqa: T201
+    Thread(target=run, daemon=True).start()

--- a/cognite/client/utils/_version_checker.py
+++ b/cognite/client/utils/_version_checker.py
@@ -26,7 +26,7 @@ def get_all_versions(package_name: str) -> list[str]:
     from cognite.client.config import global_config
 
     verify_ssl = not global_config.disable_ssl
-    res = requests.get(f"https://pypi.python.org/simple/{package_name}/#history", verify=verify_ssl, timeout=5)
+    res = requests.get(f"https://pypi.org/simple/{package_name}/", verify=verify_ssl, timeout=5)
     return re.findall(r"cognite[_-]sdk-(\d+\.\d+.[\dabrc]+)", res.content.decode())
 
 

--- a/cognite/client/utils/_version_checker.py
+++ b/cognite/client/utils/_version_checker.py
@@ -27,7 +27,7 @@ def get_all_versions(package_name: str) -> list[str]:
 
     verify_ssl = not global_config.disable_ssl
     res = requests.get(f"https://pypi.python.org/simple/{package_name}/#history", verify=verify_ssl, timeout=5)
-    return re.findall(r"cognite-sdk-(\d+\.\d+.[\dabrc]+)", res.content.decode())
+    return re.findall(r"cognite[_-]sdk-(\d+\.\d+.[\dabrc]+)", res.content.decode())
 
 
 def _is_newer_major(version_a: str, version_b: str) -> bool:

--- a/poetry.lock
+++ b/poetry.lock
@@ -1477,13 +1477,13 @@ files = [
 
 [[package]]
 name = "pygments"
-version = "2.19.0"
+version = "2.19.1"
 description = "Pygments is a syntax highlighting package written in Python."
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "pygments-2.19.0-py3-none-any.whl", hash = "sha256:4755e6e64d22161d5b61432c0600c923c5927214e7c956e31c23923c89251a9b"},
-    {file = "pygments-2.19.0.tar.gz", hash = "sha256:afc4146269910d4bdfabcd27c24923137a74d562a23a320a41a55ad303e19783"},
+    {file = "pygments-2.19.1-py3-none-any.whl", hash = "sha256:9ea1544ad55cecf4b8242fab6dd35a93bbce657034b0611ee383099054ab6d8c"},
+    {file = "pygments-2.19.1.tar.gz", hash = "sha256:61c16d2a8576dc0649d9f39e089b5f02bcd27fba10d8fb4dcc28173f7a45151f"},
 ]
 
 [package.extras]
@@ -2508,4 +2508,4 @@ yaml = ["PyYAML"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "101f0ce70011bf520a3c904393c6880f587dd154e70e8728c0e3b42c386d6c7a"
+content-hash = "f2cb7ece0e531691a61fa99ebc481daeeb5d94f2ff4fcfccad0eeafbacf027b9"

--- a/poetry.lock
+++ b/poetry.lock
@@ -2508,4 +2508,4 @@ yaml = ["PyYAML"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "5d2373f6d631fb254ee8a01e613f495b8e3face60b605b5f1ccd67dd4a92d8c6"
+content-hash = "101f0ce70011bf520a3c904393c6880f587dd154e70e8728c0e3b42c386d6c7a"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ requests = "^2.27"
 requests_oauthlib = "^1"
 msal = "^1.31"
 protobuf = ">=4"
-packaging = ">=24"
+packaging = ">=20"
 pip = ">=20.0.0"  # make optional once poetry doesn't auto-remove it on "simple install"
 typing_extensions = ">= 4"
 # Windows does not have a ANSI database and need tzdata... pyodide also needs it:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ requests = "^2.27"
 requests_oauthlib = "^1"
 msal = "^1.31"
 protobuf = ">=4"
+packaging = ">=24"
 pip = ">=20.0.0"  # make optional once poetry doesn't auto-remove it on "simple install"
 typing_extensions = ">= 4"
 # Windows does not have a ANSI database and need tzdata... pyodide also needs it:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "cognite-sdk"
 
-version = "7.71.0"
+version = "7.71.1"
 
 description = "Cognite Python SDK"
 readme = "README.md"


### PR DESCRIPTION
After version `5.3.1`, a hyphen in the package name became an underscore, and thus the regex stopped working. 

This PR fixes the regex and removes all code related to manually parsing versions.