### PR TITLE
Make `CogniteObject` abstract

### DIFF
--- a/cognite/client/data_classes/_base.py
+++ b/cognite/client/data_classes/_base.py
@@ -111,7 +111,7 @@ class _WithClientMixin:
         return self.__cognite_client
 
 
-class CogniteObject:
+class CogniteObject(ABC):
     """The Cognite Object is used to add serialization and deserialization to the data classes.
 
     It is used both by the CogniteResources and the nested classes used by the CogniteResources.

--- a/cognite/client/data_classes/simulators/routine_revisions.py
+++ b/cognite/client/data_classes/simulators/routine_revisions.py
@@ -44,7 +44,7 @@ class SimulationValueUnitInput(CogniteObject):
 
 
 @dataclass
-class SimulatorRoutineInput(CogniteObject):
+class SimulatorRoutineInput(CogniteObject, ABC):
     """
     The input of the simulator routine revision.
 

--- a/cognite/client/utils/_auxiliary.py
+++ b/cognite/client/utils/_auxiliary.py
@@ -75,7 +75,7 @@ def fast_dict_load(
         instance = cls()
     # Note: Do not use cast(Hashable, cls) here as this is often called in a hot loop
     # Accepted: {camel_case(attribute_name): attribute_name}
-    accepted = get_accepted_params(cls)  # type: ignore [arg-type]
+    accepted = get_accepted_params(cls)
     for camel_attr, value in item.items():
         try:
             setattr(instance, accepted[camel_attr], value)


### PR DESCRIPTION
It should not be instantiated itself, so it ought to be an abstract base class.
