### PR TITLE
Add argument to use instance IDs as column names in insert dataframe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@ Changes are grouped as follows
 ### Fixed
 - Fixes type annotations for Functions API. Adds new `FunctionHandle` type for annotating function handles.
 
+## [7.76.0] - 2025-05-15
+### Added
+- When ingesting datapoints, `insert_dataframe` now accepts instance IDs as column names.
+
 ## [7.75.1] - 2025-05-15
 ### Fixed
 - Fixes missing `instance_id` field in `Document` class returned from `client.documents.list()` and `client.documents.search()`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ Changes are grouped as follows
 
 ## [7.76.0] - 2025-05-15
 ### Added
-- When ingesting datapoints, `insert_dataframe` now accepts instance IDs as column names.
+- When ingesting datapoints, `insert_dataframe` now accepts instance IDs as column names when `instance_id_headers` is `True`. Note, in th next major release of the SDK, the behaviour of the column names will change and the ID type of the column will be determined based on the type of the column name. E.g. if the column name is of type `NodeId` it will automatically be interpreted as instance ID.
 
 ## [7.75.1] - 2025-05-15
 ### Fixed

--- a/cognite/client/_api/datapoints.py
+++ b/cognite/client/_api/datapoints.py
@@ -2290,7 +2290,7 @@ class DatapointsAPI(APIClient):
                     dps.append({"datapoints": datapoints, "instanceId": NodeId.load(column_id)})
                 else:
                     raise ValueError(
-                        f"Could not find instance Ids in the coulnm header. InstanceId are given as NodeId or tuple. Got {type(column_id)}"
+                        f"Could not find instance IDs in the column header. InstanceId are given as NodeId or tuple. Got {type(column_id)}"
                     )
             else:
                 dps.append({"datapoints": datapoints, "id": int(column_id)})

--- a/cognite/client/_api/datapoints.py
+++ b/cognite/client/_api/datapoints.py
@@ -2245,7 +2245,7 @@ class DatapointsAPI(APIClient):
             df (pd.DataFrame):  Pandas DataFrame object containing the time series.
             external_id_headers (bool): Interpret the column names as external IDs. Pass False if using IDs or instance IDs. Default: True.
             dropna (bool): Set to True to ignore NaNs in the given DataFrame, applied per column. Default: True.
-            instance_id_headers (bool): No description.
+            instance_id_headers (bool): Interpret the column names as instance IDs. Can either be `NodeId` objects or tuples of (space, external_id). Note, in th next major release of the SDK, the behaviour of the column names will change and the ID type of the column will be determined based on the type of the column name. Default: False.
 
         Warning:
             You can not insert datapoints with status codes using this method (``insert_dataframe``), you'll need

--- a/cognite/client/_api/datapoints.py
+++ b/cognite/client/_api/datapoints.py
@@ -2286,10 +2286,12 @@ class DatapointsAPI(APIClient):
             if external_id_headers:
                 dps.append({"datapoints": datapoints, "externalId": column_id})
             elif instance_id_headers:
-                if isinstance(column_id, NodeId):
-                    dps.append({"datapoints": datapoints, "instanceId": column_id})
-                elif isinstance(column_id, tuple):
+                if isinstance(column_id, NodeId | tuple):
                     dps.append({"datapoints": datapoints, "instanceId": NodeId.load(column_id)})
+                else:
+                    raise ValueError(
+                        f"Could not find instance Ids in the coulnm header. InstanceId are given as NodeId or tuple. Got {type(column_id)}"
+                    )
             else:
                 dps.append({"datapoints": datapoints, "id": int(column_id)})
         self.insert_multiple(dps)

--- a/cognite/client/_version.py
+++ b/cognite/client/_version.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
 
-__version__ = "7.75.1"
+__version__ = "7.76.0"
 
 __api_subversion__ = "20230101"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "cognite-sdk"
-version = "7.75.1"
+version = "7.76.0"
 
 description = "Cognite Python SDK"
 readme = "README.md"

--- a/tests/tests_unit/test_api/test_datapoints.py
+++ b/tests/tests_unit/test_api/test_datapoints.py
@@ -684,6 +684,23 @@ class TestPandasIntegration:
         ):
             cognite_client.time_series.data.insert_dataframe(df, instance_id_headers=True)
 
+    def test_insert_dataframe_malformed_instance_ids(self, cognite_client: CogniteClient):
+        import pandas as pd
+
+        timestamps = [1500000000000, 1510000000000, 1520000000000, 1530000000000]
+        index = pd.to_datetime(timestamps, unit="ms")
+        df = pd.DataFrame({"123": [1, 2, 3, 4], "456": [5.0, 6.0, 7.0, 8.0]}, index=index)
+        with pytest.raises(
+            ValueError,
+            match="Could not find instance IDs in the column header. InstanceId are given as NodeId or tuple. Got <class 'str'>",
+        ):
+            cognite_client.time_series.data.insert_dataframe(df, external_id_headers=False, instance_id_headers=True)
+
+        df = pd.DataFrame({(123,): [1, 2, 3, 4], (456,): [5.0, 6.0, 7.0, 8.0]}, index=index)
+        # TODO: NodeId does not give a correct error message when tuples have the wrong number of elements. This should be fixed in the NodeId class.
+        with pytest.raises(KeyError):
+            cognite_client.time_series.data.insert_dataframe(df, external_id_headers=False, instance_id_headers=True)
+
     def test_insert_dataframe_with_nans(self, cognite_client):
         import pandas as pd
 

--- a/tests/tests_unit/test_api/test_datapoints.py
+++ b/tests/tests_unit/test_api/test_datapoints.py
@@ -13,6 +13,7 @@ import cognite.client._api.datapoints as dps_api  # for mocking
 from cognite.client import CogniteClient
 from cognite.client._api.datapoints import _InsertDatapoint
 from cognite.client.data_classes import Datapoint, Datapoints, DatapointsList, LatestDatapointQuery
+from cognite.client.data_classes.data_modeling import NodeId
 from cognite.client.exceptions import CogniteAPIError, CogniteNotFoundError
 from cognite.client.utils import _json
 from cognite.client.utils._time import ZoneInfo, granularity_to_ms
@@ -642,6 +643,46 @@ class TestPandasIntegration:
                 },
             ]
         } == request_body
+
+    @pytest.mark.parametrize(
+        "instance_ids", [(NodeId("space", "123"), NodeId("space", "456")), (("space", "123"), ("space", "456"))]
+    )
+    def test_insert_dataframe_instance_ids(
+        self, cognite_client: CogniteClient, mock_post_datapoints, instance_ids: tuple
+    ):
+        import pandas as pd
+
+        timestamps = [1500000000000, 1510000000000, 1520000000000, 1530000000000]
+        df = pd.DataFrame(
+            {instance_ids[0]: [1, 2, 3, 4], instance_ids[1]: [5.0, 6.0, 7.0, 8.0]},
+            index=pd.to_datetime(timestamps, unit="ms"),
+        )
+        res = cognite_client.time_series.data.insert_dataframe(df, external_id_headers=False, instance_id_headers=True)
+        assert res is None
+        request_body = jsgz_load(mock_post_datapoints.calls[0].request.body)
+        assert {
+            "items": [
+                {
+                    "instanceId": {"externalId": "123", "space": "space"},
+                    "datapoints": [{"timestamp": ts, "value": val} for ts, val in zip(timestamps, range(1, 5))],
+                },
+                {
+                    "instanceId": {"externalId": "456", "space": "space"},
+                    "datapoints": [{"timestamp": ts, "value": float(val)} for ts, val in zip(timestamps, range(5, 9))],
+                },
+            ]
+        } == request_body
+
+    def test_insert_dataframe_external_ids_and_instance_ids(self, cognite_client: CogniteClient):
+        import pandas as pd
+
+        timestamps = [1500000000000, 1510000000000, 1520000000000, 1530000000000]
+        index = pd.to_datetime(timestamps, unit="ms")
+        df = pd.DataFrame({"123": [1, 2, 3, 4], "456": [5.0, 6.0, 7.0, 8.0]}, index=index)
+        with pytest.raises(
+            ValueError, match="`instance_id_headers` and `external_id_headers` cannot be used at the same time."
+        ):
+            cognite_client.time_series.data.insert_dataframe(df, instance_id_headers=True)
 
     def test_insert_dataframe_with_nans(self, cognite_client):
         import pandas as pd


### PR DESCRIPTION
## Description
The `insert_dataframe` methods does not accept instance IDs as column names. This PR adds this ability.

It adds the ability for the column names both to be of type `NodeId` or `tuple`. Dictionary style instnace IDs will not work as they are not hashable.

## Checklist:
- [x] Tests added/updated.
- [x] Documentation updated. Documentation is generated from docstrings - these must be updated according to your change.
  If a new method has been added it should be referenced in [cognite.rst](https://github.com/cognitedata/cognite-sdk-python/blob/master/docs/source/cognite.rst) in order to generate docs based on its docstring.
- [x] Changelog updated in [CHANGELOG.md](https://github.com/cognitedata/cognite-sdk-python/blob/master/CHANGELOG.md).
- [x] Version bumped. If triggering a new release is desired, bump the version number in [_version.py](https://github.com/cognitedata/cognite-sdk-python/blob/master/cognite/client/_version.py) and [pyproject.toml](https://github.com/cognitedata/cognite-sdk-python/blob/master/pyproject.toml) per [semantic versioning](https://semver.org/).
