### PR TITLE
test(integration): fix simulator object seed (attempt 2)

### DIFF
--- a/tests/tests_integration/test_api/test_simulators/conftest.py
+++ b/tests/tests_integration/test_api/test_simulators/conftest.py
@@ -78,7 +78,7 @@ def seed_simulator(cognite_client: CogniteClient, seed_resource_names: dict[str,
     if not seeded_simulator:
         cognite_client.simulators._post("/simulators", json={"items": [simulator]})
     # if any field in simulator is different from the current seeded simulator, update it
-    elif any(seeded_simulator_dump[field] != simulator[field] for field in fields_to_compare if field in simulator):
+    elif any(seeded_simulator_dump.get(field) != simulator[field] for field in fields_to_compare if field in simulator):
         simulator_update = {
             "id": seeded_simulator.id,
             "update": {field: {"set": simulator[field]} for field in fields_to_compare},


### PR DESCRIPTION
the remote object doesn't have this field defined (on the project used by gh CD action), but it does have it in CI
This leads to an error:
> TestSimulatorRoutines::test_sort - KeyError: 'modelDependencies'