### PR TITLE
Remove 'to' from 'It is used to when'

### DIFF
--- a/cognite/client/data_classes/data_modeling/cdm/v1.py
+++ b/cognite/client/data_classes/data_modeling/cdm/v1.py
@@ -36,7 +36,7 @@ class _Cognite360ImageProperties:
 class Cognite360ImageApply(_Cognite360ImageProperties, TypedNodeApply):
     """This represents the writing format of Cognite 360 image.
 
-    It is used to when data is written to CDF.
+    It is used when data is written to CDF.
 
     Args:
         space (str): The space where the node is located.
@@ -113,7 +113,7 @@ class Cognite360ImageApply(_Cognite360ImageProperties, TypedNodeApply):
 class Cognite360Image(_Cognite360ImageProperties, TypedNode):
     """This represents the reading format of Cognite 360 image.
 
-    It is used to when data is read from CDF.
+    It is used when data is read from CDF.
 
     Args:
         space (str): The space where the node is located.
@@ -231,7 +231,7 @@ class _Cognite360ImageCollectionProperties:
 class Cognite360ImageCollectionApply(_Cognite360ImageCollectionProperties, TypedNodeApply):
     """This represents the writing format of Cognite 360 image collection.
 
-    It is used to when data is written to CDF.
+    It is used when data is written to CDF.
 
     Represents a logical collection of Cognite360Image instances
     Args:
@@ -279,7 +279,7 @@ class Cognite360ImageCollectionApply(_Cognite360ImageCollectionProperties, Typed
 class Cognite360ImageCollection(_Cognite360ImageCollectionProperties, TypedNode):
     """This represents the reading format of Cognite 360 image collection.
 
-    It is used to when data is read from CDF.
+    It is used when data is read from CDF.
 
     Represents a logical collection of Cognite360Image instances
     Args:
@@ -357,7 +357,7 @@ class _Cognite360ImageModelProperties:
 class Cognite360ImageModelApply(_Cognite360ImageModelProperties, TypedNodeApply):
     """This represents the writing format of Cognite 360 image model.
 
-    It is used to when data is written to CDF.
+    It is used when data is written to CDF.
 
     Navigational aid for traversing Cognite360ImageModel instances
     Args:
@@ -399,7 +399,7 @@ class Cognite360ImageModelApply(_Cognite360ImageModelProperties, TypedNodeApply)
 class Cognite360ImageModel(_Cognite360ImageModelProperties, TypedNode):
     """This represents the reading format of Cognite 360 image model.
 
-    It is used to when data is read from CDF.
+    It is used when data is read from CDF.
 
     Navigational aid for traversing Cognite360ImageModel instances
     Args:
@@ -469,7 +469,7 @@ class _Cognite360ImageStationProperties:
 class Cognite360ImageStationApply(_Cognite360ImageStationProperties, TypedNodeApply):
     """This represents the writing format of Cognite 360 image station.
 
-    It is used to when data is written to CDF.
+    It is used when data is written to CDF.
 
     A way to group images across collections. Used for creating visual scan history
     Args:
@@ -508,7 +508,7 @@ class Cognite360ImageStationApply(_Cognite360ImageStationProperties, TypedNodeAp
 class Cognite360ImageStation(_Cognite360ImageStationProperties, TypedNode):
     """This represents the reading format of Cognite 360 image station.
 
-    It is used to when data is read from CDF.
+    It is used when data is read from CDF.
 
     A way to group images across collections. Used for creating visual scan history
     Args:
@@ -574,7 +574,7 @@ class _Cognite3DModelProperties:
 class Cognite3DModelApply(_Cognite3DModelProperties, TypedNodeApply):
     """This represents the writing format of Cognite 3D model.
 
-    It is used to when data is written to CDF.
+    It is used when data is written to CDF.
 
     Groups revisions of 3D data of various kinds together (CAD, PointCloud, Image360)
     Args:
@@ -616,7 +616,7 @@ class Cognite3DModelApply(_Cognite3DModelProperties, TypedNodeApply):
 class Cognite3DModel(_Cognite3DModelProperties, TypedNode):
     """This represents the reading format of Cognite 3D model.
 
-    It is used to when data is read from CDF.
+    It is used when data is read from CDF.
 
     Groups revisions of 3D data of various kinds together (CAD, PointCloud, Image360)
     Args:
@@ -691,7 +691,7 @@ class _Cognite3DObjectProperties:
 class Cognite3DObjectApply(_Cognite3DObjectProperties, TypedNodeApply):
     """This represents the writing format of Cognite 3D object.
 
-    It is used to when data is written to CDF.
+    It is used when data is written to CDF.
 
     This is the virtual position representation of an object in the physical world, connecting an asset to one or more 3D resources
     Args:
@@ -745,7 +745,7 @@ class Cognite3DObjectApply(_Cognite3DObjectProperties, TypedNodeApply):
 class Cognite3DObject(_Cognite3DObjectProperties, TypedNode):
     """This represents the reading format of Cognite 3D object.
 
-    It is used to when data is read from CDF.
+    It is used when data is read from CDF.
 
     This is the virtual position representation of an object in the physical world, connecting an asset to one or more 3D resources
     Args:
@@ -832,7 +832,7 @@ class _Cognite3DRevisionProperties:
 class Cognite3DRevisionApply(_Cognite3DRevisionProperties, TypedNodeApply):
     """This represents the writing format of Cognite 3D revision.
 
-    It is used to when data is written to CDF.
+    It is used when data is written to CDF.
 
     Shared revision information for various 3D data types. Normally not used directly, but through CognitePointCloudRevision, Image360Collection or CogniteCADRevision
 
@@ -869,7 +869,7 @@ class Cognite3DRevisionApply(_Cognite3DRevisionProperties, TypedNodeApply):
 class Cognite3DRevision(_Cognite3DRevisionProperties, TypedNode):
     """This represents the reading format of Cognite 3D revision.
 
-    It is used to when data is read from CDF.
+    It is used when data is read from CDF.
 
     Shared revision information for various 3D data types. Normally not used directly, but through CognitePointCloudRevision, Image360Collection or CogniteCADRevision
 
@@ -940,7 +940,7 @@ class _Cognite3DTransformationProperties:
 class Cognite3DTransformationNodeApply(_Cognite3DTransformationProperties, TypedNodeApply):
     """This represents the writing format of Cognite 3D transformation node.
 
-    It is used to when data is written to CDF.
+    It is used when data is written to CDF.
 
     The Cognite3DTransformation object defines a comprehensive 3D transformation, enabling precise adjustments to an object's position, orientation, and size in the 3D coordinate system. It allows for the translation of objects along the three spatial axes, rotation around these axes using Euler angles, and scaling along each axis to modify the object's dimensions. The object's transformation is defined in "CDF space", a coordinate system where the positive Z axis is the up direction
 
@@ -992,7 +992,7 @@ class Cognite3DTransformationNodeApply(_Cognite3DTransformationProperties, Typed
 class Cognite3DTransformationNode(_Cognite3DTransformationProperties, TypedNode):
     """This represents the reading format of Cognite 3D transformation node.
 
-    It is used to when data is read from CDF.
+    It is used when data is read from CDF.
 
     The Cognite3DTransformation object defines a comprehensive 3D transformation, enabling precise adjustments to an object's position, orientation, and size in the 3D coordinate system. It allows for the translation of objects along the three spatial axes, rotation around these axes using Euler angles, and scaling along each axis to modify the object's dimensions. The object's transformation is defined in "CDF space", a coordinate system where the positive Z axis is the up direction
 
@@ -1085,7 +1085,7 @@ class _CogniteActivityProperties:
 class CogniteActivityApply(_CogniteActivityProperties, TypedNodeApply):
     """This represents the writing format of Cognite activity.
 
-    It is used to when data is written to CDF.
+    It is used when data is written to CDF.
 
     Represents activities. Activities typically happen over a period and have a start and end time.
     Args:
@@ -1165,7 +1165,7 @@ class CogniteActivityApply(_CogniteActivityProperties, TypedNodeApply):
 class CogniteActivity(_CogniteActivityProperties, TypedNode):
     """This represents the reading format of Cognite activity.
 
-    It is used to when data is read from CDF.
+    It is used when data is read from CDF.
 
     Represents activities. Activities typically happen over a period and have a start and end time.
     Args:
@@ -1294,7 +1294,7 @@ class _CogniteAssetProperties:
 class CogniteAssetApply(_CogniteAssetProperties, TypedNodeApply):
     """This represents the writing format of Cognite asset.
 
-    It is used to when data is written to CDF.
+    It is used when data is written to CDF.
 
     Assets represent systems that support industrial functions or processes. Assets are often called 'functional location'.
     Args:
@@ -1363,7 +1363,7 @@ class CogniteAssetApply(_CogniteAssetProperties, TypedNodeApply):
 class CogniteAsset(_CogniteAssetProperties, TypedNode):
     """This represents the reading format of Cognite asset.
 
-    It is used to when data is read from CDF.
+    It is used when data is read from CDF.
 
     Assets represent systems that support industrial functions or processes. Assets are often called 'functional location'.
     Args:
@@ -1476,7 +1476,7 @@ class _CogniteAssetClassProperties:
 class CogniteAssetClassApply(_CogniteAssetClassProperties, TypedNodeApply):
     """This represents the writing format of Cognite asset clas.
 
-    It is used to when data is written to CDF.
+    It is used when data is written to CDF.
 
     Represents the class of an asset.
     Args:
@@ -1518,7 +1518,7 @@ class CogniteAssetClassApply(_CogniteAssetClassProperties, TypedNodeApply):
 class CogniteAssetClass(_CogniteAssetClassProperties, TypedNode):
     """This represents the reading format of Cognite asset clas.
 
-    It is used to when data is read from CDF.
+    It is used when data is read from CDF.
 
     Represents the class of an asset.
     Args:
@@ -1588,7 +1588,7 @@ class _CogniteAssetTypeProperties:
 class CogniteAssetTypeApply(_CogniteAssetTypeProperties, TypedNodeApply):
     """This represents the writing format of Cognite asset type.
 
-    It is used to when data is written to CDF.
+    It is used when data is written to CDF.
 
     Represents the type of an asset.
     Args:
@@ -1633,7 +1633,7 @@ class CogniteAssetTypeApply(_CogniteAssetTypeProperties, TypedNodeApply):
 class CogniteAssetType(_CogniteAssetTypeProperties, TypedNode):
     """This represents the reading format of Cognite asset type.
 
-    It is used to when data is read from CDF.
+    It is used when data is read from CDF.
 
     Represents the type of an asset.
     Args:
@@ -1707,7 +1707,7 @@ class _CogniteCADModelProperties:
 class CogniteCADModelApply(_CogniteCADModelProperties, TypedNodeApply):
     """This represents the writing format of Cognite cad model.
 
-    It is used to when data is written to CDF.
+    It is used when data is written to CDF.
 
     Navigational aid for traversing CogniteCADModel instances
     Args:
@@ -1749,7 +1749,7 @@ class CogniteCADModelApply(_CogniteCADModelProperties, TypedNodeApply):
 class CogniteCADModel(_CogniteCADModelProperties, TypedNode):
     """This represents the reading format of Cognite cad model.
 
-    It is used to when data is read from CDF.
+    It is used when data is read from CDF.
 
     Navigational aid for traversing CogniteCADModel instances
     Args:
@@ -1823,7 +1823,7 @@ class _CogniteCADNodeProperties:
 class CogniteCADNodeApply(_CogniteCADNodeProperties, TypedNodeApply):
     """This represents the writing format of Cognite cad node.
 
-    It is used to when data is written to CDF.
+    It is used when data is written to CDF.
 
     Represents nodes from the 3D model that have been contextualized
     Args:
@@ -1877,7 +1877,7 @@ class CogniteCADNodeApply(_CogniteCADNodeProperties, TypedNodeApply):
 class CogniteCADNode(_CogniteCADNodeProperties, TypedNode):
     """This represents the reading format of Cognite cad node.
 
-    It is used to when data is read from CDF.
+    It is used when data is read from CDF.
 
     Represents nodes from the 3D model that have been contextualized
     Args:
@@ -1965,7 +1965,7 @@ class _CogniteCADRevisionProperties:
 class CogniteCADRevisionApply(_CogniteCADRevisionProperties, TypedNodeApply):
     """This represents the writing format of Cognite cad revision.
 
-    It is used to when data is written to CDF.
+    It is used when data is written to CDF.
 
     Args:
         space (str): The space where the node is located.
@@ -2003,7 +2003,7 @@ class CogniteCADRevisionApply(_CogniteCADRevisionProperties, TypedNodeApply):
 class CogniteCADRevision(_CogniteCADRevisionProperties, TypedNode):
     """This represents the reading format of Cognite cad revision.
 
-    It is used to when data is read from CDF.
+    It is used when data is read from CDF.
 
     Args:
         space (str): The space where the node is located.
@@ -2066,7 +2066,7 @@ class _CogniteCubeMapProperties:
 class CogniteCubeMapApply(_CogniteCubeMapProperties, TypedNodeApply):
     """This represents the writing format of Cognite cube map.
 
-    It is used to when data is written to CDF.
+    It is used when data is written to CDF.
 
     The cube map holds references to 6 images in used to visually represent the surrounding environment
 
@@ -2109,7 +2109,7 @@ class CogniteCubeMapApply(_CogniteCubeMapProperties, TypedNodeApply):
 class CogniteCubeMap(_CogniteCubeMapProperties, TypedNode):
     """This represents the reading format of Cognite cube map.
 
-    It is used to when data is read from CDF.
+    It is used when data is read from CDF.
 
     The cube map holds references to 6 images in used to visually represent the surrounding environment
 
@@ -2178,7 +2178,7 @@ class _CogniteDescribableProperties:
 class CogniteDescribableNodeApply(_CogniteDescribableProperties, TypedNodeApply):
     """This represents the writing format of Cognite describable node.
 
-    It is used to when data is written to CDF.
+    It is used when data is written to CDF.
 
     The describable core concept is used as a standard way of holding the bare minimum of information about the instance
 
@@ -2215,7 +2215,7 @@ class CogniteDescribableNodeApply(_CogniteDescribableProperties, TypedNodeApply)
 class CogniteDescribableNode(_CogniteDescribableProperties, TypedNode):
     """This represents the reading format of Cognite describable node.
 
-    It is used to when data is read from CDF.
+    It is used when data is read from CDF.
 
     The describable core concept is used as a standard way of holding the bare minimum of information about the instance
 
@@ -2285,7 +2285,7 @@ class _CogniteEquipmentProperties:
 class CogniteEquipmentApply(_CogniteEquipmentProperties, TypedNodeApply):
     """This represents the writing format of Cognite equipment.
 
-    It is used to when data is written to CDF.
+    It is used when data is written to CDF.
 
     Equipment represents physical supplies or devices.
     Args:
@@ -2357,7 +2357,7 @@ class CogniteEquipmentApply(_CogniteEquipmentProperties, TypedNodeApply):
 class CogniteEquipment(_CogniteEquipmentProperties, TypedNode):
     """This represents the reading format of Cognite equipment.
 
-    It is used to when data is read from CDF.
+    It is used when data is read from CDF.
 
     Equipment represents physical supplies or devices.
     Args:
@@ -2468,7 +2468,7 @@ class _CogniteEquipmentTypeProperties:
 class CogniteEquipmentTypeApply(_CogniteEquipmentTypeProperties, TypedNodeApply):
     """This represents the writing format of Cognite equipment type.
 
-    It is used to when data is written to CDF.
+    It is used when data is written to CDF.
 
     Represents the type of equipment.
     Args:
@@ -2516,7 +2516,7 @@ class CogniteEquipmentTypeApply(_CogniteEquipmentTypeProperties, TypedNodeApply)
 class CogniteEquipmentType(_CogniteEquipmentTypeProperties, TypedNode):
     """This represents the reading format of Cognite equipment type.
 
-    It is used to when data is read from CDF.
+    It is used when data is read from CDF.
 
     Represents the type of equipment.
     Args:
@@ -2602,7 +2602,7 @@ class _CogniteFileProperties:
 class CogniteFileApply(_CogniteFileProperties, TypedNodeApply):
     """This represents the writing format of Cognite file.
 
-    It is used to when data is written to CDF.
+    It is used when data is written to CDF.
 
     Represents files.
     Args:
@@ -2671,7 +2671,7 @@ class CogniteFileApply(_CogniteFileProperties, TypedNodeApply):
 class CogniteFile(_CogniteFileProperties, TypedNode):
     """This represents the reading format of Cognite file.
 
-    It is used to when data is read from CDF.
+    It is used when data is read from CDF.
 
     Represents files.
     Args:
@@ -2783,7 +2783,7 @@ class _CogniteFileCategoryProperties:
 class CogniteFileCategoryApply(_CogniteFileCategoryProperties, TypedNodeApply):
     """This represents the writing format of Cognite file category.
 
-    It is used to when data is written to CDF.
+    It is used when data is written to CDF.
 
     Represents the categories of files as determined by contextualization or categorization.
     Args:
@@ -2828,7 +2828,7 @@ class CogniteFileCategoryApply(_CogniteFileCategoryProperties, TypedNodeApply):
 class CogniteFileCategory(_CogniteFileCategoryProperties, TypedNode):
     """This represents the reading format of Cognite file category.
 
-    It is used to when data is read from CDF.
+    It is used when data is read from CDF.
 
     Represents the categories of files as determined by contextualization or categorization.
     Args:
@@ -2902,7 +2902,7 @@ class _CognitePointCloudModelProperties:
 class CognitePointCloudModelApply(_CognitePointCloudModelProperties, TypedNodeApply):
     """This represents the writing format of Cognite point cloud model.
 
-    It is used to when data is written to CDF.
+    It is used when data is written to CDF.
 
     Navigational aid for traversing CognitePointCloudModel instances
     Args:
@@ -2944,7 +2944,7 @@ class CognitePointCloudModelApply(_CognitePointCloudModelProperties, TypedNodeAp
 class CognitePointCloudModel(_CognitePointCloudModelProperties, TypedNode):
     """This represents the reading format of Cognite point cloud model.
 
-    It is used to when data is read from CDF.
+    It is used when data is read from CDF.
 
     Navigational aid for traversing CognitePointCloudModel instances
     Args:
@@ -3016,7 +3016,7 @@ class _CognitePointCloudRevisionProperties:
 class CognitePointCloudRevisionApply(_CognitePointCloudRevisionProperties, TypedNodeApply):
     """This represents the writing format of Cognite point cloud revision.
 
-    It is used to when data is written to CDF.
+    It is used when data is written to CDF.
 
     Navigational aid for traversing CognitePointCloudRevision instances
     Args:
@@ -3055,7 +3055,7 @@ class CognitePointCloudRevisionApply(_CognitePointCloudRevisionProperties, Typed
 class CognitePointCloudRevision(_CognitePointCloudRevisionProperties, TypedNode):
     """This represents the reading format of Cognite point cloud revision.
 
-    It is used to when data is read from CDF.
+    It is used when data is read from CDF.
 
     Navigational aid for traversing CognitePointCloudRevision instances
     Args:
@@ -3125,7 +3125,7 @@ class _CognitePointCloudVolumeProperties:
 class CognitePointCloudVolumeApply(_CognitePointCloudVolumeProperties, TypedNodeApply):
     """This represents the writing format of Cognite point cloud volume.
 
-    It is used to when data is written to CDF.
+    It is used when data is written to CDF.
 
     PointCloud volume definition
     Args:
@@ -3182,7 +3182,7 @@ class CognitePointCloudVolumeApply(_CognitePointCloudVolumeProperties, TypedNode
 class CognitePointCloudVolume(_CognitePointCloudVolumeProperties, TypedNode):
     """This represents the reading format of Cognite point cloud volume.
 
-    It is used to when data is read from CDF.
+    It is used when data is read from CDF.
 
     PointCloud volume definition
     Args:
@@ -3275,7 +3275,7 @@ class _CogniteSchedulableProperties:
 class CogniteSchedulableApply(_CogniteSchedulableProperties, TypedNodeApply):
     """This represents the writing format of Cognite schedulable.
 
-    It is used to when data is written to CDF.
+    It is used when data is written to CDF.
 
     CogniteSchedulable represents the metadata about when an activity (or similar) starts and ends.
     Args:
@@ -3311,7 +3311,7 @@ class CogniteSchedulableApply(_CogniteSchedulableProperties, TypedNodeApply):
 class CogniteSchedulable(_CogniteSchedulableProperties, TypedNode):
     """This represents the reading format of Cognite schedulable.
 
-    It is used to when data is read from CDF.
+    It is used when data is read from CDF.
 
     CogniteSchedulable represents the metadata about when an activity (or similar) starts and ends.
     Args:
@@ -3373,7 +3373,7 @@ class _CogniteSourceSystemProperties:
 class CogniteSourceSystemApply(_CogniteSourceSystemProperties, TypedNodeApply):
     """This represents the writing format of Cognite source system.
 
-    It is used to when data is written to CDF.
+    It is used when data is written to CDF.
 
     The CogniteSourceSystem core concept is used to standardize the way source system is stored.
     Args:
@@ -3415,7 +3415,7 @@ class CogniteSourceSystemApply(_CogniteSourceSystemProperties, TypedNodeApply):
 class CogniteSourceSystem(_CogniteSourceSystemProperties, TypedNode):
     """This represents the reading format of Cognite source system.
 
-    It is used to when data is read from CDF.
+    It is used when data is read from CDF.
 
     The CogniteSourceSystem core concept is used to standardize the way source system is stored.
     Args:
@@ -3490,7 +3490,7 @@ class _CogniteSourceableProperties:
 class CogniteSourceableNodeApply(_CogniteSourceableProperties, TypedNodeApply):
     """This represents the writing format of Cognite sourceable node.
 
-    It is used to when data is written to CDF.
+    It is used when data is written to CDF.
 
     Args:
         space (str): The space where the node is located.
@@ -3534,7 +3534,7 @@ class CogniteSourceableNodeApply(_CogniteSourceableProperties, TypedNodeApply):
 class CogniteSourceableNode(_CogniteSourceableProperties, TypedNode):
     """This represents the reading format of Cognite sourceable node.
 
-    It is used to when data is read from CDF.
+    It is used when data is read from CDF.
 
     Args:
         space (str): The space where the node is located.
@@ -3615,7 +3615,7 @@ class _CogniteTimeSeriesProperties:
 class CogniteTimeSeriesApply(_CogniteTimeSeriesProperties, TypedNodeApply):
     """This represents the writing format of Cognite time series.
 
-    It is used to when data is written to CDF.
+    It is used when data is written to CDF.
 
     Represents a series of data points in time order."
     Args:
@@ -3690,7 +3690,7 @@ class CogniteTimeSeriesApply(_CogniteTimeSeriesProperties, TypedNodeApply):
 class CogniteTimeSeries(_CogniteTimeSeriesProperties, TypedNode):
     """This represents the reading format of Cognite time series.
 
-    It is used to when data is read from CDF.
+    It is used when data is read from CDF.
 
     Represents a series of data points in time order."
     Args:
@@ -3804,7 +3804,7 @@ class _CogniteUnitProperties:
 class CogniteUnitApply(_CogniteUnitProperties, TypedNodeApply):
     """This represents the writing format of Cognite unit.
 
-    It is used to when data is written to CDF.
+    It is used when data is written to CDF.
 
     Represents a single unit of measurement
     Args:
@@ -3852,7 +3852,7 @@ class CogniteUnitApply(_CogniteUnitProperties, TypedNodeApply):
 class CogniteUnit(_CogniteUnitProperties, TypedNode):
     """This represents the reading format of Cognite unit.
 
-    It is used to when data is read from CDF.
+    It is used when data is read from CDF.
 
     Represents a single unit of measurement
     Args:
@@ -3930,7 +3930,7 @@ class _CogniteVisualizableProperties:
 class CogniteVisualizableApply(_CogniteVisualizableProperties, TypedNodeApply):
     """This represents the writing format of Cognite visualizable.
 
-    It is used to when data is written to CDF.
+    It is used when data is written to CDF.
 
     CogniteVisualizable defines the standard way to reference a related 3D resource
     Args:
@@ -3957,7 +3957,7 @@ class CogniteVisualizableApply(_CogniteVisualizableProperties, TypedNodeApply):
 class CogniteVisualizable(_CogniteVisualizableProperties, TypedNode):
     """This represents the reading format of Cognite visualizable.
 
-    It is used to when data is read from CDF.
+    It is used when data is read from CDF.
 
     CogniteVisualizable defines the standard way to reference a related 3D resource
     Args:
@@ -4013,7 +4013,7 @@ class _Cognite360ImageAnnotationProperties:
 class Cognite360ImageAnnotationApply(_Cognite360ImageAnnotationProperties, TypedEdgeApply):
     """This represents the writing format of Cognite 360 image annotation.
 
-    It is used to when data is written to CDF.
+    It is used when data is written to CDF.
 
     Args:
         space (str): The space where the node is located.
@@ -4085,7 +4085,7 @@ class Cognite360ImageAnnotationApply(_Cognite360ImageAnnotationProperties, Typed
 class Cognite360ImageAnnotation(_Cognite360ImageAnnotationProperties, TypedEdge):
     """This represents the reading format of Cognite 360 image annotation.
 
-    It is used to when data is read from CDF.
+    It is used when data is read from CDF.
 
     Args:
         space (str): The space where the node is located.
@@ -4190,7 +4190,7 @@ class Cognite360ImageAnnotation(_Cognite360ImageAnnotationProperties, TypedEdge)
 class Cognite3DTransformationEdgeApply(_Cognite3DTransformationProperties, TypedEdgeApply):
     """This represents the writing format of Cognite 3D transformation edge.
 
-    It is used to when data is written to CDF.
+    It is used when data is written to CDF.
 
     The Cognite3DTransformation object defines a comprehensive 3D transformation, enabling precise adjustments to an object's position, orientation, and size in the 3D coordinate system. It allows for the translation of objects along the three spatial axes, rotation around these axes using Euler angles, and scaling along each axis to modify the object's dimensions. The object's transformation is defined in "CDF space", a coordinate system where the positive Z axis is the up direction
 
@@ -4246,7 +4246,7 @@ class Cognite3DTransformationEdgeApply(_Cognite3DTransformationProperties, Typed
 class Cognite3DTransformationEdge(_Cognite3DTransformationProperties, TypedEdge):
     """This represents the reading format of Cognite 3D transformation edge.
 
-    It is used to when data is read from CDF.
+    It is used when data is read from CDF.
 
     The Cognite3DTransformation object defines a comprehensive 3D transformation, enabling precise adjustments to an object's position, orientation, and size in the 3D coordinate system. It allows for the translation of objects along the three spatial axes, rotation around these axes using Euler angles, and scaling along each axis to modify the object's dimensions. The object's transformation is defined in "CDF space", a coordinate system where the positive Z axis is the up direction
 
@@ -4342,7 +4342,7 @@ class _CogniteAnnotationProperties:
 class CogniteAnnotationApply(_CogniteAnnotationProperties, TypedEdgeApply):
     """This represents the writing format of Cognite annotation.
 
-    It is used to when data is written to CDF.
+    It is used when data is written to CDF.
 
     Annotation represents contextualization results or links
     Args:
@@ -4409,7 +4409,7 @@ class CogniteAnnotationApply(_CogniteAnnotationProperties, TypedEdgeApply):
 class CogniteAnnotation(_CogniteAnnotationProperties, TypedEdge):
     """This represents the reading format of Cognite annotation.
 
-    It is used to when data is read from CDF.
+    It is used when data is read from CDF.
 
     Annotation represents contextualization results or links
     Args:
@@ -4507,7 +4507,7 @@ class CogniteAnnotation(_CogniteAnnotationProperties, TypedEdge):
 class CogniteDescribableEdgeApply(_CogniteDescribableProperties, TypedEdgeApply):
     """This represents the writing format of Cognite describable edge.
 
-    It is used to when data is written to CDF.
+    It is used when data is written to CDF.
 
     The describable core concept is used as a standard way of holding the bare minimum of information about the instance
 
@@ -4548,7 +4548,7 @@ class CogniteDescribableEdgeApply(_CogniteDescribableProperties, TypedEdgeApply)
 class CogniteDescribableEdge(_CogniteDescribableProperties, TypedEdge):
     """This represents the reading format of Cognite describable edge.
 
-    It is used to when data is read from CDF.
+    It is used when data is read from CDF.
 
     The describable core concept is used as a standard way of holding the bare minimum of information about the instance
 
@@ -4636,7 +4636,7 @@ class _CogniteDiagramAnnotationProperties:
 class CogniteDiagramAnnotationApply(_CogniteDiagramAnnotationProperties, TypedEdgeApply):
     """This represents the writing format of Cognite diagram annotation.
 
-    It is used to when data is written to CDF.
+    It is used when data is written to CDF.
 
     Annotation for diagrams
     Args:
@@ -4739,7 +4739,7 @@ class CogniteDiagramAnnotationApply(_CogniteDiagramAnnotationProperties, TypedEd
 class CogniteDiagramAnnotation(_CogniteDiagramAnnotationProperties, TypedEdge):
     """This represents the reading format of Cognite diagram annotation.
 
-    It is used to when data is read from CDF.
+    It is used when data is read from CDF.
 
     Annotation for diagrams
     Args:
@@ -4885,7 +4885,7 @@ class CogniteDiagramAnnotation(_CogniteDiagramAnnotationProperties, TypedEdge):
 class CogniteSourceableEdgeApply(_CogniteSourceableProperties, TypedEdgeApply):
     """This represents the writing format of Cognite sourceable edge.
 
-    It is used to when data is written to CDF.
+    It is used when data is written to CDF.
 
     Args:
         space (str): The space where the node is located.
@@ -4933,7 +4933,7 @@ class CogniteSourceableEdgeApply(_CogniteSourceableProperties, TypedEdgeApply):
 class CogniteSourceableEdge(_CogniteSourceableProperties, TypedEdge):
     """This represents the reading format of Cognite sourceable edge.
 
-    It is used to when data is read from CDF.
+    It is used when data is read from CDF.
 
     Args:
         space (str): The space where the node is located.

--- a/cognite/client/data_classes/data_modeling/extractor_extensions/v1.py
+++ b/cognite/client/data_classes/data_modeling/extractor_extensions/v1.py
@@ -23,7 +23,7 @@ class _CogniteExtractorDataProperties:
 class CogniteExtractorDataApply(_CogniteExtractorDataProperties, TypedNodeApply):
     """This represents the writing format of Cognite extractor datum.
 
-    It is used to when data is written to CDF.
+    It is used when data is written to CDF.
 
     Args:
         space (str): The space where the node is located.
@@ -49,7 +49,7 @@ class CogniteExtractorDataApply(_CogniteExtractorDataProperties, TypedNodeApply)
 class CogniteExtractorData(_CogniteExtractorDataProperties, TypedNode):
     """This represents the reading format of Cognite extractor datum.
 
-    It is used to when data is read from CDF.
+    It is used when data is read from CDF.
 
     Args:
         space (str): The space where the node is located.
@@ -107,7 +107,7 @@ class _CogniteExtractorFileProperties:
 class CogniteExtractorFileApply(_CogniteExtractorFileProperties, TypedNodeApply):
     """This represents the writing format of Cognite extractor file.
 
-    It is used to when data is written to CDF.
+    It is used when data is written to CDF.
 
     Args:
         space (str): The space where the node is located.
@@ -184,7 +184,7 @@ class CogniteExtractorFileApply(_CogniteExtractorFileProperties, TypedNodeApply)
 class CogniteExtractorFile(_CogniteExtractorFileProperties, TypedNode):
     """This represents the reading format of Cognite extractor file.
 
-    It is used to when data is read from CDF.
+    It is used when data is read from CDF.
 
     Args:
         space (str): The space where the node is located.
@@ -310,7 +310,7 @@ class _CogniteExtractorTimeSeriesProperties:
 class CogniteExtractorTimeSeriesApply(_CogniteExtractorTimeSeriesProperties, TypedNodeApply):
     """This represents the writing format of Cognite extractor time series.
 
-    It is used to when data is written to CDF.
+    It is used when data is written to CDF.
 
     Args:
         space (str): The space where the node is located.
@@ -387,7 +387,7 @@ class CogniteExtractorTimeSeriesApply(_CogniteExtractorTimeSeriesProperties, Typ
 class CogniteExtractorTimeSeries(_CogniteExtractorTimeSeriesProperties, TypedNode):
     """This represents the reading format of Cognite extractor time series.
 
-    It is used to when data is read from CDF.
+    It is used when data is read from CDF.
 
     Args:
         space (str): The space where the node is located.


### PR DESCRIPTION
## Description
In the doc strings for CDM types, there is a line describing whether the type is used for creating or reading a resource.
This line has the word "to" inside where it does not make sense. Removing this and thus also changing the official documentation. 

There is no code change, purely documentation. 

## Checklist:
- [ ] Tests added/updated.
- [x] Documentation updated. Documentation is generated from docstrings - these must be updated according to your change.
  If a new method has been added it should be referenced in [cognite.rst](https://github.com/cognitedata/cognite-sdk-python/blob/master/docs/source/cognite.rst) in order to generate docs based on its docstring.
- [ ] Changelog updated in [CHANGELOG.md](https://github.com/cognitedata/cognite-sdk-python/blob/master/CHANGELOG.md).
- [ ] Version bumped. If triggering a new release is desired, bump the version number in [_version.py](https://github.com/cognitedata/cognite-sdk-python/blob/master/cognite/client/_version.py) and [pyproject.toml](https://github.com/cognitedata/cognite-sdk-python/blob/master/pyproject.toml) per [semantic versioning](https://semver.org/).
