### PR TITLE
Use dedicated cdf test project for CD workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,12 +57,12 @@ jobs:
       - name: Test full
         env:
           LOGIN_FLOW: client_credentials
-          COGNITE_CLIENT_SECRET: ${{ secrets.COGNITE_CLIENT_SECRET }}
-          COGNITE_TOKEN_URL: https://login.microsoftonline.com/dff7763f-e2f5-4ffd-9b8a-4ba4bafba5ea/oauth2/v2.0/token
-          COGNITE_TOKEN_SCOPES: https://greenfield.cognitedata.com/.default
-          COGNITE_CLIENT_ID: 14fd282e-f77a-457d-add5-928ec2bcbf04
-          COGNITE_PROJECT: python-sdk-test
-          COGNITE_BASE_URL: https://greenfield.cognitedata.com
+          COGNITE_CLIENT_SECRET: ${{ secrets.IDP_CLIENT_SECRET_CI }}
+          COGNITE_TOKEN_URL: https://login.microsoftonline.com/cognitepysdk.onmicrosoft.com/oauth2/v2.0/token
+          COGNITE_TOKEN_SCOPES: ${{ vars.CDF_BASE_URL_CI }}/.default
+          COGNITE_CLIENT_ID: ${{ vars.IDP_CLIENT_ID_CI }}
+          COGNITE_PROJECT: ${{ vars.CDF_PROJECT_CI }}
+          COGNITE_BASE_URL: ${{ vars.CDF_BASE_URL_CI }}
           COGNITE_CLIENT_NAME: python-sdk-integration-tests
         # Testpaths are defined in the pytest.ini file:
         run: pytest --durations=10 --cov --cov-report term --cov-report xml:coverage.xml -n8 --dist loadscope --reruns 2 --maxfail 20

--- a/.github/workflows/cdf_auth.yaml
+++ b/.github/workflows/cdf_auth.yaml
@@ -16,11 +16,11 @@ jobs:
     container:
       image: cognite/toolkit:0.4.9
       env:
-        CDF_CLUSTER: ${{ vars.CDF_CLUSTER }}
-        CDF_PROJECT: ${{ vars.CDF_PROJECT }}
-        IDP_CLIENT_ID: ${{ vars.IDP_CLIENT_ID }}
-        IDP_CLIENT_SECRET: ${{ secrets.IDP_CLIENT_SECRET }}
-        IDP_TENANT_ID: ${{ vars.IDP_TENANT_ID }}
+        CDF_CLUSTER: ${{ vars.CDF_CLUSTER_CD }}
+        CDF_PROJECT: ${{ vars.CDF_PROJECT_CD }}
+        IDP_CLIENT_ID: ${{ vars.IDP_CLIENT_ID_CD }}
+        IDP_CLIENT_SECRET: ${{ secrets.IDP_CLIENT_SECRET_CD }}
+        IDP_TENANT_ID: ${{ vars.IDP_TENANT_ID_CD }}
     steps:
       - uses: actions/checkout@v4
       - name: Build the CDF Groups

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -18,12 +18,12 @@ jobs:
       - name: Test full
         env:
           LOGIN_FLOW: client_credentials
-          COGNITE_CLIENT_SECRET: ${{ secrets.COGNITE_CLIENT_SECRET }}
-          COGNITE_TOKEN_URL: https://login.microsoftonline.com/dff7763f-e2f5-4ffd-9b8a-4ba4bafba5ea/oauth2/v2.0/token
-          COGNITE_TOKEN_SCOPES: https://greenfield.cognitedata.com/.default
-          COGNITE_CLIENT_ID: 14fd282e-f77a-457d-add5-928ec2bcbf04
-          COGNITE_PROJECT: python-sdk-test
-          COGNITE_BASE_URL: https://greenfield.cognitedata.com
+          COGNITE_CLIENT_SECRET: ${{ secrets.IDP_CLIENT_SECRET_CD }}
+          COGNITE_TOKEN_URL: https://login.microsoftonline.com/cognitepysdk.onmicrosoft.com/oauth2/v2.0/token
+          COGNITE_TOKEN_SCOPES: ${{ vars.CDF_BASE_URL_CD }}/.default
+          COGNITE_CLIENT_ID: ${{ vars.IDP_CLIENT_ID_CD }}
+          COGNITE_PROJECT: ${{ vars.CDF_PROJECT_CD }}
+          COGNITE_BASE_URL: ${{ vars.CDF_BASE_URL_CD }}
           COGNITE_CLIENT_NAME: python-sdk-integration-tests
         # Testpaths are defined in the pytest.ini file:
         run: pytest --durations=10 --cov --cov-report term --cov-report xml:coverage.xml -n8 --dist loadscope --reruns 2 --maxfail 20


### PR DESCRIPTION
Using a dedicated cdf project for CD workflow for 2 reasons:
- No longer want a test project in staging since it's less stable
- Don't want devs to have write access to this project, so that we don't risk breaking master builds and we force devs to create test fixtures for setting up their data instead of ingesting it manually.

Variables and secrets have been updated accordingly through the github UI.