### PR TITLE
Make CogniteAPIError.response_code non-nullable again

### DIFF
--- a/cognite/client/_api/assets.py
+++ b/cognite/client/_api/assets.py
@@ -43,7 +43,7 @@ from cognite.client.data_classes.assets import (
     SortableAssetProperty,
 )
 from cognite.client.data_classes.filters import _BASIC_FILTERS, Filter, _validate_filter
-from cognite.client.exceptions import CogniteAPIError
+from cognite.client.exceptions import CogniteAPIError, CogniteMultiException
 from cognite.client.utils._auxiliary import split_into_chunks, split_into_n_parts
 from cognite.client.utils._concurrency import ConcurrencySettings, classify_error, execute_tasks
 from cognite.client.utils._identifier import IdentifierSequence
@@ -1434,13 +1434,9 @@ class _AssetHierarchyCreator:
                 failed=AssetList(self.failed),
             )
         # If a non-Cognite-exception was raised, we still raise CogniteAPIError, but use 'from' to not hide
-        # the underlying reason from the user. We also do this because we promise that 'successful', 'unknown'
+        # the underlying reason from the user. We do this because we promise that 'successful', 'unknown'
         # and 'failed' can be inspected:
-        raise CogniteAPIError(
-            message=f"{err_message} {type(latest_exception).__name__}('{latest_exception}')",
-            code=None,
-            cluster=self.assets_api._config.cdf_cluster,
-            project=self.assets_api._config.project,
+        raise CogniteMultiException(
             successful=AssetList(successful),
             unknown=AssetList(self.unknown),
             failed=AssetList(self.failed),

--- a/cognite/client/exceptions.py
+++ b/cognite/client/exceptions.py
@@ -162,7 +162,7 @@ class CogniteAPIError(CogniteMultiException):
 
     Args:
         message (str): The error message produced by the API.
-        code (int | None): The error code produced by the failure.
+        code (int): The error code produced by the failure.
         x_request_id (str | None): The request-id generated for the failed request.
         missing (Sequence | None): (List) List of missing identifiers.
         duplicated (Sequence | None): (List) List of duplicated identifiers.
@@ -197,7 +197,7 @@ class CogniteAPIError(CogniteMultiException):
     def __init__(
         self,
         message: str,
-        code: int | None,
+        code: int,
         x_request_id: str | None = None,
         missing: Sequence | None = None,
         duplicated: Sequence | None = None,


### PR DESCRIPTION
This attribute was changed to nullable in a recent commit due to the fact that we are actually passing response_code=None in one context, so the type hint was inaccurate. This broke static type checking for some clients. A better solution is to not abuse the CogniteAPIError in this context and raise CogniteMultiException instead

## Description
Please describe the change you have made.

## Checklist:
- [ ] Tests added/updated.
- [ ] Documentation updated. Documentation is generated from docstrings - these must be updated according to your change.
  If a new method has been added it should be referenced in [cognite.rst](https://github.com/cognitedata/cognite-sdk-python/blob/master/docs/source/cognite.rst) in order to generate docs based on its docstring.
- [ ] Changelog updated in [CHANGELOG.md](https://github.com/cognitedata/cognite-sdk-python/blob/master/CHANGELOG.md).
- [ ] Version bumped. If triggering a new release is desired, bump the version number in [_version.py](https://github.com/cognitedata/cognite-sdk-python/blob/master/cognite/client/_version.py) and [pyproject.toml](https://github.com/cognitedata/cognite-sdk-python/blob/master/pyproject.toml) per [semantic versioning](https://semver.org/).
