### PR TITLE
Don't trigger full build+test CI when only markdown files are edited

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,6 +5,8 @@ on:
   merge_group:
   pull_request:
     branches: [master]
+    paths-ignore:
+      - '**/*.md'
 
 concurrency:
   group: pr-${{ github.workflow }}-${{ github.head_ref }}


### PR DESCRIPTION
## Description
### Change Summary
Currently, the `build` CI workflow will run even when a push changes **only markdown files** (e.g., README.md).
With these changes, a push that changes *only* markdown files will not trigger the workflow, thus speeding up the project's CI and saving compute resources 🌱 (see below for quantity).

### Example
Here is an example of the behaviour described above: the commit [`306833f`](https://github.com/cognitedata/cognite-sdk-python/commit/306833f0dfd55c77d0b1c744b8f4b129fa16e354) changed these files: `CHANGELOG.md` and, when pushed, triggered [this](https://github.com/cognitedata/cognite-sdk-python/actions/runs/11328436748) workflow run, which ran for ~1.5 CPU hours. With the proposed changes, these 1.5 CPU hours would have been saved, clearing the queue for other workflows and speeding up the CI of the project, while also saving resources in general 🌱. 

Note that this is a single example out of (a minimum of) 81 examples over the last few months; a lower estimate for the accumulated gain is **23 CPU hours**, but the actual number could be much **higher** because we could only look at a subset of the data.

Other such examples include [`42213cc`](https://github.com/cognitedata/cognite-sdk-python/commit/42213cc81d3694b11cd558dbc82a5d7b44779341), [`b99b248`](https://github.com/cognitedata/cognite-sdk-python/commit/b99b2486f45619f84ef0a250824344589a1830ad), [`17b287c`](https://github.com/cognitedata/cognite-sdk-python/commit/17b287c21244d7f27bee7de310041902651de71c).

### Context
Hi,

We are a team of [researchers](https://www.ifi.uzh.ch/en/zest.html) from University of Zurich and we are currently working on energy optimizations in GitHub Actions workflows.

Kindly let us know (here or in the email below) if you would like to **ignore other file types **or apply the filter to **other workflows**, or if you have any question whatsoever.

Best regards,  
[Konstantinos Kitsios](https://www.ifi.uzh.ch/en/zest/team/konstantinos_kitsios.html)  
konstantinos.kitsios@uzh.ch

## Checklist:
- [ ] Tests added/updated.
- [ ] Documentation updated. Documentation is generated from docstrings - these must be updated according to your change.
  If a new method has been added it should be referenced in [cognite.rst](https://github.com/cognitedata/cognite-sdk-python/blob/master/docs/source/cognite.rst) in order to generate docs based on its docstring.
- [ ] Changelog updated in [CHANGELOG.md](https://github.com/cognitedata/cognite-sdk-python/blob/master/CHANGELOG.md).
- [ ] Version bumped. If triggering a new release is desired, bump the version number in [_version.py](https://github.com/cognitedata/cognite-sdk-python/blob/master/cognite/client/_version.py) and [pyproject.toml](https://github.com/cognitedata/cognite-sdk-python/blob/master/pyproject.toml) per [semantic versioning](https://semver.org/).
