### PR TITLE
Fix dps iter instance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,11 @@ Changes are grouped as follows
 - Support for the `/simulators/models` and `/simulators/models/revisions` API endpoints.
 - Support for the `/simulators` and `/simulators/integration` API endpoints.
 
-## [7.74.0] - 2025-03-30
+## [7.74.1] - 2025-04-01
+### Fixed
+- When iterating through datapoints, any instance IDs used would max out after 100k values.
+
+## [7.74.0] - 2025-04-01
 ### Added
 - Support for new (object) datapoint aggregates `min_datapoint` and `max_datapoint`.
 

--- a/cognite/client/_api/datapoints.py
+++ b/cognite/client/_api/datapoints.py
@@ -692,7 +692,7 @@ class DatapointsAPI(APIClient):
     ) -> None:
         for query in to_fetch_queries:
             ident = query.identifier
-            dps = dps_lst.get(**ident.as_dict(camel_case=False))
+            dps = dps_lst.get(**{ident.name(camel_case=False): ident.as_primitive()})
             if isinstance(dps, list):
                 raise RuntimeError(
                     "When iterating datapoints, identifiers must be unique! You cannot get around this by passing "

--- a/cognite/client/_version.py
+++ b/cognite/client/_version.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
 
-__version__ = "7.74.0"
+__version__ = "7.74.1"
 
 __api_subversion__ = "20230101"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "cognite-sdk"
-version = "7.74.0"
+version = "7.74.1"
 
 description = "Cognite Python SDK"
 readme = "README.md"


### PR DESCRIPTION
## [7.73.10] - 2025-04-01
### Fixed
- Iterating through datapoints would max out at 100k values total for any instance IDs used.

### Risk review notes
Low risk, single line of code changed.

The line does lookup using either `id=123` or `external_id="foo"` so when we started accepting instance IDs, the identifier wasn't propagated "as a primitive" (e.g. `NodeId`) but as a `dict`, e.g. `instance_id={"space": ..., "external_id": ...}`.

Why low risk? The datapoints API implementation has the best/most tested API in the SDK and this change doesn't interact with code outside of `def __call__`.

Issue raised on slack: https://cognitedata.slack.com/archives/CM71GE7CN/p1743448330023459

## Checklist:
- [x] Tests added/updated.
- [x] Changelog updated in [CHANGELOG.md](https://github.com/cognitedata/cognite-sdk-python/blob/master/CHANGELOG.md).
- [x] Version bumped. If triggering a new release is desired, bump the version number in [_version.py](https://github.com/cognitedata/cognite-sdk-python/blob/master/cognite/client/_version.py) and [pyproject.toml](https://github.com/cognitedata/cognite-sdk-python/blob/master/pyproject.toml) per [semantic versioning](https://semver.org/).
