### PR TITLE
fix(documents): add `instance_id` field to `Document` class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ Changes are grouped as follows
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
+## [7.75.1] - 2025-05-15
+### Fixed
+- Fixes missing `instance_id` field in `Document` class returned from `client.documents.list()` and `client.documents.search()`.
+
 ## [7.75.0] - 2025-04-22
 ### Added
 - Support for data modeling query set operations - union, unionAll, and intersection

--- a/cognite/client/_version.py
+++ b/cognite/client/_version.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
 
-__version__ = "7.75.0"
+__version__ = "7.75.1"
 
 __api_subversion__ = "20230101"

--- a/cognite/client/data_classes/documents.py
+++ b/cognite/client/data_classes/documents.py
@@ -18,6 +18,7 @@ from cognite.client.data_classes._base import (
 )
 from cognite.client.data_classes.aggregations import UniqueResult
 from cognite.client.data_classes.labels import Label, LabelDefinition
+from cognite.client.utils._identifier import InstanceId
 
 if TYPE_CHECKING:
     from cognite.client import CogniteClient
@@ -204,6 +205,7 @@ class Document(CogniteResource):
         created_time (int): The creation time of the document in CDF in milliseconds since Jan 1, 1970.
         source_file (SourceFile): The source file that this document is derived from.
         external_id (str | None): The external ID provided by the client. Must be unique for the resource type.
+        instance_id (InstanceId | None): No description.
         title (str | None): The title of the document.
         author (str | None): The author of the document.
         producer (str | None): The producer of the document. Many document types contain metadata indicating what software or system was used to create the document.
@@ -228,6 +230,7 @@ class Document(CogniteResource):
         created_time: int,
         source_file: SourceFile,
         external_id: str | None = None,
+        instance_id: InstanceId | None = None,
         title: str | None = None,
         author: str | None = None,
         producer: str | None = None,
@@ -249,6 +252,7 @@ class Document(CogniteResource):
         self.created_time = created_time
         self.source_file = source_file
         self.external_id = external_id
+        self.instance_id = instance_id
         self.title = title
         self.author = author
         self.producer = producer
@@ -272,6 +276,7 @@ class Document(CogniteResource):
             created_time=resource["createdTime"],
             source_file=SourceFile._load(resource["sourceFile"]),
             external_id=resource.get("externalId"),
+            instance_id=InstanceId.load_if(resource.get("instanceId")),
             title=resource.get("title"),
             author=resource.get("author"),
             producer=resource.get("producer"),
@@ -297,6 +302,8 @@ class Document(CogniteResource):
             output["labels"] = [label.dump(camel_case) for label in self.labels]
         if self.geo_location:
             output[("geoLocation" if camel_case else "geo_location")] = self.geo_location.dump(camel_case)
+        if self.instance_id:
+            output["instanceId" if camel_case else "instance_id"] = self.instance_id.dump(camel_case)
         return output
 
 

--- a/cognite/client/data_classes/documents.py
+++ b/cognite/client/data_classes/documents.py
@@ -205,7 +205,7 @@ class Document(CogniteResource):
         created_time (int): The creation time of the document in CDF in milliseconds since Jan 1, 1970.
         source_file (SourceFile): The source file that this document is derived from.
         external_id (str | None): The external ID provided by the client. Must be unique for the resource type.
-        instance_id (InstanceId | None): No description.
+        instance_id (InstanceId | None): The instance ID of the node this document is associated with.
         title (str | None): The title of the document.
         author (str | None): The author of the document.
         producer (str | None): The producer of the document. Many document types contain metadata indicating what software or system was used to create the document.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "cognite-sdk"
-version = "7.75.0"
+version = "7.75.1"
 
 description = "Cognite Python SDK"
 readme = "README.md"

--- a/tests/tests_unit/test_api/test_documents.py
+++ b/tests/tests_unit/test_api/test_documents.py
@@ -113,7 +113,7 @@ class TestDocumentsAPI:
         assert isinstance(file_wo_instance_id, Document)
         assert file_with_instance_id.instance_id is not None
         assert file_with_instance_id.instance_id.space == "demo-space"
-        assert file_with_instance_id.instance_id.external_id == "doc-001"
+        assert file_with_instance_id.instance_id.external_id == "7a05f794-d6b0-413a-a0ff-c03eb38d9e83"
         assert file_wo_instance_id.instance_id is None
         for i, doc in enumerate(documents):
             expected = mock_documents_response.calls[0].response.json()["items"][i]

--- a/tests/tests_unit/test_api/test_documents.py
+++ b/tests/tests_unit/test_api/test_documents.py
@@ -25,6 +25,10 @@ def mock_documents_response(rsps, cognite_client):
                     },
                 },
                 "externalId": "7a05f794-d6b0-413a-a0ff-c03eb38d9e83",
+                "instanceId": {
+                    "space": "demo-space",
+                    "externalId": "7a05f794-d6b0-413a-a0ff-c03eb38d9e83",
+                },
                 "title": "Sample Scanned Image",
                 "author": "Paperless 800-387-9001",
                 "producer": "Imaging Dept.",
@@ -49,7 +53,46 @@ def mock_documents_response(rsps, cognite_client):
                         },
                     ],
                 },
-            }
+            },
+            {
+                "id": 952558513813,
+                "sourceFile": {
+                    "name": "04.pdf",
+                    "source": "foo",
+                    "hash": "4ad0156942d1c26a4aa74fe6d52c082c6871b33b0e933f40566f6740fdae0ebb",
+                    "assetIds": [2728768807111995],
+                    "metadata": {"myKey": "myValue"},
+                    "geoLocation": {
+                        "type": "Polygon",
+                        "coordinates": [[[3.0, 1.0], [4.0, 4.0], [2.0, 4.0], [1.0, 2.0], [3.0, 1.0]]],
+                    },
+                },
+                "externalId": "7a05f794-d6b0-413a-a0ff-c03eb38d9e83",
+                "title": "Sample Scanned Image",
+                "author": "Paperless 800-387-9001",
+                "producer": "Imaging Dept.",
+                "mimeType": "application/pdf",
+                "extension": "pdf",
+                "pageCount": 1,
+                "type": "PDF",
+                "language": "en",
+                "truncatedContent": "test",
+                "assetIds": [2728768807111995, 7234953846172358],
+                "labels": [],
+                "createdTime": 1659617852965,
+                "modifiedTime": 970589816000,
+                "lastIndexedTime": 1707210718089,
+                "geoLocation": {
+                    "type": "GeometryCollection",
+                    "geometries": [
+                        {"type": "Point", "coordinates": [-2.3, 50.8]},
+                        {
+                            "type": "Polygon",
+                            "coordinates": [[[3.0, 1.0], [4.0, 4.0], [2.0, 4.0], [1.0, 2.0], [3.0, 1.0]]],
+                        },
+                    ],
+                },
+            },
         ]
     }
 
@@ -64,7 +107,14 @@ def mock_documents_response(rsps, cognite_client):
 class TestDocumentsAPI:
     def test_list(self, cognite_client, mock_documents_response):
         documents = cognite_client.documents.list()
-        assert len(documents) == 1
-        document = documents[0]
-        assert isinstance(document, Document)
-        assert mock_documents_response.calls[0].response.json()["items"][0] == document.dump(camel_case=True)
+        assert len(documents) == 2
+        file_with_instance_id, file_wo_instance_id = documents
+        assert isinstance(file_with_instance_id, Document)
+        assert isinstance(file_wo_instance_id, Document)
+        assert file_with_instance_id.instance_id is not None
+        assert file_with_instance_id.instance_id.space == "demo-space"
+        assert file_with_instance_id.instance_id.external_id == "doc-001"
+        assert file_wo_instance_id.instance_id is None
+        for i, doc in enumerate(documents):
+            expected = mock_documents_response.calls[0].response.json()["items"][i]
+            assert expected == doc.dump(camel_case=True)


### PR DESCRIPTION
## Description

`documents/search` and `documents/list` API endpoint may return instanceId as additional parameter in the response. The SDK [Document](https://github.com/cognitedata/cognite-sdk-python/blob/master/cognite/client/data_classes/documents.py#L198) class is currently missing this parameter.

## Checklist:
- [x] Tests added/updated.
- [x] Documentation updated. Documentation is generated from docstrings - these must be updated according to your change.
  If a new method has been added it should be referenced in [cognite.rst](https://github.com/cognitedata/cognite-sdk-python/blob/master/docs/source/cognite.rst) in order to generate docs based on its docstring.
- [x] Changelog updated in [CHANGELOG.md](https://github.com/cognitedata/cognite-sdk-python/blob/master/CHANGELOG.md).
- [x] Version bumped. If triggering a new release is desired, bump the version number in [_version.py](https://github.com/cognitedata/cognite-sdk-python/blob/master/cognite/client/_version.py) and [pyproject.toml](https://github.com/cognitedata/cognite-sdk-python/blob/master/pyproject.toml) per [semantic versioning](https://semver.org/).
