### PR TITLE
Set lower limits for create/update/delete of postgres gateway users

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ Changes are grouped as follows
 ## [Unreleased]
 ### Added
 - Support for the `/simulators` and `/simulators/integration` API endpoints.
+### Changed
+- Set the limit for create, update, and delete endpoints for postgres gateway users to 1.
 
 ## [7.73.1] - 2025-01-23
 ### Fixed

--- a/cognite/client/_api/postgres_gateway/users.py
+++ b/cognite/client/_api/postgres_gateway/users.py
@@ -27,6 +27,11 @@ class UsersAPI(APIClient):
     def __init__(self, config: ClientConfig, api_version: str | None, cognite_client: CogniteClient) -> None:
         super().__init__(config, api_version, cognite_client)
         self._warning = FeaturePreviewWarning(api_maturity="beta", sdk_maturity="alpha", feature_name="Users")
+        self._CREATE_LIMIT = 1
+        self._UPDATE_LIMIT = 1
+        self._DELETE_LIMIT = 1
+        self._LIST_LIMIT = 100
+        self._RETRIEVE_LIMIT = 10
 
     @overload
     def __call__(

--- a/tests/tests_integration/test_api/test_datapoints.py
+++ b/tests/tests_integration/test_api/test_datapoints.py
@@ -480,7 +480,7 @@ class TestTimeSeriesCreatedInDMS:
 
 
 @pytest.fixture
-def queries_for_iteration():
+def queries_for_iteration(all_test_time_series):
     # Mix of ids, external_ids, and instance_ids
     return [
         DatapointsQuery(
@@ -495,7 +495,7 @@ def queries_for_iteration():
             start=132710400000,
         ),
         DatapointsQuery(
-            id=1162585250935723,  # 'PYSDK integration test 089: weekly values, 1950-2000, string,
+            id=all_test_time_series.get(external_id="PYSDK integration test 089: weekly values, 1950-2000, string").id,
             start=-334195200000,
             end=270000000000 + 1,
         ),
@@ -504,11 +504,15 @@ def queries_for_iteration():
             start=1166400000,
         ),
         DatapointsQuery(
-            id=7134564432527017,  # 'PYSDK integration test 108: every millisecond, 1969-12-31 23:59:58.500 - 1970-01-01 00:00:01.500, numeric,
+            id=all_test_time_series.get(
+                external_id="PYSDK integration test 108: every millisecond, 1969-12-31 23:59:58.500 - 1970-01-01 00:00:01.500, numeric"
+            ).id,
             start=-1118,
         ),
         DatapointsQuery(
-            id=8856777097037888,  # 'PYSDK integration test 114: 1mill dps, random distribution, 1950-2020, numeric,
+            id=all_test_time_series.get(
+                external_id="PYSDK integration test 114: 1mill dps, random distribution, 1950-2020, numeric"
+            ).id,
             start=-111360848336,
         ),
         DatapointsQuery(
@@ -529,7 +533,9 @@ def queries_for_iteration():
             start=1702252800000,
         ),
         DatapointsQuery(
-            id=6236123831652881,  # 'PYSDK integration test 121: mixed status codes, daily values, 2023-2024, numeric,
+            id=all_test_time_series.get(
+                external_id="PYSDK integration test 121: mixed status codes, daily values, 2023-2024, numeric"
+            ).id,
             start=1678924800000,
         ),
         DatapointsQuery(

--- a/tests/tests_integration/test_api/test_datapoints.py
+++ b/tests/tests_integration/test_api/test_datapoints.py
@@ -1880,6 +1880,9 @@ class TestRetrieveAggregateDatapointsAPI:
                 [349079144838.96564, 512343998481.7162, 159180999248.7119, 529224146671.5178],
             )
 
+    @pytest.mark.skip(
+        reason="TODO(doctrino): Skipped while awaiting https://github.com/cognitedata/cognite-sdk-python/pull/2102"
+    )
     def test_timezone_agg_query_dst_transitions(self, all_retrieve_endpoints, dps_queries_dst_transitions):
         expected_values1 = [0.23625579717753353, 0.02829928231631262, -0.0673823850533647, -0.20908049925449418]
         expected_values2 = [-0.13218082741552517, -0.20824244773820486, 0.02566169899072951, 0.15040625644292185]


### PR DESCRIPTION
## Description
Set the limit for number of postgres gateway users to create/update/delete to 1.

These operations have a tendency to be extremely heavy, so the limits are low for now.

## Checklist:
- [ ] Tests added/updated.
- [ ] Documentation updated. Documentation is generated from docstrings - these must be updated according to your change.
  If a new method has been added it should be referenced in [cognite.rst](https://github.com/cognitedata/cognite-sdk-python/blob/master/docs/source/cognite.rst) in order to generate docs based on its docstring.
- [x] Changelog updated in [CHANGELOG.md](https://github.com/cognitedata/cognite-sdk-python/blob/master/CHANGELOG.md).
- [ ] Version bumped. If triggering a new release is desired, bump the version number in [_version.py](https://github.com/cognitedata/cognite-sdk-python/blob/master/cognite/client/_version.py) and [pyproject.toml](https://github.com/cognitedata/cognite-sdk-python/blob/master/pyproject.toml) per [semantic versioning](https://semver.org/).
