### PR TITLE
Fix typing of DatapointSubscription.time_series_count

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,10 @@ Changes are grouped as follows
 - Support for the `/simulators/models` and `/simulators/models/revisions` API endpoints.
 - Support for the `/simulators` and `/simulators/integration` API endpoints.
 
+## [7.74.5] - 2025-04-08
+### Fixed
+- Empty datapoint subscriptions may return timeSeriesCount=None. This is now handled.
+
 ## [7.74.4] - 2025-04-08
 ### Fixed
 - When iterating datapoints, object aggregates `min_datapoint` and `max_datapoint` no longer raise

--- a/cognite/client/_version.py
+++ b/cognite/client/_version.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
 
-__version__ = "7.74.4"
+__version__ = "7.74.5"
 
 __api_subversion__ = "20230101"

--- a/cognite/client/data_classes/datapoints_subscriptions.py
+++ b/cognite/client/data_classes/datapoints_subscriptions.py
@@ -66,7 +66,7 @@ class DatapointSubscription(DatapointSubscriptionCore):
         partition_count (int): The maximum effective parallelism of this subscription (the number of clients that can read from it concurrently) will be limited to this number, but a higher partition count will cause a higher time overhead.
         created_time (int): Time when the subscription was created in CDF in milliseconds since Jan 1, 1970.
         last_updated_time (int): Time when the subscription was last updated in CDF in milliseconds since Jan 1, 1970.
-        time_series_count (int): The number of time series in the subscription.
+        time_series_count (int | None): The number of time series in the subscription. None if no timeseries.
         filter (Filter | None): If present, the subscription is defined by this filter.
         name (str | None): No description.
         description (str | None): A summary explanation for the subscription.
@@ -79,7 +79,7 @@ class DatapointSubscription(DatapointSubscriptionCore):
         partition_count: int,
         created_time: int,
         last_updated_time: int,
-        time_series_count: int,
+        time_series_count: int | None,
         filter: Filter | None = None,
         name: str | None = None,
         description: str | None = None,
@@ -99,7 +99,7 @@ class DatapointSubscription(DatapointSubscriptionCore):
             name=resource.get("name"),
             description=resource.get("description"),
             data_set_id=resource.get("dataSetId"),
-            time_series_count=resource["timeSeriesCount"],
+            time_series_count=resource.get("timeSeriesCount"),
             created_time=resource["createdTime"],
             last_updated_time=resource["lastUpdatedTime"],
         )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "cognite-sdk"
-version = "7.74.4"
+version = "7.74.5"
 
 description = "Cognite Python SDK"
 readme = "README.md"

--- a/tests/tests_unit/test_data_classes/test_datapoint_subscriptions.py
+++ b/tests/tests_unit/test_data_classes/test_datapoint_subscriptions.py
@@ -1,17 +1,29 @@
 import pytest
 
 from cognite.client.data_classes import filters
-from cognite.client.data_classes.datapoints_subscriptions import DataPointSubscriptionWrite
+from cognite.client.data_classes.datapoints_subscriptions import DatapointSubscription, DataPointSubscriptionWrite
 
 
 class TestDataPointSubscription:
     def test_raises_value_error_on_invalid_filter(self):
         f = filters
-        nested_fileter = f.Nested(
+        nested_filter = f.Nested(
             scope=("some", "direct_relation", "property"), filter=f.Equals(property=["node", "name"], value="ACME")
         )
         with pytest.raises(ValueError) as e:
             DataPointSubscriptionWrite(
-                external_id="MySubscription", partition_count=10, name="MySubscription", filter=nested_fileter
+                external_id="MySubscription", partition_count=10, name="MySubscription", filter=nested_filter
             )
         assert "Nested" in str(e.value) and "not supported" in str(e.value)
+
+    def test_handles_null_timeseries_count(self) -> None:
+        sub = DatapointSubscription.load(
+            {
+                "externalId": "MySubscription",
+                "partitionCount": 10,
+                "name": "MySubscription",
+                "createdTime": 123,
+                "lastUpdatedTime": 456,
+            }
+        )
+        assert sub.time_series_count is None


### PR DESCRIPTION
- **Make DatapointsSubscription.time_series_count nullable as per service contract**
- **Bump version and update changelog**

## Description
Please describe the change you have made.

## Checklist:
- [ ] Tests added/updated.
- [ ] Documentation updated. Documentation is generated from docstrings - these must be updated according to your change.
  If a new method has been added it should be referenced in [cognite.rst](https://github.com/cognitedata/cognite-sdk-python/blob/master/docs/source/cognite.rst) in order to generate docs based on its docstring.
- [ ] Changelog updated in [CHANGELOG.md](https://github.com/cognitedata/cognite-sdk-python/blob/master/CHANGELOG.md).
- [ ] Version bumped. If triggering a new release is desired, bump the version number in [_version.py](https://github.com/cognitedata/cognite-sdk-python/blob/master/cognite/client/_version.py) and [pyproject.toml](https://github.com/cognitedata/cognite-sdk-python/blob/master/pyproject.toml) per [semantic versioning](https://semver.org/).
