### PR TITLE
MyPy pass on windows

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -12,7 +12,7 @@ no_implicit_reexport = true
 exclude = cognite/client/_proto.*
 no_implicit_optional = true
 warn_redundant_casts = true
-warn_unused_ignores = false
+warn_unused_ignores = true
 
 [mypy-msal.*]
 ignore_missing_imports = true

--- a/mypy.ini
+++ b/mypy.ini
@@ -12,7 +12,7 @@ no_implicit_reexport = true
 exclude = cognite/client/_proto.*
 no_implicit_optional = true
 warn_redundant_casts = true
-warn_unused_ignores = true
+warn_unused_ignores = false
 
 [mypy-msal.*]
 ignore_missing_imports = true

--- a/tests/tests_unit/test_utils/test_time.py
+++ b/tests/tests_unit/test_utils/test_time.py
@@ -85,7 +85,7 @@ class TestDatetimeToMsIsoTimestamp:
     def test_timezone_unaware(self) -> None:
         input_datetime = datetime(2021, 1, 1, 0, 0, 0, 0)
         with tmp_set_envvar("TZ", "CET"):
-            time.tzset()  # type: ignore[attr-defined]
+            call_time_tzset()
             assert datetime_to_ms_iso_timestamp(input_datetime) == "2021-01-01T00:00:00.000+01:00"
 
     @pytest.mark.dsl
@@ -100,7 +100,7 @@ class TestDatetimeToMsIsoTimestamp:
     def test_timezone_cet_in_local_tz(self) -> None:
         input_datetime = datetime(2021, 1, 1, 0, 0, 0, 0, tzinfo=ZoneInfo("CET"))
         with tmp_set_envvar("TZ", "UTC"):
-            time.tzset()  # type: ignore[attr-defined]
+            call_time_tzset()
             assert datetime_to_ms_iso_timestamp(input_datetime) == "2021-01-01T00:00:00.000+01:00"
 
     def test_incorrect_type(self) -> None:
@@ -120,7 +120,7 @@ class TestDatetimeToMs:
     )
     def test_naive_datetime_to_ms_unix(self, local_tz: str, expected_ms: int) -> None:
         with tmp_set_envvar("TZ", local_tz):
-            time.tzset()  # type: ignore[attr-defined]
+            call_time_tzset()
             assert datetime_to_ms(datetime(2018, 1, 31, tzinfo=None)) == expected_ms
             assert timestamp_to_ms(datetime(2018, 1, 31, tzinfo=None)) == expected_ms
 
@@ -180,7 +180,7 @@ class TestTimestampToMs:
     def test_datetime(self) -> None:
         # Note: See also `TestDatetimeToMs.test_naive_datetime_to_ms`
         with tmp_set_envvar("TZ", "UTC"):
-            time.tzset()  # type: ignore[attr-defined]
+            call_time_tzset()
             assert 1514764800000 == timestamp_to_ms(datetime(2018, 1, 1))
             assert 1546300800000 == timestamp_to_ms(datetime(2019, 1, 1))
             assert MIN_TIMESTAMP_MS == timestamp_to_ms(datetime(1900, 1, 1))
@@ -826,3 +826,11 @@ class TestTimedCache:
         time.sleep(2.01)
         the_function(42)
         assert len(hello) == 2 and hello[-1] == 42
+
+
+def call_time_tzset() -> None:
+    # This is a workaround to call time.tzset() that stops MyPy
+    # from complaining on Windows where tzset is not available.
+    tzset = getattr(time, "tzset", None)
+    if tzset is not None:
+        tzset()

--- a/tests/tests_unit/test_utils/test_time.py
+++ b/tests/tests_unit/test_utils/test_time.py
@@ -85,7 +85,7 @@ class TestDatetimeToMsIsoTimestamp:
     def test_timezone_unaware(self) -> None:
         input_datetime = datetime(2021, 1, 1, 0, 0, 0, 0)
         with tmp_set_envvar("TZ", "CET"):
-            time.tzset()
+            time.tzset()  # type: ignore[attr-defined]
             assert datetime_to_ms_iso_timestamp(input_datetime) == "2021-01-01T00:00:00.000+01:00"
 
     @pytest.mark.dsl
@@ -100,7 +100,7 @@ class TestDatetimeToMsIsoTimestamp:
     def test_timezone_cet_in_local_tz(self) -> None:
         input_datetime = datetime(2021, 1, 1, 0, 0, 0, 0, tzinfo=ZoneInfo("CET"))
         with tmp_set_envvar("TZ", "UTC"):
-            time.tzset()
+            time.tzset()  # type: ignore[attr-defined]
             assert datetime_to_ms_iso_timestamp(input_datetime) == "2021-01-01T00:00:00.000+01:00"
 
     def test_incorrect_type(self) -> None:
@@ -120,7 +120,7 @@ class TestDatetimeToMs:
     )
     def test_naive_datetime_to_ms_unix(self, local_tz: str, expected_ms: int) -> None:
         with tmp_set_envvar("TZ", local_tz):
-            time.tzset()
+            time.tzset()  # type: ignore[attr-defined]
             assert datetime_to_ms(datetime(2018, 1, 31, tzinfo=None)) == expected_ms
             assert timestamp_to_ms(datetime(2018, 1, 31, tzinfo=None)) == expected_ms
 
@@ -180,7 +180,7 @@ class TestTimestampToMs:
     def test_datetime(self) -> None:
         # Note: See also `TestDatetimeToMs.test_naive_datetime_to_ms`
         with tmp_set_envvar("TZ", "UTC"):
-            time.tzset()
+            time.tzset()  # type: ignore[attr-defined]
             assert 1514764800000 == timestamp_to_ms(datetime(2018, 1, 1))
             assert 1546300800000 == timestamp_to_ms(datetime(2019, 1, 1))
             assert MIN_TIMESTAMP_MS == timestamp_to_ms(datetime(1900, 1, 1))


### PR DESCRIPTION
## Description
These four lines fails to run on Windows, MyPy fails to account for the check that these tests are no run on Windows.
<img width="1119" height="475" alt="image" src="https://github.com/user-attachments/assets/a00c5c9d-d822-41e8-b2d1-9afbf79fe293" />



## Checklist:
- [ ] Tests added/updated.
- [ ] Documentation updated. Documentation is generated from docstrings - these must be updated according to your change.
  If a new method has been added it should be referenced in [cognite.rst](https://github.com/cognitedata/cognite-sdk-python/blob/master/docs/source/cognite.rst) in order to generate docs based on its docstring.
- [ ] Changelog updated in [CHANGELOG.md](https://github.com/cognitedata/cognite-sdk-python/blob/master/CHANGELOG.md).
- [ ] Version bumped. If triggering a new release is desired, bump the version number in [_version.py](https://github.com/cognitedata/cognite-sdk-python/blob/master/cognite/client/_version.py) and [pyproject.toml](https://github.com/cognitedata/cognite-sdk-python/blob/master/pyproject.toml) per [semantic versioning](https://semver.org/).
