### PR TITLE
Cancel current CI build if new commit is pushed

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [master]
 
+concurrency:
+  group: pr-${{ github.workflow }}-${{ github.head_ref }}
+  cancel-in-progress: true
+
 jobs:
   lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Replicates changes in https://github.com/cognitedata/cognite-sdk-python/pull/2181. That PR is from a public fork, which can't currently run integration tests, so just reapplying the changes here.

Thank you @kitsiosk

> Here is an example of the behaviour described above: the commit af8abcb triggered [this](https://github.com/cognitedata/cognite-sdk-python/actions/runs/11839295788/) workflow run, and shortly after the commit af8abcb, that happened on top of the first commit, triggered [this](https://github.com/cognitedata/cognite-sdk-python/actions/runs/11839295883/) workflow. Both workflows ran till the end, spending approximately 10 CPU minutes each. With the proposed changes, the first run would be cancelled, hence saving ~10 CPU minutes and clearing the queue for other workflows. Note that this is an example of a single concurrent run; the accumulated gain for all PRs would be higher, with a lower estimate at 2.4 CPU days.