### PR TITLE
[CDF-25318] Agents handle unknown properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,12 @@ Changes are grouped as follows
 ### Fixed
 - Fixes type annotations for Functions API. Adds new `FunctionHandle` type for annotating function handles.
 
+## [7.77.2] - 2025-07-25
+### Added
+- Agents now maintains all properties returned from the API when using the `.load(...)` and `.dump(...)` methods. 
+  Similarly, you can load an `AgentUpsert` from a `dict`/`YAML`/`JSON` object using the `AgentUpsert.load(...)` method
+  and all properties will be sent to the API.
+
 ## [7.77.1] - 2025-07-23
 ### Added
 - Added new `agentsAcl` capability.

--- a/cognite/client/_version.py
+++ b/cognite/client/_version.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
 
-__version__ = "7.77.1"
+__version__ = "7.77.2"
 
 __api_subversion__ = "20230101"

--- a/cognite/client/data_classes/agents/agents.py
+++ b/cognite/client/data_classes/agents/agents.py
@@ -69,11 +69,14 @@ class AgentUpsert(AgentCore):
             external_id=external_id, name=name, description=description, instructions=instructions, model=model
         )
         self.tools: AgentToolUpsertList | None = AgentToolUpsertList(tools) if tools is not None else None
+        self._unknown_properties: dict[str, object] = {}
 
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         result = super().dump(camel_case=camel_case)
         if self.tools:
             result["tools"] = [item.dump(camel_case=camel_case) for item in self.tools]
+        if self._unknown_properties:
+            result.update(self._unknown_properties)
         return result
 
     def as_write(self) -> AgentUpsert:
@@ -88,7 +91,7 @@ class AgentUpsert(AgentCore):
             else None
         )
 
-        return cls(
+        instances = cls(
             external_id=resource["externalId"],
             name=resource["name"],
             description=resource.get("description"),
@@ -96,6 +99,9 @@ class AgentUpsert(AgentCore):
             model=resource.get("model"),
             tools=tools,
         )
+        existing = set(instances.dump(camel_case=True).keys())
+        instances._unknown_properties = {key: value for key, value in resource.items() if key not in existing}
+        return instances
 
 
 class Agent(AgentCore):
@@ -138,11 +144,14 @@ class Agent(AgentCore):
         self.created_time = created_time
         self.last_updated_time = last_updated_time
         self.owner_id = owner_id
+        self._unknown_properties: dict[str, object] = {}
 
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         result = super().dump(camel_case=camel_case)
         if self.tools:
             result["tools"] = [item.dump(camel_case=camel_case) for item in self.tools]
+        if self._unknown_properties:
+            result.update(self._unknown_properties)
         return result
 
     def as_write(self) -> AgentUpsert:
@@ -164,7 +173,7 @@ class Agent(AgentCore):
             else None
         )
 
-        return cls(
+        instance = cls(
             external_id=resource["externalId"],
             name=resource["name"],
             description=resource.get("description"),
@@ -175,6 +184,9 @@ class Agent(AgentCore):
             last_updated_time=resource.get("lastUpdatedTime"),
             owner_id=resource.get("ownerId"),
         )
+        existing = set(instance.dump(camel_case=True).keys())
+        instance._unknown_properties = {key: value for key, value in resource.items() if key not in existing}
+        return instance
 
 
 class AgentUpsertList(CogniteResourceList[AgentUpsert], ExternalIDTransformerMixin):

--- a/cognite/client/data_classes/agents/agents.py
+++ b/cognite/client/data_classes/agents/agents.py
@@ -69,6 +69,8 @@ class AgentUpsert(AgentCore):
             external_id=external_id, name=name, description=description, instructions=instructions, model=model
         )
         self.tools: AgentToolUpsertList | None = AgentToolUpsertList(tools) if tools is not None else None
+        # This stores any unknown properties that are not part of the defined fields.
+        # This is useful while the API is evolving and new fields are added.
         self._unknown_properties: dict[str, object] = {}
 
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
@@ -144,6 +146,8 @@ class Agent(AgentCore):
         self.created_time = created_time
         self.last_updated_time = last_updated_time
         self.owner_id = owner_id
+        # This stores any unknown properties that are not part of the defined fields.
+        # This is useful while the API is evolving and new fields are added.
         self._unknown_properties: dict[str, object] = {}
 
     def dump(self, camel_case: bool = True) -> dict[str, Any]:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "cognite-sdk"
-version = "7.77.1"
+version = "7.77.2"
 
 description = "Cognite Python SDK"
 readme = "README.md"

--- a/tests/tests_unit/test_data_classes/test_agents/test_agents.py
+++ b/tests/tests_unit/test_data_classes/test_agents/test_agents.py
@@ -73,6 +73,18 @@ class TestAgentUpsert:
         dumped = agent.dump(camel_case=True)
         assert agent_upsert_dump == dumped
 
+    def test_load_dump_maintain_unknown_properties(self) -> None:
+        """Test that unknown properties are maintained in the dump."""
+        agent_data = {
+            "externalId": "test_agent",
+            "name": "Test Agent",
+            "unknownProperty": "unknown_value",
+            "labels": ["published"],
+        }
+        dumped = AgentUpsert._load(agent_data).dump(camel_case=True)
+
+        assert dumped == agent_data
+
     def test_as_write(self) -> None:
         agent_upsert = AgentUpsert(
             external_id="test_agent",
@@ -110,6 +122,17 @@ class TestAgent:
 
         dumped = agent.dump(camel_case=True)
         assert agent_minimal_dump == dumped
+
+    def test_load_dump_maintain_unknown_properties(self) -> None:
+        """Test that unknown properties are maintained in the dump."""
+        agent_data = {
+            "externalId": "test_agent",
+            "name": "Test Agent",
+            "unknownProperty": "unknown_value",
+        }
+        dumped = Agent._load(agent_data).dump(camel_case=True)
+
+        assert dumped == agent_data
 
     def test_tools_handling(self) -> None:
         # Test with no tools


### PR DESCRIPTION
## Description

Agents is still in development and there are properties such as `labels` we need to support for early use cases even though they are not part of the official API documentation. Suggest while we are in alpha that we allow unknown properties. [Ref slack.](https://cognitedata.slack.com/archives/C07MH4VBBC5/p1753431756073749?thread_ts=1753427290.917109&cid=C07MH4VBBC5)


## Checklist:
- [x] Tests added/updated.
- [ ] Documentation updated. Documentation is generated from docstrings - these must be updated according to your change.
  If a new method has been added it should be referenced in [cognite.rst](https://github.com/cognitedata/cognite-sdk-python/blob/master/docs/source/cognite.rst) in order to generate docs based on its docstring.
- [x] Changelog updated in [CHANGELOG.md](https://github.com/cognitedata/cognite-sdk-python/blob/master/CHANGELOG.md).
- [x] Version bumped. If triggering a new release is desired, bump the version number in [_version.py](https://github.com/cognitedata/cognite-sdk-python/blob/master/cognite/client/_version.py) and [pyproject.toml](https://github.com/cognitedata/cognite-sdk-python/blob/master/pyproject.toml) per [semantic versioning](https://semver.org/).
