### PR TITLE
[CDF-23684] Fix update kafka or mqtt source in hosted extractor.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,10 +17,11 @@ Changes are grouped as follows
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
-## [7.73.0] - 2025-01-19
+## TBD
 ### Added
 - Support for the `/simulators` and `/simulators/integration` API endpoints.
 
+## [7.72.2] - 2025-01-20
 ### Fixed
 - Updating a Kafka or MQTT source with a write object in `mode="replace"` no longer raises a `CogniteAPIError` with
   422 status code.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,9 +17,13 @@ Changes are grouped as follows
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
-## [Unreleased]
+## [7.73.0] - 2025-01-19
 ### Added
 - Support for the `/simulators` and `/simulators/integration` API endpoints.
+
+### Fixed
+- Updating a Kafka or MQTT source with a write object in `mode="replace"` no longer raises a `CogniteAPIError` with
+  422 status code.
 
 ## [7.72.1] - 2025-01-14
 ### Fixed

--- a/cognite/client/_api_client.py
+++ b/cognite/client/_api_client.py
@@ -1277,8 +1277,10 @@ class APIClient:
         for prop in update_attributes:
             if prop.is_beta:
                 continue
+            elif prop.is_explicit_nullable_object:
+                clear_with: dict = {"setNull": True}
             elif prop.is_object:
-                clear_with: dict = {"set": {}}
+                clear_with = {"set": {}}
             elif prop.is_list:
                 clear_with = {"set": []}
             elif prop.is_nullable:

--- a/cognite/client/_version.py
+++ b/cognite/client/_version.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
 
-__version__ = "7.73.0"
+__version__ = "7.72.2"
 
 __api_subversion__ = "20230101"

--- a/cognite/client/_version.py
+++ b/cognite/client/_version.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
 
-__version__ = "7.72.1"
+__version__ = "7.73.0"
 
 __api_subversion__ = "20230101"

--- a/cognite/client/data_classes/_base.py
+++ b/cognite/client/data_classes/_base.py
@@ -447,6 +447,8 @@ class PropertySpec:
     is_nullable: bool = True
     # Used to skip replace when the value is None
     is_beta: bool = False
+    # Objects that are nullable and support setNull. This is hosted extractor source and destination
+    is_explicit_nullable_object: bool = False
 
     def __post_init__(self) -> None:
         assert not (self.is_list and self.is_object), "PropertySpec cannot be both list and object"

--- a/cognite/client/data_classes/hosted_extractors/destinations.py
+++ b/cognite/client/data_classes/hosted_extractors/destinations.py
@@ -145,7 +145,10 @@ class DestinationUpdate(CogniteUpdate):
 
     @classmethod
     def _get_update_properties(cls, item: CogniteResource | None = None) -> list[PropertySpec]:
-        return [PropertySpec("credentials", is_nullable=True), PropertySpec("target_data_set_id", is_nullable=True)]
+        return [
+            PropertySpec("credentials", is_nullable=True, is_object=True, is_explicit_nullable_object=True),
+            PropertySpec("target_data_set_id", is_nullable=True),
+        ]
 
 
 class DestinationWriteList(CogniteResourceList[DestinationWrite], ExternalIDTransformerMixin):

--- a/cognite/client/data_classes/hosted_extractors/sources.py
+++ b/cognite/client/data_classes/hosted_extractors/sources.py
@@ -391,10 +391,10 @@ class _MQTTUpdate(SourceUpdate, ABC):
         return [
             PropertySpec("host", is_nullable=False),
             PropertySpec("port", is_nullable=True),
-            PropertySpec("authentication", is_nullable=True, is_object=True),
+            PropertySpec("authentication", is_nullable=True, is_object=True, is_explicit_nullable_object=True),
             PropertySpec("use_tls", is_nullable=False),
-            PropertySpec("ca_certificate", is_nullable=True, is_object=True),
-            PropertySpec("auth_certificate", is_nullable=True, is_object=True),
+            PropertySpec("ca_certificate", is_nullable=True, is_object=True, is_explicit_nullable_object=True),
+            PropertySpec("auth_certificate", is_nullable=True, is_object=True, is_explicit_nullable_object=True),
         ]
 
 
@@ -662,10 +662,10 @@ class KafkaSourceUpdate(SourceUpdate):
     def _get_update_properties(cls, item: CogniteResource | None = None) -> list[PropertySpec]:
         return [
             PropertySpec("bootstrap_brokers", is_nullable=False),
-            PropertySpec("authentication", is_nullable=True, is_object=True),
+            PropertySpec("authentication", is_nullable=True, is_object=True, is_explicit_nullable_object=True),
             PropertySpec("use_tls", is_nullable=False),
-            PropertySpec("ca_certificate", is_nullable=True, is_object=True),
-            PropertySpec("auth_certificate", is_nullable=True, is_object=True),
+            PropertySpec("ca_certificate", is_nullable=True, is_object=True, is_explicit_nullable_object=True),
+            PropertySpec("auth_certificate", is_nullable=True, is_object=True, is_explicit_nullable_object=True),
         ]
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "cognite-sdk"
 
-version = "7.73.0"
+version = "7.72.2"
 
 description = "Cognite Python SDK"
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "cognite-sdk"
 
-version = "7.72.1"
+version = "7.73.0"
 
 description = "Cognite Python SDK"
 readme = "README.md"

--- a/tests/tests_unit/test_api_client.py
+++ b/tests/tests_unit/test_api_client.py
@@ -1466,10 +1466,12 @@ class TestHelpers:
                     "externalId": {"set": "my-source-mqtt"},
                     "host": {"set": "mqtt.hsl.fi"},
                     "port": {"set": 1883},
+                    "useTls": {"set": False},
                     "authentication": {"setNull": True},
                     "caCertificate": {"setNull": True},
                     "authCertificate": {"setNull": True},
                 },
+                id="replace with setNull key",
             ),
         ],
     )

--- a/tests/tests_unit/test_api_client.py
+++ b/tests/tests_unit/test_api_client.py
@@ -1463,7 +1463,6 @@ class TestHelpers:
                 MQTT5SourceUpdate,
                 "replace",
                 {
-                    "externalId": {"set": "my-source-mqtt"},
                     "host": {"set": "mqtt.hsl.fi"},
                     "port": {"set": 1883},
                     "useTls": {"set": False},

--- a/tests/tests_unit/test_data_classes/test_hosted_extractors/test_destinations.py
+++ b/tests/tests_unit/test_data_classes/test_hosted_extractors/test_destinations.py
@@ -1,0 +1,10 @@
+from cognite.client.data_classes.hosted_extractors import DestinationUpdate
+
+
+class TestDestinations:
+    def test_dump_update_obj(self) -> None:
+        obj = DestinationUpdate(external_id="my-destination").target_data_set_id.set(123).credentials.set(None)
+        assert obj.dump(camel_case=True) == {
+            "externalId": "my-destination",
+            "update": {"targetDataSetId": {"set": 123}, "credentials": {"setNull": True}},
+        }


### PR DESCRIPTION
## Description

Issue is that these source uses a `{"setNull": True}` instead of of `{"set": {}}` for clearing objects.

## Checklist:
- [ ] Tests added/updated.
- [ ] Documentation updated. Documentation is generated from docstrings - these must be updated according to your change.
  If a new method has been added it should be referenced in [cognite.rst](https://github.com/cognitedata/cognite-sdk-python/blob/master/docs/source/cognite.rst) in order to generate docs based on its docstring.
- [ ] Changelog updated in [CHANGELOG.md](https://github.com/cognitedata/cognite-sdk-python/blob/master/CHANGELOG.md).
- [ ] Version bumped. If triggering a new release is desired, bump the version number in [_version.py](https://github.com/cognitedata/cognite-sdk-python/blob/master/cognite/client/_version.py) and [pyproject.toml](https://github.com/cognitedata/cognite-sdk-python/blob/master/pyproject.toml) per [semantic versioning](https://semver.org/).
