### PR TITLE
Add support for simulator routine revisions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ Changes are grouped as follows
 ## [Unreleased]
 ### Added
 - Support for the `/simulators/logs` API endpoint.
-- Support for the `/simulators/routines` API endpoints.
+- Support for the `/simulators/routines` and `/simulators/routines/revisions` API endpoints.
 - Support for the `/simulators/models` and `/simulators/models/revisions` API endpoints.
 - Support for the `/simulators` and `/simulators/integration` API endpoints.
 

--- a/cognite/client/_api/simulators/models_revisions.py
+++ b/cognite/client/_api/simulators/models_revisions.py
@@ -30,7 +30,7 @@ class SimulatorModelRevisionsAPI(APIClient):
             api_maturity="General Availability", sdk_maturity="alpha", feature_name="Simulators"
         )
         self._CREATE_LIMIT = 1
-        self._RETRIEVE_LIMIT = 1
+        self._RETRIEVE_LIMIT = 100
 
     def list(
         self,

--- a/cognite/client/_api/simulators/routine_revisions.py
+++ b/cognite/client/_api/simulators/routine_revisions.py
@@ -1,0 +1,358 @@
+from __future__ import annotations
+
+from collections.abc import Iterator, Sequence
+from typing import TYPE_CHECKING, NoReturn, overload
+
+from cognite.client._api_client import APIClient
+from cognite.client.data_classes.shared import TimestampRange
+from cognite.client.data_classes.simulators import PropertySort
+from cognite.client.data_classes.simulators.filters import SimulatorRoutineRevisionsFilter
+from cognite.client.data_classes.simulators.routine_revisions import (
+    SimulatorRoutineRevision,
+    SimulatorRoutineRevisionList,
+    SimulatorRoutineRevisionWrite,
+)
+from cognite.client.utils._experimental import FeaturePreviewWarning
+from cognite.client.utils._identifier import IdentifierSequence
+from cognite.client.utils._validation import assert_type
+from cognite.client.utils.useful_types import SequenceNotStr
+
+if TYPE_CHECKING:
+    from cognite.client import ClientConfig, CogniteClient
+
+
+class SimulatorRoutineRevisionsAPI(APIClient):
+    _RESOURCE_PATH = "/simulators/routines/revisions"
+
+    def __init__(self, config: ClientConfig, api_version: str | None, cognite_client: CogniteClient) -> None:
+        super().__init__(config, api_version, cognite_client)
+        self._warning = FeaturePreviewWarning(
+            api_maturity="General Availability", sdk_maturity="alpha", feature_name="Simulators"
+        )
+        self._LIST_LIMIT = 20
+        self._CREATE_LIMIT = 1
+        self._RETRIEVE_LIMIT = 20
+
+    def __iter__(self) -> Iterator[SimulatorRoutineRevision]:
+        """Iterate over simulator routine revisions
+
+        Fetches simulator routine revisions as they are iterated over, so you keep a limited number of simulator routine revisions in memory.
+
+        Returns:
+            Iterator[SimulatorRoutineRevision]: yields Simulator routine revisions one by one.
+        """
+        return self()
+
+    @overload
+    def __call__(
+        self,
+        chunk_size: int,
+        routine_external_ids: SequenceNotStr[str] | None = None,
+        model_external_ids: SequenceNotStr[str] | None = None,
+        simulator_integration_external_ids: SequenceNotStr[str] | None = None,
+        simulator_external_ids: SequenceNotStr[str] | None = None,
+        created_time: TimestampRange | None = None,
+        all_versions: bool = False,
+        include_all_fields: bool = False,
+        limit: int | None = None,
+        sort: PropertySort | None = None,
+    ) -> Iterator[SimulatorRoutineRevisionList]: ...
+
+    @overload
+    def __call__(
+        self,
+        chunk_size: None = None,
+        routine_external_ids: SequenceNotStr[str] | None = None,
+        model_external_ids: SequenceNotStr[str] | None = None,
+        simulator_integration_external_ids: SequenceNotStr[str] | None = None,
+        simulator_external_ids: SequenceNotStr[str] | None = None,
+        created_time: TimestampRange | None = None,
+        all_versions: bool = False,
+        include_all_fields: bool = False,
+        limit: int | None = None,
+        sort: PropertySort | None = None,
+    ) -> Iterator[SimulatorRoutineRevision]: ...
+
+    def __call__(
+        self,
+        chunk_size: int | None = None,
+        routine_external_ids: SequenceNotStr[str] | None = None,
+        model_external_ids: SequenceNotStr[str] | None = None,
+        simulator_integration_external_ids: SequenceNotStr[str] | None = None,
+        simulator_external_ids: SequenceNotStr[str] | None = None,
+        created_time: TimestampRange | None = None,
+        all_versions: bool = False,
+        include_all_fields: bool = False,
+        limit: int | None = None,
+        sort: PropertySort | None = None,
+    ) -> Iterator[SimulatorRoutineRevision] | Iterator[SimulatorRoutineRevisionList]:
+        """Iterate over simulator routine revisions
+
+        Fetches simulator routine revisions as they are iterated over, so you keep a limited number of simulator routine revisions in memory.
+
+        Args:
+            chunk_size (int | None): Number of simulator routine revisions to return in each chunk. Defaults to yielding one simulator routine revision a time.
+            routine_external_ids (SequenceNotStr[str] | None): Filter on routine external ids.
+            model_external_ids (SequenceNotStr[str] | None): Filter on model external ids.
+            simulator_integration_external_ids (SequenceNotStr[str] | None): Filter on simulator integration external ids.
+            simulator_external_ids (SequenceNotStr[str] | None): Filter on simulator external ids.
+            created_time (TimestampRange | None): Filter on created time.
+            all_versions (bool): If all versions of the routine should be returned. Defaults to false which only returns the latest version.
+            include_all_fields (bool): If all fields should be included in the response. Defaults to false which does not include script, configuration.inputs and configuration.outputs in the response.
+            limit (int | None): Maximum number of simulator routine revisions to return. Defaults to return all items.
+            sort (PropertySort | None): The criteria to sort by.
+
+        Returns:
+            Iterator[SimulatorRoutineRevision] | Iterator[SimulatorRoutineRevisionList]: yields SimulatorRoutineRevision one by one if chunk is not specified, else SimulatorRoutineRevisionList objects.
+        """
+        self._warning.warn()
+        filter = SimulatorRoutineRevisionsFilter(
+            all_versions=all_versions,
+            routine_external_ids=routine_external_ids,
+            model_external_ids=model_external_ids,
+            simulator_integration_external_ids=simulator_integration_external_ids,
+            simulator_external_ids=simulator_external_ids,
+            created_time=created_time,
+        )
+        return self._list_generator(
+            method="POST",
+            limit=limit,
+            url_path="/simulators/routines/revisions/list",
+            resource_cls=SimulatorRoutineRevision,
+            list_cls=SimulatorRoutineRevisionList,
+            chunk_size=chunk_size,
+            filter=filter.dump(),
+            sort=[PropertySort.load(sort).dump()] if sort else None,
+            other_params={"includeAllFields": include_all_fields},
+        )
+
+    @overload
+    def retrieve(self, ids: None = None, external_ids: None = None) -> NoReturn: ...
+
+    @overload
+    def retrieve(self, ids: int, external_ids: None = None) -> SimulatorRoutineRevision | None: ...
+
+    @overload
+    def retrieve(
+        self,
+        ids: None,
+        external_ids: str,
+    ) -> SimulatorRoutineRevision | None: ...
+
+    @overload
+    def retrieve(
+        self,
+        ids: Sequence[int] | None = None,
+        external_ids: SequenceNotStr[str] | None = None,
+    ) -> SimulatorRoutineRevisionList | None: ...
+
+    def retrieve(
+        self,
+        ids: int | Sequence[int] | None = None,
+        external_ids: str | SequenceNotStr[str] | None = None,
+    ) -> SimulatorRoutineRevision | SimulatorRoutineRevisionList | None:
+        """`Retrieve simulator routine revisions <https://developer.cognite.com/api#tag/Simulator-Routines/operation/retrieve_simulator_routine_revisions_simulators_routines_revisions_byids_post>`_
+
+        Retrieve simulator routine revisions by ID or External Id.
+
+        Args:
+            ids (int | Sequence[int] | None): Simulator routine revision ID or list of IDs
+            external_ids (str | SequenceNotStr[str] | None): Simulator routine revision External ID or list of external IDs
+
+        Returns:
+            SimulatorRoutineRevision | SimulatorRoutineRevisionList | None: Requested simulator routine revision
+
+        Examples:
+
+            Get simulator routine revision by id:
+                >>> from cognite.client import CogniteClient
+                >>> client = CogniteClient()
+                >>> res = client.simulators.routines.revisions.retrieve(ids=123)
+
+            Get simulator routine revision by external id:
+                >>> res = client.simulators.routines.revisions.retrieve(external_ids="routine_v1")
+        """
+        self._warning.warn()
+        identifiers = IdentifierSequence.load(ids=ids, external_ids=external_ids)
+        return self._retrieve_multiple(
+            resource_cls=SimulatorRoutineRevision,
+            list_cls=SimulatorRoutineRevisionList,
+            identifiers=identifiers,
+            resource_path="/simulators/routines/revisions",
+        )
+
+    @overload
+    def create(self, routine_revision: Sequence[SimulatorRoutineRevisionWrite]) -> SimulatorRoutineRevisionList: ...
+
+    @overload
+    def create(self, routine_revision: SimulatorRoutineRevisionWrite) -> SimulatorRoutineRevision: ...
+
+    def create(
+        self,
+        routine_revision: SimulatorRoutineRevisionWrite | Sequence[SimulatorRoutineRevisionWrite],
+    ) -> SimulatorRoutineRevision | SimulatorRoutineRevisionList:
+        """`Create simulator routine revisions <https://api-docs.cognite.com/20230101/tag/Simulator-Routines/operation/create_simulator_routine_revision_simulators_routines_revisions_post>`_
+        Args:
+            routine_revision (SimulatorRoutineRevisionWrite | Sequence[SimulatorRoutineRevisionWrite]): Simulator routine revisions to create.
+        Returns:
+            SimulatorRoutineRevision | SimulatorRoutineRevisionList: Created simulator routine revision(s)
+        Examples:
+            Create new simulator routine revisions:
+                >>> from cognite.client import CogniteClient
+                >>> from cognite.client.data_classes.simulators.routine_revisions import SimulatorRoutineRevisionWrite, SimulatorRoutineConfiguration, SimulatorRoutineInputConstant, SimulatorRoutineOutput, SimulatorRoutineDataSampling, SimulatorRoutineStep, SimulatorRoutineStepArguments, SimulatorRoutineStage, SimulationValueUnitInput
+                >>> client = CogniteClient()
+                >>> routine_revs = [
+                ...     SimulatorRoutineRevisionWrite(
+                ...         external_id="routine_rev_1",
+                ...         routine_external_id="routine_1",
+                ...         configuration=SimulatorRoutineConfiguration(
+                ...             data_sampling=SimulatorRoutineDataSampling(sampling_window=15, granularity="1m"),
+                ...             inputs=[
+                ...                 SimulatorRoutineInputConstant(
+                ...                     name="Cold Water Temperature",
+                ...                     reference_id="CWTC",
+                ...                     value=10.0,
+                ...                     value_type="DOUBLE",
+                ...                     unit=SimulationValueUnitInput(name="C", quantity="temperature"),
+                ...                     save_timeseries_external_id="TEST-ROUTINE-INPUT-CWTC",
+                ...                 ),
+                ...             ],
+                ...             outputs=[
+                ...                 SimulatorRoutineOutput(
+                ...                     name="Shower Temperature",
+                ...                     reference_id="ST",
+                ...                     unit=SimulationValueUnitInput(name="C", quantity="temperature"),
+                ...                     value_type="DOUBLE",
+                ...                     save_timeseries_external_id="TEST-ROUTINE-OUTPUT-ST",
+                ...                 ),
+                ...             ],
+                ...         ),
+                ...         script=[
+                ...             SimulatorRoutineStage(
+                ...                 order=1,
+                ...                 description="Set Inputs",
+                ...                 steps=[
+                ...                     SimulatorRoutineStep(
+                ...                         order=1,
+                ...                         step_type="Set",
+                ...                         arguments=SimulatorRoutineStepArguments(
+                ...                             {
+                ...                                 "referenceId": "CWTC",
+                ...                                 "objectName": "Cold water",
+                ...                                 "objectProperty": "Temperature",
+                ...                             }
+                ...                         ),
+                ...                     ),
+                ...                 ],
+                ...             ),
+                ...             SimulatorRoutineStage(
+                ...                 order=2,
+                ...                 description="Solve the flowsheet",
+                ...                 steps=[
+                ...                     SimulatorRoutineStep(
+                ...                         order=1, step_type="Command", arguments=SimulatorRoutineStepArguments({"command": "Solve"})
+                ...                     ),
+                ...                 ],
+                ...             ),
+                ...             SimulatorRoutineStage(
+                ...                 order=3,
+                ...                 description="Set simulation outputs",
+                ...                 steps=[
+                ...                     SimulatorRoutineStep(
+                ...                         order=1,
+                ...                         step_type="Get",
+                ...                         arguments=SimulatorRoutineStepArguments(
+                ...                             {
+                ...                                 "referenceId": "ST",
+                ...                                 "objectName": "Shower",
+                ...                                 "objectProperty": "Temperature",
+                ...                             }
+                ...                         ),
+                ...                     ),
+                ...                 ],
+                ...             ),
+                ...         ],
+                ...     ),
+                ... ]
+                >>> res = client.simulators.routines.revisions.create(routine_revs)
+        """
+        self._warning.warn()
+        assert_type(
+            routine_revision,
+            "simulator_routine_revision",
+            [SimulatorRoutineRevisionWrite, Sequence],
+        )
+
+        return self._create_multiple(
+            list_cls=SimulatorRoutineRevisionList,
+            resource_cls=SimulatorRoutineRevision,
+            items=routine_revision,
+            input_resource_cls=SimulatorRoutineRevisionWrite,
+            resource_path=self._RESOURCE_PATH,
+        )
+
+    def list(
+        self,
+        routine_external_ids: SequenceNotStr[str] | None = None,
+        model_external_ids: SequenceNotStr[str] | None = None,
+        simulator_integration_external_ids: SequenceNotStr[str] | None = None,
+        simulator_external_ids: SequenceNotStr[str] | None = None,
+        created_time: TimestampRange | None = None,
+        all_versions: bool = False,
+        include_all_fields: bool = False,
+        limit: int | None = None,
+        sort: PropertySort | None = None,
+    ) -> SimulatorRoutineRevisionList:
+        """`Filter simulator routine revisions <https://developer.cognite.com/api#tag/Simulator-Routines/operation/filter_simulator_routine_revisions_simulators_routines_revisions_list_post>`_
+
+        Retrieves a list of simulator routine revisions that match the given criteria.
+
+        Args:
+            routine_external_ids (SequenceNotStr[str] | None): Filter on routine external ids.
+            model_external_ids (SequenceNotStr[str] | None): Filter on model external ids.
+            simulator_integration_external_ids (SequenceNotStr[str] | None): Filter on simulator integration external ids.
+            simulator_external_ids (SequenceNotStr[str] | None): Filter on simulator external ids.
+            created_time (TimestampRange | None): Filter on created time.
+            all_versions (bool): If all versions of the routine should be returned. Defaults to false which only returns the latest version.
+            include_all_fields (bool): If all fields should be included in the response. Defaults to false which does not include script, configuration.inputs and configuration.outputs in the response.
+            limit (int | None): Maximum number of simulator routine revisions to return. Defaults to return all items.
+            sort (PropertySort | None): The criteria to sort by.
+
+        Returns:
+            SimulatorRoutineRevisionList: List of simulator routine revisions
+
+        Examples:
+
+            List simulator routine revisions:
+                >>> from cognite.client import CogniteClient
+                >>> client = CogniteClient()
+                >>> res = client.simulators.routines.revisions.list()
+
+            List simulator routine revisions with filter:
+                >>> res = client.simulators.routines.revisions.list(
+                ...     routine_external_ids=["routine_1"],
+                ...     all_versions=True,
+                ...     sort=PropertySort(order="asc", property="createdTime"),
+                ...     include_all_fields=True
+                ... )
+
+        """
+        self._warning.warn()
+        filter = SimulatorRoutineRevisionsFilter(
+            all_versions=all_versions,
+            routine_external_ids=routine_external_ids,
+            model_external_ids=model_external_ids,
+            simulator_integration_external_ids=simulator_integration_external_ids,
+            simulator_external_ids=simulator_external_ids,
+            created_time=created_time,
+        )
+        return self._list(
+            method="POST",
+            limit=limit,
+            url_path="/simulators/routines/revisions/list",
+            resource_cls=SimulatorRoutineRevision,
+            list_cls=SimulatorRoutineRevisionList,
+            filter=filter.dump(),
+            sort=[PropertySort.load(sort).dump()] if sort else None,
+            other_params={"includeAllFields": include_all_fields},
+        )

--- a/cognite/client/_api/simulators/routines.py
+++ b/cognite/client/_api/simulators/routines.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from collections.abc import Iterator, Sequence
 from typing import TYPE_CHECKING, overload
 
+from cognite.client._api.simulators.routine_revisions import SimulatorRoutineRevisionsAPI
 from cognite.client._api_client import APIClient
 from cognite.client._constants import DEFAULT_LIMIT_READ
 from cognite.client.data_classes.simulators.filters import PropertySort, SimulatorRoutinesFilter
@@ -25,9 +26,12 @@ class SimulatorRoutinesAPI(APIClient):
 
     def __init__(self, config: ClientConfig, api_version: str | None, cognite_client: CogniteClient) -> None:
         super().__init__(config, api_version, cognite_client)
+        self.revisions = SimulatorRoutineRevisionsAPI(config, api_version, cognite_client)
         self._warning = FeaturePreviewWarning(
             api_maturity="General Availability", sdk_maturity="alpha", feature_name="Simulators"
         )
+        self._CREATE_LIMIT = 1
+        self._DELETE_LIMIT = 1
 
     def __iter__(self) -> Iterator[SimulatorRoutine]:
         """Iterate over simulator routines
@@ -95,7 +99,7 @@ class SimulatorRoutinesAPI(APIClient):
     def create(self, routine: Sequence[SimulatorRoutineWrite]) -> SimulatorRoutineList: ...
 
     @overload
-    def create(self, routine: SimulatorRoutineWrite) -> SimulatorRoutineList: ...
+    def create(self, routine: SimulatorRoutineWrite) -> SimulatorRoutine: ...
 
     def create(
         self,

--- a/cognite/client/data_classes/simulators/filters.py
+++ b/cognite/client/data_classes/simulators/filters.py
@@ -4,6 +4,8 @@ from collections.abc import Sequence
 from typing import Any, Literal
 
 from cognite.client.data_classes._base import CogniteFilter, CogniteSort
+from cognite.client.data_classes.shared import TimestampRange
+from cognite.client.utils.useful_types import SequenceNotStr
 
 
 class SimulatorIntegrationFilter(CogniteFilter):
@@ -59,3 +61,21 @@ class PropertySort(CogniteSort):
         dumped = super().dump(camel_case=camel_case)
         dumped["property"] = self.property
         return dumped
+
+
+class SimulatorRoutineRevisionsFilter(CogniteFilter):
+    def __init__(
+        self,
+        routine_external_ids: SequenceNotStr[str] | None = None,
+        all_versions: bool | None = None,
+        model_external_ids: SequenceNotStr[str] | None = None,
+        simulator_integration_external_ids: SequenceNotStr[str] | None = None,
+        simulator_external_ids: SequenceNotStr[str] | None = None,
+        created_time: TimestampRange | None = None,
+    ) -> None:
+        self.model_external_ids = model_external_ids
+        self.all_versions = all_versions
+        self.routine_external_ids = routine_external_ids
+        self.simulator_integration_external_ids = simulator_integration_external_ids
+        self.simulator_external_ids = simulator_external_ids
+        self.created_time = created_time

--- a/cognite/client/data_classes/simulators/routine_revisions.py
+++ b/cognite/client/data_classes/simulators/routine_revisions.py
@@ -75,7 +75,7 @@ class SimulatorRoutineInput(CogniteObject):
         if type_ is None:
             return UnknownCogniteObject(resource)  # type: ignore[return-value]
         input_class = _INPUT_CLASS_BY_TYPE.get(type_)
-        if type_ is None or input_class is None:
+        if input_class is None:
             return UnknownCogniteObject(resource)  # type: ignore[return-value]
         return cast(Self, input_class._load_input(resource))
 

--- a/cognite/client/data_classes/simulators/routine_revisions.py
+++ b/cognite/client/data_classes/simulators/routine_revisions.py
@@ -1,0 +1,437 @@
+from __future__ import annotations
+
+import itertools
+from abc import ABC, abstractmethod
+from collections.abc import MutableMapping
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, ClassVar, Literal, cast
+
+from typing_extensions import Self
+
+from cognite.client.data_classes._base import (
+    CogniteObject,
+    CogniteResourceList,
+    ExternalIDTransformerMixin,
+    IdTransformerMixin,
+    UnknownCogniteObject,
+    WriteableCogniteResource,
+    WriteableCogniteResourceList,
+)
+
+if TYPE_CHECKING:
+    from cognite.client import CogniteClient
+
+
+@dataclass
+class SimulationValueUnitInput(CogniteObject):
+    """
+    The unit of the simulation value.
+
+    Args:
+        name (str): The name of the unit.
+        quantity (str | None): The quantity of the unit.
+    """
+
+    name: str
+    quantity: str | None = None
+
+    @classmethod
+    def _load(cls, resource: dict[str, Any], cognite_client: CogniteClient | None = None) -> Self:
+        return cls(
+            name=resource["name"],
+            quantity=resource.get("quantity"),
+        )
+
+
+@dataclass
+class SimulatorRoutineInput(CogniteObject):
+    """
+    The input of the simulator routine revision.
+
+    Args:
+        name (str): The name of the input.
+        reference_id (str): The reference ID of the input.
+        save_timeseries_external_id (str | None): The external ID of the timeseries to save the input. If not provided, the input is not saved to a timeseries.
+        unit (SimulationValueUnitInput | None): The unit of the input.
+    """
+
+    _type: ClassVar[str]
+
+    name: str
+    reference_id: str
+    save_timeseries_external_id: str | None = None
+    unit: SimulationValueUnitInput | None = None
+
+    @classmethod
+    @abstractmethod
+    def _load_input(cls, resource: dict[str, Any], cognite_client: CogniteClient | None = None) -> Self:
+        raise NotImplementedError()
+
+    @classmethod
+    def _load(cls, resource: dict[str, Any], cognite_client: CogniteClient | None = None) -> Self:
+        is_constant = resource.get("value")
+        is_timeseries = resource.get("sourceExternalId")
+        type_ = "constant" if is_constant else "timeseries" if is_timeseries else None
+        if type_ is None:
+            return UnknownCogniteObject(resource)  # type: ignore[return-value]
+        input_class = _INPUT_CLASS_BY_TYPE.get(type_)
+        if type_ is None or input_class is None:
+            return UnknownCogniteObject(resource)  # type: ignore[return-value]
+        return cast(Self, input_class._load_input(resource))
+
+    def dump(self, camel_case: bool = True) -> dict[str, Any]:
+        output = super().dump(camel_case)
+        if self.unit is not None:
+            output["unit"] = self.unit.dump(camel_case=camel_case)
+        return output
+
+
+@dataclass
+class SimulatorRoutineInputTimeseries(SimulatorRoutineInput):
+    """
+    The timeseries input of the simulator routine revision.
+
+    Args:
+        name (str): The name of the input.
+        reference_id (str): The reference ID of the input.
+        source_external_id (str): The external ID of the source timeseries.
+        aggregate (Literal["average", "interpolation", "stepInterpolation"] | None): The aggregation method to use for the timeseries.
+        save_timeseries_external_id (str | None): The external ID of the timeseries to save the input. If not provided, the input is not saved to a timeseries.
+        unit (SimulationValueUnitInput | None): The unit of the input.
+    """
+
+    _type = "timeseries"
+
+    def __init__(
+        self,
+        name: str,
+        reference_id: str,
+        source_external_id: str,
+        aggregate: Literal["average", "interpolation", "stepInterpolation"] | None = None,
+        save_timeseries_external_id: str | None = None,
+        unit: SimulationValueUnitInput | None = None,
+    ) -> None:
+        super().__init__(name, reference_id, save_timeseries_external_id, unit)
+        self.source_external_id = source_external_id
+        self.aggregate = aggregate
+
+    @classmethod
+    def _load_input(cls, resource: dict[str, Any], cognite_client: CogniteClient | None = None) -> Self:
+        return cls(
+            name=resource["name"],
+            reference_id=resource["referenceId"],
+            source_external_id=resource["sourceExternalId"],
+            aggregate=resource.get("aggregate"),
+            save_timeseries_external_id=resource.get("saveTimeseriesExternalId"),
+            unit=SimulationValueUnitInput._load(resource["unit"], cognite_client) if "unit" in resource else None,
+        )
+
+
+@dataclass
+class SimulatorRoutineInputConstant(SimulatorRoutineInput):
+    """
+    The constant input of the simulator routine revision.
+
+    Args:
+        name (str): The name of the input.
+        reference_id (str): The reference ID of the input.
+        value (str | int | float | list[str] | list[int] | list[float]): The value of the input.
+        value_type (Literal["STRING", "DOUBLE", "STRING_ARRAY", "DOUBLE_ARRAY"]): The value type of the input.
+        unit (SimulationValueUnitInput | None): The unit of the input.
+        save_timeseries_external_id (str | None): The external ID of the timeseries to save the input. If not provided, the input is not saved to a timeseries.
+    """
+
+    _type = "constant"
+
+    def __init__(
+        self,
+        name: str,
+        reference_id: str,
+        value: str | int | float | list[str] | list[int] | list[float],
+        value_type: Literal["STRING", "DOUBLE", "STRING_ARRAY", "DOUBLE_ARRAY"],
+        unit: SimulationValueUnitInput | None = None,
+        save_timeseries_external_id: str | None = None,
+    ) -> None:
+        super().__init__(name, reference_id, save_timeseries_external_id, unit)
+        self.value = value
+        self.value_type = value_type
+
+    @classmethod
+    def _load_input(cls, resource: dict[str, Any], cognite_client: CogniteClient | None = None) -> Self:
+        return cls(
+            name=resource["name"],
+            reference_id=resource["referenceId"],
+            value=resource["value"],
+            value_type=resource["valueType"],
+            unit=SimulationValueUnitInput._load(resource["unit"], cognite_client) if "unit" in resource else None,
+            save_timeseries_external_id=resource.get("saveTimeseriesExternalId"),
+        )
+
+
+@dataclass
+class SimulatorRoutineOutput(CogniteObject):
+    """
+    The output of the simulator routine revision.
+
+    Args:
+        name (str): The name of the output.
+        reference_id (str): The reference ID of the output.
+        value_type (str): The value type of the output.
+        unit (SimulationValueUnitInput | None): The unit of the output.
+        save_timeseries_external_id (str | None): The external ID of the timeseries to save the output. If not provided, the output is not saved to a timeseries.
+    """
+
+    name: str
+    reference_id: str
+    value_type: str
+    unit: SimulationValueUnitInput | None = None
+    save_timeseries_external_id: str | None = None
+
+    @classmethod
+    def _load(cls, resource: dict[str, Any], cognite_client: CogniteClient | None = None) -> Self:
+        return cls(
+            name=resource["name"],
+            reference_id=resource["referenceId"],
+            value_type=resource["valueType"],
+            unit=SimulationValueUnitInput._load(resource["unit"], cognite_client) if "unit" in resource else None,
+            save_timeseries_external_id=resource.get("saveTimeseriesExternalId"),
+        )
+
+    def dump(self, camel_case: bool = True) -> dict[str, Any]:
+        output = super().dump(camel_case=camel_case)
+        if self.unit is not None:
+            output["unit"] = self.unit.dump(camel_case=camel_case)
+
+        return output
+
+
+@dataclass
+class SimulatorRoutineSchedule(CogniteObject):
+    """
+    The schedule configuration of the simulator routine revision.
+
+    Args:
+        cron_expression (str): The cron expression of the schedule.
+    """
+
+    cron_expression: str
+
+    @classmethod
+    def _load(cls, resource: dict[str, Any], cognite_client: CogniteClient | None = None) -> SimulatorRoutineSchedule:
+        return cls(
+            cron_expression=resource["cronExpression"],
+        )
+
+
+@dataclass
+class SimulatorRoutineDataSampling(CogniteObject):
+    """
+    The data sampling configuration of the simulator routine revision.
+    Learn more about data sampling <https://docs.cognite.com/cdf/integration/guides/simulators/about_data_sampling>.
+
+    Args:
+        sampling_window (int): Sampling window of the data sampling. Represented in minutes
+        granularity (str): The granularity of the data sampling.
+        validation_window (int | None): Validation window of the data sampling. Represented in minutes. Used when either logical check or steady state detection is enabled.
+    """
+
+    sampling_window: int
+    granularity: str
+    validation_window: int | None = None
+
+    @classmethod
+    def _load(cls, resource: dict[str, Any], cognite_client: CogniteClient | None = None) -> Self:
+        return cls(
+            sampling_window=resource["samplingWindow"],
+            granularity=resource["granularity"],
+            validation_window=resource.get("validationWindow"),
+        )
+
+
+@dataclass
+class SimulatorRoutineLogicalCheck(CogniteObject):
+    """
+    The logical check configuration of the simulator routine revision.
+    Learn more about logical checks <https://docs.cognite.com/cdf/integration/guides/simulators/about_data_sampling/#data-validation-methods>.
+
+    Args:
+        aggregate (Literal["average", "interpolation", "stepInterpolation"]): The aggregation method to use for the time series.
+        operator (Literal["eq", "ne", "gt", "ge", "lt", "le"]): The operator to use for the logical check.
+        value (float): The value to use for the logical check.
+        timeseries_external_id (str | None): The external ID of the time series to check.
+    """
+
+    aggregate: Literal["average", "interpolation", "stepInterpolation"]
+    operator: Literal["eq", "ne", "gt", "ge", "lt", "le"]
+    value: float
+    timeseries_external_id: str | None = None
+
+    @classmethod
+    def _load(cls, resource: dict[str, Any], cognite_client: CogniteClient | None = None) -> Self:
+        return cls(
+            aggregate=resource["aggregate"],
+            operator=resource["operator"],
+            value=resource["value"],
+            timeseries_external_id=resource.get("timeseriesExternalId"),
+        )
+
+
+@dataclass
+class SimulatorRoutineSteadyStateDetection(CogniteObject):
+    """
+    Steady State Detection checks for steady state regions in a given time series.
+    The user specifies the time series and three parameters: min section size, var threshold, and slope threshold.
+    It returns a binary time series, with 1 for timestamps where the steady state criteria is met and 0 otherwise.
+
+    Args:
+        aggregate (Literal["average", "interpolation", "stepInterpolation"]): The aggregation method to use for the time series.
+        min_section_size (int): The minimum number of consecutive data points that must meet the steady state criteria.
+        var_threshold (float): The maximum variance allowed for the steady state region.
+        slope_threshold (float): The maximum slope allowed for the steady state region.
+        timeseries_external_id (str | None): The external ID of the time series to check.
+    """
+
+    aggregate: Literal["average", "interpolation", "stepInterpolation"]
+    min_section_size: int
+    var_threshold: float
+    slope_threshold: float
+    timeseries_external_id: str | None = None
+
+    @classmethod
+    def _load(cls, resource: dict[str, Any], cognite_client: CogniteClient | None = None) -> Self:
+        return cls(
+            aggregate=resource["aggregate"],
+            min_section_size=resource["minSectionSize"],
+            var_threshold=resource["varThreshold"],
+            slope_threshold=resource["slopeThreshold"],
+            timeseries_external_id=resource.get("timeseriesExternalId"),
+        )
+
+
+@dataclass
+class SimulatorRoutineConfiguration(CogniteObject):
+    """
+    The simulator routine configuration defines the configuration of a simulator routine revision.
+    Learn more about simulator routine configuration <https://docs.cognite.com/cdf/integration/guides/simulators/simulator_routines>.
+
+    Args:
+        inputs (list[SimulatorRoutineInput] | None): The inputs of the simulator routine revision. Each element can be either a constant or a timeseries input.
+        outputs (list[SimulatorRoutineOutput] | None): The outputs of the simulator routine revision.
+        logical_check (list[SimulatorRoutineLogicalCheck] | None): Logical check configuration.
+        steady_state_detection (list[SimulatorRoutineSteadyStateDetection] | None): Steady state detection configuration.
+        schedule (SimulatorRoutineSchedule | None): Schedule configuration.
+        data_sampling (SimulatorRoutineDataSampling | None): Data sampling configuration. Learn more about data sampling <https://docs.cognite.com/cdf/integration/guides/simulators/about_data_sampling>.
+    """
+
+    inputs: list[SimulatorRoutineInput] | None
+    outputs: list[SimulatorRoutineOutput] | None
+    logical_check: list[SimulatorRoutineLogicalCheck]
+    steady_state_detection: list[SimulatorRoutineSteadyStateDetection]
+    schedule: SimulatorRoutineSchedule | None = None
+    data_sampling: SimulatorRoutineDataSampling | None = None
+
+    def __init__(
+        self,
+        inputs: list[SimulatorRoutineInput] | None,
+        outputs: list[SimulatorRoutineOutput] | None,
+        logical_check: list[SimulatorRoutineLogicalCheck] | None = None,
+        steady_state_detection: list[SimulatorRoutineSteadyStateDetection] | None = None,
+        schedule: SimulatorRoutineSchedule | None = None,
+        data_sampling: SimulatorRoutineDataSampling | None = None,
+    ) -> None:
+        self.inputs = inputs
+        self.outputs = outputs
+        self.logical_check = logical_check or []
+        self.steady_state_detection = steady_state_detection or []
+        self.schedule = schedule
+        self.data_sampling = data_sampling
+
+    @classmethod
+    def _load(cls, resource: dict[str, Any], cognite_client: CogniteClient | None = None) -> Self:
+        inputs = None
+        outputs = None
+
+        if resource.get("inputs", None) is not None:
+            inputs = []
+            for input in resource["inputs"]:
+                if issubclass(type(input), type(SimulatorRoutineInput)):
+                    inputs.append(input)
+                else:
+                    inputs.append(SimulatorRoutineInput._load(input, cognite_client))
+
+        if resource.get("outputs", None) is not None:
+            outputs = []
+            for output_ in resource["outputs"]:
+                if isinstance(output_, SimulatorRoutineOutput):
+                    outputs.append(output_)
+                else:
+                    outputs.append(SimulatorRoutineOutput._load(output_, cognite_client))
+
+        schedule = resource["schedule"] if resource.get("schedule") and resource["schedule"]["enabled"] else None
+        data_sampling = (
+            resource["dataSampling"] if resource.get("dataSampling") and resource["dataSampling"]["enabled"] else None
+        )
+
+        return cls(
+            schedule=SimulatorRoutineSchedule.load(schedule, cognite_client) if schedule else None,
+            data_sampling=SimulatorRoutineDataSampling._load(data_sampling, cognite_client) if data_sampling else None,
+            logical_check=[
+                SimulatorRoutineLogicalCheck._load(check_, cognite_client) for check_ in resource["logicalCheck"]
+            ],
+            steady_state_detection=[
+                SimulatorRoutineSteadyStateDetection._load(detection_, cognite_client)
+                for detection_ in resource["steadyStateDetection"]
+            ],
+            inputs=inputs,
+            outputs=outputs,
+        )
+
+    def dump(self, camel_case: bool = True) -> dict[str, Any]:
+        output = super().dump(camel_case=camel_case)
+        output["inputs"] = [input_.dump(camel_case=camel_case) for input_ in self.inputs] if self.inputs else None
+        output["outputs"] = [output_.dump(camel_case=camel_case) for output_ in self.outputs] if self.outputs else None
+
+        if self.schedule is None:
+            output["schedule"] = {"enabled": False}
+        else:
+            output["schedule"] = {"enabled": True, **self.schedule.dump(camel_case=camel_case)}
+
+        if self.data_sampling is None:
+            output["dataSampling"] = {"enabled": False}
+        else:
+            output["dataSampling"] = {"enabled": True, **self.data_sampling.dump(camel_case=camel_case)}
+
+        output["logicalCheck"] = [
+            {"enabled": True, **check_.dump(camel_case=camel_case)} for check_ in self.logical_check
+        ]
+        output["steadyStateDetection"] = [
+            {"enabled": True, **detection_.dump(camel_case=camel_case)} for detection_ in self.steady_state_detection
+        ]
+
+        return output
+
+
+@dataclass
+class SimulatorRoutineStepArguments(CogniteObject, dict, MutableMapping[str, str]):
+    """
+    The arguments of the simulator routine step.
+
+    Depending on the step type and simulator, the arguments can be different.
+    For "Get" and "Set" step type the reference ID is required.
+    """
+
+    def __init__(self, data: dict[str, str]) -> None:
+        super().__init__(data)
+
+    @classmethod
+    def _load(cls, resource: dict[str, Any], cognite_client: CogniteClient | None = None) -> Self:
+        return cls(resource)
+
+    def dump(self, camel_case: bool = True) -> dict[str, Any]:
+        return {key: value for key, value in self.items()}
+
+
+_INPUT_CLASS_BY_TYPE: dict[str, type[SimulatorRoutineInput]] = {
+    subclass._type: subclass  # type: ignore[type-abstract]
+    for subclass in itertools.chain(SimulatorRoutineInput.__subclasses__())
+}

--- a/cognite/client/data_classes/simulators/simulators.py
+++ b/cognite/client/data_classes/simulators/simulators.py
@@ -97,19 +97,6 @@ class Simulator(CogniteResource):
 
 
 @dataclass
-class SimulatorRoutineStep(CogniteObject):
-    step_type: str
-    arguments: dict[str, Any]
-
-    @classmethod
-    def _load(cls, resource: dict[str, Any], cognite_client: CogniteClient | None = None) -> Self:
-        return cls(
-            step_type=resource["stepType"],
-            arguments=resource["arguments"],
-        )
-
-
-@dataclass
 class SimulatorUnitEntry(CogniteObject):
     label: str
     name: str

--- a/cognite/client/testing.py
+++ b/cognite/client/testing.py
@@ -51,6 +51,7 @@ from cognite.client._api.simulators.integrations import SimulatorIntegrationsAPI
 from cognite.client._api.simulators.logs import SimulatorLogsAPI
 from cognite.client._api.simulators.models import SimulatorModelsAPI
 from cognite.client._api.simulators.models_revisions import SimulatorModelRevisionsAPI
+from cognite.client._api.simulators.routine_revisions import SimulatorRoutineRevisionsAPI
 from cognite.client._api.simulators.routines import SimulatorRoutinesAPI
 from cognite.client._api.synthetic_time_series import SyntheticDatapointsAPI
 from cognite.client._api.templates import (
@@ -159,7 +160,8 @@ class CogniteClientMock(MagicMock):
         self.simulators.integrations = MagicMock(spec_set=SimulatorIntegrationsAPI)
         self.simulators.models = MagicMock(spec=SimulatorModelsAPI)
         self.simulators.models.revisions = MagicMock(spec_set=SimulatorModelRevisionsAPI)
-        self.simulators.routines = MagicMock(spec_set=SimulatorRoutinesAPI)
+        self.simulators.routines = MagicMock(spec=SimulatorRoutinesAPI)
+        self.simulators.routines.revisions = MagicMock(spec_set=SimulatorRoutineRevisionsAPI)
         self.simulators.logs = MagicMock(spec_set=SimulatorLogsAPI)
 
         self.sequences = MagicMock(spec=SequencesAPI)

--- a/tests/tests_integration/test_api/test_simulators/conftest.py
+++ b/tests/tests_integration/test_api/test_simulators/conftest.py
@@ -3,20 +3,26 @@ from __future__ import annotations
 import time
 from collections.abc import Iterator
 from pathlib import Path
+from typing import Any
 
 import pytest
 
 from cognite.client._cognite_client import CogniteClient
 from cognite.client.data_classes.data_sets import DataSetWrite
 from cognite.client.data_classes.files import FileMetadata
-from cognite.client.data_classes.simulators.filters import SimulatorModelRevisionsFilter
+from cognite.client.data_classes.simulators.filters import (
+    SimulatorModelRevisionsFilter,
+)
 from cognite.client.data_classes.simulators.models import SimulatorModelWrite
+from cognite.client.data_classes.simulators.routine_revisions import SimulatorRoutineRevisionWrite
+from cognite.client.data_classes.simulators.routines import SimulatorRoutineWrite
 from tests.tests_integration.test_api.test_simulators.seed.data import (
     resource_names,
     simulator,
     simulator_integration,
     simulator_model,
     simulator_routine,
+    simulator_routine_revision,
 )
 from tests.tests_integration.test_api.test_simulators.utils import update_logs
 
@@ -37,7 +43,7 @@ def seed_resource_names(cognite_client: CogniteClient) -> dict[str, str]:
 
 
 @pytest.fixture(scope="session")
-def seed_file(cognite_client: CogniteClient, seed_resource_names) -> FileMetadata | None:
+def seed_file(cognite_client: CogniteClient, seed_resource_names: dict[str, str]) -> Iterator[FileMetadata | None]:
     data_set_id = seed_resource_names["simulator_test_data_set_id"]
     file = cognite_client.files.retrieve(external_id=seed_resource_names["simulator_model_file_external_id"])
     if not file:
@@ -51,7 +57,7 @@ def seed_file(cognite_client: CogniteClient, seed_resource_names) -> FileMetadat
 
 
 @pytest.fixture(scope="session")
-def seed_simulator(cognite_client: CogniteClient, seed_resource_names) -> Iterator[None]:
+def seed_simulator(cognite_client: CogniteClient, seed_resource_names: dict[str, str]) -> Iterator[None]:
     simulator_external_id = seed_resource_names["simulator_external_id"]
     simulators = cognite_client.simulators.list(limit=None)
     if not simulators.get(external_id=simulator_external_id):
@@ -59,7 +65,9 @@ def seed_simulator(cognite_client: CogniteClient, seed_resource_names) -> Iterat
 
 
 @pytest.fixture(scope="session")
-def seed_simulator_integration(cognite_client: CogniteClient, seed_simulator, seed_resource_names) -> None:
+def seed_simulator_integration(
+    cognite_client: CogniteClient, seed_simulator: None, seed_resource_names: dict[str, str]
+) -> Iterator[None]:
     log_id = None
     timestamp = int(time.time() * 1000)
     simulator_integrations = cognite_client.simulators.integrations.list(limit=None)
@@ -89,28 +97,32 @@ def seed_simulator_integration(cognite_client: CogniteClient, seed_simulator, se
 
 
 @pytest.fixture(scope="session")
-def seed_simulator_models(cognite_client: CogniteClient, seed_simulator_integration, seed_resource_names) -> None:
+def seed_simulator_models(
+    cognite_client: CogniteClient, seed_simulator_integration: None, seed_resource_names: dict[str, str]
+) -> Iterator[dict[str, Any]]:
     model_unique_external_id = seed_resource_names["simulator_model_external_id"]
     models = cognite_client.simulators.models.list(limit=None)
     model_exists = models.get(external_id=model_unique_external_id)
 
-    if model_exists:
-        return
+    if not model_exists:
+        simulator_model["dataSetId"] = seed_resource_names["simulator_test_data_set_id"]
+        simulator_model["externalId"] = model_unique_external_id
 
-    simulator_model["dataSetId"] = seed_resource_names["simulator_test_data_set_id"]
-    simulator_model["externalId"] = model_unique_external_id
+        model = SimulatorModelWrite._load(
+            {
+                "externalId": simulator_model["externalId"],
+                "simulatorExternalId": simulator_model["simulatorExternalId"],
+                "dataSetId": simulator_model["dataSetId"],
+                "name": simulator_model["name"],
+                "type": simulator_model["type"],
+                "description": simulator_model["description"],
+            }
+        )
+        cognite_client.simulators.models.create(model)
 
-    model = SimulatorModelWrite._load(
-        {
-            "externalId": simulator_model["externalId"],
-            "simulatorExternalId": simulator_model["simulatorExternalId"],
-            "dataSetId": simulator_model["dataSetId"],
-            "name": simulator_model["name"],
-            "type": simulator_model["type"],
-            "description": simulator_model["description"],
-        }
-    )
-    cognite_client.simulators.models.create(model)
+    yield simulator_model
+
+    cognite_client.simulators.models.delete(external_id=model_unique_external_id)
 
 
 @pytest.fixture(scope="session")
@@ -139,24 +151,56 @@ def seed_simulator_model_revisions(cognite_client: CogniteClient, seed_simulator
 
 
 @pytest.fixture(scope="session")
-def seed_simulator_routines(cognite_client: CogniteClient, seed_simulator_model_revisions) -> None:
+def seed_simulator_routines(cognite_client: CogniteClient, seed_simulator_model_revisions):
     model_unique_external_id = resource_names["simulator_model_external_id"]
     simulator_routine_unique_external_id = resource_names["simulator_routine_external_id"]
-    simulator_routine_external_ids = [f"{simulator_routine_unique_external_id}_{i}" for i in range(5)]
 
-    routines = cognite_client.simulators.routines.list(model_external_ids=[model_unique_external_id])
+    routines = cognite_client.simulators.routines.create(
+        [
+            SimulatorRoutineWrite.load(
+                {
+                    **simulator_routine,
+                    "modelExternalId": model_unique_external_id,
+                    "externalId": simulator_routine_unique_external_id,
+                }
+            ),
+            SimulatorRoutineWrite.load(
+                {
+                    **simulator_routine,
+                    "modelExternalId": model_unique_external_id,
+                    "externalId": simulator_routine_unique_external_id + "_1",
+                }
+            ),
+        ]
+    )
 
-    for routine_external_id in simulator_routine_external_ids:
-        if routines.get(external_id=routine_external_id) is None:
-            cognite_client.simulators._post(
-                "/simulators/routines",
-                json={
-                    "items": [
-                        {
-                            **simulator_routine,
-                            "modelExternalId": model_unique_external_id,
-                            "externalId": routine_external_id,
-                        }
-                    ]
-                },
-            )
+    yield routines
+
+    cognite_client.simulators.routines.delete(
+        external_ids=[simulator_routine_unique_external_id, simulator_routine_unique_external_id + "_1"]
+    )
+
+
+def seed_simulator_routine_revision(
+    cognite_client: CogniteClient, routine_external_id: str, version: str
+) -> dict[str, Any]:
+    routine_revs = cognite_client.simulators.routines.revisions.list(routine_external_ids=[routine_external_id])
+    rev_external_id = f"{routine_external_id}_{version}"
+    routine_rev_exists = routine_revs.get(external_id=rev_external_id)
+
+    revision = {**simulator_routine_revision, "externalId": rev_external_id}
+
+    if not routine_rev_exists:
+        cognite_client.simulators.routines.revisions.create(SimulatorRoutineRevisionWrite.load(revision))
+
+    return revision
+
+
+@pytest.fixture(scope="session")
+def seed_simulator_routine_revisions(cognite_client: CogniteClient, seed_simulator_routines):
+    simulator_routine_external_id = resource_names["simulator_routine_external_id"]
+
+    rev1 = seed_simulator_routine_revision(cognite_client, simulator_routine_external_id, "v1")
+    rev2 = seed_simulator_routine_revision(cognite_client, simulator_routine_external_id, "v2")
+
+    yield rev1, rev2

--- a/tests/tests_integration/test_api/test_simulators/seed/data.py
+++ b/tests/tests_integration/test_api/test_simulators/seed/data.py
@@ -1,14 +1,17 @@
 # This file contains the data used to seed the test environment for the simulator tests
+from cognite.client.utils._text import random_string
+
 data_set_external_id = "sdk_tests_dwsim1"
+
+random_str = random_string(10)
 
 resource_names = {
     "simulator_external_id": "py_sdk_integration_tests",
     "simulator_integration_external_id": "py_sdk_integration_tests_connector",
-    "simulator_model_external_id": "py_sdk_integration_tests_model",
-    "simulator_model_revision_external_id": "pysdk_model_revision",
+    "simulator_model_external_id": f"py_sdk_integration_tests_model_{random_str}",
+    "simulator_model_revision_external_id": f"py_sdk_integration_tests_model_{random_str}_v1",
     "simulator_model_file_external_id": "ShowerMixer_simulator_model_file_5",
-    "simulator_routine_external_id": "pysdk_routine",
-    "simulator_routine_revision_external_id": "pysdk_routine_revision",
+    "simulator_routine_external_id": f"pysdk_routine_{random_str}",
     "simulator_test_data_set_id": None,
     "simulator_test_data_set_external_id": data_set_external_id,
 }
@@ -231,4 +234,89 @@ simulator_routine = {
     "simulatorIntegrationExternalId": resource_names["simulator_integration_external_id"],
     "name": "Simulator Routine - Test",
     "description": "Simulator Routine - Description Test",
+}
+
+
+simulator_routine_revision = {
+    "externalId": None,
+    "routineExternalId": resource_names["simulator_routine_external_id"],
+    "configuration": {
+        "schedule": {"enabled": True, "cronExpression": "*/10 * * * *"},
+        "dataSampling": {"enabled": True, "samplingWindow": 15, "granularity": 1},
+        "logicalCheck": [],
+        "steadyStateDetection": [],
+        "inputs": [
+            {
+                "name": "Cold Water Temperature",
+                "referenceId": "CWT",
+                "value": 10.0,
+                "valueType": "DOUBLE",
+                "unit": {"name": "C", "quantity": "temperature"},
+                "saveTimeseriesExternalId": "TEST-ROUTINE-INPUT-CWT",
+            },
+            {
+                "name": "Cold Water Pressure",
+                "referenceId": "CWP",
+                "value": [3.6],
+                "valueType": "DOUBLE_ARRAY",
+                "unit": {"name": "bar", "quantity": "pressure"},
+            },
+        ],
+        "outputs": [
+            {
+                "name": "Shower Temperature",
+                "referenceId": "ST",
+                "unit": {"name": "C", "quantity": "temperature"},
+                "valueType": "DOUBLE",
+                "saveTimeseriesExternalId": "TEST-ROUTINE-OUTPUT-ST",
+            },
+            {
+                "name": "Shower Pressure",
+                "referenceId": "SP",
+                "unit": {"name": "bar", "quantity": "pressure"},
+                "valueType": "DOUBLE",
+            },
+        ],
+    },
+    "script": [
+        {
+            "order": 1,
+            "description": "Set Inputs",
+            "steps": [
+                {
+                    "order": 1,
+                    "stepType": "Set",
+                    "description": "Set Cold Water Temperature",
+                    "arguments": {"referenceId": "CWT", "objectName": "Cold water", "objectProperty": "Temperature"},
+                },
+                {
+                    "order": 2,
+                    "stepType": "Set",
+                    "description": "Set Cold Water Pressure",
+                    "arguments": {"referenceId": "CWP", "objectName": "Cold water", "objectProperty": "Pressure"},
+                },
+            ],
+        },
+        {
+            "order": 2,
+            "description": "Solve the flowsheet",
+            "steps": [{"order": 1, "stepType": "Command", "arguments": {"command": "Solve"}}],
+        },
+        {
+            "order": 3,
+            "description": "Set simulation outputs",
+            "steps": [
+                {
+                    "order": 1,
+                    "stepType": "Get",
+                    "arguments": {"referenceId": "ST", "objectName": "Shower", "objectProperty": "Temperature"},
+                },
+                {
+                    "order": 2,
+                    "stepType": "Get",
+                    "arguments": {"referenceId": "SP", "objectName": "Shower", "objectProperty": "Pressure"},
+                },
+            ],
+        },
+    ],
 }

--- a/tests/tests_integration/test_api/test_simulators/test_integrations.py
+++ b/tests/tests_integration/test_api/test_simulators/test_integrations.py
@@ -15,7 +15,7 @@ class TestSimulatorIntegrations:
 
         assert len(integrations) > 0
 
-    def test_filter_integrations_asdfdsa(self, cognite_client: CogniteClient, seed_resource_names) -> None:
+    def test_filter_integrations(self, cognite_client: CogniteClient, seed_resource_names) -> None:
         for integration in cognite_client.simulators.integrations(filter=SimulatorIntegrationFilter(active=True)):
             assert integration.active is True
 

--- a/tests/tests_integration/test_api/test_simulators/test_routine_revisions.py
+++ b/tests/tests_integration/test_api/test_simulators/test_routine_revisions.py
@@ -1,0 +1,128 @@
+import time
+from typing import Any
+
+from cognite.client import CogniteClient
+from cognite.client.data_classes.shared import TimestampRange
+from cognite.client.data_classes.simulators import PropertySort
+from cognite.client.data_classes.simulators.routine_revisions import (
+    SimulatorRoutineInputConstant,
+    SimulatorRoutineRevision,
+    SimulatorRoutineRevisionWrite,
+)
+from cognite.client.utils._time import timestamp_to_ms
+from tests.tests_integration.test_api.test_simulators.conftest import simulator_routine_revision
+
+
+class TestSimulatorRoutineRevisions:
+    def test_list_and_filtering_routine_revisions(
+        self,
+        cognite_client: CogniteClient,
+        seed_simulator_routine_revisions: list[dict[str, Any]],
+        seed_resource_names: dict[str, str],
+    ) -> None:
+        simulator_routine_external_id = seed_resource_names["simulator_routine_external_id"]
+        one_min_ahead = timestamp_to_ms("1m-ahead")
+        revisions_by_routine = cognite_client.simulators.routines.revisions.list(
+            created_time=TimestampRange(min=0, max=one_min_ahead),
+            routine_external_ids=[simulator_routine_external_id],
+            all_versions=True,
+        )
+        assert len(revisions_by_routine) == 2
+        model_external_id = seed_resource_names["simulator_model_external_id"]
+        revisions_by_model: list[SimulatorRoutineRevision] = []
+
+        for revision in cognite_client.simulators.routines.revisions(
+            sort=PropertySort(order="asc", property="createdTime"),
+            model_external_ids=[model_external_id],
+            all_versions=True,
+            include_all_fields=True,
+        ):
+            revisions_by_model.append(revision)
+
+        assert len(revisions_by_model) == 2
+        revisions_by_model_json = [item.dump() for item in revisions_by_model]
+        # Inputs, outputs and script are not included in the response by default
+        for revision_json in revisions_by_model_json:
+            revision_json["configuration"]["inputs"] = None
+            revision_json["configuration"]["outputs"] = None
+            revision_json["script"] = None
+
+        revisions_by_routine_json = [item.dump() for item in revisions_by_routine]
+        assert revisions_by_model_json == revisions_by_routine_json
+
+        seed_rev2 = seed_simulator_routine_revisions[0]
+
+        last_revision = revisions_by_model[1]
+        assert last_revision.external_id == seed_resource_names["simulator_routine_external_id"] + "_v2"
+
+        last_revision_script_json = [item.dump() for item in last_revision.script]
+        assert last_revision_script_json == seed_rev2["script"]
+        assert (
+            last_revision.script[0].steps[0].arguments["referenceId"]
+            == seed_rev2["script"][0]["steps"][0]["arguments"]["referenceId"]
+        )
+
+        last_revision_config_json = last_revision.configuration.dump()
+        assert last_revision_config_json == seed_rev2["configuration"]
+
+    def test_retrieve_routine_revision(
+        self,
+        cognite_client: CogniteClient,
+        seed_simulator_routine_revisions: list[dict[str, Any]],
+        seed_resource_names: dict[str, str],
+    ) -> None:
+        simulator_routine_external_id = seed_resource_names["simulator_routine_external_id"]
+        revisions_all = cognite_client.simulators.routines.revisions.list(
+            routine_external_ids=[simulator_routine_external_id], all_versions=True
+        )
+
+        assert len(revisions_all) == 2
+
+        rev1 = revisions_all[0]
+        rev2 = revisions_all[1]
+
+        rev1_retrieve = cognite_client.simulators.routines.revisions.retrieve(external_ids=rev1.external_id)
+        assert rev1_retrieve is not None
+        assert rev1_retrieve.external_id == rev1.external_id
+        rev2_retrieve = cognite_client.simulators.routines.revisions.retrieve(external_ids=rev2.external_id)
+        assert rev2_retrieve is not None
+        assert rev2_retrieve.external_id == rev2.external_id
+
+    def test_create_routine_revision(
+        self, cognite_client: CogniteClient, seed_simulator_models: dict[str, Any], seed_resource_names: dict[str, str]
+    ):
+        routine_external_id = seed_resource_names["simulator_routine_external_id"]
+        revisions = cognite_client.simulators.routines.revisions.create(
+            [
+                SimulatorRoutineRevisionWrite.load(
+                    {
+                        **simulator_routine_revision,
+                        "externalId": f"{routine_external_id}_v3",
+                    }
+                ),
+                SimulatorRoutineRevisionWrite.load(
+                    {
+                        **simulator_routine_revision,
+                        "externalId": f"{routine_external_id}_1_v1",
+                        "routineExternalId": f"{routine_external_id}_1",
+                    }
+                ),
+            ]
+        )
+        assert len(revisions) == 2
+
+        revision_1 = revisions[0]
+        assert revision_1 is not None
+        assert revision_1.external_id == f"{routine_external_id}_v3"
+        assert revision_1.configuration.dump() == simulator_routine_revision["configuration"]
+        assert [item.dump(camel_case=True) for item in revision_1.script] == simulator_routine_revision["script"]
+        assert revision_1.created_time
+        assert revision_1.created_time > int(time.time() - 60) * 1000
+
+        revision_2 = revisions[1]
+        assert revision_2 is not None
+        assert revision_2.external_id == f"{routine_external_id}_1_v1"
+        assert revision_2.configuration.inputs[0].reference_id == "CWT"
+        assert type(revision_2.configuration.inputs[0]) is SimulatorRoutineInputConstant
+        assert revision_2.configuration.outputs[0].reference_id == "ST"
+        assert revision_2.script[0].steps[0].arguments["referenceId"] == "CWT"

--- a/tests/tests_unit/test_docstring_examples.py
+++ b/tests/tests_unit/test_docstring_examples.py
@@ -149,4 +149,5 @@ class TestDocstringExamples:
         run_docstring_tests(simulators.models_revisions)
         run_docstring_tests(simulators.integrations)
         run_docstring_tests(simulators.routines)
+        run_docstring_tests(simulators.routine_revisions)
         run_docstring_tests(simulators.logs)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -43,6 +43,7 @@ from cognite.client.data_classes.data_modeling.query import NodeResultSetExpress
 from cognite.client.data_classes.datapoints import _INT_AGGREGATES, ALL_SORTED_DP_AGGS, Datapoints, DatapointsArray
 from cognite.client.data_classes.filters import Filter
 from cognite.client.data_classes.hosted_extractors.jobs import BodyLoad, NextUrlLoad, RestConfig
+from cognite.client.data_classes.simulators.routine_revisions import SimulatorRoutineStepArguments
 from cognite.client.data_classes.transformations.notifications import TransformationNotificationWrite
 from cognite.client.data_classes.transformations.schedules import TransformationScheduleWrite
 from cognite.client.data_classes.transformations.schema import TransformationSchemaUnknownType
@@ -466,6 +467,8 @@ class FakeCogniteResourceGenerator:
         elif issubclass(resource_cls, ListablePropertyType):
             if not keyword_arguments.get("is_list"):
                 keyword_arguments.pop("max_list_size", None)
+        elif resource_cls is SimulatorRoutineStepArguments:
+            keyword_arguments = {"data": {"reference_id": self._random_string(50), "arg2": self._random_string(50)}}
 
         return resource_cls(*positional_arguments, **keyword_arguments)
 


### PR DESCRIPTION
## Description
Support for the /simulators/routines/revisions API endpoints. (list, retrieve, and create)
api docs: https://api-docs.cognite.com/20230101/tag/Simulator-Routines/operation/create_simulator_routine_revision_simulators_routines_revisions_post

## Note for the risk-review team
This is bigger than 500 lines of code but each commit is made the way that it's less than 500. It's currently not feasible to split this without a major rewrite.

## Checklist:
- [x] Tests added/updated.
- [ ] Documentation - no, we would like to do it once all the parts of the API are available.
- [x] Changelog updated in [CHANGELOG.md](https://github.com/cognitedata/cognite-sdk-python/blob/master/CHANGELOG.md).
- [ ] Version not bumped, we don't have to release it just yet

To avoid any misunderstanding here, the Simulators API is bigger, so this PR for instance doesn't include docs, to make it smaller. We will make a separate PR for docs once we have all the pieces.