### PR TITLE
feat(iam): add support for attributes in groups create, groups list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,11 @@ Changes are grouped as follows
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
+
+## [7.80.1] - 2025-08-11
+### Added
+- Support for creating and listing groups with attributes.
+
 ## [7.80.0] - 2025-08-01
 ### Added
 - Emit project name in exceptions to make it easier to gather relevant context.

--- a/cognite/client/_version.py
+++ b/cognite/client/_version.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
 
-__version__ = "7.80.0"
+__version__ = "7.80.1"
 
 __api_subversion__ = "20230101"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "cognite-sdk"
-version = "7.80.0"
+version = "7.80.1"
 
 description = "Cognite Python SDK"
 readme = "README.md"

--- a/tests/tests_unit/test_api/test_iam.py
+++ b/tests/tests_unit/test_api/test_iam.py
@@ -4,7 +4,7 @@ import pytest
 
 from cognite.client.data_classes import Group, GroupList, SecurityCategory, SecurityCategoryList
 from cognite.client.data_classes.capabilities import AllScope, GroupsAcl, ProjectCapability, ProjectCapabilityList
-from cognite.client.data_classes.iam import ProjectSpec, TokenInspection
+from cognite.client.data_classes.iam import GroupAttributes, GroupAttributesToken, ProjectSpec, TokenInspection
 from tests.utils import jsgz_load
 
 
@@ -29,11 +29,40 @@ def mock_groups(rsps, cognite_client):
     yield rsps
 
 
+@pytest.fixture
+def mock_groups_with_attributes(rsps, cognite_client):
+    response_body = {
+        "items": [
+            {
+                "name": "Production Engineers",
+                "sourceId": "b7c9a5a4-99c2-4785-bed3-5e6ad9a78603",
+                "capabilities": [{"groupsAcl": {"actions": ["LIST"], "scope": {"all": {}}}}],
+                "id": 0,
+                "isDeleted": False,
+                "deletedTime": 0,
+                "attributes": {
+                    "token": {"appIds": ["app1", "app2"]},
+                },
+            }
+        ]
+    }
+    url_pattern = re.compile(re.escape(cognite_client.iam._get_base_url_with_base_path()) + "/groups.*")
+    rsps.assert_all_requests_are_fired = False
+    rsps.add(rsps.POST, url_pattern, status=200, json=response_body)
+    rsps.add(rsps.GET, url_pattern, status=200, json=response_body)
+    yield rsps
+
+
 class TestGroups:
     def test_list(self, cognite_client, mock_groups):
         res = cognite_client.iam.groups.list()
         assert isinstance(res, GroupList)
         assert mock_groups.calls[0].response.json()["items"] == res.dump(camel_case=True)
+
+    def test_list_with_attributes(self, cognite_client, mock_groups_with_attributes):
+        res = cognite_client.iam.groups.list()
+        assert isinstance(res, GroupList)
+        assert mock_groups_with_attributes.calls[0].response.json()["items"] == res.dump(camel_case=True)
 
     def test_create(self, cognite_client, mock_groups):
         my_group = Group(name="My Group", capabilities=[GroupsAcl([GroupsAcl.Action.List], AllScope())])
@@ -45,6 +74,26 @@ class TestGroups:
             ]
         } == jsgz_load(mock_groups.calls[0].request.body)
         assert mock_groups.calls[0].response.json()["items"][0] == res.dump(camel_case=True)
+
+    def test_create_with_attributes(self, cognite_client, mock_groups_with_attributes):
+        my_group = Group(
+            name="My Group",
+            capabilities=[GroupsAcl([GroupsAcl.Action.List], AllScope())],
+            attributes=GroupAttributes(token=GroupAttributesToken(app_ids=["app1", "app2"])),
+        )
+        res = cognite_client.iam.groups.create(my_group)
+        assert isinstance(res, Group)
+
+        assert {
+            "items": [
+                {
+                    "name": "My Group",
+                    "capabilities": [{"groupsAcl": {"actions": ["LIST"], "scope": {"all": {}}}}],
+                    "attributes": {"token": {"appIds": ["app1", "app2"]}},
+                },
+            ]
+        } == jsgz_load(mock_groups_with_attributes.calls[0].request.body)
+        assert mock_groups_with_attributes.calls[0].response.json()["items"][0] == res.dump()
 
     def test_create_multiple(self, cognite_client, mock_groups):
         res = cognite_client.iam.groups.create([1])


### PR DESCRIPTION
## Description
Added support for: https://api-docs.cognite.com/20230101/tag/Groups/operation/createGroups#!path=items/0/attributes/token/appIds&t=request.

## Checklist:
- [x] Tests added/updated.
- [x] Documentation updated. Documentation is generated from docstrings - these must be updated according to your change.
  If a new method has been added it should be referenced in [cognite.rst](https://github.com/cognitedata/cognite-sdk-python/blob/master/docs/source/cognite.rst) in order to generate docs based on its docstring.
- [x] Changelog updated in [CHANGELOG.md](https://github.com/cognitedata/cognite-sdk-python/blob/master/CHANGELOG.md).
- [x] Version bumped. If triggering a new release is desired, bump the version number in [_version.py](https://github.com/cognitedata/cognite-sdk-python/blob/master/cognite/client/_version.py) and [pyproject.toml](https://github.com/cognitedata/cognite-sdk-python/blob/master/pyproject.toml) per [semantic versioning](https://semver.org/).
