### PR TITLE
Make run time and simulation time Pandas timestamps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@ Changes are grouped as follows
 ### Fixed
 - Fixes type annotations for Functions API. Adds new `FunctionHandle` type for annotating function handles.
 
+## [7.76.0] - 2025-06-12
+### Changed
+- When listing simalation runs and converting the result to a Pandas dataframe, the `simulation_time` and `run_time` columns now have type `pd.Timestamp`.
+
 ## [7.75.1] - 2025-05-15
 ### Fixed
 - Fixes missing `instance_id` field in `Document` class returned from `client.documents.list()` and `client.documents.search()`.

--- a/cognite/client/_version.py
+++ b/cognite/client/_version.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
 
-__version__ = "7.75.1"
+__version__ = "7.76.0"
 
 __api_subversion__ = "20230101"

--- a/cognite/client/utils/_time.py
+++ b/cognite/client/utils/_time.py
@@ -305,6 +305,8 @@ TIME_ATTRIBUTES = {
     "start_time",
     "timestamp",
     "uploaded_time",
+    "run_time",
+    "simulation_time",
 }
 TIME_ATTRIBUTES |= set(map(to_camel_case, TIME_ATTRIBUTES))
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "cognite-sdk"
-version = "7.75.1"
+version = "7.76.0"
 
 description = "Cognite Python SDK"
 readme = "README.md"

--- a/tests/tests_unit/test_api/test_simulators/test_run_data.py
+++ b/tests/tests_unit/test_api/test_simulators/test_run_data.py
@@ -104,6 +104,7 @@ class TestSimulationRunDataItemPandasIntegration:
         pd.testing.assert_frame_equal(df, expected_df)
 
 
+@pytest.mark.dsl
 class TestRunsPandasIntegration:
     def test_run_and_run_list_to_pandas(self):
         import pandas as pd

--- a/tests/tests_unit/test_api/test_simulators/test_run_data.py
+++ b/tests/tests_unit/test_api/test_simulators/test_run_data.py
@@ -3,8 +3,10 @@ import pytest
 from cognite.client.data_classes.simulators.runs import (
     SimulationInput,
     SimulationOutput,
+    SimulationRun,
     SimulationRunDataItem,
     SimulationValueUnitName,
+    SimulatorRunList,
 )
 
 
@@ -100,3 +102,41 @@ class TestSimulationRunDataItemPandasIntegration:
 
         expected_df = pd.DataFrame(expected_data_rows)
         pd.testing.assert_frame_equal(df, expected_df)
+
+
+class TestRunsPandasIntegration:
+    def test_run_and_run_list_to_pandas(self):
+        import pandas as pd
+
+        # Create a sample SimulationRun
+        expected_data = {
+            "run_type": "external",
+            "run_time": 1760000000000,
+            "routine_external_id": "routine",
+            "id": 123,
+            "created_time": 1700000000000,
+            "last_updated_time": 1800000000000,
+            "simulator_external_id": "simulator",
+            "simulator_integration_external_id": "sim_integration",
+            "model_external_id": "model",
+            "model_revision_external_id": "model_revision",
+            "routine_revision_external_id": "routine_revision",
+            "simulation_time": 1750000000000,
+            "status": "ready",
+            "data_set_id": 456,
+            "user_id": "user",
+            "log_id": 789,
+        }
+        run = SimulationRun(**expected_data)
+        run_df = run.to_pandas()
+        run_list_df = SimulatorRunList([run]).to_pandas()
+
+        # Assertions
+        for key in ["run_time", "created_time", "last_updated_time", "simulation_time"]:
+            expected_data[key] = pd.to_datetime(expected_data[key], unit="ms")
+        expected_df = pd.DataFrame(expected_data, index=["value"])
+        pd.testing.assert_frame_equal(run_df, expected_df.T)
+
+        expected_df.index = pd.Index([0])
+        expected_df.data_set_id = expected_df.data_set_id.astype("Int64")
+        pd.testing.assert_frame_equal(run_list_df, expected_df)


### PR DESCRIPTION
## Description
Run time and simulation time are currently displayed as integer timestamps even when converted to Pandas dataframe. This PR changes that so these columns are displayed in the same human friendly format as other columns such as created time etc.

## Checklist:
- [x] Tests added/updated.
- [ ] Documentation updated. Documentation is generated from docstrings - these must be updated according to your change.
  If a new method has been added it should be referenced in [cognite.rst](https://github.com/cognitedata/cognite-sdk-python/blob/master/docs/source/cognite.rst) in order to generate docs based on its docstring.
- [x] Changelog updated in [CHANGELOG.md](https://github.com/cognitedata/cognite-sdk-python/blob/master/CHANGELOG.md).
- [x] Version bumped. If triggering a new release is desired, bump the version number in [_version.py](https://github.com/cognitedata/cognite-sdk-python/blob/master/cognite/client/_version.py) and [pyproject.toml](https://github.com/cognitedata/cognite-sdk-python/blob/master/pyproject.toml) per [semantic versioning](https://semver.org/).
