### PR TITLE
[typing, tests] Datetime accepts a tzinfo parameter, use this directly instead of unpacking

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,6 +33,7 @@ repos:
         entry: |
           poetry run dmypy run -- cognite tests/tests_integration/test_api/test_data_modeling
           tests/tests_unit/test_data_classes/test_data_models
+          tests/tests_unit/test_utils/test_time.py
         files: ^.*.(py|pyi)$
         language: system
         pass_filenames: false

--- a/poetry.lock
+++ b/poetry.lock
@@ -2352,6 +2352,17 @@ files = [
 ]
 
 [[package]]
+name = "types-pytz"
+version = "2025.2.0.20250516"
+description = "Typing stubs for pytz"
+optional = false
+python-versions = ">=3.9"
+files = [
+    {file = "types_pytz-2025.2.0.20250516-py3-none-any.whl", hash = "sha256:e0e0c8a57e2791c19f718ed99ab2ba623856b11620cb6b637e5f62ce285a7451"},
+    {file = "types_pytz-2025.2.0.20250516.tar.gz", hash = "sha256:e1216306f8c0d5da6dafd6492e72eb080c9a166171fa80dd7a1990fd8be7a7b3"},
+]
+
+[[package]]
 name = "types-pyyaml"
 version = "6.0.12.20241230"
 description = "Typing stubs for PyYAML"
@@ -2500,4 +2511,4 @@ yaml = ["PyYAML"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c66c329b375fe52969995f654375035e0b35bcd7e720e80266f10cb5cfcf12a4"
+content-hash = "c1a5ef3376dadbffa230a31dd9e8070dbb3261a56c50698f609f15c7b3826ece"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,6 +74,7 @@ IPython = ">=7.0.0"  # Used in docstring examples
 PyYAML = "^6.0"
 pytest-icdiff = "*"  # Used for better diffs in pytest
 types-simplejson = "^3.19.0.20240801"
+types-pytz = "^2025.2.0.20250516"
 
 [build-system]
 requires = ["poetry-core"]

--- a/tests/tests_unit/test_utils/test_time.py
+++ b/tests/tests_unit/test_utils/test_time.py
@@ -3,10 +3,10 @@ from __future__ import annotations
 import platform
 import re
 import time
-from collections.abc import Iterable
+from collections.abc import Generator, Iterable
 from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime, timedelta, timezone
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 from unittest import mock
 
 import pytest
@@ -56,7 +56,7 @@ if TYPE_CHECKING:
         ("18", timedelta(seconds=64800)),
     ),
 )
-def test_parse_str_timezone_offset(offset_inp, expected):
+def test_parse_str_timezone_offset(offset_inp: str, expected: timedelta) -> None:
     for pm in "+-":
         for prefix in ["", "UTC", "UT", "GMT"]:
             if not prefix and not offset_inp:
@@ -76,20 +76,20 @@ def test_parse_str_timezone_offset(offset_inp, expected):
         ("UTC+01:15", timezone(timedelta(seconds=4500))),
     ),
 )
-def test_parse_str_timezone(inp, expected):
+def test_parse_str_timezone(inp: str, expected: ZoneInfo) -> None:
     assert expected == parse_str_timezone(inp)
 
 
 class TestDatetimeToMsIsoTimestamp:
     @pytest.mark.skipif(platform.system() == "Windows", reason="Overriding timezone is too much hassle on Windows")
-    def test_timezone_unaware(self):
+    def test_timezone_unaware(self) -> None:
         input_datetime = datetime(2021, 1, 1, 0, 0, 0, 0)
         with tmp_set_envvar("TZ", "CET"):
             time.tzset()
             assert datetime_to_ms_iso_timestamp(input_datetime) == "2021-01-01T00:00:00.000+01:00"
 
     @pytest.mark.dsl
-    def test_timezone_cet(self):
+    def test_timezone_cet(self) -> None:
         input_datetime = datetime(2021, 1, 1, 0, 0, 0, 0, tzinfo=ZoneInfo("CET"))
         utc_datetime = input_datetime.astimezone(timezone.utc)
         assert datetime_to_ms_iso_timestamp(input_datetime) == "2021-01-01T00:00:00.000+01:00"
@@ -97,15 +97,15 @@ class TestDatetimeToMsIsoTimestamp:
 
     @pytest.mark.dsl
     @pytest.mark.skipif(platform.system() == "Windows", reason="Overriding timezone is too much hassle on Windows")
-    def test_timezone_cet_in_local_tz(self):
+    def test_timezone_cet_in_local_tz(self) -> None:
         input_datetime = datetime(2021, 1, 1, 0, 0, 0, 0, tzinfo=ZoneInfo("CET"))
         with tmp_set_envvar("TZ", "UTC"):
             time.tzset()
             assert datetime_to_ms_iso_timestamp(input_datetime) == "2021-01-01T00:00:00.000+01:00"
 
-    def test_incorrect_type(self):
+    def test_incorrect_type(self) -> None:
         with pytest.raises(TypeError, match="Expected datetime object, got <class 'str'>"):
-            datetime_to_ms_iso_timestamp("2021-01-01T00:00:00.000")
+            datetime_to_ms_iso_timestamp("2021-01-01T00:00:00.000")  # type: ignore[arg-type]
 
 
 class TestDatetimeToMs:
@@ -118,14 +118,14 @@ class TestDatetimeToMs:
             ("America/Los_Angeles", 1517385600000),
         ],
     )
-    def test_naive_datetime_to_ms_unix(self, local_tz, expected_ms):
+    def test_naive_datetime_to_ms_unix(self, local_tz: str, expected_ms: int) -> None:
         with tmp_set_envvar("TZ", local_tz):
             time.tzset()
             assert datetime_to_ms(datetime(2018, 1, 31, tzinfo=None)) == expected_ms
             assert timestamp_to_ms(datetime(2018, 1, 31, tzinfo=None)) == expected_ms
 
     @pytest.mark.skipif(platform.system() != "Windows", reason="Windows is typically unable to handle negative epochs.")
-    def test_naive_datetime_to_ms_windows(self):
+    def test_naive_datetime_to_ms_windows(self) -> None:
         with pytest.raises(
             ValueError,
             match="Failed to convert datetime to epoch. "
@@ -134,29 +134,29 @@ class TestDatetimeToMs:
         ):
             datetime_to_ms(datetime(1925, 8, 3))
 
-    def test_aware_datetime_to_ms(self):
+    def test_aware_datetime_to_ms(self) -> None:
         utc = timezone.utc
         assert datetime_to_ms(datetime(2018, 1, 31, tzinfo=utc)) == 1517356800000
         assert datetime_to_ms(datetime(2018, 1, 31, 11, 11, 11, tzinfo=utc)) == 1517397071000
         assert datetime_to_ms(datetime(100, 1, 31, tzinfo=utc)) == -59008867200000
 
-    def test_aware_datetime_to_ms_zoneinfo(self):
+    def test_aware_datetime_to_ms_zoneinfo(self) -> None:
         # The correct answer was obtained using: https://dencode.com/en/date/unix-time
         assert datetime_to_ms(datetime(2018, 1, 31, tzinfo=ZoneInfo("Europe/Oslo"))) == 1517353200000
         assert datetime_to_ms(datetime(1900, 1, 1, tzinfo=ZoneInfo("Europe/Oslo"))) == -2208992400000
         assert datetime_to_ms(datetime(1900, 1, 1, tzinfo=ZoneInfo("America/New_York"))) == -2208970800000
         assert datetime_to_ms(datetime(2020, 10, 31, 12, tzinfo=ZoneInfo("America/Los_Angeles"))) == 1604170800000
 
-    def test_ms_to_datetime__valid_input(self):  # TODO: Many tests here could benefit from parametrize
+    def test_ms_to_datetime__valid_input(self) -> None:  # TODO: Many tests here could benefit from parametrize
         utc = timezone.utc
         assert ms_to_datetime(1517356800000) == datetime(2018, 1, 31, tzinfo=utc)
         assert ms_to_datetime(1517397071000) == datetime(2018, 1, 31, 11, 11, 11, tzinfo=utc)
         assert ms_to_datetime(MIN_TIMESTAMP_MS) == datetime(1900, 1, 1, 0, 0, tzinfo=utc)
         assert ms_to_datetime(MAX_TIMESTAMP_MS) == datetime(2099, 12, 31, 23, 59, 59, 999000, tzinfo=utc)
 
-    def test_ms_to_datetime__bad_input(self):
+    def test_ms_to_datetime__bad_input(self) -> None:
         with pytest.raises(TypeError):
-            ms_to_datetime(None)
+            ms_to_datetime(None)  # type: ignore[arg-type]
         err_msg = "Input ms={} does not satisfy: -2208988800000 <= ms <= 4102444799999"
         too_low, too_high = MIN_TIMESTAMP_MS - 1, MAX_TIMESTAMP_MS + 1
         with pytest.raises(ValueError, match=re.escape(err_msg.format(too_low))):
@@ -167,17 +167,17 @@ class TestDatetimeToMs:
 
 class TestTimestampToMs:
     @pytest.mark.parametrize("t", [None, [], {}])
-    def test_invalid_type(self, t):
+    def test_invalid_type(self, t: Any) -> None:
         with pytest.raises(TypeError, match="must be"):
             timestamp_to_ms(t)
 
-    def test_ms(self):
+    def test_ms(self) -> None:
         assert 1514760000000 == timestamp_to_ms(1514760000000)
         assert 1514764800000 == timestamp_to_ms(1514764800000)
         assert -1514764800000 == timestamp_to_ms(-1514764800000)
 
     @pytest.mark.skipif(platform.system() == "Windows", reason="Overriding timezone is too much hassle on Windows")
-    def test_datetime(self):
+    def test_datetime(self) -> None:
         # Note: See also `TestDatetimeToMs.test_naive_datetime_to_ms`
         with tmp_set_envvar("TZ", "UTC"):
             time.tzset()
@@ -186,7 +186,7 @@ class TestTimestampToMs:
             assert MIN_TIMESTAMP_MS == timestamp_to_ms(datetime(1900, 1, 1))
             assert MAX_TIMESTAMP_MS == timestamp_to_ms(datetime(2100, 1, 1)) - 1
 
-    def test_float(self):
+    def test_float(self) -> None:
         assert 1514760000000 == timestamp_to_ms(1514760000000.0)
         assert 1514764800000 == timestamp_to_ms(1514764800000.0)
         assert -1514764800000 == timestamp_to_ms(-1514764800000.0)
@@ -218,17 +218,16 @@ class TestTimestampToMs:
             ("13w-ahead", 10**12 + 13 * 7 * 24 * 60 * 60 * 1000),
         ],
     )
-    def test_time_shift(self, time_mock, time_shift_string, expected_timestamp):
+    def test_time_shift(self, time_mock: mock.MagicMock, time_shift_string: str, expected_timestamp: int) -> None:
         time_mock.return_value = 10**9
-
         assert timestamp_to_ms(time_shift_string) == expected_timestamp
 
     @pytest.mark.parametrize("time_shift_string", ["1s", "4h", "13m-ag", "13m-ahe", "13m ago", "13m ahead", "bla"])
-    def test_invalid(self, time_shift_string):
+    def test_invalid(self, time_shift_string: str) -> None:
         with pytest.raises(ValueError, match=time_shift_string):
             timestamp_to_ms(time_shift_string)
 
-    def test_time_shift_real_time(self):
+    def test_time_shift_real_time(self) -> None:
         expected_time_now = datetime.now().timestamp() * 1000
         time_now = timestamp_to_ms("now")
         assert abs(expected_time_now - time_now) < 15
@@ -239,7 +238,7 @@ class TestTimestampToMs:
         assert abs(expected_time_now - time_now) > 190
 
     @pytest.mark.parametrize("t", [MIN_TIMESTAMP_MS - 1, datetime(1899, 12, 31, tzinfo=timezone.utc), "100000000w-ago"])
-    def test_negative(self, t):
+    def test_negative(self, t: int | float | str | datetime) -> None:
         with pytest.raises(ValueError, match="must represent a time after 1.1.1900"):
             timestamp_to_ms(t)
 
@@ -279,11 +278,11 @@ class TestGranularityToMs:
             ("13d", 13 * 24 * 60 * 60 * 1000),
         ],
     )
-    def test_to_ms(self, granularity, expected_ms):
+    def test_to_ms(self, granularity: str, expected_ms: int) -> None:
         assert granularity_to_ms(granularity) == expected_ms
 
     @pytest.mark.parametrize("granularity", ["2w", "-3h", "13m-ago", "13", "bla"])
-    def test_to_ms_invalid(self, granularity):
+    def test_to_ms_invalid(self, granularity: str) -> None:
         with pytest.raises(ValueError, match=granularity):
             granularity_to_ms(granularity)
 
@@ -300,11 +299,11 @@ class TestGranularityToMs:
             ("13d", 1 * 24 * 60 * 60 * 1000),
         ],
     )
-    def test_to_ms_as_unit(self, granularity, expected_ms):
+    def test_to_ms_as_unit(self, granularity: str, expected_ms: int) -> None:
         assert granularity_to_ms(granularity, as_unit=True) == expected_ms
 
     @pytest.mark.parametrize("granularity", ["2w", "-3h", "13m-ago", "13", "bla"])
-    def test_to_ms_as_unit_invalid(self, granularity):
+    def test_to_ms_as_unit_invalid(self, granularity: str) -> None:
         with pytest.raises(ValueError, match=rf"Invalid granularity format: `{granularity}`"):
             granularity_to_ms(granularity, as_unit=True)
 
@@ -332,16 +331,16 @@ class TestObjectTimeConversion:
             ([{"created_time": int(1e15)}], [{"created_time": int(1e15)}]),
         ],
     )
-    def test_convert_and_isoformat_time_attrs(self, item, expected_output):
+    def test_convert_and_isoformat_time_attrs(self, item: dict[str, int], expected_output: dict[str, str]) -> None:
         assert expected_output == convert_and_isoformat_time_attrs(item)
 
 
 class TestSplitTimeDomain:
-    def test_split_time_range__zero_splits(self):
+    def test_split_time_range__zero_splits(self) -> None:
         with pytest.raises(ValueError, match="Cannot split"):
             split_time_range(-100, 100, 0, 1)
 
-    def test_split_time_range__too_large_delta_ms(self):
+    def test_split_time_range__too_large_delta_ms(self) -> None:
         with pytest.raises(ValueError, match="is larger than the interval itself"):
             split_time_range(-100, 100, 1, 201)
 
@@ -354,7 +353,7 @@ class TestSplitTimeDomain:
             (4, [-100, -50, 0, 50, 100]),
         ],
     )
-    def test_split_time_range__raw_granularity(self, n_splits, expected):
+    def test_split_time_range__raw_granularity(self, n_splits: int, expected: list[int]) -> None:
         assert expected == split_time_range(-100, 100, n_splits, 1)
 
     @pytest.mark.parametrize(
@@ -366,7 +365,7 @@ class TestSplitTimeDomain:
             (1, "1d", 950400000),
         ],
     )
-    def test_split_time_range__agg_granularity(self, n_splits, granularity, expected):
+    def test_split_time_range__agg_granularity(self, n_splits: int, granularity: str, expected: int) -> None:
         one_day_ms, gran_ms = 86_400_000, granularity_to_ms(granularity)
         res = split_time_range(-2 * one_day_ms, 9 * one_day_ms, n_splits, gran_ms)
         assert n_splits == len(res) - 1
@@ -377,7 +376,7 @@ class TestSplitTimeDomain:
 
 class TestAlignToGranularity:
     @pytest.mark.parametrize("granularity", ["2s", "3m", "4h", "5d"])
-    def test_exactly_on_granularity_boundary(self, granularity):
+    def test_exactly_on_granularity_boundary(self, granularity: str) -> None:
         gran_ms = granularity_to_ms(granularity)
         start, end = gran_ms, 2 * gran_ms
         assert start, end == align_start_and_end_for_granularity(start, end, granularity)
@@ -391,7 +390,7 @@ class TestAlignToGranularity:
             ("5d", (345600000, 1209600000)),
         ],
     )
-    def test_start_not_on_granularity_boundary(self, granularity, expected):
+    def test_start_not_on_granularity_boundary(self, granularity: str, expected: tuple[int, int]) -> None:
         gran_ms = granularity_to_ms(granularity)
         start, end = gran_ms - 1, 2 * gran_ms
         assert expected == align_start_and_end_for_granularity(start, end, granularity)
@@ -414,14 +413,14 @@ class TestAlignToGranularity:
     )
     def test_align_with_granularity(
         start: datetime, end: datetime, granularity: str, expected_start: datetime, expected_end: datetime
-    ):
+    ) -> None:
         actual_start, actual_end = align_large_granularity(start, end, granularity)
 
         assert actual_start == expected_start, "Start is not aligning"
         assert actual_end == expected_end, "End is not aligning"
 
 
-def cdf_aggregate_test_data():
+def cdf_aggregate_test_data() -> Generator[ParameterSet, Any, list[object] | None]:
     try:
         import pandas as pd
     except ModuleNotFoundError:
@@ -438,6 +437,8 @@ def cdf_aggregate_test_data():
         id="1week aggregation",
     )
 
+    return None
+
 
 class TestCDFAggregation:
     @staticmethod
@@ -445,7 +446,7 @@ class TestCDFAggregation:
     @pytest.mark.parametrize("start, end, raw_freq, granularity, expected_aggregate", list(cdf_aggregate_test_data()))
     def test_cdf_aggregation(
         start: str, end: str, raw_freq: str, granularity: str, expected_aggregate: pandas.DataFrame
-    ):
+    ) -> None:
         import pandas as pd
 
         index = pd.date_range(start, end, freq=raw_freq)
@@ -592,7 +593,7 @@ class TestToFixedUTCIntervals:
     )
     def test_to_fixed_utc_intervals(
         start: datetime, end: datetime, granularity: str, expected_intervals: list[dict[str, int | str]]
-    ):
+    ) -> None:
         actual_intervals = to_fixed_utc_intervals(start, end, granularity)
 
         assert actual_intervals == expected_intervals
@@ -696,14 +697,14 @@ class TestValidateTimeZone:
     @staticmethod
     @pytest.mark.dsl
     @pytest.mark.parametrize("start, end, expected_message", validate_time_zone_invalid_arguments_data())
-    def test_raise_value_error_invalid_arguments(start: datetime, end: datetime, expected_message: str):
+    def test_raise_value_error_invalid_arguments(start: datetime, end: datetime, expected_message: str) -> None:
         with pytest.raises(ValueError, match=expected_message):
             _ = validate_timezone(start, end)
 
     @staticmethod
     @pytest.mark.dsl
     @pytest.mark.parametrize("start, end, expected_tz", validate_time_zone_valid_arguments_data())
-    def test_infer_timezone(start: datetime, end: datetime, expected_tz):
+    def test_infer_timezone(start: datetime, end: datetime, expected_tz: ZoneInfo) -> None:
         actual_tz = validate_timezone(start, end)
 
         assert isinstance(actual_tz, ZoneInfo)
@@ -731,13 +732,13 @@ class TestToPandasFreq:
             ("2weeks", "2023-01-02", "2023-01-16"),
         ],
     )
-    def test_to_pandas_freq(granularity: str, start: str, expected_first_step: str):
+    def test_to_pandas_freq(granularity: str, start: str, expected_first_step: str) -> None:
         import pandas as pd
 
-        start = pd.Timestamp(start)
+        start_ts = pd.Timestamp(start)
         expected_index = pd.DatetimeIndex([start, expected_first_step])
 
-        freq = to_pandas_freq(granularity, start.to_pydatetime())
+        freq = to_pandas_freq(granularity, start_ts.to_pydatetime())
 
         actual_index = pd.date_range(start, periods=2, freq=freq)
         pd.testing.assert_index_equal(actual_index, expected_index)
@@ -746,7 +747,7 @@ class TestToPandasFreq:
 class TestPandasDateRangeTz:
     @staticmethod
     @pytest.mark.dsl
-    def test_pandas_date_range_tz_ambiguous_time_error():
+    def test_pandas_date_range_tz_ambiguous_time_error() -> None:
         oslo = ZoneInfo("Europe/Oslo")
         start = datetime(1916, 8, 1, tzinfo=oslo)
         end = datetime(1916, 12, 1, tzinfo=oslo)
@@ -776,10 +777,10 @@ class TestDateTimeAligner:
             (datetime(2023, 11, 2), datetime(2023, 12, 1)),
         ),
     )
-    def test_month_aligner__ceil(self, dt, expected):
+    def test_month_aligner__ceil(self, dt: datetime, expected: datetime) -> None:
         assert expected == MonthAligner.ceil(dt)
 
-    def test_month_aligner_ceil__invalid_date(self):
+    def test_month_aligner_ceil__invalid_date(self) -> None:
         with pytest.raises(ValueError, match="^day is out of range for month$"):
             MonthAligner.add_units(datetime(2023, 7, 31), 2)  # sept has 30 days
 
@@ -795,23 +796,23 @@ class TestDateTimeAligner:
             (datetime(2024, 1, 15), -1, datetime(2023, 12, 15)),
         ),
     )
-    def test_month_aligner__add_unites(self, dt, n_units, expected):
+    def test_month_aligner__add_unites(self, dt: datetime, n_units: int, expected: datetime) -> None:
         assert expected == MonthAligner.add_units(dt, n_units)
 
-    def test_month_aligner_add_unites__invalid_date(self):
+    def test_month_aligner_add_unites__invalid_date(self) -> None:
         with pytest.raises(ValueError, match="^day is out of range for month$"):
             MonthAligner.add_units(datetime(2023, 1, 29), 1)  # 2023 = non-leap year
 
 
 class TestTimedCache:
-    def test_is_thread_safe(self):
+    def test_is_thread_safe(self) -> None:
         hello = []
 
         @timed_cache(ttl=2)
-        def the_function(i):
+        def the_function(i: int) -> None:
             hello.append(i)
 
-        def entry(i):
+        def entry(i: int) -> int:
             the_function(i)
             return i
 


### PR DESCRIPTION
## Description

I had many typing errors in this file, so I decided to fix it. There is no new release or change in documentation; this is purely a change in tests.

We were constructing a dictionary with a single key `tzinfo` and then unpacking it for every call to datetime. The type linter complains that it does not recognize that this dict contains the `tzinfo` key, so it might as well be set explicitly.
 
## Checklist:
- [x] Tests added/updated.
