### PR TITLE
Fix flaky workflow tests

### DIFF
--- a/tests/tests_integration/test_api/test_workflows.py
+++ b/tests/tests_integration/test_api/test_workflows.py
@@ -88,22 +88,27 @@ def new_workflow(cognite_client: CogniteClient, data_set: DataSet):
 
 
 @pytest.fixture(scope="class")
-def workflow_list(cognite_client: CogniteClient, data_set: DataSet):
+def workflow_list(cognite_client: CogniteClient, data_set: DataSet) -> WorkflowList:
     workflow_1 = WorkflowUpsert(
-        external_id=f"integration_test-workflow_1_{random_string(5)}",
+        external_id="integration_test-workflow_1",
         description="This workflow is for testing purposes",
         data_set_id=data_set.id,
     )
     workflow_2 = WorkflowUpsert(
-        external_id=f"integration_test-workflow_2_{random_string(5)}",
+        external_id="integration_test-workflow_2",
         description="This workflow is for testing purposes",
     )
-    for workflow in [workflow_1, workflow_2]:
-        cognite_client.workflows.upsert(workflow)
-    yield cognite_client.workflows.list()
-    cognite_client.workflows.delete([workflow_1.external_id, workflow_2.external_id], ignore_unknown_ids=True)
-    assert cognite_client.workflows.retrieve(workflow_1.external_id) is None
-    assert cognite_client.workflows.retrieve(workflow_2.external_id) is None
+    workflows = WorkflowList([])
+    retrieved1 = cognite_client.data_sets.retrieve(external_id=workflow_1.external_id)
+    if retrieved1 is None:
+        retrieved1 = cognite_client.workflows.upsert(workflow_1)
+    workflows.append(retrieved1)
+    retrieved2 = cognite_client.data_sets.retrieve(external_id=workflow_2.external_id)
+    if retrieved2 is None:
+        retrieved2 = cognite_client.workflows.upsert(workflow_2)
+
+    workflows.append(retrieved2)
+    return workflows
 
 
 @pytest.fixture


### PR DESCRIPTION
## Description

The `retrieve_workflow` tests is flaky and has failed a few times
<img width="1318" height="297" alt="image" src="https://github.com/user-attachments/assets/287dae3f-d853-4b4e-932c-bdb0ad4310e5" />

**The fix**: The fixture `workflow_list` is only used to test retrieve/list. So instead of recreating new workflows each run, I have made them permanent test data. Then, they should always be availalbe.

## Checklist:
- [ ] Tests added/updated.
- [ ] Documentation updated. Documentation is generated from docstrings - these must be updated according to your change.
  If a new method has been added it should be referenced in [cognite.rst](https://github.com/cognitedata/cognite-sdk-python/blob/master/docs/source/cognite.rst) in order to generate docs based on its docstring.
- [ ] Changelog updated in [CHANGELOG.md](https://github.com/cognitedata/cognite-sdk-python/blob/master/CHANGELOG.md).
- [ ] Version bumped. If triggering a new release is desired, bump the version number in [_version.py](https://github.com/cognitedata/cognite-sdk-python/blob/master/cognite/client/_version.py) and [pyproject.toml](https://github.com/cognitedata/cognite-sdk-python/blob/master/pyproject.toml) per [semantic versioning](https://semver.org/).
