### PR TITLE
[prep CDF-25523] Fix datapoint subscription update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,11 @@ Changes are grouped as follows
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
+## [7.80.2] - 2025-08-16
+### Fixed
+- Added missing parameter `description` to `DatapointSubscriptionUpdate` object such that it can be updated
+  in the `client.time_series.subscriptions.update(...)` method.
+
 ## [7.80.1] - 2025-08-14
 ### Fixed
 - Make CogniteAPIError.response_code non-nullable again, addressing a regression introduced in the previous version.

--- a/cognite/client/_version.py
+++ b/cognite/client/_version.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
 
-__version__ = "7.80.1"
+__version__ = "7.80.2"
 
 __api_subversion__ = "20230101"

--- a/cognite/client/data_classes/datapoints_subscriptions.py
+++ b/cognite/client/data_classes/datapoints_subscriptions.py
@@ -190,8 +190,12 @@ class DataPointSubscriptionUpdate(CogniteUpdate):
     def __init__(self, external_id: str) -> None:
         super().__init__(external_id=external_id)
 
-    class _PrimitiveDataPointSubscriptionUpdate(CognitePrimitiveUpdate):
-        def set(self, value: Any) -> DataPointSubscriptionUpdate:
+    class _StringDataPointSubscriptionUpdate(CognitePrimitiveUpdate):
+        def set(self, value: str) -> DataPointSubscriptionUpdate:
+            return self._set(value)
+
+    class _IntegerDataPointSubscriptionUpdate(CognitePrimitiveUpdate):
+        def set(self, value: int) -> DataPointSubscriptionUpdate:
             return self._set(value)
 
     class _FilterDataPointSubscriptionUpdate(CognitePrimitiveUpdate):
@@ -219,12 +223,12 @@ class DataPointSubscriptionUpdate(CogniteUpdate):
             return self._remove([item.dump(include_instance_type=False) for item in value])
 
     @property
-    def name(self) -> _PrimitiveDataPointSubscriptionUpdate:
-        return DataPointSubscriptionUpdate._PrimitiveDataPointSubscriptionUpdate(self, "name")
+    def name(self) -> _StringDataPointSubscriptionUpdate:
+        return DataPointSubscriptionUpdate._StringDataPointSubscriptionUpdate(self, "name")
 
     @property
-    def data_set_id(self) -> _PrimitiveDataPointSubscriptionUpdate:
-        return DataPointSubscriptionUpdate._PrimitiveDataPointSubscriptionUpdate(self, "dataSetId")
+    def data_set_id(self) -> _IntegerDataPointSubscriptionUpdate:
+        return DataPointSubscriptionUpdate._IntegerDataPointSubscriptionUpdate(self, "dataSetId")
 
     @property
     def time_series_ids(self) -> _ListDataPointSubscriptionUpdate:

--- a/cognite/client/data_classes/datapoints_subscriptions.py
+++ b/cognite/client/data_classes/datapoints_subscriptions.py
@@ -227,6 +227,10 @@ class DataPointSubscriptionUpdate(CogniteUpdate):
         return DataPointSubscriptionUpdate._StringDataPointSubscriptionUpdate(self, "name")
 
     @property
+    def description(self) -> _StringDataPointSubscriptionUpdate:
+        return DataPointSubscriptionUpdate._StringDataPointSubscriptionUpdate(self, "description")
+
+    @property
     def data_set_id(self) -> _IntegerDataPointSubscriptionUpdate:
         return DataPointSubscriptionUpdate._IntegerDataPointSubscriptionUpdate(self, "dataSetId")
 
@@ -246,6 +250,7 @@ class DataPointSubscriptionUpdate(CogniteUpdate):
     def _get_update_properties(cls, item: CogniteResource | None = None) -> list[PropertySpec]:
         return [
             PropertySpec("name"),
+            PropertySpec("description"),
             PropertySpec("time_series_ids", is_list=True),
             PropertySpec("instance_ids", is_list=True),
             PropertySpec("filter", is_nullable=False),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "cognite-sdk"
-version = "7.80.1"
+version = "7.80.2"
 
 description = "Cognite Python SDK"
 readme = "README.md"

--- a/tests/tests_integration/test_api/test_datapoint_subscriptions.py
+++ b/tests/tests_integration/test_api/test_datapoint_subscriptions.py
@@ -176,6 +176,7 @@ class TestDatapointSubscriptions:
             name="PYSDKDataPointSubscriptionUpdateTest",
             time_series_ids=time_series_external_ids,
             partition_count=1,
+            description="Original description",
         )
         data_set = cognite_client.data_sets.list(limit=1)[0]
         with create_subscription_with_cleanup(cognite_client, new_subscription):
@@ -184,12 +185,14 @@ class TestDatapointSubscriptions:
                 .name.set("New Name")
                 .time_series_ids.remove([time_series_external_ids[0]])
                 .data_set_id.set(data_set.id)
+                .description.set("Updated description")
             )
             updated = cognite_client.time_series.subscriptions.update(update)
 
             assert updated.name == "New Name"
             assert updated.time_series_count == len(time_series_external_ids) - 1
             assert updated.data_set_id == data_set.id
+            assert updated.description == "Updated description"
 
     def test_update_subscription_write_object(self, cognite_client: CogniteClient, time_series_external_ids: list[str]):
         new_subscription = DataPointSubscriptionWrite(


### PR DESCRIPTION
## Description

The `description` parameter was missing in the `DatapointSubscriptionUpdate` object.

## Checklist:
- [x] Tests added/updated.
- [ ] Documentation updated. Documentation is generated from docstrings - these must be updated according to your change.
  If a new method has been added it should be referenced in [cognite.rst](https://github.com/cognitedata/cognite-sdk-python/blob/master/docs/source/cognite.rst) in order to generate docs based on its docstring.
- [x] Changelog updated in [CHANGELOG.md](https://github.com/cognitedata/cognite-sdk-python/blob/master/CHANGELOG.md).
- [x] Version bumped. If triggering a new release is desired, bump the version number in [_version.py](https://github.com/cognitedata/cognite-sdk-python/blob/master/cognite/client/_version.py) and [pyproject.toml](https://github.com/cognitedata/cognite-sdk-python/blob/master/pyproject.toml) per [semantic versioning](https://semver.org/).
