### PR TITLE
Only deploy auth setup for prod project (for now)

### DIFF
--- a/.github/workflows/cdf_auth.yaml
+++ b/.github/workflows/cdf_auth.yaml
@@ -12,7 +12,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        config_env: ["contributor", "prod"]
+        config_env: [
+          # TODO: Add this back once we get a new contributor project (one that's not in a staging cluster)
+          #"contributor",
+          "prod"
+        ]
     container:
       image: cognite/toolkit:0.4.9
       env:


### PR DESCRIPTION

Should fix CD. Only deploy auth setup for prod project. For now. Still using the old test project in greenfield for CI, we'll make a project in a different cluster for this soon. Then we can reenable this.

<img width="596" alt="Screenshot 2025-03-06 at 19 47 38" src="https://github.com/user-attachments/assets/eb135e02-d869-43c2-902b-6fd703bbe066" />
