### PR TITLE
Improve the error message when using InstanceId.load with a tuple of wrong length

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@ Changes are grouped as follows
 ### Fixed
 - Fixes type annotations for Functions API. Adds new `FunctionHandle` type for annotating function handles.
 
+## [7.75.4] - 2025-06-25
+### Improved
+- Improved the error message when using `InstanceId.load` with a tuple of wrong length.
+
 ## [7.75.3] - 2025-06-25
 ### Added
 - Added new `appConfigAcl` capability.

--- a/cognite/client/_version.py
+++ b/cognite/client/_version.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
 
-__version__ = "7.75.3"
+__version__ = "7.75.4"
 
 __api_subversion__ = "20230101"

--- a/cognite/client/utils/_identifier.py
+++ b/cognite/client/utils/_identifier.py
@@ -52,8 +52,13 @@ class InstanceId:
     def load(cls, data: dict[str, str] | tuple[str, str] | Self) -> Self:
         if isinstance(data, cls):
             return data
-        elif isinstance(data, tuple) and len(data) == 2:
-            return cls(*data)
+        elif isinstance(data, tuple):
+            try:
+                return cls(*data)
+            except TypeError:
+                raise ValueError(
+                    f"Cannot load {data} into {cls}, expected tuple of exactly two elements, (space, external_id)"
+                )
         elif isinstance(data, dict):
             if "externalId" in data:
                 return cls(space=data["space"], external_id=data["externalId"])

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "cognite-sdk"
-version = "7.75.3"
+version = "7.75.4"
 
 description = "Cognite Python SDK"
 readme = "README.md"

--- a/tests/tests_unit/test_data_classes/test_data_models/test_resource_class_methods.py
+++ b/tests/tests_unit/test_data_classes/test_data_models/test_resource_class_methods.py
@@ -107,9 +107,3 @@ def test_extend_method(node_lst: NodeList, edge_lst: EdgeList, space_lst: SpaceL
     lst.extend(not_overlapping)
     with pytest.raises(ValueError, match=r"^Unable to extend as this would introduce duplicates$"):
         lst.extend(overlapping)
-
-
-@pytest.mark.parametrize("instance_ids", (("space",), ("space", "external_id", "version")))
-def test_instance_id_tuple_length(instance_ids: tuple[str, ...]) -> None:
-    with pytest.raises(ValueError, match=r".*expected tuple of exactly two elements, \(space, external_id\)"):
-        InstanceId.load(instance_ids)  # type: ignore[arg-type]

--- a/tests/tests_unit/test_data_classes/test_data_models/test_resource_class_methods.py
+++ b/tests/tests_unit/test_data_classes/test_data_models/test_resource_class_methods.py
@@ -107,3 +107,9 @@ def test_extend_method(node_lst: NodeList, edge_lst: EdgeList, space_lst: SpaceL
     lst.extend(not_overlapping)
     with pytest.raises(ValueError, match=r"^Unable to extend as this would introduce duplicates$"):
         lst.extend(overlapping)
+
+
+@pytest.mark.parametrize("instance_ids", (("space",), ("space", "external_id", "version")))
+def test_instance_id_tuple_length(instance_ids: tuple[str, ...]) -> None:
+    with pytest.raises(ValueError, match=r".*expected tuple of exactly two elements, \(space, external_id\)"):
+        InstanceId.load(instance_ids)  # type: ignore[arg-type]

--- a/tests/tests_unit/test_utils/test_identifier.py
+++ b/tests/tests_unit/test_utils/test_identifier.py
@@ -17,6 +17,13 @@ from cognite.client.utils._identifier import (
 )
 
 
+class TestInstanceId:
+    @pytest.mark.parametrize("instance_ids", (("space",), ("space", "external_id", "version")))
+    def test_instance_id_tuple_length(self, instance_ids: tuple[str, ...]) -> None:
+        with pytest.raises(ValueError, match=r".*expected tuple of exactly two elements, \(space, external_id\)"):
+            InstanceId.load(instance_ids)  # type: ignore[arg-type]
+
+
 class TestIdentifier:
     @pytest.mark.parametrize(
         "id, external_id, instance_id, exp_tpl",


### PR DESCRIPTION
## Description
Curren error message talks about missing external ID key

## Checklist:
- [x] Tests added/updated.
- [ ] Documentation updated. Documentation is generated from docstrings - these must be updated according to your change.
  If a new method has been added it should be referenced in [cognite.rst](https://github.com/cognitedata/cognite-sdk-python/blob/master/docs/source/cognite.rst) in order to generate docs based on its docstring.
- [x] Changelog updated in [CHANGELOG.md](https://github.com/cognitedata/cognite-sdk-python/blob/master/CHANGELOG.md).
- [x] Version bumped. If triggering a new release is desired, bump the version number in [_version.py](https://github.com/cognitedata/cognite-sdk-python/blob/master/cognite/client/_version.py) and [pyproject.toml](https://github.com/cognitedata/cognite-sdk-python/blob/master/pyproject.toml) per [semantic versioning](https://semver.org/).
