### PR TITLE
cancel CI build that becomes obsolete after a new commit is pushed in an open PR

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [master]
 
+concurrency:
+  group: pr-${{ github.workflow }}-${{ github.head_ref }}
+  cancel-in-progress: true
+
 jobs:
   lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION

## Description

### Change Summary
Currently, if a PR is open and a push happens, the **build** workflow will start running. If, shortly after a subsequent push on the *same* PR happens, the workflow will start running again without cancelling the previous (now obsolete) run. With these changes, the first run would be cancelled, thus saving compute resources (see below for quantity) without sacrificing functionality, since the second run will contain the changes from the first push as well.

### Context
Hi,

We are a team of [researchers](https://www.ifi.uzh.ch/en/zest.html) from University of Zurich and we are currently working on energy optimizations in GitHub Actions workflows.

Here is an example of the behaviour described above: the commit `af8abcb` triggered [this](https://github.com/cognitedata/cognite-sdk-python/actions/runs/11839295788/) workflow run, and shortly after the commit `af8abcb`, that happened on top of the first commit, triggered [this](https://github.com/cognitedata/cognite-sdk-python/actions/runs/11839295883/) workflow. Both workflows ran till the end, spending approximately 10 CPU minutes each. With the proposed changes, the first run would be cancelled, hence saving ~10 CPU minutes and clearing the queue for other workflows. Note that this is an example of a single concurrent run; the accumulated gain for all PRs would be higher, with a lower estimate at **2.4 CPU days**.

Kindly let us know (here or in the email below) if you would like more details, if you want to reject the proposed changes for other reasons, or if you have any question whatsoever.

Best regards,  
[Konstantinos Kitsios](https://www.ifi.uzh.ch/en/zest/team/konstantinos_kitsios.html)  
konstantinos.kitsios@uzh.ch

PS: Some hyperlinks may not work if the corresponding workflows have been deleted.

## Checklist:
- [ ] Tests added/updated.
- [ ] Documentation updated. Documentation is generated from docstrings - these must be updated according to your change.
  If a new method has been added it should be referenced in [cognite.rst](https://github.com/cognitedata/cognite-sdk-python/blob/master/docs/source/cognite.rst) in order to generate docs based on its docstring.
- [ ] Changelog updated in [CHANGELOG.md](https://github.com/cognitedata/cognite-sdk-python/blob/master/CHANGELOG.md).
- [ ] Version bumped. If triggering a new release is desired, bump the version number in [_version.py](https://github.com/cognitedata/cognite-sdk-python/blob/master/cognite/client/_version.py) and [pyproject.toml](https://github.com/cognitedata/cognite-sdk-python/blob/master/pyproject.toml) per [semantic versioning](https://semver.org/).
