### PR TITLE
[V8] Ingesting no datapoints no longer raises an exception

### DIFF
--- a/tests/tests_unit/test_api/test_datapoints.py
+++ b/tests/tests_unit/test_api/test_datapoints.py
@@ -258,9 +258,11 @@ class TestInsertDatapoints:
             "items": [{"id": 1, "datapoints": [{"timestamp": int(i * 1e11), "value": i} for i in range(6, 11)]}]
         } in request_bodies
 
-    def test_insert_datapoints_no_data(self, cognite_client):
-        with pytest.raises(ValueError, match="No datapoints provided"):
-            cognite_client.time_series.data.insert(id=1, datapoints=[])
+    @pytest.mark.parametrize("datapoints, id", [([], 1), (Datapoints(id=1), 1)])
+    def test_insert_datapoints_no_data(
+        self, cognite_client: CogniteClient, datapoints: list | Datapoints, id: int | None
+    ):
+        cognite_client.time_series.data.insert(datapoints=datapoints, id=id)
 
     def test_insert_datapoints_in_multiple_time_series(self, cognite_client, mock_post_datapoints):
         dps = [{"timestamp": i * 1e11, "value": i} for i in range(1, 11)]


### PR DESCRIPTION
`v8` overview: https://cognitedata.atlassian.net/browse/DM-3055
----

## Description
Ingesting no datapoints will no longer raise an error. When ingesting datapoints into multiple time series, if one of them contains no datapoints, that will be removed from the request.

## Checklist:
- [x] Tests added/updated.
- [ ] Documentation updated. Documentation is generated from docstrings - these must be updated according to your change.
  If a new method has been added it should be referenced in [cognite.rst](https://github.com/cognitedata/cognite-sdk-python/blob/master/docs/source/cognite.rst) in order to generate docs based on its docstring.
- [ ] Changelog updated in [CHANGELOG.md](https://github.com/cognitedata/cognite-sdk-python/blob/master/CHANGELOG.md).
- [ ] Version bumped. If triggering a new release is desired, bump the version number in [_version.py](https://github.com/cognitedata/cognite-sdk-python/blob/master/cognite/client/_version.py) and [pyproject.toml](https://github.com/cognitedata/cognite-sdk-python/blob/master/pyproject.toml) per [semantic versioning](https://semver.org/).
