### PR TITLE
[CDF-24400] Dump and load workflow tasks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,22 @@ Changes are grouped as follows
 - Support for the `/simulators/models` and `/simulators/models/revisions` API endpoints.
 - Support for the `/simulators` and `/simulators/integration` API endpoints.
 
+## [7.74.2] - 2025-04-01
+### Fixed
+- When loading a Workflow version from dict, no longer gives a `400` when calling 
+  `client.workflows.versions.upsert(...)`. For example the following workflow version can now be upserted:
+```python
+WorkflowVersionUpsert.load({
+    "workflowExternalId": "my_workflow", "version": 1, 
+    "workflowDefinition": {
+      "tasks": {
+        "externalId": "task1",
+        "type": "function",
+        "parameters": {"function": {"externalId": "myFunction"}}}
+    }
+})
+```
+
 ## [7.74.1] - 2025-04-01
 ### Fixed
 - When iterating through datapoints, any instance IDs used would max out after 100k values.

--- a/cognite/client/_version.py
+++ b/cognite/client/_version.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
 
-__version__ = "7.74.1"
+__version__ = "7.74.2"
 
 __api_subversion__ = "20230101"

--- a/cognite/client/data_classes/workflows.py
+++ b/cognite/client/data_classes/workflows.py
@@ -572,10 +572,13 @@ class WorkflowTask(CogniteResource):
             "externalId" if camel_case else "external_id": self.external_id,
             "type": self.type,
             "parameters": self.parameters.dump(camel_case),
-            "retries": self.retries,
-            "timeout": self.timeout,
-            "onFailure" if camel_case else "on_failure": self.on_failure,
         }
+        if self.retries is not None:
+            output["retries"] = self.retries
+        if self.timeout is not None:
+            output["timeout"] = self.timeout
+        if self.on_failure is not None:
+            output["onFailure" if camel_case else "on_failure"] = self.on_failure
         if self.name:
             output["name"] = self.name
         if self.description:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "cognite-sdk"
-version = "7.74.1"
+version = "7.74.2"
 
 description = "Cognite Python SDK"
 readme = "README.md"

--- a/tests/tests_unit/test_data_classes/test_workflows.py
+++ b/tests/tests_unit/test_data_classes/test_workflows.py
@@ -215,3 +215,36 @@ class TestWorkflowExecutionDetailed:
 
             if actual_task.id == "38b3e696-adcb-4bf8-9217-747449f55289":
                 assert actual_task.dump(camel_case=True) == execution_data["executedTasks"][0]
+
+
+class TestWorkflowTask:
+    @pytest.mark.parametrize(
+        ["raw"],
+        [
+            (
+                {
+                    "externalId": "task1",
+                    "type": "function",
+                    "parameters": {
+                        "function": {"externalId": "myFunction"},
+                    },
+                },
+            ),
+            (
+                {
+                    "externalId": "task1",
+                    "type": "transformation",
+                    "parameters": {
+                        "transformation": {
+                            "externalId": "myTransformation",
+                            "concurrencyPolicy": "fail",
+                            "useTransformationCredentials": False,
+                        }
+                    },
+                },
+            ),
+        ],
+    )
+    def test_serialization(self, raw: dict):
+        loaded = WorkflowTask._load(raw)
+        assert loaded.dump() == raw


### PR DESCRIPTION
## Description

When you load a `WorkflowTask` from a dict you can get `None` for `retries`, `timeout`, `onFailure` which all has to be either int or string and cannot be `null` in the request to the API. This was not accounted for in the `.dump()` method of the `WorkflowTask`. 


## Checklist:
- [ ] Tests added/updated.
- [ ] Documentation updated. Documentation is generated from docstrings - these must be updated according to your change.
  If a new method has been added it should be referenced in [cognite.rst](https://github.com/cognitedata/cognite-sdk-python/blob/master/docs/source/cognite.rst) in order to generate docs based on its docstring.
- [ ] Changelog updated in [CHANGELOG.md](https://github.com/cognitedata/cognite-sdk-python/blob/master/CHANGELOG.md).
- [ ] Version bumped. If triggering a new release is desired, bump the version number in [_version.py](https://github.com/cognitedata/cognite-sdk-python/blob/master/cognite/client/_version.py) and [pyproject.toml](https://github.com/cognitedata/cognite-sdk-python/blob/master/pyproject.toml) per [semantic versioning](https://semver.org/).
