### PR TITLE
feat(simint-alpha): consistency and dev experience of simulation run

### DIFF
--- a/cognite/client/_api/simulators/__init__.py
+++ b/cognite/client/_api/simulators/__init__.py
@@ -21,12 +21,7 @@ if TYPE_CHECKING:
 class SimulatorsAPI(APIClient):
     _RESOURCE_PATH = "/simulators"
 
-    def __init__(
-        self,
-        config: ClientConfig,
-        api_version: str | None,
-        cognite_client: CogniteClient,
-    ) -> None:
+    def __init__(self, config: ClientConfig, api_version: str | None, cognite_client: CogniteClient) -> None:
         super().__init__(config, api_version, cognite_client)
         self.integrations = SimulatorIntegrationsAPI(config, api_version, cognite_client)
         self.models = SimulatorModelsAPI(config, api_version, cognite_client)
@@ -34,9 +29,7 @@ class SimulatorsAPI(APIClient):
         self.routines = SimulatorRoutinesAPI(config, api_version, cognite_client)
         self.logs = SimulatorLogsAPI(config, api_version, cognite_client)
         self._warning = FeaturePreviewWarning(
-            api_maturity="General Availability",
-            sdk_maturity="alpha",
-            feature_name="Simulators",
+            api_maturity="General Availability", sdk_maturity="alpha", feature_name="Simulators"
         )
 
     def __iter__(self) -> Iterator[Simulator]:
@@ -83,7 +76,7 @@ class SimulatorsAPI(APIClient):
         List simulators
 
         Args:
-            limit (int): Maximum number of results to return. Defaults to 25. Set to -1, float("inf") or None to return all items.
+            limit (int): Maximum number of results to return. Defaults to 25. Set to -1, float(“inf”) or None to return all items.
 
         Returns:
             SimulatorList: List of simulators

--- a/cognite/client/_api/simulators/__init__.py
+++ b/cognite/client/_api/simulators/__init__.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from collections.abc import Iterator
+from collections.abc import Iterator, Sequence
 from typing import TYPE_CHECKING, Literal, overload
 
 from cognite.client._api.simulators.integrations import SimulatorIntegrationsAPI
@@ -10,8 +10,11 @@ from cognite.client._api.simulators.routines import SimulatorRoutinesAPI
 from cognite.client._api.simulators.runs import SimulatorRunsAPI
 from cognite.client._api_client import APIClient
 from cognite.client._constants import DEFAULT_LIMIT_READ
+from cognite.client.data_classes.simulators.runs import (
+    SimulationInputOverride,
+    SimulationRun,
+)
 from cognite.client.data_classes.simulators.simulators import Simulator, SimulatorList
-from cognite.client.data_classes.simulators.runs import SimulationInputOverride, SimulationRun
 from cognite.client.utils._experimental import FeaturePreviewWarning
 
 if TYPE_CHECKING:
@@ -23,7 +26,12 @@ class SimulatorsAPI(APIClient):
     _RESOURCE_PATH = "/simulators"
     _RESOURCE_PATH_RUN = "/simulators/run"
 
-    def __init__(self, config: ClientConfig, api_version: str | None, cognite_client: CogniteClient) -> None:
+    def __init__(
+        self,
+        config: ClientConfig,
+        api_version: str | None,
+        cognite_client: CogniteClient,
+    ) -> None:
         super().__init__(config, api_version, cognite_client)
         self.integrations = SimulatorIntegrationsAPI(config, api_version, cognite_client)
         self.models = SimulatorModelsAPI(config, api_version, cognite_client)
@@ -31,7 +39,9 @@ class SimulatorsAPI(APIClient):
         self.routines = SimulatorRoutinesAPI(config, api_version, cognite_client)
         self.logs = SimulatorLogsAPI(config, api_version, cognite_client)
         self._warning = FeaturePreviewWarning(
-            api_maturity="General Availability", sdk_maturity="alpha", feature_name="Simulators"
+            api_maturity="General Availability",
+            sdk_maturity="alpha",
+            feature_name="Simulators",
         )
 
     def __iter__(self) -> Iterator[Simulator]:
@@ -78,7 +88,7 @@ class SimulatorsAPI(APIClient):
         List simulators
 
         Args:
-            limit (int): Maximum number of results to return. Defaults to 25. Set to -1, float(“inf”) or None to return all items.
+            limit (int): Maximum number of results to return. Defaults to 25. Set to -1, float("inf") or None to return all items.
 
         Returns:
             SimulatorList: List of simulators
@@ -100,7 +110,7 @@ class SimulatorsAPI(APIClient):
         routine_external_id: str | None = None,
         routine_revision_external_id: str | None = None,
         model_revision_external_id: str | None = None,
-        inputs: list[SimulationInputOverride] | None = None,
+        inputs: Sequence[SimulationInputOverride] | None = None,
         run_time: int | None = None,
         queue: bool | None = None,
         log_severity: Literal["Debug", "Information", "Warning", "Error"] | None = None,
@@ -111,13 +121,13 @@ class SimulatorsAPI(APIClient):
             routine_external_id (str | None): External id of the simulator routine
             routine_revision_external_id (str | None): External id of the simulator routine revision
             model_revision_external_id (str | None): External id of the simulator model revision
-            inputs (list[SimulationInputOverride] | None): List of input overrides
+            inputs (Sequence[SimulationInputOverride] | None): List of input overrides
             run_time (int | None): Run time in milliseconds. Reference timestamp used for data pre-processing and data sampling.
             queue (bool | None): Queue the simulation run when connector is down.
-            log_severity (Literal["Debug", "Information", "Warning", "Error"] | None): Override the minimum severity level for the simulation run logs. If not provided, the minimum severity is read from the connector logger configuration.
+            log_severity (Literal['Debug', 'Information', 'Warning', 'Error'] | None): Override the minimum severity level for the simulation run logs. If not provided, the minimum severity is read from the connector logger configuration.
             wait (bool): Wait until the simulation run is finished. Defaults to True.
         Returns:
-            SimulationRun : Created simulation run
+            SimulationRun: Created simulation run
         Examples:
             Create new simulation run:
                 >>> from cognite.client import CogniteClient
@@ -131,11 +141,11 @@ class SimulatorsAPI(APIClient):
                 "routineExternalId": routine_external_id,
                 "routine_revision_external_id": routine_revision_external_id,
                 "model_revision_external_id": model_revision_external_id,
-                "inputs": inputs.dump() if inputs else None,
+                "inputs": [item.dump for item in inputs] if inputs else None,
                 "runTime": run_time,
                 "queue": queue,
-                "logSeverity": log_severity
-            }
+                "logSeverity": log_severity,
+            },
         )
         simulation_run = SimulationRun._load(res.json(), cognite_client=self._cognite_client)
         if wait:

--- a/cognite/client/_api/simulators/__init__.py
+++ b/cognite/client/_api/simulators/__init__.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Iterator
-from typing import TYPE_CHECKING, overload
+from typing import TYPE_CHECKING, Literal, overload
 
 from cognite.client._api.simulators.integrations import SimulatorIntegrationsAPI
 from cognite.client._api.simulators.logs import SimulatorLogsAPI
@@ -11,6 +11,7 @@ from cognite.client._api.simulators.runs import SimulatorRunsAPI
 from cognite.client._api_client import APIClient
 from cognite.client._constants import DEFAULT_LIMIT_READ
 from cognite.client.data_classes.simulators.simulators import Simulator, SimulatorList
+from cognite.client.data_classes.simulators.runs import SimulationInputOverride, SimulationRun
 from cognite.client.utils._experimental import FeaturePreviewWarning
 
 if TYPE_CHECKING:
@@ -20,6 +21,7 @@ if TYPE_CHECKING:
 
 class SimulatorsAPI(APIClient):
     _RESOURCE_PATH = "/simulators"
+    _RESOURCE_PATH_RUN = "/simulators/run"
 
     def __init__(self, config: ClientConfig, api_version: str | None, cognite_client: CogniteClient) -> None:
         super().__init__(config, api_version, cognite_client)
@@ -92,3 +94,50 @@ class SimulatorsAPI(APIClient):
         """
         self._warning.warn()
         return self._list(method="POST", limit=limit, resource_cls=Simulator, list_cls=SimulatorList)
+
+    def run(
+        self,
+        routine_external_id: str | None = None,
+        routine_revision_external_id: str | None = None,
+        model_revision_external_id: str | None = None,
+        inputs: list[SimulationInputOverride] | None = None,
+        run_time: int | None = None,
+        queue: bool | None = None,
+        log_severity: Literal["Debug", "Information", "Warning", "Error"] | None = None,
+        wait: bool = True,
+    ) -> SimulationRun:
+        """`Run a simulation <https://developer.cognite.com/api#tag/Simulation-Runs/operation/filter_simulation_runs_simulators_runs_list_post>``
+        Args:
+            routine_external_id (str | None): External id of the simulator routine
+            routine_revision_external_id (str | None): External id of the simulator routine revision
+            model_revision_external_id (str | None): External id of the simulator model revision
+            inputs (list[SimulationInputOverride] | None): List of input overrides
+            run_time (int | None): Run time in milliseconds. Reference timestamp used for data pre-processing and data sampling.
+            queue (bool | None): Queue the simulation run when connector is down.
+            log_severity (Literal["Debug", "Information", "Warning", "Error"] | None): Override the minimum severity level for the simulation run logs. If not provided, the minimum severity is read from the connector logger configuration.
+            wait (bool): Wait until the simulation run is finished. Defaults to True.
+        Returns:
+            SimulationRun : Created simulation run
+        Examples:
+            Create new simulation run:
+                >>> from cognite.client import CogniteClient
+                >>> client = CogniteClient()
+                >>> run = client.simulators.run(routine_external_id="routine1", log_severity="Debug")
+        """
+        self._warning.warn()
+        res = self._post(
+            url_path=self._RESOURCE_PATH_RUN,
+            json={
+                "routineExternalId": routine_external_id,
+                "routine_revision_external_id": routine_revision_external_id,
+                "model_revision_external_id": model_revision_external_id,
+                "inputs": inputs.dump() if inputs else None,
+                "runTime": run_time,
+                "queue": queue,
+                "logSeverity": log_severity
+            }
+        )
+        simulation_run = SimulationRun._load(res.json(), cognite_client=self._cognite_client)
+        if wait:
+            simulation_run.wait()
+        return simulation_run

--- a/cognite/client/_api/simulators/routine_revisions.py
+++ b/cognite/client/_api/simulators/routine_revisions.py
@@ -117,7 +117,7 @@ class SimulatorRoutineRevisionsAPI(APIClient):
         return self._list_generator(
             method="POST",
             limit=limit,
-            url_path="/simulators/routines/revisions/list",
+            url_path=self._RESOURCE_PATH + "/list",
             resource_cls=SimulatorRoutineRevision,
             list_cls=SimulatorRoutineRevisionList,
             chunk_size=chunk_size,
@@ -178,7 +178,7 @@ class SimulatorRoutineRevisionsAPI(APIClient):
             resource_cls=SimulatorRoutineRevision,
             list_cls=SimulatorRoutineRevisionList,
             identifiers=identifiers,
-            resource_path="/simulators/routines/revisions",
+            resource_path=self._RESOURCE_PATH,
         )
 
     @overload
@@ -349,7 +349,7 @@ class SimulatorRoutineRevisionsAPI(APIClient):
         return self._list(
             method="POST",
             limit=limit,
-            url_path="/simulators/routines/revisions/list",
+            url_path=self._RESOURCE_PATH + "/list",
             resource_cls=SimulatorRoutineRevision,
             list_cls=SimulatorRoutineRevisionList,
             filter=filter.dump(),

--- a/cognite/client/_api/simulators/routines.py
+++ b/cognite/client/_api/simulators/routines.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Iterator, Sequence
-from typing import TYPE_CHECKING, overload
+from typing import TYPE_CHECKING, Literal, overload
 
 from cognite.client._api.simulators.routine_revisions import SimulatorRoutineRevisionsAPI
 from cognite.client._api_client import APIClient
@@ -11,6 +11,12 @@ from cognite.client.data_classes.simulators.routines import (
     SimulatorRoutine,
     SimulatorRoutineList,
     SimulatorRoutineWrite,
+)
+from cognite.client.data_classes.simulators.runs import (
+    SimulationInputOverride,
+    SimulationRun,
+    SimulationRunWrite,
+    SimulatorRunsList,
 )
 from cognite.client.utils._experimental import FeaturePreviewWarning
 from cognite.client.utils._identifier import IdentifierSequence
@@ -23,6 +29,7 @@ if TYPE_CHECKING:
 
 class SimulatorRoutinesAPI(APIClient):
     _RESOURCE_PATH = "/simulators/routines"
+    _RESOURCE_PATH_RUN = "/simulators/run"
 
     def __init__(self, config: ClientConfig, api_version: str | None, cognite_client: CogniteClient) -> None:
         super().__init__(config, api_version, cognite_client)
@@ -217,3 +224,48 @@ class SimulatorRoutinesAPI(APIClient):
             sort=[PropertySort.load(sort).dump()] if sort else None,
             filter=routines_filter.dump(),
         )
+
+    def run(
+        self,
+        routine_external_id: str,
+        inputs: Sequence[SimulationInputOverride] | None = None,
+        run_time: int | None = None,
+        queue: bool | None = None,
+        log_severity: Literal["Debug", "Information", "Warning", "Error"] | None = None,
+        wait: bool = True,
+    ) -> SimulationRun:
+        """`Run a simulation <https://developer.cognite.com/api#tag/Simulation-Runs/operation/filter_simulation_runs_simulators_runs_list_post>``
+        Args:
+            routine_external_id (str): External id of the simulator routine
+            inputs (Sequence[SimulationInputOverride] | None): List of input overrides
+            run_time (int | None): Run time in milliseconds. Reference timestamp used for data pre-processing and data sampling.
+            queue (bool | None): Queue the simulation run when connector is down.
+            log_severity (Literal['Debug', 'Information', 'Warning', 'Error'] | None): Override the minimum severity level for the simulation run logs. If not provided, the minimum severity is read from the connector logger configuration.
+            wait (bool): Wait until the simulation run is finished. Defaults to True.
+        Returns:
+            SimulationRun: Created simulation run
+        Examples:
+            Create new simulation run:
+                >>> from cognite.client import CogniteClient
+                >>> client = CogniteClient()
+                >>> run = client.simulators.run(routine_external_id="routine1", log_severity="Debug")
+        """
+        self._warning.warn()
+        run_object = SimulationRunWrite(
+            routine_external_id=routine_external_id,
+            inputs=list(inputs) if inputs is not None else None,
+            run_time=run_time,
+            queue=queue,
+            log_severity=log_severity,
+        )
+
+        simulation_run = self._create_multiple(
+            list_cls=SimulatorRunsList,
+            resource_cls=SimulationRun,
+            items=run_object,
+            input_resource_cls=SimulationRunWrite,
+            resource_path=self._RESOURCE_PATH_RUN,
+        )
+        if wait:
+            simulation_run.wait()
+        return simulation_run

--- a/cognite/client/_api/simulators/routines.py
+++ b/cognite/client/_api/simulators/routines.py
@@ -248,7 +248,7 @@ class SimulatorRoutinesAPI(APIClient):
             Create new simulation run:
                 >>> from cognite.client import CogniteClient
                 >>> client = CogniteClient()
-                >>> run = client.simulators.run(routine_external_id="routine1", log_severity="Debug")
+                >>> run = client.simulators.routines.run(routine_external_id="routine1", log_severity="Debug")
         """
         self._warning.warn()
         run_object = SimulationRunWrite(

--- a/cognite/client/_api/simulators/routines.py
+++ b/cognite/client/_api/simulators/routines.py
@@ -28,7 +28,6 @@ if TYPE_CHECKING:
 
 class SimulatorRoutinesAPI(APIClient):
     _RESOURCE_PATH = "/simulators/routines"
-    _RESOURCE_PATH_RUN = "/simulators/run"
 
     def __init__(self, config: ClientConfig, api_version: str | None, cognite_client: CogniteClient) -> None:
         super().__init__(config, api_version, cognite_client)
@@ -232,6 +231,7 @@ class SimulatorRoutinesAPI(APIClient):
         queue: bool | None = None,
         log_severity: Literal["Debug", "Information", "Warning", "Error"] | None = None,
         wait: bool = True,
+        timeout: float = 60,
     ) -> SimulationRun:
         """`Run a simulation <https://developer.cognite.com/api#tag/Simulation-Runs/operation/filter_simulation_runs_simulators_runs_list_post>``
         Args:
@@ -241,6 +241,7 @@ class SimulatorRoutinesAPI(APIClient):
             queue (bool | None): Queue the simulation run when connector is down.
             log_severity (Literal['Debug', 'Information', 'Warning', 'Error'] | None): Override the minimum severity level for the simulation run logs. If not provided, the minimum severity is read from the connector logger configuration.
             wait (bool): Wait until the simulation run is finished. Defaults to True.
+            timeout (float): Timeout in seconds for waiting for the simulation run to finish. Defaults to 60 seconds.
         Returns:
             SimulationRun: Created simulation run
         Examples:

--- a/cognite/client/_api/simulators/routines.py
+++ b/cognite/client/_api/simulators/routines.py
@@ -262,5 +262,5 @@ class SimulatorRoutinesAPI(APIClient):
         simulation_run = self._cognite_client.simulators.runs.create(run_object)
 
         if wait:
-            simulation_run.wait()
+            simulation_run.wait(timeout)
         return simulation_run

--- a/cognite/client/_api/simulators/routines.py
+++ b/cognite/client/_api/simulators/routines.py
@@ -16,7 +16,6 @@ from cognite.client.data_classes.simulators.runs import (
     SimulationInputOverride,
     SimulationRun,
     SimulationRunWrite,
-    SimulatorRunsList,
 )
 from cognite.client.utils._experimental import FeaturePreviewWarning
 from cognite.client.utils._identifier import IdentifierSequence
@@ -259,13 +258,8 @@ class SimulatorRoutinesAPI(APIClient):
             log_severity=log_severity,
         )
 
-        simulation_run = self._create_multiple(
-            list_cls=SimulatorRunsList,
-            resource_cls=SimulationRun,
-            items=run_object,
-            input_resource_cls=SimulationRunWrite,
-            resource_path=self._RESOURCE_PATH_RUN,
-        )
+        simulation_run = self._cognite_client.simulators.runs.create(run_object)
+
         if wait:
             simulation_run.wait()
         return simulation_run

--- a/cognite/client/_api/simulators/runs.py
+++ b/cognite/client/_api/simulators/runs.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING, overload
 from cognite.client._api_client import APIClient
 from cognite.client._constants import DEFAULT_LIMIT_READ
 from cognite.client.data_classes.simulators.filters import SimulatorRunsFilter
-from cognite.client.data_classes.simulators.runs import SimulationRun, SimulationRunWrite, SimulatorRunsList
+from cognite.client.data_classes.simulators.runs import SimulationRun, SimulationRunWrite, SimulatorRunList
 from cognite.client.utils._experimental import FeaturePreviewWarning
 from cognite.client.utils._identifier import IdentifierSequence
 from cognite.client.utils._validation import assert_type
@@ -59,7 +59,7 @@ class SimulatorRunsAPI(APIClient):
         routine_external_ids: SequenceNotStr[str] | None = None,
         routine_revision_external_ids: SequenceNotStr[str] | None = None,
         model_revision_external_ids: SequenceNotStr[str] | None = None,
-    ) -> Iterator[SimulatorRunsList]: ...
+    ) -> Iterator[SimulatorRunList]: ...
 
     @overload
     def __call__(
@@ -88,7 +88,7 @@ class SimulatorRunsAPI(APIClient):
         routine_external_ids: SequenceNotStr[str] | None = None,
         routine_revision_external_ids: SequenceNotStr[str] | None = None,
         model_revision_external_ids: SequenceNotStr[str] | None = None,
-    ) -> Iterator[SimulationRun] | Iterator[SimulatorRunsList]:
+    ) -> Iterator[SimulationRun] | Iterator[SimulatorRunList]:
         """Iterate over simulation runs
 
         Fetches simulation runs as they are iterated over, so you keep a limited number of simulation runs in memory.
@@ -106,7 +106,7 @@ class SimulatorRunsAPI(APIClient):
             model_revision_external_ids (SequenceNotStr[str] | None): Filter by model revision external ids
 
         Returns:
-            Iterator[SimulationRun] | Iterator[SimulatorRunsList]: yields Simulation Run one by one if chunk is not specified, else SimulatorRunsList objects.
+            Iterator[SimulationRun] | Iterator[SimulatorRunList]: yields Simulation Run one by one if chunk is not specified, else SimulatorRunsList objects.
         """
 
         filter_runs = SimulatorRunsFilter(
@@ -121,7 +121,7 @@ class SimulatorRunsAPI(APIClient):
         )
 
         return self._list_generator(
-            list_cls=SimulatorRunsList,
+            list_cls=SimulatorRunList,
             resource_cls=SimulationRun,
             method="POST",
             filter=filter_runs.dump(),
@@ -140,7 +140,7 @@ class SimulatorRunsAPI(APIClient):
         routine_external_ids: SequenceNotStr[str] | None = None,
         routine_revision_external_ids: SequenceNotStr[str] | None = None,
         model_revision_external_ids: SequenceNotStr[str] | None = None,
-    ) -> SimulatorRunsList:
+    ) -> SimulatorRunList:
         """`Filter simulation runs <https://developer.cognite.com/api#tag/Simulation-Runs/operation/filter_simulation_runs_simulators_runs_list_post>`_
         Retrieves a list of simulation runs that match the given criteria
 
@@ -156,7 +156,7 @@ class SimulatorRunsAPI(APIClient):
             model_revision_external_ids (SequenceNotStr[str] | None): Filter by model revision external ids
 
         Returns:
-            SimulatorRunsList: List of simulation runs
+            SimulatorRunList: List of simulation runs
 
         Examples:
 
@@ -187,19 +187,28 @@ class SimulatorRunsAPI(APIClient):
             method="POST",
             limit=limit,
             resource_cls=SimulationRun,
-            list_cls=SimulatorRunsList,
+            list_cls=SimulatorRunList,
             filter=filter_runs.dump(),
         )
+
+    @overload
+    def retrieve(self, ids: int) -> SimulationRun | None: ...
+
+    @overload
+    def retrieve(
+        self,
+        ids: Sequence[int],
+    ) -> SimulatorRunList | None: ...
 
     def retrieve(
         self,
         ids: int | Sequence[int],
-    ) -> SimulationRun | SimulatorRunsList | None:
-        """`Retrieve a simulation run by ID <https://developer.cognite.com/api#tag/Simulation-Runs/operation/filter_simulation_runs_simulators_runs_list_post>`
+    ) -> SimulationRun | SimulatorRunList | None:
+        """`Retrieve a simulation run by ID <https://api-docs.cognite.com/20230101/tag/Simulation-Runs/operation/simulation_by_id_simulators_runs_byids_post>`
         Args:
             ids (int | Sequence[int]): The ID(s) of the simulation run(s) to retrieve.
         Returns:
-            SimulationRun | SimulatorRunsList | None: The simulation run(s) with the given ID(s)
+            SimulationRun | SimulatorRunList | None: The simulation run(s) with the given ID(s)
         Examples:
             Retrieve a single simulation run by id:
                 >>> from cognite.client import CogniteClient
@@ -210,7 +219,7 @@ class SimulatorRunsAPI(APIClient):
         identifiers = IdentifierSequence.load(ids=ids)
         return self._retrieve_multiple(
             resource_cls=SimulationRun,
-            list_cls=SimulatorRunsList,
+            list_cls=SimulatorRunList,
             identifiers=identifiers,
             resource_path=self._RESOURCE_PATH,
         )
@@ -219,14 +228,14 @@ class SimulatorRunsAPI(APIClient):
     def create(self, run: SimulationRunWrite) -> SimulationRun: ...
 
     @overload
-    def create(self, run: Sequence[SimulationRunWrite]) -> SimulatorRunsList: ...
+    def create(self, run: Sequence[SimulationRunWrite]) -> SimulatorRunList: ...
 
-    def create(self, run: SimulationRunWrite | Sequence[SimulationRunWrite]) -> SimulationRun | SimulatorRunsList:
+    def create(self, run: SimulationRunWrite | Sequence[SimulationRunWrite]) -> SimulationRun | SimulatorRunList:
         """`Create simulation runs <https://developer.cognite.com/api#tag/Simulation-Runs/operation/filter_simulation_runs_simulators_runs_list_post>`_
         Args:
             run (SimulationRunWrite | Sequence[SimulationRunWrite]): The simulation run(s) to execute.
         Returns:
-            SimulationRun | SimulatorRunsList: Created simulation run(s)
+            SimulationRun | SimulatorRunList: Created simulation run(s)
         Examples:
             Create new simulation run:
                 >>> from cognite.client import CogniteClient
@@ -244,7 +253,7 @@ class SimulatorRunsAPI(APIClient):
         assert_type(run, "simulation_run", [SimulationRunWrite, Sequence])
 
         return self._create_multiple(
-            list_cls=SimulatorRunsList,
+            list_cls=SimulatorRunList,
             resource_cls=SimulationRun,
             items=run,
             input_resource_cls=SimulationRunWrite,

--- a/cognite/client/_api/simulators/runs.py
+++ b/cognite/client/_api/simulators/runs.py
@@ -1,14 +1,13 @@
 from __future__ import annotations
 
-from collections.abc import Iterator, Sequence
+from collections.abc import Iterator
 from typing import TYPE_CHECKING, overload
 
 from cognite.client._api_client import APIClient
 from cognite.client._constants import DEFAULT_LIMIT_READ
 from cognite.client.data_classes.simulators.filters import SimulatorRunsFilter
-from cognite.client.data_classes.simulators.runs import SimulationRun, SimulationRunWrite, SimulatorRunsList
+from cognite.client.data_classes.simulators.runs import SimulationRun, SimulatorRunsList
 from cognite.client.utils._experimental import FeaturePreviewWarning
-from cognite.client.utils._validation import assert_type
 from cognite.client.utils.useful_types import SequenceNotStr
 
 if TYPE_CHECKING:
@@ -182,38 +181,18 @@ class SimulatorRunsAPI(APIClient):
             filter=filter_runs.dump(),
         )
 
-    @overload
-    def create(self, run: SimulationRunWrite) -> SimulationRun: ...
-
-    @overload
-    def create(self, run: Sequence[SimulationRunWrite]) -> SimulatorRunsList: ...
-
-    def create(self, run: SimulationRunWrite | Sequence[SimulationRunWrite]) -> SimulationRun | SimulatorRunsList:
-        """`Create simulation runs <https://developer.cognite.com/api#tag/Simulation-Runs/operation/filter_simulation_runs_simulators_runs_list_post>`_
+    def retrieve(self, id: int) -> SimulationRun:
+        """`Retrieve a simulation run by ID <https://developer.cognite.com/api#tag/Simulation-Runs/operation/filter_simulation_runs_simulators_runs_list_post>`
         Args:
-            run (SimulationRunWrite | Sequence[SimulationRunWrite]): The simulation run(s) to execute.
+            id (int): ID of the simulation run
         Returns:
-            SimulationRun | SimulatorRunsList: Created simulation run(s)
+            SimulationRun: Requested simulation run
         Examples:
-            Create new simulation run:
+            Retrieve a single simulation run by id:
                 >>> from cognite.client import CogniteClient
-                >>> from cognite.client.data_classes.simulators.runs import SimulationRunWrite
                 >>> client = CogniteClient()
-                >>> run = [
-                ...     SimulationRunWrite(
-                ...         routine_external_id="routine1",
-                ...         log_severity="Debug",
-                ...         run_type="external",
-                ...     ),
-                ... ]
-                >>> res = client.simulators.runs.create(run)
+                >>> run = client.simulators.runs.retrieve(id=2)
         """
-        assert_type(run, "simulation_run", [SimulationRunWrite, Sequence])
-
-        return self._create_multiple(
-            list_cls=SimulatorRunsList,
-            resource_cls=SimulationRun,
-            items=run,
-            input_resource_cls=SimulationRunWrite,
-            resource_path=self._RESOURCE_PATH_RUN,
-        )
+        self._warning.warn()
+        res = self._post(url=self._RESOURCE_PATH+"byids", json={"items": [{"id": id}]})
+        return SimulationRun._load(res.json(), cognite_client=self._cognite_client)

--- a/cognite/client/_api/simulators/runs.py
+++ b/cognite/client/_api/simulators/runs.py
@@ -19,11 +19,18 @@ class SimulatorRunsAPI(APIClient):
     _RESOURCE_PATH = "/simulators/runs"
     _RESOURCE_PATH_RUN = "/simulators/run"
 
-    def __init__(self, config: ClientConfig, api_version: str | None, cognite_client: CogniteClient) -> None:
+    def __init__(
+        self,
+        config: ClientConfig,
+        api_version: str | None,
+        cognite_client: CogniteClient,
+    ) -> None:
         super().__init__(config, api_version, cognite_client)
         self._CREATE_LIMIT = 1
         self._warning = FeaturePreviewWarning(
-            api_maturity="General Availability", sdk_maturity="alpha", feature_name="Simulators"
+            api_maturity="General Availability",
+            sdk_maturity="alpha",
+            feature_name="Simulators",
         )
 
     def __iter__(self) -> Iterator[SimulationRun]:
@@ -194,5 +201,5 @@ class SimulatorRunsAPI(APIClient):
                 >>> run = client.simulators.runs.retrieve(id=2)
         """
         self._warning.warn()
-        res = self._post(url=self._RESOURCE_PATH+"byids", json={"items": [{"id": id}]})
+        res = self._post(url_path=self._RESOURCE_PATH + "byids", json={"items": [{"id": id}]})
         return SimulationRun._load(res.json(), cognite_client=self._cognite_client)

--- a/cognite/client/data_classes/simulators/__init__.py
+++ b/cognite/client/data_classes/simulators/__init__.py
@@ -18,7 +18,7 @@ from cognite.client.data_classes.simulators.runs import (
     SimulationRun,
     SimulationRunWrite,
     SimulationRunWriteList,
-    SimulatorRunsList,
+    SimulatorRunList,
 )
 from cognite.client.data_classes.simulators.simulators import (
     Simulator,
@@ -50,7 +50,7 @@ __all__ = [
     "SimulatorModelRevisionsFilter",
     "SimulatorModelWrite",
     "SimulatorModelsFilter",
-    "SimulatorRunsList",
+    "SimulatorRunList",
     "SimulatorStep",
     "SimulatorStepField",
     "SimulatorStepOption",

--- a/cognite/client/data_classes/simulators/runs.py
+++ b/cognite/client/data_classes/simulators/runs.py
@@ -223,11 +223,12 @@ class SimulationRun(SimulationRunCore):
         return self._cognite_client.simulators.logs.retrieve(id=self.log_id)
 
     def update(self) -> None:
-        """Update the simulation run object. Can be useful if the run was created with wait=False."""
+        """Update the simulation run object to the latest state. Useful if the run was created with wait=False."""
         # same logic as Cognite Functions
-        latest = self._cognite_client.simulators.runs.retrieve(id=self.id)
+        latest = self._cognite_client.simulators.runs.retrieve(ids=self.id)
         if latest is None:
             raise RuntimeError("Unable to update the simulation run object (it was not found)")
+        assert isinstance(latest, SimulationRun)
         self.status = latest.status
         self.status_message = latest.status_message
         self.simulation_time = latest.simulation_time
@@ -258,6 +259,7 @@ class SimulationRun(SimulationRunCore):
             status_message=resource.get("statusMessage"),
             run_time=resource.get("runTime"),
             simulation_time=resource.get("simulationTime"),
+            cognite_client=cognite_client,
         )
 
 

--- a/cognite/client/data_classes/simulators/runs.py
+++ b/cognite/client/data_classes/simulators/runs.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import time
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, Literal
+from typing import TYPE_CHECKING, Any, Literal, cast
 
 from typing_extensions import Self
 
@@ -161,6 +161,7 @@ class SimulationRun(SimulationRunCore):
         status_message (str | None): The status message of the simulation run
         simulation_time (int | None): Simulation time in milliseconds. Timestamp when the input data was sampled. Used for indexing input and output time series.
         run_time (int | None): Run time in milliseconds. Reference timestamp used for data pre-processing and data sampling.
+        cognite_client (CogniteClient | None): An optional CogniteClient to associate with this data class.
 
     """
 
@@ -183,6 +184,7 @@ class SimulationRun(SimulationRunCore):
         status_message: str | None = None,
         simulation_time: int | None = None,
         run_time: int | None = None,
+        cognite_client: CogniteClient | None = None,
     ) -> None:
         super().__init__(
             run_type=run_type,
@@ -203,6 +205,7 @@ class SimulationRun(SimulationRunCore):
         self.data_set_id = data_set_id
         self.user_id = user_id
         self.log_id = log_id
+        self._cognite_client = cast("CogniteClient", cognite_client)
 
     def as_write(self) -> SimulationRunWrite:
         return SimulationRunWrite(

--- a/cognite/client/data_classes/simulators/runs.py
+++ b/cognite/client/data_classes/simulators/runs.py
@@ -51,7 +51,7 @@ class SimulationInputOverride(CogniteObject):
         return cls(
             reference_id=resource["referenceId"],
             value=resource["value"],
-            unit=SimulationValueUnitName._load(resource["unit"], cognite_client) if resource.get("unit") else None,
+            unit=(SimulationValueUnitName._load(resource["unit"], cognite_client) if resource.get("unit") else None),
         )
 
     def __post_init__(self) -> None:
@@ -117,7 +117,7 @@ class SimulationRunWrite(SimulationRunCore):
             run_time=resource.get("runTime"),
             queue=resource.get("queue"),
             log_severity=resource.get("logSeverity"),
-            inputs=[SimulationInputOverride._load(_input) for _input in inputs] if inputs else None,
+            inputs=([SimulationInputOverride._load(_input) for _input in inputs] if inputs else None),
         )
 
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
@@ -211,11 +211,11 @@ class SimulationRun(SimulationRunCore):
             run_time=self.run_time,
         )
 
-    def get_logs(self) -> SimulatorLog:
+    def get_logs(self) -> SimulatorLog | None:
         """`Retrieve logs for this simulation run. <https://developer.cognite.com/api#tag/Simulator-Logs/operation/simulator_logs_by_ids_simulators_logs_byids_post>`_
 
         Returns:
-            SimulatorLog: Log for the simulation run.
+            SimulatorLog | None: Log for the simulation run.
         """
         return self._cognite_client.simulators.logs.retrieve(id=self.log_id)
 

--- a/cognite/client/data_classes/simulators/runs.py
+++ b/cognite/client/data_classes/simulators/runs.py
@@ -14,6 +14,7 @@ from cognite.client.data_classes._base import (
     WriteableCogniteResource,
     WriteableCogniteResourceList,
 )
+from cognite.client.data_classes.simulators.logs import SimulatorLog
 from cognite.client.utils._experimental import FeaturePreviewWarning
 
 if TYPE_CHECKING:
@@ -209,6 +210,14 @@ class SimulationRun(SimulationRunCore):
             run_type=self.run_type,
             run_time=self.run_time,
         )
+
+    def get_logs(self) -> SimulatorLog:
+        """`Retrieve logs for this simulation run. <https://developer.cognite.com/api#tag/Simulator-Logs/operation/simulator_logs_by_ids_simulators_logs_byids_post>`_
+
+        Returns:
+            SimulatorLog: Log for the simulation run.
+        """
+        return self._cognite_client.simulators.logs.retrieve(id=self.log_id)
 
     def update(self) -> None:
         """Update the simulation run object. Can be useful if the run was created with wait=False."""

--- a/cognite/client/data_classes/simulators/runs.py
+++ b/cognite/client/data_classes/simulators/runs.py
@@ -267,7 +267,7 @@ class SimulationRunWriteList(CogniteResourceList[SimulationRunWrite], ExternalID
     _RESOURCE = SimulationRunWrite
 
 
-class SimulatorRunsList(WriteableCogniteResourceList[SimulationRunWrite, SimulationRun], IdTransformerMixin):
+class SimulatorRunList(WriteableCogniteResourceList[SimulationRunWrite, SimulationRun], IdTransformerMixin):
     _RESOURCE = SimulationRun
 
     def as_write(self) -> SimulationRunWriteList:

--- a/cognite/client/data_classes/simulators/runs.py
+++ b/cognite/client/data_classes/simulators/runs.py
@@ -229,11 +229,11 @@ class SimulationRun(SimulationRunCore):
         latest = self._cognite_client.simulators.runs.retrieve(ids=self.id)
         if latest is None:
             raise RuntimeError("Unable to update the simulation run object (it was not found)")
-        assert isinstance(latest, SimulationRun)
-        self.status = latest.status
-        self.status_message = latest.status_message
-        self.simulation_time = latest.simulation_time
-        self.last_updated_time = latest.last_updated_time
+        else:
+            self.status = latest.status
+            self.status_message = latest.status_message
+            self.simulation_time = latest.simulation_time
+            self.last_updated_time = latest.last_updated_time
 
     def wait(self, timeout: float = 60) -> None:
         """Waits for simulation status to become either success or failure.

--- a/tests/tests_integration/test_api/test_simulators/test_routines.py
+++ b/tests/tests_integration/test_api/test_simulators/test_routines.py
@@ -43,13 +43,6 @@ class TestSimulatorRoutines:
             sort=PropertySort(order="asc", property="createdTime"),
         )
 
-        routines_desc = cognite_client.simulators.routines.list(
-            simulator_integration_external_ids=[simulator_integration_unique_external_id],
-            sort=PropertySort(order="desc", property="createdTime"),
-        )
-
-        assert len(routines_asc) > 0
-        assert len(routines_desc) > 0
-        assert len(routines_asc) == len(routines_desc)
-
-        assert routines_asc[0].external_id == routines_desc[-1].external_id
+        assert len(routines_asc) > 1
+        for i in range(1, len(routines_asc)):
+            assert routines_asc[i].created_time >= routines_asc[i - 1].created_time

--- a/tests/tests_integration/test_api/test_simulators/test_runs.py
+++ b/tests/tests_integration/test_api/test_simulators/test_runs.py
@@ -9,7 +9,7 @@ class TestSimulatorRuns:
         routine_external_id = seed_resource_names["simulator_routine_external_id"]
         runs_filtered_by_status = []
         for current_status in ["running", "success", "failure"]:
-            created_run = cognite_client.simulators.run(routine_external_id=routine_external_id)
+            created_run = cognite_client.simulators.routines.run(routine_external_id=routine_external_id)
 
             cognite_client.simulators._post(
                 "/simulators/run/callback",
@@ -35,7 +35,7 @@ class TestSimulatorRuns:
 
     def test_retrieve_run(self, cognite_client: CogniteClient, seed_resource_names) -> None:
         routine_external_id = seed_resource_names["simulator_routine_external_id"]
-        created_run = cognite_client.simulators.run(routine_external_id=routine_external_id)
+        created_run = cognite_client.simulators.routines.run(routine_external_id=routine_external_id)
         retrieved_run = cognite_client.simulators.runs.retrieve(id=created_run.id)
         assert created_run.id == retrieved_run.id
 
@@ -43,12 +43,12 @@ class TestSimulatorRuns:
         self, cognite_client: CogniteClient, seed_simulator_routine_revisions, seed_resource_names
     ) -> None:
         routine_external_id = seed_resource_names["simulator_routine_external_id"]
-        created_run = cognite_client.simulators.run(routine_external_id=routine_external_id)
+        created_run = cognite_client.simulators.routines.run(routine_external_id=routine_external_id)
         assert created_run.routine_external_id == routine_external_id
         assert created_run.id is not None
 
     def test_get_logs(self, cognite_client: CogniteClient, seed_resource_names) -> None:
         routine_external_id = seed_resource_names["simulator_routine_external_id"]
-        created_run = cognite_client.simulators.run(routine_external_id=routine_external_id)
+        created_run = cognite_client.simulators.routines.run(routine_external_id=routine_external_id)
         simulation_log = created_run.get_logs()
         assert simulation_log.id == created_run.log_id

--- a/tests/tests_integration/test_api/test_simulators/test_runs.py
+++ b/tests/tests_integration/test_api/test_simulators/test_runs.py
@@ -1,7 +1,6 @@
 import pytest
 
 from cognite.client._cognite_client import CogniteClient
-from cognite.client.data_classes.simulators.runs import SimulationRunWrite
 
 
 @pytest.mark.usefixtures("seed_resource_names", "seed_simulator_routine_revisions")

--- a/tests/tests_integration/test_api/test_simulators/test_runs.py
+++ b/tests/tests_integration/test_api/test_simulators/test_runs.py
@@ -87,6 +87,12 @@ class TestSimulatorRuns:
         retrieved_run = cognite_client.simulators.runs.retrieve(ids=created_run.id)
         assert created_run.id == retrieved_run.id
 
+        logs_res = retrieved_run.get_logs()
+        logs_res2 = cognite_client.simulators.logs.retrieve(id=created_run.log_id)
+
+        assert logs_res is not None
+        assert logs_res.dump() == logs_res2.dump()
+
     def test_create_run(
         self, cognite_client: CogniteClient, seed_simulator_routine_revisions, seed_resource_names
     ) -> None:

--- a/tests/tests_integration/test_api/test_simulators/test_runs.py
+++ b/tests/tests_integration/test_api/test_simulators/test_runs.py
@@ -10,21 +10,14 @@ class TestSimulatorRuns:
         routine_external_id = seed_resource_names["simulator_routine_external_id"]
         runs_filtered_by_status = []
         for current_status in ["running", "success", "failure"]:
-            created_runs = cognite_client.simulators.runs.create(
-                [
-                    SimulationRunWrite(
-                        run_type="external",
-                        routine_external_id=routine_external_id,
-                    )
-                ]
-            )
+            created_run = cognite_client.simulators.run(routine_external_id=routine_external_id)
 
             cognite_client.simulators._post(
                 "/simulators/run/callback",
                 json={
                     "items": [
                         {
-                            "id": created_runs[0].id,
+                            "id": created_run.id,
                             "status": current_status,
                         }
                     ]
@@ -41,18 +34,16 @@ class TestSimulatorRuns:
             filter_by_routine, key=lambda x: x["id"]
         )
 
+    def test_retrieve_run(self, cognite_client: CogniteClient, seed_resource_names) -> None:
+        routine_external_id = seed_resource_names["simulator_routine_external_id"]
+        created_run = cognite_client.simulators.run(routine_external_id=routine_external_id)
+        retrieved_run = cognite_client.simulators.runs.retrieve(id=created_run.id)
+        assert created_run.id == retrieved_run.id
+
     def test_create_run(
         self, cognite_client: CogniteClient, seed_simulator_routine_revisions, seed_resource_names
     ) -> None:
         routine_external_id = seed_resource_names["simulator_routine_external_id"]
-        created_runs = cognite_client.simulators.runs.create(
-            [
-                SimulationRunWrite(
-                    run_type="external",
-                    routine_external_id=routine_external_id,
-                )
-            ]
-        )
-        assert len(created_runs) == 1
-        assert created_runs[0].routine_external_id == routine_external_id
-        assert created_runs[0].id is not None
+        created_run = cognite_client.simulators.run(routine_external_id=routine_external_id)
+        assert created_run.routine_external_id == routine_external_id
+        assert created_run.id is not None

--- a/tests/tests_integration/test_api/test_simulators/test_runs.py
+++ b/tests/tests_integration/test_api/test_simulators/test_runs.py
@@ -47,3 +47,9 @@ class TestSimulatorRuns:
         created_run = cognite_client.simulators.run(routine_external_id=routine_external_id)
         assert created_run.routine_external_id == routine_external_id
         assert created_run.id is not None
+
+    def test_get_logs(self, cognite_client: CogniteClient, seed_resource_names) -> None:
+        routine_external_id = seed_resource_names["simulator_routine_external_id"]
+        created_run = cognite_client.simulators.run(routine_external_id=routine_external_id)
+        simulation_log = created_run.get_logs()
+        assert simulation_log.id == created_run.log_id

--- a/tests/tests_integration/test_api/test_simulators/test_runs.py
+++ b/tests/tests_integration/test_api/test_simulators/test_runs.py
@@ -1,7 +1,10 @@
+import asyncio
+import time
+
 import pytest
 
 from cognite.client._cognite_client import CogniteClient
-from cognite.client.data_classes.simulators.runs import SimulationRunWrite
+from cognite.client.data_classes.simulators.runs import SimulationRun, SimulationRunWrite
 
 
 @pytest.mark.usefixtures("seed_resource_names", "seed_simulator_routine_revisions")
@@ -41,10 +44,47 @@ class TestSimulatorRuns:
             filter_by_routine, key=lambda x: x["id"]
         )
 
-    def test_retrieve_run(self, cognite_client: CogniteClient, seed_resource_names) -> None:
+    @pytest.mark.asyncio
+    async def test_run_with_wait_and_retrieve(self, cognite_client: CogniteClient, seed_resource_names) -> None:
         routine_external_id = seed_resource_names["simulator_routine_external_id"]
-        created_run = cognite_client.simulators.routines.run(routine_external_id=routine_external_id)
-        retrieved_run = cognite_client.simulators.runs.retrieve(id=created_run.id)
+
+        run_task = asyncio.create_task(
+            asyncio.to_thread(lambda: cognite_client.simulators.routines.run(routine_external_id=routine_external_id))
+        )
+
+        run_to_update: SimulationRun | None = None
+        start_time = time.time()
+
+        # 1. Wait for the run to be created
+        # 2. Emulate it being finished by the simulator
+        while run_to_update is None and time.time() - start_time < 30:
+            runs_to_update = cognite_client.simulators.runs.list(
+                routine_external_ids=[routine_external_id],
+                status="ready",
+                limit=5,
+            )
+            if len(runs_to_update) == 1:
+                run_to_update = runs_to_update[0]
+            else:
+                await asyncio.sleep(1)
+
+        assert run_to_update is not None
+
+        cognite_client.simulators._post(
+            "/simulators/run/callback",
+            json={
+                "items": [
+                    {
+                        "id": run_to_update.id,
+                        "status": "success",
+                    }
+                ]
+            },
+        )
+
+        created_run = await run_task
+
+        retrieved_run = cognite_client.simulators.runs.retrieve(ids=created_run.id)
         assert created_run.id == retrieved_run.id
 
     def test_create_run(


### PR DESCRIPTION
## Description
Creating a new simulation run is a bit more complex than we would like it to be, for the basic use cases we would like to provide a way of running a single simulation in a simple way. It should be easy to wait syncronously for the simulation to finish and get logs when it fails.

- added a syntactic sugar to run the simulation via `routines.run()` that doesn't require creating s SimulationRunWrite object
- added retrieve for simulation runs
- added `SimulationRun.wait` so user can wait for the simulation to finish (similar to functions)
- syntactic sugar to read the logs of the run
- renamed `SimulatorRunsList` to `SimulatorRunList` for consistency, and other minor refactoring
- fixed a flaky test

NOTE: we have not officially released this part of the SDK yet, we wait for all resources to be in place before bumping the version/updating changelog / docs.

## Checklist:
- [x] Tests added/updated.
- [x] Documentation updated. Documentation is generated from docstrings - these must be updated according to your change.
  If a new method has been added it should be referenced in [cognite.rst](https://github.com/cognitedata/cognite-sdk-python/blob/master/docs/source/cognite.rst) in order to generate docs based on its docstring.
- [ ] Changelog updated in [CHANGELOG.md](https://github.com/cognitedata/cognite-sdk-python/blob/master/CHANGELOG.md).
- [ ] Version bumped. If triggering a new release is desired, bump the version number in [_version.py](https://github.com/cognitedata/cognite-sdk-python/blob/master/cognite/client/_version.py) and [pyproject.toml](https://github.com/cognitedata/cognite-sdk-python/blob/master/pyproject.toml) per [semantic versioning](https://semver.org/).
