### PR TITLE
Enhance SimulatorRoutineRevision with pandas support and new time attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,14 @@ Changes are grouped as follows
 - `Security` in case of vulnerabilities.
 
 ## [Unreleased]
+
+## [7.78.1] - 2025-07-30
+### Added
+- New convenience methods `script_to_pandas()`, `inputs_to_pandas()` and `outputs_to_pandas()` to `SimulatorRoutineRevisionCore` for displaying script, inputs and outputs as DataFrames in Jupyter notebooks
+- New time attributes `run_time` and `simulation_time` to the list of fields that get automatically converted to timestamp format when converted to DataFrames
+
 ### Fixed
+- Fixed naming inconsistencies in simulators module: renamed `SimulatorRunList` to `SimulationRunList` and `SimulatorRunDataList` to `SimulationRunDataList`
 - Fixes type annotations for Functions API. Adds new `FunctionHandle` type for annotating function handles.
 
 ## [7.78.0] - 2025-07-29

--- a/cognite/client/_api/simulators/runs.py
+++ b/cognite/client/_api/simulators/runs.py
@@ -8,9 +8,9 @@ from cognite.client._constants import DEFAULT_LIMIT_READ
 from cognite.client.data_classes.simulators.filters import SimulatorRunsFilter
 from cognite.client.data_classes.simulators.runs import (
     SimulationRun,
+    SimulationRunDataList,
+    SimulationRunList,
     SimulationRunWrite,
-    SimulatorRunDataList,
-    SimulatorRunList,
 )
 from cognite.client.utils._experimental import FeaturePreviewWarning
 from cognite.client.utils._identifier import IdentifierSequence
@@ -64,7 +64,7 @@ class SimulatorRunsAPI(APIClient):
         routine_external_ids: SequenceNotStr[str] | None = None,
         routine_revision_external_ids: SequenceNotStr[str] | None = None,
         model_revision_external_ids: SequenceNotStr[str] | None = None,
-    ) -> Iterator[SimulatorRunList]: ...
+    ) -> Iterator[SimulationRunList]: ...
 
     @overload
     def __call__(
@@ -93,7 +93,7 @@ class SimulatorRunsAPI(APIClient):
         routine_external_ids: SequenceNotStr[str] | None = None,
         routine_revision_external_ids: SequenceNotStr[str] | None = None,
         model_revision_external_ids: SequenceNotStr[str] | None = None,
-    ) -> Iterator[SimulationRun] | Iterator[SimulatorRunList]:
+    ) -> Iterator[SimulationRun] | Iterator[SimulationRunList]:
         """Iterate over simulation runs
 
         Fetches simulation runs as they are iterated over, so you keep a limited number of simulation runs in memory.
@@ -111,7 +111,7 @@ class SimulatorRunsAPI(APIClient):
             model_revision_external_ids (SequenceNotStr[str] | None): Filter by model revision external ids
 
         Returns:
-            Iterator[SimulationRun] | Iterator[SimulatorRunList]: yields Simulation Run one by one if chunk is not specified, else SimulatorRunsList objects.
+            Iterator[SimulationRun] | Iterator[SimulationRunList]: yields Simulation Run one by one if chunk is not specified, else SimulatorRunsList objects.
         """
 
         filter_runs = SimulatorRunsFilter(
@@ -126,7 +126,7 @@ class SimulatorRunsAPI(APIClient):
         )
 
         return self._list_generator(
-            list_cls=SimulatorRunList,
+            list_cls=SimulationRunList,
             resource_cls=SimulationRun,
             method="POST",
             filter=filter_runs.dump(),
@@ -145,7 +145,7 @@ class SimulatorRunsAPI(APIClient):
         routine_external_ids: SequenceNotStr[str] | None = None,
         routine_revision_external_ids: SequenceNotStr[str] | None = None,
         model_revision_external_ids: SequenceNotStr[str] | None = None,
-    ) -> SimulatorRunList:
+    ) -> SimulationRunList:
         """`Filter simulation runs <https://developer.cognite.com/api#tag/Simulation-Runs/operation/filter_simulation_runs_simulators_runs_list_post>`_
 
         Retrieves a list of simulation runs that match the given criteria.
@@ -162,7 +162,7 @@ class SimulatorRunsAPI(APIClient):
             model_revision_external_ids (SequenceNotStr[str] | None): Filter by model revision external ids
 
         Returns:
-            SimulatorRunList: List of simulation runs
+            SimulationRunList: List of simulation runs
 
         Examples:
             List simulation runs:
@@ -192,7 +192,7 @@ class SimulatorRunsAPI(APIClient):
             method="POST",
             limit=limit,
             resource_cls=SimulationRun,
-            list_cls=SimulatorRunList,
+            list_cls=SimulationRunList,
             filter=filter_runs.dump(),
         )
 
@@ -203,19 +203,19 @@ class SimulatorRunsAPI(APIClient):
     def retrieve(
         self,
         ids: Sequence[int],
-    ) -> SimulatorRunList | None: ...
+    ) -> SimulationRunList | None: ...
 
     def retrieve(
         self,
         ids: int | Sequence[int],
-    ) -> SimulationRun | SimulatorRunList | None:
+    ) -> SimulationRun | SimulationRunList | None:
         """`Retrieve simulation runs by ID <https://api-docs.cognite.com/20230101/tag/Simulation-Runs/operation/simulation_by_id_simulators_runs_byids_post>`_
 
         Args:
             ids (int | Sequence[int]): The ID(s) of the simulation run(s) to retrieve.
 
         Returns:
-            SimulationRun | SimulatorRunList | None: The simulation run(s) with the given ID(s)
+            SimulationRun | SimulationRunList | None: The simulation run(s) with the given ID(s)
 
         Examples:
             Retrieve a single simulation run by id:
@@ -227,7 +227,7 @@ class SimulatorRunsAPI(APIClient):
         identifiers = IdentifierSequence.load(ids=ids)
         return self._retrieve_multiple(
             resource_cls=SimulationRun,
-            list_cls=SimulatorRunList,
+            list_cls=SimulationRunList,
             identifiers=identifiers,
             resource_path=self._RESOURCE_PATH,
         )
@@ -236,16 +236,16 @@ class SimulatorRunsAPI(APIClient):
     def create(self, items: SimulationRunWrite) -> SimulationRun: ...
 
     @overload
-    def create(self, items: Sequence[SimulationRunWrite]) -> SimulatorRunList: ...
+    def create(self, items: Sequence[SimulationRunWrite]) -> SimulationRunList: ...
 
-    def create(self, items: SimulationRunWrite | Sequence[SimulationRunWrite]) -> SimulationRun | SimulatorRunList:
+    def create(self, items: SimulationRunWrite | Sequence[SimulationRunWrite]) -> SimulationRun | SimulationRunList:
         """`Create simulation runs <https://developer.cognite.com/api#tag/Simulation-Runs/operation/run_simulation_simulators_run_post>`_
 
         Args:
             items (SimulationRunWrite | Sequence[SimulationRunWrite]): The simulation run(s) to execute.
 
         Returns:
-            SimulationRun | SimulatorRunList: Created simulation run(s)
+            SimulationRun | SimulationRunList: Created simulation run(s)
 
         Examples:
             Create new simulation run:
@@ -264,7 +264,7 @@ class SimulatorRunsAPI(APIClient):
         assert_type(items, "simulation_run", [SimulationRunWrite, Sequence])
 
         return self._create_multiple(
-            list_cls=SimulatorRunList,
+            list_cls=SimulationRunList,
             resource_cls=SimulationRun,
             items=items,
             input_resource_cls=SimulationRunWrite,
@@ -274,7 +274,7 @@ class SimulatorRunsAPI(APIClient):
     def list_run_data(
         self,
         run_id: int,
-    ) -> SimulatorRunDataList:
+    ) -> SimulationRunDataList:
         """`Get simulation run data <https://developer.cognite.com/api#tag/Simulation-Runs/operation/simulation_data_by_run_id_simulators_runs_data_list_post>`_
 
         Retrieve data associated with a simulation run by ID.
@@ -283,7 +283,7 @@ class SimulatorRunsAPI(APIClient):
             run_id (int): Simulation run id.
 
         Returns:
-            SimulatorRunDataList: List of simulation run data
+            SimulationRunDataList: List of simulation run data
 
         Examples:
             Get simulation run data by run id:
@@ -303,4 +303,4 @@ class SimulatorRunsAPI(APIClient):
         )
 
         items = req.json().get("items", [])
-        return SimulatorRunDataList._load(items, cognite_client=self._cognite_client)
+        return SimulationRunDataList._load(items, cognite_client=self._cognite_client)

--- a/cognite/client/_version.py
+++ b/cognite/client/_version.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
 
-__version__ = "7.78.0"
+__version__ = "7.78.1"
 
 __api_subversion__ = "20230101"

--- a/cognite/client/data_classes/simulators/__init__.py
+++ b/cognite/client/data_classes/simulators/__init__.py
@@ -16,9 +16,9 @@ from cognite.client.data_classes.simulators.models import (
 )
 from cognite.client.data_classes.simulators.runs import (
     SimulationRun,
+    SimulationRunList,
     SimulationRunWrite,
     SimulationRunWriteList,
-    SimulatorRunList,
 )
 from cognite.client.data_classes.simulators.simulators import (
     Simulator,
@@ -35,6 +35,7 @@ __all__ = [
     "PropertySort",
     "PropertySort",
     "SimulationRun",
+    "SimulationRunList",
     "SimulationRunWrite",
     "SimulationRunWriteList",
     "Simulator",
@@ -50,7 +51,6 @@ __all__ = [
     "SimulatorModelRevisionsFilter",
     "SimulatorModelWrite",
     "SimulatorModelsFilter",
-    "SimulatorRunList",
     "SimulatorStep",
     "SimulatorStepField",
     "SimulatorStepOption",

--- a/cognite/client/data_classes/simulators/runs.py
+++ b/cognite/client/data_classes/simulators/runs.py
@@ -475,7 +475,7 @@ class SimulationRunDataItem(CogniteResource):
         return pd.DataFrame(rows)
 
 
-class SimulatorRunDataList(CogniteResourceList[SimulationRunDataItem], IdTransformerMixin):
+class SimulationRunDataList(CogniteResourceList[SimulationRunDataItem], IdTransformerMixin):
     _RESOURCE = SimulationRunDataItem
 
     def to_pandas(  # type: ignore [override]
@@ -494,7 +494,7 @@ class SimulationRunWriteList(CogniteResourceList[SimulationRunWrite], ExternalID
     _RESOURCE = SimulationRunWrite
 
 
-class SimulatorRunList(WriteableCogniteResourceList[SimulationRunWrite, SimulationRun], IdTransformerMixin):
+class SimulationRunList(WriteableCogniteResourceList[SimulationRunWrite, SimulationRun], IdTransformerMixin):
     _RESOURCE = SimulationRun
 
     def as_write(self) -> SimulationRunWriteList:

--- a/cognite/client/utils/_time.py
+++ b/cognite/client/utils/_time.py
@@ -305,6 +305,8 @@ TIME_ATTRIBUTES = {
     "start_time",
     "timestamp",
     "uploaded_time",
+    "run_time",
+    "simulation_time",
 }
 TIME_ATTRIBUTES |= set(map(to_camel_case, TIME_ATTRIBUTES))
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "cognite-sdk"
-version = "7.78.0"
+version = "7.78.1"
 
 description = "Cognite Python SDK"
 readme = "README.md"

--- a/tests/tests_unit/test_data_classes/test_simulators.py
+++ b/tests/tests_unit/test_data_classes/test_simulators.py
@@ -1,0 +1,303 @@
+from __future__ import annotations
+
+import pytest
+
+from cognite.client.data_classes.simulators.routine_revisions import (
+    SimulationValueUnitInput,
+    SimulatorRoutineConfiguration,
+    SimulatorRoutineInputConstant,
+    SimulatorRoutineInputTimeseries,
+    SimulatorRoutineOutput,
+    SimulatorRoutineRevisionWrite,
+    SimulatorRoutineStage,
+    SimulatorRoutineStep,
+    SimulatorRoutineStepArguments,
+)
+from cognite.client.data_classes.simulators.runs import (
+    SimulationInput,
+    SimulationOutput,
+    SimulationRunDataItem,
+    SimulationRunDataList,
+    SimulationValueUnitName,
+)
+from cognite.client.utils._importing import local_import
+
+
+class TestSimulatorRoutineRevisionCore:
+    @pytest.fixture
+    def sample_configuration(self) -> SimulatorRoutineConfiguration:
+        """Create a sample configuration with inputs and outputs."""
+        inputs = [
+            SimulatorRoutineInputConstant(
+                name="Temperature",
+                reference_id="temp_001",
+                value=25.5,
+                value_type="DOUBLE",
+                unit=SimulationValueUnitInput(name="°C", quantity="temperature"),
+                save_timeseries_external_id="ts_temp_001",
+            ),
+            SimulatorRoutineInputTimeseries(
+                name="Pressure",
+                reference_id="pressure_001",
+                source_external_id="ts_pressure_source",
+                aggregate="average",
+                unit=SimulationValueUnitInput(name="bar", quantity="pressure"),
+            ),
+        ]
+
+        outputs = [
+            SimulatorRoutineOutput(
+                name="Flow Rate",
+                reference_id="flow_001",
+                value_type="DOUBLE",
+                unit=SimulationValueUnitInput(name="m³/h", quantity="flow_rate"),
+                save_timeseries_external_id="ts_flow_001",
+            ),
+            SimulatorRoutineOutput(
+                name="Efficiency",
+                reference_id="eff_001",
+                value_type="DOUBLE",
+                unit=SimulationValueUnitInput(name="%", quantity="percentage"),
+            ),
+        ]
+
+        return SimulatorRoutineConfiguration(inputs=inputs, outputs=outputs)
+
+    @pytest.fixture
+    def sample_routine_revision(
+        self, sample_configuration: SimulatorRoutineConfiguration
+    ) -> SimulatorRoutineRevisionWrite:
+        """Create a sample routine revision with script stages and steps."""
+        steps_stage1 = [
+            SimulatorRoutineStep(
+                step_type="Get",
+                order=1,
+                arguments=SimulatorRoutineStepArguments({"referenceId": "temp_001", "unitId": "°C"}),
+                description="Get temperature value",
+            ),
+            SimulatorRoutineStep(
+                step_type="Set",
+                order=2,
+                arguments=SimulatorRoutineStepArguments({"referenceId": "pressure_001", "value": "1.5"}),
+                description="Set pressure value",
+            ),
+        ]
+
+        steps_stage2 = [
+            SimulatorRoutineStep(
+                step_type="Command",
+                order=1,
+                arguments=SimulatorRoutineStepArguments({"command": "run_simulation", "timeout": "300"}),
+                description="Run simulation",
+            ),
+            SimulatorRoutineStep(
+                step_type="Get",
+                order=2,
+                arguments=SimulatorRoutineStepArguments({"referenceId": "flow_001"}),
+                description="Get flow rate",
+            ),
+        ]
+
+        # Create stages
+        stages = [
+            SimulatorRoutineStage(order=1, steps=steps_stage1, description="Initialization stage"),
+            SimulatorRoutineStage(order=2, steps=steps_stage2, description="Execution stage"),
+        ]
+
+        return SimulatorRoutineRevisionWrite(
+            external_id="test_revision",
+            routine_external_id="test_routine",
+            script=stages,
+            configuration=sample_configuration,
+        )
+
+    def test_inputs_to_pandas(self, sample_routine_revision: SimulatorRoutineRevisionWrite) -> None:
+        pd = local_import("pandas")
+
+        df = sample_routine_revision.inputs_to_pandas()
+
+        assert isinstance(df, pd.DataFrame)
+        assert len(df) == 2
+        assert "name" in df.columns
+        assert "reference_id" in df.columns
+        assert "unit_name" in df.columns
+        assert "unit_quantity" in df.columns
+        assert df.iloc[0]["name"] == "Temperature"
+        assert df.iloc[1]["name"] == "Pressure"
+        assert df.iloc[0]["unit_name"] == "°C"
+        assert df.iloc[0]["unit_quantity"] == "temperature"
+        assert df.iloc[1]["unit_name"] == "bar"
+        assert df.iloc[1]["unit_quantity"] == "pressure"
+
+    def test_outputs_to_pandas(self, sample_routine_revision: SimulatorRoutineRevisionWrite) -> None:
+        pd = local_import("pandas")
+
+        df = sample_routine_revision.outputs_to_pandas()
+
+        assert isinstance(df, pd.DataFrame)
+        assert len(df) == 2
+        assert "name" in df.columns
+        assert "reference_id" in df.columns
+        assert "value_type" in df.columns
+        assert "unit_name" in df.columns
+        assert "unit_quantity" in df.columns
+        assert df.iloc[0]["name"] == "Flow Rate"
+        assert df.iloc[1]["name"] == "Efficiency"
+        assert df.iloc[0]["unit_name"] == "m³/h"
+        assert df.iloc[0]["unit_quantity"] == "flow_rate"
+        assert df.iloc[1]["unit_name"] == "%"
+        assert df.iloc[1]["unit_quantity"] == "percentage"
+
+    def test_script_to_pandas(self, sample_routine_revision: SimulatorRoutineRevisionWrite) -> None:
+        pd = local_import("pandas")
+
+        df = sample_routine_revision.script_to_pandas()
+
+        assert isinstance(df, pd.DataFrame)
+        assert len(df) == 4  # 2 stages with 2 steps each
+
+        # Check required columns
+        assert "stage_order" in df.columns
+        assert "stage_description" in df.columns
+        assert "step_order" in df.columns
+        assert "step_type" in df.columns
+        assert "step_description" in df.columns
+
+        # Check argument columns are present (now in snake_case)
+        assert "arg_reference_id" in df.columns
+        assert "arg_unit_id" in df.columns
+        assert "arg_value" in df.columns
+        assert "arg_command" in df.columns
+        assert "arg_timeout" in df.columns
+
+        # Check values
+        assert df.iloc[0]["stage_order"] == 1
+        assert df.iloc[0]["stage_description"] == "Initialization stage"
+        assert df.iloc[0]["step_order"] == 1
+        assert df.iloc[0]["step_type"] == "Get"
+        assert df.iloc[0]["step_description"] == "Get temperature value"
+        assert df.iloc[0]["arg_reference_id"] == "temp_001"
+        assert df.iloc[0]["arg_unit_id"] == "°C"
+
+        assert df.iloc[1]["stage_order"] == 1
+        assert df.iloc[1]["step_type"] == "Set"
+        assert df.iloc[1]["arg_value"] == "1.5"
+
+        assert df.iloc[2]["stage_order"] == 2
+        assert df.iloc[2]["stage_description"] == "Execution stage"
+        assert df.iloc[2]["step_type"] == "Command"
+        assert df.iloc[2]["arg_command"] == "run_simulation"
+        assert df.iloc[2]["arg_timeout"] == "300"
+
+        assert df.iloc[3]["step_type"] == "Get"
+        assert df.iloc[3]["arg_reference_id"] == "flow_001"
+
+
+class TestSimulationRunData:
+    @pytest.fixture
+    def sample_simulation_inputs(self) -> list[SimulationInput]:
+        """Create sample simulation inputs."""
+        return [
+            SimulationInput(
+                reference_id="temp_input",
+                value=25.5,
+                value_type="DOUBLE",
+                unit=SimulationValueUnitName(name="°C"),
+                overridden=False,
+            ),
+            SimulationInput(
+                reference_id="pressure_input",
+                value=1.5,
+                value_type="DOUBLE",
+                unit=SimulationValueUnitName(name="bar"),
+                simulator_object_reference={"objectName": "Tank1", "objectProperty": "Pressure"},
+                overridden=True,
+            ),
+        ]
+
+    @pytest.fixture
+    def sample_simulation_outputs(self) -> list[SimulationOutput]:
+        """Create sample simulation outputs."""
+        return [
+            SimulationOutput(
+                reference_id="flow_output",
+                value=150.3,
+                value_type="DOUBLE",
+                unit=SimulationValueUnitName(name="m³/h"),
+                timeseries_external_id="ts_flow_001",
+            ),
+            SimulationOutput(
+                reference_id="status_output",
+                value="OK",
+                value_type="STRING",
+            ),
+        ]
+
+    @pytest.fixture
+    def sample_run_data_item(
+        self, sample_simulation_inputs: list[SimulationInput], sample_simulation_outputs: list[SimulationOutput]
+    ) -> SimulationRunDataItem:
+        """Create a sample SimulationRunDataItem."""
+        return SimulationRunDataItem(
+            run_id=12345,
+            inputs=sample_simulation_inputs,
+            outputs=sample_simulation_outputs,
+        )
+
+    def test_simulation_run_data_item_to_pandas(self, sample_run_data_item: SimulationRunDataItem) -> None:
+        pd = local_import("pandas")
+
+        df = sample_run_data_item.to_pandas()
+
+        assert isinstance(df, pd.DataFrame)
+        assert len(df) == 4  # 2 inputs + 2 outputs
+
+        # Check required columns
+        assert "run_id" in df.columns
+        assert "type" in df.columns
+        assert "reference_id" in df.columns
+        assert "value" in df.columns
+        assert "value_type" in df.columns
+        assert "unit_name" in df.columns
+        assert "overridden" in df.columns
+        assert "timeseries_external_id" in df.columns
+
+        # Check values
+        assert all(df["run_id"] == 12345)
+        assert list(df["type"]) == ["Input", "Input", "Output", "Output"]
+        assert df.iloc[0]["reference_id"] == "temp_input"
+        assert df.iloc[0]["value"] == 25.5
+        assert df.iloc[0]["unit_name"] == "°C"
+        assert not df.iloc[0]["overridden"]
+
+        # Check simulator object reference columns (snake_case)
+        assert "object_name" in df.columns
+        assert "object_property" in df.columns
+        assert df.iloc[1]["object_name"] == "Tank1"
+        assert df.iloc[1]["object_property"] == "Pressure"
+
+    def test_simulation_run_data_list_to_pandas(
+        self, sample_simulation_inputs: list[SimulationInput], sample_simulation_outputs: list[SimulationOutput]
+    ) -> None:
+        pd = local_import("pandas")
+
+        # Create multiple run data items
+        items = [
+            SimulationRunDataItem(
+                run_id=12345,
+                inputs=sample_simulation_inputs[:1],
+                outputs=sample_simulation_outputs[:1],
+            ),
+            SimulationRunDataItem(
+                run_id=12346,
+                inputs=sample_simulation_inputs[1:],
+                outputs=sample_simulation_outputs[1:],
+            ),
+        ]
+
+        data_list = SimulationRunDataList(items)
+        df = data_list.to_pandas()
+
+        assert isinstance(df, pd.DataFrame)
+        assert len(df) == 4  # 2 items with 2 rows each
+        assert list(df["run_id"].unique()) == [12345, 12346]

--- a/tests/tests_unit/test_utils/test_time.py
+++ b/tests/tests_unit/test_utils/test_time.py
@@ -329,6 +329,10 @@ class TestObjectTimeConversion:
             ([{"source_modified_time": 0}], [{"source_modified_time": "1970-01-01 00:00:00.000+00:00"}]),
             ([{"not_a_time": 0}], [{"not_a_time": 0}]),
             ([{"created_time": int(1e15)}], [{"created_time": int(1e15)}]),
+            ({"run_time": 1609459200000}, {"run_time": "2021-01-01 00:00:00.000+00:00"}),
+            ({"simulation_time": 1609459200000}, {"simulation_time": "2021-01-01 00:00:00.000+00:00"}),
+            ({"runTime": 1609459200000}, {"runTime": "2021-01-01 00:00:00.000+00:00"}),
+            ({"simulationTime": 1609459200000}, {"simulationTime": "2021-01-01 00:00:00.000+00:00"}),
         ],
     )
     def test_convert_and_isoformat_time_attrs(self, item: dict[str, int], expected_output: dict[str, str]) -> None:


### PR DESCRIPTION
## Description
- New pandas conversion methods to help demo/visualize/inspect SimulatorRoutineRevision attributes in Jupyter Notebooks
- Fixed a typo in class names
- Added new simulator specific time attributes for auto timestamp conversion

### Screenshots
#### `inputs_to_pandas()`
<img width="1202" height="519" alt="image" src="https://github.com/user-attachments/assets/c4b06b34-9894-4a5f-bc9a-b9ba02eceb47" />

#### `outputs_to_pandas()`
<img width="1195" height="317" alt="image" src="https://github.com/user-attachments/assets/d05522e8-b8f6-4a13-bba3-dbdbd1ff1609" />

#### `script_to_pandas()`
<img width="1193" height="601" alt="image" src="https://github.com/user-attachments/assets/8ea7c927-92a6-4f72-a742-89d3c97f7e8d" />

## Checklist:
- [x] Tests added/updated.
- [x] Documentation updated. Documentation is generated from docstrings - these must be updated according to your change.
  If a new method has been added it should be referenced in [cognite.rst](https://github.com/cognitedata/cognite-sdk-python/blob/master/docs/source/cognite.rst) in order to generate docs based on its docstring.
- [x] Changelog updated in [CHANGELOG.md](https://github.com/cognitedata/cognite-sdk-python/blob/master/CHANGELOG.md).
- [x] Version bumped. If triggering a new release is desired, bump the version number in [_version.py](https://github.com/cognitedata/cognite-sdk-python/blob/master/cognite/client/_version.py) and [pyproject.toml](https://github.com/cognitedata/cognite-sdk-python/blob/master/pyproject.toml) per [semantic versioning](https://semver.org/).
