### PR TITLE
Some improvements to workflow/functions tests

### DIFF
--- a/tests/tests_integration/test_api/test_functions.py
+++ b/tests/tests_integration/test_api/test_functions.py
@@ -18,9 +18,9 @@ def a_function(cognite_client: CogniteClient) -> Function:
     name = "python-sdk-test-function"
     external_id = "python-sdk-test-function"
     description = "test function"
-    retrieved = cognite_client.functions.retrieve_multiple(external_ids=[external_id], ignore_unknown_ids=True)
+    retrieved = cognite_client.functions.retrieve(external_id=external_id)
     if retrieved:
-        return retrieved[0]
+        return retrieved
 
     function = cognite_client.functions.create(
         name=name,
@@ -197,3 +197,4 @@ class TestFunctionSchedulesAPI:
     def test_raise_retrieve_unknown(self, cognite_client: CogniteClient) -> None:
         with pytest.raises(CogniteNotFoundError):
             cognite_client.functions.schedules.retrieve(id=[123])
+        assert cognite_client.functions.schedules.retrieve(id=123) is None

--- a/tests/tests_integration/test_api/test_workflows.py
+++ b/tests/tests_integration/test_api/test_workflows.py
@@ -208,7 +208,11 @@ def workflow_version_list(cognite_client: CogniteClient, new_workflow: Workflow)
             ],
         ),
     )
-    upserted_versions = cognite_client.workflows.versions.upsert([version_1, version_2])
+
+    upserted_versions = WorkflowVersionList([])
+    for version in [version_1, version_2]:
+        upserted_version = cognite_client.workflows.versions.upsert(version)
+        upserted_versions.append(upserted_version)
     yield upserted_versions
     cognite_client.workflows.versions.delete(upserted_versions.as_ids(), ignore_unknown_ids=True)
 

--- a/tests/tests_integration/test_api/test_workflows.py
+++ b/tests/tests_integration/test_api/test_workflows.py
@@ -99,15 +99,12 @@ def persisted_workflow_list(cognite_client: CogniteClient, data_set: DataSet) ->
         description="This workflow is for testing purposes",
     )
     workflows = WorkflowList([])
-    retrieved1 = cognite_client.data_sets.retrieve(external_id=workflow_1.external_id)
-    if retrieved1 is None:
-        retrieved1 = cognite_client.workflows.upsert(workflow_1)
-    workflows.append(retrieved1)
-    retrieved2 = cognite_client.data_sets.retrieve(external_id=workflow_2.external_id)
-    if retrieved2 is None:
-        retrieved2 = cognite_client.workflows.upsert(workflow_2)
+    for workflow in [workflow_1, workflow_2]:
+        retrieved = cognite_client.workflows.retrieve(external_id=workflow.external_id)
+        if retrieved is None:
+            retrieved = cognite_client.workflows.upsert(workflow)
+        workflows.append(retrieved)
 
-    workflows.append(retrieved2)
     return workflows
 
 


### PR DESCRIPTION
I believe #[2545034](https://github.com/cognitedata/cognite-sdk-python/pull/2220/commits/25450342be9ccf2bec56cbf65ef07ad944798f6c) fixes a flaky test. It was checking for existence of dataset when determining whether to upsert a worfklow, so it was being reupserted on every run. This again caused lastUpdatedTime to change in the middle of a test execution, causing certain tests to fail.