### PR TITLE
add support for simulation run data

### DIFF
--- a/cognite/client/_api/simulators/runs.py
+++ b/cognite/client/_api/simulators/runs.py
@@ -8,7 +8,6 @@ from cognite.client._constants import DEFAULT_LIMIT_READ
 from cognite.client.data_classes.simulators.filters import SimulatorRunsFilter
 from cognite.client.data_classes.simulators.runs import (
     SimulationRun,
-    SimulationRunDataItem,
     SimulationRunWrite,
     SimulatorRunDataList,
     SimulatorRunsList,
@@ -251,6 +250,4 @@ class SimulatorRunsAPI(APIClient):
         )
 
         items = req.json().get("items", [])
-        run_items = [SimulationRunDataItem.load(item) for item in items]
-
-        return SimulatorRunDataList(resources=run_items, cognite_client=self._cognite_client)
+        return SimulatorRunDataList._load(items, cognite_client=self._cognite_client)

--- a/cognite/client/_api/simulators/runs.py
+++ b/cognite/client/_api/simulators/runs.py
@@ -25,7 +25,6 @@ if TYPE_CHECKING:
 class SimulatorRunsAPI(APIClient):
     _RESOURCE_PATH = "/simulators/runs"
     _RESOURCE_PATH_RUN = "/simulators/run"
-    _RESOURCE_RUNS_DATA_PATH = "/simulators/runs/data"
 
     def __init__(self, config: ClientConfig, api_version: str | None, cognite_client: CogniteClient) -> None:
         super().__init__(config, api_version, cognite_client)
@@ -247,7 +246,7 @@ class SimulatorRunsAPI(APIClient):
         self._warning.warn()
 
         req = self._post(
-            url_path=f"{self._RESOURCE_RUNS_DATA_PATH}/list",
+            url_path=f"{self._RESOURCE_PATH}/data/list",
             json={"items": [{"runId": run_id}]},
         )
 

--- a/cognite/client/_api/simulators/runs.py
+++ b/cognite/client/_api/simulators/runs.py
@@ -6,7 +6,13 @@ from typing import TYPE_CHECKING, overload
 from cognite.client._api_client import APIClient
 from cognite.client._constants import DEFAULT_LIMIT_READ
 from cognite.client.data_classes.simulators.filters import SimulatorRunsFilter
-from cognite.client.data_classes.simulators.runs import SimulationRun, SimulationRunWrite, SimulatorRunsList
+from cognite.client.data_classes.simulators.runs import (
+    SimulationRun,
+    SimulationRunDataItem,
+    SimulationRunWrite,
+    SimulatorRunDataList,
+    SimulatorRunsList,
+)
 from cognite.client.utils._experimental import FeaturePreviewWarning
 from cognite.client.utils._validation import assert_type
 from cognite.client.utils.useful_types import SequenceNotStr
@@ -19,6 +25,7 @@ if TYPE_CHECKING:
 class SimulatorRunsAPI(APIClient):
     _RESOURCE_PATH = "/simulators/runs"
     _RESOURCE_PATH_RUN = "/simulators/run"
+    _RESOURCE_RUNS_DATA_PATH = "/simulators/runs/data"
 
     def __init__(self, config: ClientConfig, api_version: str | None, cognite_client: CogniteClient) -> None:
         super().__init__(config, api_version, cognite_client)
@@ -217,3 +224,34 @@ class SimulatorRunsAPI(APIClient):
             input_resource_cls=SimulationRunWrite,
             resource_path=self._RESOURCE_PATH_RUN,
         )
+
+    def list_run_data(
+        self,
+        run_id: int,
+    ) -> SimulatorRunDataList:
+        """`Get simulation run data <https://developer.cognite.com/api#tag/Simulation-Runs/operation/simulation_data_by_run_id_simulators_runs_data_list_post>`_
+        Retrieve data associated with a simulation run by ID.
+
+        Args:
+            run_id (int): Simulation run id.
+
+        Returns:
+            SimulatorRunDataList: List of simulation run data
+
+        Examples:
+            Get simulation run data:
+                >>> from cognite.client import CogniteClient
+                >>> client = CogniteClient()
+                >>> res = client.simulators.runs.list_run_data(run_id=12345)
+        """
+        self._warning.warn()
+
+        req = self._post(
+            url_path=f"{self._RESOURCE_RUNS_DATA_PATH}/list",
+            json={"items": [{"runId": run_id}]},
+        )
+
+        items = req.json().get("items", [])
+        run_items = [SimulationRunDataItem.load(item) for item in items]
+
+        return SimulatorRunDataList(resources=run_items, cognite_client=self._cognite_client)

--- a/cognite/client/data_classes/simulators/runs.py
+++ b/cognite/client/data_classes/simulators/runs.py
@@ -23,8 +23,22 @@ _WARNING = FeaturePreviewWarning(api_maturity="General Availability", sdk_maturi
 
 
 @dataclass
-class SimulationValueUnitName(CogniteObject):
-    name: str
+class SimulationValueUnit(CogniteObject):
+    external_id: str | None = None
+
+    @classmethod
+    def _load(cls, resource: dict[str, Any], cognite_client: CogniteClient | None = None) -> Self:
+        return cls(
+            external_id=resource.get("externalId"),
+        )
+
+    def __post_init__(self) -> None:
+        _WARNING.warn()
+
+
+@dataclass
+class SimulationValueUnitName(SimulationValueUnit):
+    name: str | None = None
 
     @classmethod
     def _load(cls, resource: dict[str, Any], cognite_client: CogniteClient | None = None) -> Self:

--- a/cognite/client/data_classes/simulators/runs.py
+++ b/cognite/client/data_classes/simulators/runs.py
@@ -29,7 +29,7 @@ class SimulationValueUnitName(CogniteObject):
     @classmethod
     def _load(cls, resource: dict[str, Any], cognite_client: CogniteClient | None = None) -> Self:
         return cls(
-            name=resource["name"],
+            name=resource.get("name"),
         )
 
     def __post_init__(self) -> None:

--- a/cognite/client/data_classes/simulators/runs.py
+++ b/cognite/client/data_classes/simulators/runs.py
@@ -23,13 +23,13 @@ _WARNING = FeaturePreviewWarning(api_maturity="General Availability", sdk_maturi
 
 
 @dataclass
-class SimulationValueUnit(CogniteObject):
-    external_id: str | None = None
+class SimulationValueUnitName(CogniteObject):
+    name: str | None = None
 
     @classmethod
     def _load(cls, resource: dict[str, Any], cognite_client: CogniteClient | None = None) -> Self:
         return cls(
-            external_id=resource.get("externalId"),
+            name=resource["name"],
         )
 
     def __post_init__(self) -> None:
@@ -37,13 +37,13 @@ class SimulationValueUnit(CogniteObject):
 
 
 @dataclass
-class SimulationValueUnitName(SimulationValueUnit):
-    name: str | None = None
+class SimulationValueUnit(SimulationValueUnitName):
+    external_id: str | None = None
 
     @classmethod
     def _load(cls, resource: dict[str, Any], cognite_client: CogniteClient | None = None) -> Self:
         return cls(
-            name=resource["name"],
+            external_id=resource.get("externalId"),
         )
 
     def __post_init__(self) -> None:

--- a/cognite/client/data_classes/simulators/runs.py
+++ b/cognite/client/data_classes/simulators/runs.py
@@ -44,6 +44,7 @@ class SimulationValueUnit(SimulationValueUnitName):
     def _load(cls, resource: dict[str, Any], cognite_client: CogniteClient | None = None) -> Self:
         return cls(
             external_id=resource.get("externalId"),
+            name=resource.get("name"),
         )
 
     def __post_init__(self) -> None:

--- a/cognite/client/data_classes/simulators/runs.py
+++ b/cognite/client/data_classes/simulators/runs.py
@@ -7,6 +7,7 @@ from typing_extensions import Self
 
 from cognite.client.data_classes._base import (
     CogniteObject,
+    CogniteResource,
     CogniteResourceList,
     ExternalIDTransformerMixin,
     IdTransformerMixin,
@@ -230,6 +231,141 @@ class SimulationRun(SimulationRunCore):
             run_time=resource.get("runTime"),
             simulation_time=resource.get("simulationTime"),
         )
+
+
+class SimulationValueBase(CogniteObject):
+    """
+    Base class for simulation values. This class is used to define the value and its type.
+    The value can be a string, double, array of strings or array of doubles.
+    The maximum length is 1024 for strings and 200 for arrays.
+    """
+
+    def __init__(
+        self,
+        reference_id: str,
+        value: str | int | float | list[str] | list[int] | list[float],
+        value_type: Literal["STRING", "DOUBLE", "STRING_ARRAY", "DOUBLE_ARRAY"],
+        unit: SimulationValueUnitName | None = None,
+        simulator_object_reference: Any | None = None,
+        timeseries_external_id: str | None = None,
+    ) -> None:
+        super().__init__()
+        self.reference_id = reference_id
+        self.value = value
+        self.value_type = value_type
+        self.unit = unit
+        self.simulator_object_reference = simulator_object_reference
+        self.timeseries_external_id = timeseries_external_id
+
+    @classmethod
+    def _load(cls, resource: dict[str, Any], cognite_client: CogniteClient | None = None) -> Self:
+        return cls(
+            reference_id=resource["referenceId"],
+            value=resource["value"],
+            value_type=resource["valueType"],
+            unit=SimulationValueUnitName._load(resource["unit"], cognite_client) if resource.get("unit") else None,
+            simulator_object_reference=resource.get("simulatorObjectReference"),
+            timeseries_external_id=resource.get("timeseriesExternalId"),
+        )
+
+    def dump(self, camel_case: bool = True) -> dict[str, Any]:
+        output = super().dump(camel_case=camel_case)
+        if self.unit is not None:
+            output["unit"] = self.unit.dump(camel_case=camel_case)
+        if self.simulator_object_reference is not None:
+            output["simulatorObjectReference"] = self.simulator_object_reference
+        if self.timeseries_external_id is not None:
+            output["timeseriesExternalId"] = self.timeseries_external_id
+        return output
+
+
+class SimulationValue(SimulationValueBase):
+    """
+    This class is used to define the value and its type.
+    The value can be a string, double, array of strings or array of doubles.
+    The maximum length is 1024 for strings and 200 for arrays.
+    """
+
+    def __init__(
+        self,
+        reference_id: str,
+        value: str | int | float | list[str] | list[int] | list[float],
+        value_type: Literal["STRING", "DOUBLE", "STRING_ARRAY", "DOUBLE_ARRAY"],
+        unit: SimulationValueUnitName | None = None,
+        simulator_object_reference: Any | None = None,
+        timeseries_external_id: str | None = None,
+        overridden: bool | None = None,
+    ) -> None:
+        super().__init__(
+            reference_id=reference_id,
+            value=value,
+            value_type=value_type,
+            unit=unit,
+            simulator_object_reference=simulator_object_reference,
+            timeseries_external_id=timeseries_external_id,
+        )
+        self.overridden = overridden
+
+    @classmethod
+    def _load(cls, resource: dict[str, Any], cognite_client: CogniteClient | None = None) -> Self:
+        return cls(
+            reference_id=resource["referenceId"],
+            value=resource["value"],
+            value_type=resource["valueType"],
+            unit=SimulationValueUnitName._load(resource["unit"], cognite_client) if resource.get("unit") else None,
+            simulator_object_reference=resource.get("simulatorObjectReference"),
+            timeseries_external_id=resource.get("timeseriesExternalId"),
+            overridden=resource.get("overridden"),
+        )
+
+    def dump(self, camel_case: bool = True) -> dict[str, Any]:
+        output = super().dump(camel_case=camel_case)
+        if self.unit is not None:
+            output["unit"] = self.unit.dump(camel_case=camel_case)
+        if self.simulator_object_reference is not None:
+            output["simulatorObjectReference"] = self.simulator_object_reference
+        if self.timeseries_external_id is not None:
+            output["timeseriesExternalId"] = self.timeseries_external_id
+        if self.overridden is not None:
+            output["overridden"] = self.overridden
+        return output
+
+
+class SimulationRunDataItem(CogniteResource):
+    run_id: int
+    inputs: list[SimulationValue]
+    outputs: list[SimulationValueBase]
+
+    def __init__(
+        self,
+        run_id: int,
+        inputs: list[SimulationValue],
+        outputs: list[SimulationValueBase],
+    ) -> None:
+        super().__init__()
+        self.run_id = run_id
+        self.inputs = inputs
+        self.outputs = outputs
+
+    @classmethod
+    def _load(cls, resource: dict[str, Any], cognite_client: CogniteClient | None = None) -> Self:
+        inputs = [SimulationValue._load(input_) for input_ in resource["inputs"]]
+        outputs = [SimulationValueBase._load(output_) for output_ in resource["outputs"]]
+        return cls(
+            run_id=resource["runId"],
+            inputs=inputs,
+            outputs=outputs,
+        )
+
+    def dump(self, camel_case: bool = True) -> dict[str, Any]:
+        output = super().dump(camel_case=camel_case)
+        output["inputs"] = [input_.dump(camel_case=camel_case) for input_ in self.inputs]
+        output["outputs"] = [output_.dump(camel_case=camel_case) for output_ in self.outputs]
+        return output
+
+
+class SimulatorRunDataList(CogniteResourceList[SimulationRunDataItem], IdTransformerMixin):
+    _RESOURCE = SimulationRunDataItem
 
 
 class SimulationRunWriteList(CogniteResourceList[SimulationRunWrite], ExternalIDTransformerMixin):

--- a/cognite/client/data_classes/simulators/runs.py
+++ b/cognite/client/data_classes/simulators/runs.py
@@ -35,9 +35,6 @@ class SimulationValueUnitName(CogniteObject):
     def __post_init__(self) -> None:
         _WARNING.warn()
 
-    def dump(self, camel_case: bool = True) -> dict[str, Any]:
-        return super().dump(camel_case=camel_case)
-
 
 @dataclass
 class SimulationInputOverride(CogniteObject):
@@ -246,10 +243,9 @@ class SimulationValueBase(CogniteObject):
         value: str | int | float | list[str] | list[int] | list[float],
         value_type: Literal["STRING", "DOUBLE", "STRING_ARRAY", "DOUBLE_ARRAY"],
         unit: SimulationValueUnitName | None = None,
-        simulator_object_reference: Any | None = None,
+        simulator_object_reference: dict[str, str] | None = None,
         timeseries_external_id: str | None = None,
     ) -> None:
-        super().__init__()
         self.reference_id = reference_id
         self.value = value
         self.value_type = value_type
@@ -332,14 +328,15 @@ class SimulationInput(SimulationValueBase):
 
 
 class SimulationOutput(SimulationValueBase):
+    """
+    This class is used to return the outputs generated during the simulation.
+    The value can be a string, double, array of strings or array of doubles.
+    """
+
     pass
 
 
 class SimulationRunDataItem(CogniteResource):
-    run_id: int
-    inputs: list[SimulationInput]
-    outputs: list[SimulationOutput]
-
     def __init__(
         self,
         run_id: int,

--- a/cognite/client/data_classes/simulators/runs.py
+++ b/cognite/client/data_classes/simulators/runs.py
@@ -279,7 +279,7 @@ class SimulationValueBase(CogniteObject):
         return output
 
 
-class SimulationValue(SimulationValueBase):
+class SimulationInput(SimulationValueBase):
     """
     This class is used to define the value and its type.
     The value can be a string, double, array of strings or array of doubles.
@@ -292,7 +292,7 @@ class SimulationValue(SimulationValueBase):
         value: str | int | float | list[str] | list[int] | list[float],
         value_type: Literal["STRING", "DOUBLE", "STRING_ARRAY", "DOUBLE_ARRAY"],
         unit: SimulationValueUnitName | None = None,
-        simulator_object_reference: Any | None = None,
+        simulator_object_reference: dict[str, str] | None = None,
         timeseries_external_id: str | None = None,
         overridden: bool | None = None,
     ) -> None:
@@ -331,16 +331,20 @@ class SimulationValue(SimulationValueBase):
         return output
 
 
+class SimulationOutput(SimulationValueBase):
+    pass
+
+
 class SimulationRunDataItem(CogniteResource):
     run_id: int
-    inputs: list[SimulationValue]
-    outputs: list[SimulationValueBase]
+    inputs: list[SimulationInput]
+    outputs: list[SimulationOutput]
 
     def __init__(
         self,
         run_id: int,
-        inputs: list[SimulationValue],
-        outputs: list[SimulationValueBase],
+        inputs: list[SimulationInput],
+        outputs: list[SimulationOutput],
     ) -> None:
         super().__init__()
         self.run_id = run_id
@@ -349,8 +353,8 @@ class SimulationRunDataItem(CogniteResource):
 
     @classmethod
     def _load(cls, resource: dict[str, Any], cognite_client: CogniteClient | None = None) -> Self:
-        inputs = [SimulationValue._load(input_) for input_ in resource["inputs"]]
-        outputs = [SimulationValueBase._load(output_) for output_ in resource["outputs"]]
+        inputs = [SimulationInput._load(input_) for input_ in resource["inputs"]]
+        outputs = [SimulationOutput._load(output_) for output_ in resource["outputs"]]
         return cls(
             run_id=resource["runId"],
             inputs=inputs,

--- a/tests/tests_integration/test_api/test_simulators/test_runs.py
+++ b/tests/tests_integration/test_api/test_simulators/test_runs.py
@@ -1,7 +1,12 @@
 import pytest
 
 from cognite.client._cognite_client import CogniteClient
-from cognite.client.data_classes.simulators.runs import SimulationRunWrite
+from cognite.client.data_classes.simulators.runs import (
+    SimulationInput,
+    SimulationOutput,
+    SimulationRunWrite,
+    SimulationValueUnitName,
+)
 
 
 @pytest.mark.usefixtures("seed_resource_names", "seed_simulator_routine_revisions")
@@ -69,30 +74,30 @@ class TestSimulatorRuns:
         )
 
         outputs = [
-            {
-                "referenceId": "ST",
-                "simulatorObjectReference": {"address": "test_out"},
-                "value": 18.5,
-                "valueType": "DOUBLE",
-                "unit": {"name": "C"},
-            },
+            SimulationOutput(
+                reference_id="ST",
+                simulator_object_reference={"address": "test_out"},
+                value=18.5,
+                value_type="DOUBLE",
+                unit=SimulationValueUnitName(name="C"),
+            ).dump(),
         ]
 
         inputs = [
-            {
-                "referenceId": "CWT",
-                "value": 11.0,
-                "valueType": "DOUBLE",
-                "overridden": True,
-                "unit": {"name": "C"},
-            },
-            {
-                "referenceId": "CWP",
-                "overridden": True,
-                "value": [5.0],
-                "valueType": "DOUBLE_ARRAY",
-                "unit": {"name": "bar"},
-            },
+            SimulationInput(
+                reference_id="CWT",
+                value=11.0,
+                value_type="DOUBLE",
+                overridden=True,
+                unit=SimulationValueUnitName(name="C"),
+            ).dump(),
+            SimulationInput(
+                reference_id="CWP",
+                overridden=True,
+                value=[5.0],
+                value_type="DOUBLE_ARRAY",
+                unit=SimulationValueUnitName(name="bar"),
+            ).dump(),
         ]
 
         cognite_client.simulators._post(


### PR DESCRIPTION
## Description

We previously implemented simulation runs which tracks execution status, progress, timestamps, and configuration details throughout a defined lifecycle, in this PR we introduce the implementation for accessing runs data, an associated resource of the simulation run, which stores the inputs and outputs of the run.


## Checklist:
- [x] Tests added/updated.
- [ ] Documentation updated. Documentation is generated from docstrings - these must be updated according to your change.
  If a new method has been added it should be referenced in [cognite.rst](https://github.com/cognitedata/cognite-sdk-python/blob/master/docs/source/cognite.rst) in order to generate docs based on its docstring.
- [ ] Changelog updated in [CHANGELOG.md](https://github.com/cognitedata/cognite-sdk-python/blob/master/CHANGELOG.md).
- [ ] Version bumped. If triggering a new release is desired, bump the version number in [_version.py](https://github.com/cognitedata/cognite-sdk-python/blob/master/cognite/client/_version.py) and [pyproject.toml](https://github.com/cognitedata/cognite-sdk-python/blob/master/pyproject.toml) per [semantic versioning](https://semver.org/).
