### PR TITLE
Added missing PropertySpec to RestSourceupdate 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ Changes are grouped as follows
 
 ## [7.73.7] - 2025-03-14
 ### Fixed
-- When RestSource for hosted extractors were updated, the authentication and ca_ceryificate objects were omitted. This is now fixed.
+- When RestSource for hosted extractors were updated, the authentication and ca_certificate objects were omitted. This is now fixed.
 
 ## [7.73.6] - 2025-03-10
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ Changes are grouped as follows
 - Support for the `/simulators` and `/simulators/integration` API endpoints.
 
 ### Fixed
-- When RestSource for hosted extractors were updated, the authentication object was omitted. This is now fixed.
+- When RestSource for hosted extractors were updated, the authentication and ca_ceryificate objects were omitted. This is now fixed.
 
 ## [7.73.6] - 2025-03-10
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,9 @@ Changes are grouped as follows
 - Support for the `/simulators/models` and `/simulators/models/revisions` API endpoints.
 - Support for the `/simulators` and `/simulators/integration` API endpoints.
 
+### Fixed
+- When RestSource for hosted extractors were updated, the authentication object was omitted. This is now fixed.
+
 ## [7.73.6] - 2025-03-10
 ### Fixed
 - An issue with `client.data_modeling.instances.aggregates(..., filter=my_filter)` no longer raises a `KeyError` if you

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Changes are grouped as follows
 - Support for the `/simulators/models` and `/simulators/models/revisions` API endpoints.
 - Support for the `/simulators` and `/simulators/integration` API endpoints.
 
+## [7.73.7] - 2025-03-14
 ### Fixed
 - When RestSource for hosted extractors were updated, the authentication and ca_ceryificate objects were omitted. This is now fixed.
 

--- a/cognite/client/_version.py
+++ b/cognite/client/_version.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
 
-__version__ = "7.73.6"
+__version__ = "7.73.7"
 
 __api_subversion__ = "20230101"

--- a/cognite/client/data_classes/hosted_extractors/sources.py
+++ b/cognite/client/data_classes/hosted_extractors/sources.py
@@ -809,6 +809,10 @@ class RestSourceUpdate(SourceUpdate):
         def set(self, value: int) -> RestSourceUpdate:
             return self._set(value)
 
+    class _AuthenticationUpdate(CognitePrimitiveUpdate):
+        def set(self, value: Authentication | None) -> RestSourceUpdate:
+            return self._set(value.dump() if value else None)
+
     @property
     def host(self) -> _HostUpdate:
         return RestSourceUpdate._HostUpdate(self, "host")
@@ -820,6 +824,10 @@ class RestSourceUpdate(SourceUpdate):
     @property
     def port(self) -> _PortUpdate:
         return RestSourceUpdate._PortUpdate(self, "port")
+
+    @property
+    def authentication(self) -> _AuthenticationUpdate:
+        return RestSourceUpdate._AuthenticationUpdate(self, "authentication")
 
     @classmethod
     def _get_update_properties(cls, item: CogniteResource | None = None) -> list[PropertySpec]:

--- a/cognite/client/data_classes/hosted_extractors/sources.py
+++ b/cognite/client/data_classes/hosted_extractors/sources.py
@@ -809,6 +809,10 @@ class RestSourceUpdate(SourceUpdate):
         def set(self, value: int) -> RestSourceUpdate:
             return self._set(value)
 
+    class _CACertificateUpdate(CognitePrimitiveUpdate):
+        def set(self, value: CACertificate | None) -> RestSourceUpdate:
+            return self._set(value.dump() if value else None)
+
     class _AuthenticationUpdate(CognitePrimitiveUpdate):
         def set(self, value: Authentication | None) -> RestSourceUpdate:
             return self._set(value.dump() if value else None)
@@ -826,6 +830,10 @@ class RestSourceUpdate(SourceUpdate):
         return RestSourceUpdate._PortUpdate(self, "port")
 
     @property
+    def ca_certificate(self) -> _CACertificateUpdate:
+        return RestSourceUpdate._CACertificateUpdate(self, "caCertificate")
+
+    @property
     def authentication(self) -> _AuthenticationUpdate:
         return RestSourceUpdate._AuthenticationUpdate(self, "authentication")
 
@@ -835,6 +843,7 @@ class RestSourceUpdate(SourceUpdate):
             PropertySpec("host", is_nullable=False),
             PropertySpec("scheme", is_nullable=False),
             PropertySpec("port", is_nullable=False),
+            PropertySpec("ca_certificate", is_nullable=True, is_object=True, is_explicit_nullable_object=True),
             PropertySpec("authentication", is_nullable=True, is_object=True, is_explicit_nullable_object=True),
         ]
 

--- a/cognite/client/data_classes/hosted_extractors/sources.py
+++ b/cognite/client/data_classes/hosted_extractors/sources.py
@@ -827,6 +827,7 @@ class RestSourceUpdate(SourceUpdate):
             PropertySpec("host", is_nullable=False),
             PropertySpec("scheme", is_nullable=False),
             PropertySpec("port", is_nullable=False),
+            PropertySpec("authentication", is_nullable=True, is_object=True, is_explicit_nullable_object=True),
         ]
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "cognite-sdk"
 
-version = "7.73.6"
+version = "7.73.7"
 
 description = "Cognite Python SDK"
 readme = "README.md"


### PR DESCRIPTION
## Description

When RestSource for hosted extractors were updated, the `authentication` object was omitted. The same was the case for `ca_certificate` This is now fixed. Test added.


## Checklist:
- [ ] Tests added/updated.
- [ ] Documentation updated. Documentation is generated from docstrings - these must be updated according to your change.
  If a new method has been added it should be referenced in [cognite.rst](https://github.com/cognitedata/cognite-sdk-python/blob/master/docs/source/cognite.rst) in order to generate docs based on its docstring.
- [ ] Changelog updated in [CHANGELOG.md](https://github.com/cognitedata/cognite-sdk-python/blob/master/CHANGELOG.md).
- [ ] Version bumped. If triggering a new release is desired, bump the version number in [_version.py](https://github.com/cognitedata/cognite-sdk-python/blob/master/cognite/client/_version.py) and [pyproject.toml](https://github.com/cognitedata/cognite-sdk-python/blob/master/pyproject.toml) per [semantic versioning](https://semver.org/).
