### PR TITLE
feat(CDF-19308): Add timezone as an optional param to WorkflowScheduledTriggerRule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ Changes are grouped as follows
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
+## [7.83.0] - 2025-08-28
+### Added
+- Add `timezone` as an optional param to the WorkflowScheduledTriggerRule.
+
 ## [7.82.1] - 2025-08-28
 ### Fixed
 - Fix documentation of files.upload_content. It does not support directories. Use more meaningful errors when the path is not a file. 

--- a/cognite/client/_api/workflows.py
+++ b/cognite/client/_api/workflows.py
@@ -81,11 +81,12 @@ class WorkflowTriggerAPI(APIClient):
 
                 >>> from cognite.client import CogniteClient
                 >>> from cognite.client.data_classes.workflows import WorkflowTriggerUpsert, WorkflowScheduledTriggerRule
+                >>> from zoneinfo import ZoneInfo
                 >>> client = CogniteClient()
                 >>> client.workflows.triggers.upsert(
                 ...     WorkflowTriggerUpsert(
                 ...         external_id="my_trigger",
-                ...         trigger_rule=WorkflowScheduledTriggerRule(cron_expression="0 0 * * *"),
+                ...         trigger_rule=WorkflowScheduledTriggerRule(cron_expression="0 0 * * *", timezone=ZoneInfo("UTC")),
                 ...         workflow_external_id="my_workflow",
                 ...         workflow_version="1",
                 ...         input={"a": 1, "b": 2},

--- a/cognite/client/_version.py
+++ b/cognite/client/_version.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
 
-__version__ = "7.82.1"
+__version__ = "7.83.0"
 
 __api_subversion__ = "20230101"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "cognite-sdk"
-version = "7.82.1"
+version = "7.83.0"
 
 description = "Cognite Python SDK"
 readme = "README.md"

--- a/tests/tests_integration/test_api/test_workflows.py
+++ b/tests/tests_integration/test_api/test_workflows.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import time
 import unittest
+from zoneinfo import ZoneInfo
 
 import pytest
 
@@ -593,7 +594,7 @@ class TestWorkflowTriggers:
             created = cognite_client.workflows.triggers.upsert(existing)
 
             update = WorkflowTriggerUpsert._load(existing.dump())
-            new_rule = WorkflowScheduledTriggerRule(cron_expression="0 * * * *")
+            new_rule = WorkflowScheduledTriggerRule(cron_expression="0 * * * *", timezone=ZoneInfo("Europe/Oslo"))
             update.trigger_rule = new_rule
 
             updated = cognite_client.workflows.triggers.upsert(update)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -18,6 +18,7 @@ from datetime import timedelta, timezone
 from pathlib import Path
 from types import UnionType
 from typing import TYPE_CHECKING, Any, Literal, TypeVar, cast, get_args, get_origin, get_type_hints
+from zoneinfo import ZoneInfo
 
 from cognite.client import CogniteClient
 from cognite.client._api_client import APIClient
@@ -538,6 +539,9 @@ class FakeCogniteResourceGenerator:
             return {self._random_string(10): self._random_string(10) for _ in range(self._random.randint(1, 3))}
         elif type_ is CogniteClient:
             return self._cognite_client
+        elif type_ is ZoneInfo:
+            # Special case for ZoneInfo - provide a default timezone
+            return ZoneInfo("UTC")
         elif inspect.isclass(type_) and any(base is abc.ABC for base in type_.__bases__):
             implementations = all_concrete_subclasses(type_)
             if type_ is Filter:


### PR DESCRIPTION
## Description

The timezone is added to the workflow scheduled trigger. It is an optional param . if no value is provided, the underlining jazz API would consider it as UTC. 

Also I had to update the existing assertions. because of the default response of the UTC if timezone wasn not provided


## Checklist:
- [ tes] Tests added/updated.
- [ yes] Documentation updated. Documentation is generated from docstrings - these must be updated according to your change.
  If a new method has been added it should be referenced in [cognite.rst](https://github.com/cognitedata/cognite-sdk-python/blob/master/docs/source/cognite.rst) in order to generate docs based on its docstring.
- [yes ] Changelog updated in [CHANGELOG.md](https://github.com/cognitedata/cognite-sdk-python/blob/master/CHANGELOG.md).
- [yes ] Version bumped. If triggering a new release is desired, bump the version number in [_version.py](https://github.com/cognitedata/cognite-sdk-python/blob/master/cognite/client/_version.py) and [pyproject.toml](https://github.com/cognitedata/cognite-sdk-python/blob/master/pyproject.toml) per [semantic versioning](https://semver.org/).
