### PR TITLE
Only emit number of failed/successfull/unknown items in exception __str__ reprs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,10 @@ Changes are grouped as follows
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
-## [Unreleased]
+## [7.78.1] - 2025-08-01
+### Changed
+- Only emit counts for each status (successful, failed, unknown, skipped) in exception __str__ reprs. The actual 
+  underlying objects are still available through the `succesful`, `unknown`, `failed`, and `skipped` attributes.
 ### Fixed
 - Fixes type annotations for Functions API. Adds new `FunctionHandle` type for annotating function handles.
 

--- a/cognite/client/_api/files.py
+++ b/cognite/client/_api/files.py
@@ -1102,8 +1102,7 @@ class FilesAPI(APIClient):
         tasks = [(directory, {"id": id}, filepath, headers) for id, filepath in zip(all_ids, filepaths)]
         tasks_summary = execute_tasks(self._process_file_download, tasks, max_workers=self._config.max_workers)
         tasks_summary.raise_compound_exception_if_failed_tasks(
-            task_unwrap_fn=lambda task: id_to_metadata[task[1]["id"]],
-            str_format_element_fn=lambda metadata: metadata.id,
+            task_unwrap_fn=lambda task: id_to_metadata[task[1]["id"]]
         )
 
     def _get_download_link(self, identifier: dict[str, int | str]) -> str:

--- a/cognite/client/_api/three_d.py
+++ b/cognite/client/_api/three_d.py
@@ -758,7 +758,5 @@ class ThreeDAssetMappingAPI(APIClient):
         tasks = [{"url_path": path + "/delete", "json": {"items": chunk}} for chunk in chunks]
         summary = execute_tasks(self._post, tasks, self._config.max_workers)
         summary.raise_compound_exception_if_failed_tasks(
-            task_unwrap_fn=unpack_items_in_payload,
-            task_list_element_unwrap_fn=lambda el: ThreeDAssetMapping._load(el),
-            str_format_element_fn=lambda el: (el.asset_id, el.node_id),
+            task_unwrap_fn=unpack_items_in_payload, task_list_element_unwrap_fn=lambda el: ThreeDAssetMapping._load(el)
         )

--- a/cognite/client/_api_client.py
+++ b/cognite/client/_api_client.py
@@ -933,24 +933,8 @@ class APIClient:
             else:
                 return el
 
-        def str_format_element(el: T) -> str | dict | T:
-            if isinstance(el, CogniteResource):
-                dumped = el.dump()
-                if "external_id" in dumped:
-                    if "space" in dumped:
-                        return f"{dumped['space']}:{dumped['external_id']}"
-                    return dumped["external_id"]
-                if "externalId" in dumped:
-                    if "space" in dumped:
-                        return f"{dumped['space']}:{dumped['externalId']}"
-                    return dumped["externalId"]
-                return dumped
-            return el
-
         summary.raise_compound_exception_if_failed_tasks(
-            task_unwrap_fn=lambda task: task[1]["items"],
-            task_list_element_unwrap_fn=unwrap_element,
-            str_format_element_fn=str_format_element,
+            task_unwrap_fn=lambda task: task[1]["items"], task_list_element_unwrap_fn=unwrap_element
         )
         created_resources = summary.joined_results(lambda res: res.json()["items"])
 
@@ -1150,9 +1134,9 @@ class APIClient:
                         cdf_item_by_id=cast(Mapping | None, cdf_item_by_id),
                     )
             except CogniteAPIError as api_error:
-                successful = api_error.successful
-                unknown = api_error.unknown
-                failed = api_error.failed
+                successful = list(api_error.successful)
+                unknown = list(api_error.unknown)
+                failed = list(api_error.failed)
 
                 successful.extend(not_found_error.successful)
                 unknown.extend(not_found_error.unknown)

--- a/cognite/client/_version.py
+++ b/cognite/client/_version.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
 
-__version__ = "7.78.0"
+__version__ = "7.78.1"
 
 __api_subversion__ = "20230101"

--- a/cognite/client/exceptions.py
+++ b/cognite/client/exceptions.py
@@ -1,13 +1,12 @@
 from __future__ import annotations
 
 import reprlib
-from collections.abc import Callable
+from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
 from cognite.client._constants import _RUNNING_IN_BROWSER
 from cognite.client.utils import _json
-from cognite.client.utils._auxiliary import no_op
 from cognite.client.utils._time import timed_cache
 
 if TYPE_CHECKING:
@@ -121,22 +120,17 @@ class CogniteFileUploadError(CogniteException):
 class CogniteMultiException(CogniteException):
     def __init__(
         self,
-        successful: list | None = None,
-        failed: list | None = None,
-        unknown: list | None = None,
-        skipped: list | None = None,
-        unwrap_fn: Callable = no_op,
+        successful: Sequence | None = None,
+        failed: Sequence | None = None,
+        unknown: Sequence | None = None,
+        skipped: Sequence | None = None,
     ) -> None:
-        self.successful = successful or []
-        self.failed = failed or []
-        self.unknown = unknown or []
-        self.skipped = skipped or []
-        self._unwrap_fn = unwrap_fn
+        self.successful: Sequence = successful or []
+        self.failed: Sequence = failed or []
+        self.unknown: Sequence = unknown or []
+        self.skipped: Sequence = skipped or []
 
-    def _unwrap_list(self, lst: list) -> list:
-        return [self._unwrap_fn(elem) for elem in lst]
-
-    def _truncate_elements(self, lst: list) -> str:
+    def _truncate_elements(self, lst: Sequence) -> str:
         truncate_at = 10
         elements = ",".join([str(element) for element in lst[:truncate_at]])
         if len(elements) > truncate_at:
@@ -149,13 +143,13 @@ class CogniteMultiException(CogniteException):
         summary = [
             "",  # start string with newline
             "The API Failed to process some items.",
-            f"Successful (2xx): {self._truncate_elements(self._unwrap_list(self.successful))}",
-            f"Unknown (5xx): {self._truncate_elements(self._unwrap_list(self.unknown))}",
-            f"Failed (4xx): {self._truncate_elements(self._unwrap_list(self.failed))}",
+            f"Successful (2xx): {len(self.successful)}",
+            f"Unknown (5xx): {len(self.unknown)}",
+            f"Failed (4xx): {len(self.failed)}",
         ]
         # Only show 'skipped' when tasks were skipped to avoid confusion:
-        if skipped := self._unwrap_list(self.skipped):
-            summary.append(f"Skipped: {skipped}")
+        if skipped := self.skipped:
+            summary.append(f"Skipped: {len(skipped)}")
         return "\n".join(summary)
 
 
@@ -170,13 +164,12 @@ class CogniteAPIError(CogniteMultiException):
         message (str): The error message produced by the API.
         code (int): The error code produced by the failure.
         x_request_id (str | None): The request-id generated for the failed request.
-        missing (list | None): (List) List of missing identifiers.
-        duplicated (list | None): (List) List of duplicated identifiers.
-        successful (list | None): List of items which were successfully processed.
-        failed (list | None): List of items which failed.
-        unknown (list | None): List of items which may or may not have been successfully processed.
-        skipped (list | None): List of items that were skipped due to "fail fast" mode.
-        unwrap_fn (Callable): Function to extract identifier from the Cognite resource.
+        missing (Sequence | None): (List) List of missing identifiers.
+        duplicated (Sequence | None): (List) List of duplicated identifiers.
+        successful (Sequence | None): List of items which were successfully processed.
+        failed (Sequence | None): List of items which failed.
+        unknown (Sequence | None): List of items which may or may not have been successfully processed.
+        skipped (Sequence | None): List of items that were skipped due to "fail fast" mode.
         cluster (str | None): Which Cognite cluster the user's project is on.
         extra (dict | None): A dict of any additional information.
 
@@ -205,13 +198,12 @@ class CogniteAPIError(CogniteMultiException):
         message: str,
         code: int,
         x_request_id: str | None = None,
-        missing: list | None = None,
-        duplicated: list | None = None,
-        successful: list | None = None,
-        failed: list | None = None,
-        unknown: list | None = None,
-        skipped: list | None = None,
-        unwrap_fn: Callable = no_op,
+        missing: Sequence | None = None,
+        duplicated: Sequence | None = None,
+        successful: Sequence | None = None,
+        failed: Sequence | None = None,
+        unknown: Sequence | None = None,
+        skipped: Sequence | None = None,
         cluster: str | None = None,
         extra: dict | None = None,
     ) -> None:
@@ -222,7 +214,7 @@ class CogniteAPIError(CogniteMultiException):
         self.duplicated = duplicated
         self.cluster = cluster
         self.extra = extra
-        super().__init__(successful, failed, unknown, skipped, unwrap_fn)
+        super().__init__(successful, failed, unknown, skipped)
 
     def __str__(self) -> str:
         msg = f"{self.message} | code: {self.code} | X-Request-ID: {self.x_request_id}"
@@ -245,29 +237,27 @@ class CogniteNotFoundError(CogniteMultiException):
     Raised if one or more of the referenced ids/external ids are not found.
 
     Args:
-        not_found (list): The ids not found.
-        successful (list | None): List of items which were successfully processed.
-        failed (list | None): List of items which failed.
-        unknown (list | None): List of items which may or may not have been successfully processed.
-        skipped (list | None): List of items that were skipped due to "fail fast" mode.
-        unwrap_fn (Callable): No description.
+        not_found (Sequence): The ids not found.
+        successful (Sequence | None): List of items which were successfully processed.
+        failed (Sequence | None): List of items which failed.
+        unknown (Sequence | None): List of items which may or may not have been successfully processed.
+        skipped (Sequence | None): List of items that were skipped due to "fail fast" mode.
     """
 
     def __init__(
         self,
-        not_found: list,
-        successful: list | None = None,
-        failed: list | None = None,
-        unknown: list | None = None,
-        skipped: list | None = None,
-        unwrap_fn: Callable = no_op,
+        not_found: Sequence,
+        successful: Sequence | None = None,
+        failed: Sequence | None = None,
+        unknown: Sequence | None = None,
+        skipped: Sequence | None = None,
     ) -> None:
         self.not_found = not_found
-        super().__init__(successful, failed, unknown, skipped, unwrap_fn)
+        super().__init__(successful, failed, unknown, skipped)
 
     def __str__(self) -> str:
         if len(not_found := self.not_found) > 200:
-            not_found = reprlib.repr(self.not_found)  # type: ignore [assignment]
+            not_found = reprlib.repr(self.not_found)
         return f"Not found: {not_found}{self._get_multi_exception_summary()}"
 
 
@@ -277,25 +267,23 @@ class CogniteDuplicatedError(CogniteMultiException):
     Raised if one or more of the referenced ids/external ids have been duplicated in the request.
 
     Args:
-        duplicated (list): The duplicated ids.
-        successful (list | None): List of items which were successfully processed.
-        failed (list | None): List of items which failed.
-        unknown (list | None): List of items which may or may not have been successfully processed.
-        skipped (list | None): List of items that were skipped due to "fail fast" mode.
-        unwrap_fn (Callable): Function to extract identifier from the Cognite resource.
+        duplicated (Sequence): The duplicated ids.
+        successful (Sequence | None): List of items which were successfully processed.
+        failed (Sequence | None): List of items which failed.
+        unknown (Sequence | None): List of items which may or may not have been successfully processed.
+        skipped (Sequence | None): List of items that were skipped due to "fail fast" mode.
     """
 
     def __init__(
         self,
-        duplicated: list,
-        successful: list | None = None,
-        failed: list | None = None,
-        unknown: list | None = None,
-        skipped: list | None = None,
-        unwrap_fn: Callable = no_op,
+        duplicated: Sequence,
+        successful: Sequence | None = None,
+        failed: Sequence | None = None,
+        unknown: Sequence | None = None,
+        skipped: Sequence | None = None,
     ) -> None:
         self.duplicated = duplicated
-        super().__init__(successful, failed, unknown, skipped, unwrap_fn)
+        super().__init__(successful, failed, unknown, skipped)
 
     def __str__(self) -> str:
         msg = f"Duplicated: {self.duplicated}"

--- a/cognite/client/utils/_concurrency.py
+++ b/cognite/client/utils/_concurrency.py
@@ -53,10 +53,7 @@ class TasksSummary:
         return [res.json() for res in self.results]
 
     def raise_compound_exception_if_failed_tasks(
-        self,
-        task_unwrap_fn: Callable = no_op,
-        task_list_element_unwrap_fn: Callable | None = None,
-        str_format_element_fn: Callable = no_op,
+        self, task_unwrap_fn: Callable = no_op, task_list_element_unwrap_fn: Callable | None = None
     ) -> None:
         if not (self.unknown_error or self.not_found_error or self.duplicated_error):
             return None
@@ -72,16 +69,17 @@ class TasksSummary:
             failed = [task_list_element_unwrap_fn(el) for t in self.failed_tasks for el in task_unwrap_fn(t)]
             skipped = [task_list_element_unwrap_fn(el) for t in self.skipped_tasks for el in task_unwrap_fn(t)]
 
-        task_lists = dict(successful=successful, failed=failed, unknown=unknown, skipped=skipped)
         if self.unknown_error:
-            self._raise_basic_api_error(str_format_element_fn, **task_lists)
+            self._raise_basic_api_error(successful=successful, failed=failed, unknown=unknown, skipped=skipped)
         if self.not_found_error:
-            self._raise_not_found_error(str_format_element_fn, **task_lists)
+            self._raise_not_found_error(successful=successful, failed=failed, unknown=unknown, skipped=skipped)
         if self.duplicated_error:
-            self._raise_duplicated_error(str_format_element_fn, **task_lists)
+            self._raise_duplicated_error(successful=successful, failed=failed, unknown=unknown, skipped=skipped)
 
-    def _inspect_exceptions(self, exceptions: list[Exception]) -> tuple[list, list, str | None]:
-        cluster, missing, duplicated = None, [], []
+    def _inspect_exceptions(self, exceptions: list[Exception]) -> tuple[Sequence, Sequence, str | None]:
+        cluster = None
+        missing: list[dict] = []
+        duplicated: list[dict] = []
         for exc in exceptions:
             if not isinstance(exc, CogniteAPIError):
                 self.unknown_error = exc
@@ -99,8 +97,10 @@ class TasksSummary:
                 self.unknown_error = exc
         return missing, duplicated, cluster
 
-    def _raise_basic_api_error(self, unwrap_fn: Callable, **task_lists: list) -> NoReturn:
-        if isinstance(self.unknown_error, CogniteAPIError) and (task_lists["failed"] or task_lists["unknown"]):
+    def _raise_basic_api_error(
+        self, successful: Sequence, failed: Sequence, unknown: Sequence, skipped: Sequence
+    ) -> NoReturn:
+        if isinstance(self.unknown_error, CogniteAPIError) and (failed or unknown):
             raise CogniteAPIError(
                 message=self.unknown_error.message,
                 code=self.unknown_error.code,
@@ -108,17 +108,27 @@ class TasksSummary:
                 missing=self.missing,
                 duplicated=self.duplicated,
                 extra=self.unknown_error.extra,
-                unwrap_fn=unwrap_fn,
                 cluster=self.cluster,
-                **task_lists,
+                successful=successful,
+                failed=failed,
+                unknown=unknown,
+                skipped=skipped,
             )
         raise self.unknown_error  # type: ignore [misc]
 
-    def _raise_not_found_error(self, unwrap_fn: Callable, **task_lists: list) -> NoReturn:
-        raise CogniteNotFoundError(self.missing, unwrap_fn=unwrap_fn, **task_lists) from self.not_found_error
+    def _raise_not_found_error(
+        self, successful: Sequence, failed: Sequence, unknown: Sequence, skipped: Sequence
+    ) -> NoReturn:
+        raise CogniteNotFoundError(
+            self.missing, successful=successful, failed=failed, unknown=unknown, skipped=skipped
+        ) from self.not_found_error
 
-    def _raise_duplicated_error(self, unwrap_fn: Callable, **task_lists: list) -> NoReturn:
-        raise CogniteDuplicatedError(self.duplicated, unwrap_fn=unwrap_fn, **task_lists) from self.duplicated_error
+    def _raise_duplicated_error(
+        self, successful: Sequence, failed: Sequence, unknown: Sequence, skipped: Sequence
+    ) -> NoReturn:
+        raise CogniteDuplicatedError(
+            self.duplicated, successful=successful, failed=failed, unknown=unknown, skipped=skipped
+        ) from self.duplicated_error
 
 
 T_Result = TypeVar("T_Result", covariant=True)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "cognite-sdk"
-version = "7.78.0"
+version = "7.78.1"
 
 description = "Cognite Python SDK"
 readme = "README.md"

--- a/tests/tests_integration/test_api/test_simulators/test_integrations.py
+++ b/tests/tests_integration/test_api/test_simulators/test_integrations.py
@@ -29,7 +29,7 @@ class TestSimulatorIntegrations:
 
         assert len(integrations) > 0
 
-    def test_filter_integrations(self, cognite_client: CogniteClient, seed_resource_names) -> None:
+    def test_filter_integrations(self, cognite_client: CogniteClient, seed_resource_names: dict[str, str]) -> None:
         for integration in cognite_client.simulators.integrations(filter=SimulatorIntegrationFilter(active=True)):
             assert integration.active is True
 
@@ -44,7 +44,6 @@ class TestSimulatorIntegrations:
 
         item = filtered_integrations.get(external_id=seed_resource_names["simulator_integration_external_id"])
         assert item is not None
-        # assert item.data_set_id == seed_resource_names["simulator_test_data_set_id"]
         assert item.active is True
         assert item.created_time is not None
         assert item.last_updated_time is not None
@@ -53,11 +52,11 @@ class TestSimulatorIntegrations:
         assert log is not None
         assert log.data is not None
         assert log.data[0].timestamp is not None
-        assert log.data[0].timestamp > int(time.time() * 1000) - 10000  # updated less than 10 seconds ago
         assert log.data[0].message == "Testing logs update for simulator integration"
+        assert log.data[0].timestamp > int(time.time() * 1000) - 30000  # updated less than 30 seconds ago
         assert log.data[0].severity == "Debug"
 
-    def test_delete_integrations(self, cognite_client: CogniteClient, seed_resource_names) -> None:
+    def test_delete_integrations(self, cognite_client: CogniteClient, seed_resource_names: dict[str, str]) -> None:
         test_integration = simulator_integration.copy()
         test_integration["heartbeat"] = int(time.time() * 1000)
         test_integration["externalId"] = random_string(50)

--- a/tests/tests_integration/test_api/test_workflows.py
+++ b/tests/tests_integration/test_api/test_workflows.py
@@ -283,50 +283,52 @@ def _create_scheduled_trigger(version: WorkflowVersion, cron_expression: str) ->
 
 
 @pytest.fixture(scope="class")
-def permanent_scheduled_trigger(cognite_client: CogniteClient, permanent_workflow_for_triggers: WorkflowVersion):
+def permanent_scheduled_trigger(
+    cognite_client: CogniteClient, permanent_workflow_for_triggers: WorkflowVersion
+) -> WorkflowTrigger:
     version = permanent_workflow_for_triggers
     ever_minute_expression = "* * * * *"
 
     on_the_minute = _create_scheduled_trigger(version, ever_minute_expression)
 
-    retrieved = cognite_client.workflows.triggers.upsert(on_the_minute)
-    # Have to sleep until workflow is triggered because it's the only way to properly test get_trigger_run_history
-    # ...and as of Jan 14, 2025, there's "an artificial delay of 90 sec to scheduled triggers to prevent a stampede
-    # effect on downstream services for overlapping triggers (up to two minutes, stable per trigger)".
-    time.sleep(90 + 60)
+    existing_triggers = {trigger.external_id: trigger for trigger in cognite_client.workflows.triggers.list(limit=-1)}
+    if on_the_minute.external_id not in existing_triggers:
+        retrieved = cognite_client.workflows.triggers.upsert(on_the_minute)
+    else:
+        retrieved = existing_triggers[on_the_minute.external_id]
 
-    yield retrieved
-
-    never_trigger = _create_scheduled_trigger(version, ALMOST_NEVER_TRIGGER_CRON_EXPRESSION)
-    # Instead of deleting the trigger, we upsert a new one with a cron expression that will never trigger.
-    # This is to avoid deleting/recreating the trigger every time the test runs, which leads to flaky tests.
-    cognite_client.workflows.triggers.upsert(never_trigger)
+    return retrieved
 
 
 @pytest.fixture(scope="class")
-def workflow_data_modeling_trigger(cognite_client: CogniteClient, permanent_workflow_for_triggers: WorkflowVersion):
+def permanent_data_modeling_trigger(cognite_client: CogniteClient, permanent_workflow_for_triggers: WorkflowVersion):
     version = permanent_workflow_for_triggers
-    trigger = cognite_client.workflows.triggers.create(
-        WorkflowTriggerUpsert(
-            external_id=f"data-modeling-trigger_{version.workflow_external_id}",
-            trigger_rule=WorkflowDataModelingTriggerRule(
-                data_modeling_query=WorkflowTriggerDataModelingQuery(
-                    with_={"timeseries": NodeResultSetExpression()},
-                    select={
-                        "timeseries": Select(
-                            sources=[SourceSelector(ViewId("cdf_cdm", "CogniteTimeSeries", "v1"), ["name"])]
-                        )
-                    },
-                ),
-                batch_size=500,
-                batch_timeout=300,
+
+    trigger = WorkflowTriggerUpsert(
+        external_id=f"data-modeling-trigger_{version.workflow_external_id}",
+        trigger_rule=WorkflowDataModelingTriggerRule(
+            data_modeling_query=WorkflowTriggerDataModelingQuery(
+                with_={"timeseries": NodeResultSetExpression()},
+                select={
+                    "timeseries": Select(
+                        sources=[SourceSelector(ViewId("cdf_cdm", "CogniteTimeSeries", "v1"), ["name"])]
+                    )
+                },
             ),
-            workflow_external_id=version.workflow_external_id,
-            workflow_version=version.version,
-        )
+            batch_size=500,
+            batch_timeout=300,
+        ),
+        workflow_external_id=version.workflow_external_id,
+        workflow_version=version.version,
     )
-    yield trigger
-    cognite_client.workflows.triggers.delete(trigger.external_id)
+
+    existing_triggers = {trigger.external_id: trigger for trigger in cognite_client.workflows.triggers.list(limit=-1)}
+    if trigger.external_id not in existing_triggers:
+        retrieved = cognite_client.workflows.triggers.create(trigger)
+    else:
+        retrieved = existing_triggers[trigger.external_id]
+
+    yield retrieved
 
 
 class TestWorkflows:
@@ -604,11 +606,11 @@ class TestWorkflowTriggers:
     def test_create_update_delete_data_modeling_trigger(
         self,
         cognite_client: CogniteClient,
-        workflow_data_modeling_trigger: WorkflowTrigger,
+        permanent_data_modeling_trigger: WorkflowTrigger,
     ) -> None:
-        assert workflow_data_modeling_trigger is not None
-        assert workflow_data_modeling_trigger.external_id.startswith("data-modeling-trigger_integration_test-workflow")
-        assert workflow_data_modeling_trigger.trigger_rule == WorkflowDataModelingTriggerRule(
+        assert permanent_data_modeling_trigger is not None
+        assert permanent_data_modeling_trigger.external_id.startswith("data-modeling-trigger_integration_test-workflow")
+        assert permanent_data_modeling_trigger.trigger_rule == WorkflowDataModelingTriggerRule(
             data_modeling_query=WorkflowTriggerDataModelingQuery(
                 with_={"timeseries": NodeResultSetExpression()},
                 select={
@@ -620,13 +622,13 @@ class TestWorkflowTriggers:
             batch_size=500,
             batch_timeout=300,
         )
-        assert workflow_data_modeling_trigger.workflow_external_id.startswith("integration_test-workflow_")
-        assert workflow_data_modeling_trigger.workflow_version == "1"
-        assert workflow_data_modeling_trigger.created_time is not None
-        assert workflow_data_modeling_trigger.last_updated_time is not None
+        assert permanent_data_modeling_trigger.workflow_external_id.startswith("integration_test-workflow_")
+        assert permanent_data_modeling_trigger.workflow_version == "1"
+        assert permanent_data_modeling_trigger.created_time is not None
+        assert permanent_data_modeling_trigger.last_updated_time is not None
         updated_trigger = cognite_client.workflows.triggers.upsert(
             WorkflowTriggerUpsert(
-                external_id=workflow_data_modeling_trigger.external_id,
+                external_id=permanent_data_modeling_trigger.external_id,
                 trigger_rule=WorkflowDataModelingTriggerRule(
                     data_modeling_query=WorkflowTriggerDataModelingQuery(
                         with_={"timeseries": NodeResultSetExpression()},
@@ -639,12 +641,12 @@ class TestWorkflowTriggers:
                     batch_size=100,
                     batch_timeout=100,
                 ),
-                workflow_external_id=workflow_data_modeling_trigger.workflow_external_id,
-                workflow_version=workflow_data_modeling_trigger.workflow_version,
+                workflow_external_id=permanent_data_modeling_trigger.workflow_external_id,
+                workflow_version=permanent_data_modeling_trigger.workflow_version,
             )
         )
         assert updated_trigger is not None
-        assert updated_trigger.external_id == workflow_data_modeling_trigger.external_id
+        assert updated_trigger.external_id == permanent_data_modeling_trigger.external_id
         assert updated_trigger.trigger_rule == WorkflowDataModelingTriggerRule(
             data_modeling_query=WorkflowTriggerDataModelingQuery(
                 with_={"timeseries": NodeResultSetExpression()},
@@ -657,21 +659,21 @@ class TestWorkflowTriggers:
             batch_size=100,
             batch_timeout=100,
         )
-        assert updated_trigger.workflow_external_id == workflow_data_modeling_trigger.workflow_external_id
-        assert updated_trigger.workflow_version == workflow_data_modeling_trigger.workflow_version
-        assert updated_trigger.created_time == workflow_data_modeling_trigger.created_time
-        assert updated_trigger.last_updated_time > workflow_data_modeling_trigger.last_updated_time
+        assert updated_trigger.workflow_external_id == permanent_data_modeling_trigger.workflow_external_id
+        assert updated_trigger.workflow_version == permanent_data_modeling_trigger.workflow_version
+        assert updated_trigger.created_time == permanent_data_modeling_trigger.created_time
+        assert updated_trigger.last_updated_time > permanent_data_modeling_trigger.last_updated_time
 
     def test_trigger_list(
         self,
         cognite_client: CogniteClient,
         permanent_scheduled_trigger: WorkflowTrigger,
-        workflow_data_modeling_trigger: WorkflowTrigger,
+        permanent_data_modeling_trigger: WorkflowTrigger,
     ) -> None:
         listed = cognite_client.workflows.triggers.get_triggers(limit=-1)
         external_ids = set(listed.as_external_ids())
         assert permanent_scheduled_trigger.external_id in external_ids
-        assert workflow_data_modeling_trigger.external_id in external_ids
+        assert permanent_data_modeling_trigger.external_id in external_ids
 
     def test_trigger_run_history(
         self,


### PR DESCRIPTION
Previously we would emit the external id of the item, falling back to logging the whole request body if the external id doesn't exist. We often don't want to log the entire request body, as it may for example emit secrets, like we currently do for UserWrite. I think it may be better to just emit the number of each status for these exceptions, and let the user access the full objects by access the appropriate attributes

## Description
Please describe the change you have made.

## Checklist:
- [ ] Tests added/updated.
- [ ] Documentation updated. Documentation is generated from docstrings - these must be updated according to your change.
  If a new method has been added it should be referenced in [cognite.rst](https://github.com/cognitedata/cognite-sdk-python/blob/master/docs/source/cognite.rst) in order to generate docs based on its docstring.
- [ ] Changelog updated in [CHANGELOG.md](https://github.com/cognitedata/cognite-sdk-python/blob/master/CHANGELOG.md).
- [ ] Version bumped. If triggering a new release is desired, bump the version number in [_version.py](https://github.com/cognitedata/cognite-sdk-python/blob/master/cognite/client/_version.py) and [pyproject.toml](https://github.com/cognitedata/cognite-sdk-python/blob/master/pyproject.toml) per [semantic versioning](https://semver.org/).
