### PR TITLE
feat(simulators): Add created_time and simulation_time filters to simulation runs list method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ Changes are grouped as follows
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
+## [Unreleased]
+### Added
+- [alpha] Support for `created_time` and `simulation_time` filters in `client.simulators.runs.list()` to filter simulation runs by timestamp ranges.
+
 ## [7.82.0] - 2025-08-26
 ### Added
 - Added support for specifying `max_text_size` in DMS text properties.

--- a/cognite/client/_api/simulators/runs.py
+++ b/cognite/client/_api/simulators/runs.py
@@ -5,6 +5,7 @@ from typing import TYPE_CHECKING, overload
 
 from cognite.client._api_client import APIClient
 from cognite.client._constants import DEFAULT_LIMIT_READ
+from cognite.client.data_classes.shared import TimestampRange
 from cognite.client.data_classes.simulators.filters import SimulatorRunsFilter
 from cognite.client.data_classes.simulators.runs import (
     SimulationRun,
@@ -64,6 +65,8 @@ class SimulatorRunsAPI(APIClient):
         routine_external_ids: SequenceNotStr[str] | None = None,
         routine_revision_external_ids: SequenceNotStr[str] | None = None,
         model_revision_external_ids: SequenceNotStr[str] | None = None,
+        created_time: TimestampRange | None = None,
+        simulation_time: TimestampRange | None = None,
     ) -> Iterator[SimulationRunList]: ...
 
     @overload
@@ -79,6 +82,8 @@ class SimulatorRunsAPI(APIClient):
         routine_external_ids: SequenceNotStr[str] | None = None,
         routine_revision_external_ids: SequenceNotStr[str] | None = None,
         model_revision_external_ids: SequenceNotStr[str] | None = None,
+        created_time: TimestampRange | None = None,
+        simulation_time: TimestampRange | None = None,
     ) -> Iterator[SimulationRun]: ...
 
     def __call__(
@@ -93,6 +98,8 @@ class SimulatorRunsAPI(APIClient):
         routine_external_ids: SequenceNotStr[str] | None = None,
         routine_revision_external_ids: SequenceNotStr[str] | None = None,
         model_revision_external_ids: SequenceNotStr[str] | None = None,
+        created_time: TimestampRange | None = None,
+        simulation_time: TimestampRange | None = None,
     ) -> Iterator[SimulationRun] | Iterator[SimulationRunList]:
         """Iterate over simulation runs
 
@@ -109,6 +116,8 @@ class SimulatorRunsAPI(APIClient):
             routine_external_ids (SequenceNotStr[str] | None): Filter by routine external ids
             routine_revision_external_ids (SequenceNotStr[str] | None): Filter by routine revision external ids
             model_revision_external_ids (SequenceNotStr[str] | None): Filter by model revision external ids
+            created_time (TimestampRange | None): Filter by created time
+            simulation_time (TimestampRange | None): Filter by simulation time
 
         Returns:
             Iterator[SimulationRun] | Iterator[SimulationRunList]: yields Simulation Run one by one if chunk is not specified, else SimulatorRunsList objects.
@@ -123,6 +132,8 @@ class SimulatorRunsAPI(APIClient):
             routine_external_ids=routine_external_ids,
             routine_revision_external_ids=routine_revision_external_ids,
             model_revision_external_ids=model_revision_external_ids,
+            created_time=created_time,
+            simulation_time=simulation_time,
         )
 
         return self._list_generator(
@@ -145,6 +156,8 @@ class SimulatorRunsAPI(APIClient):
         routine_external_ids: SequenceNotStr[str] | None = None,
         routine_revision_external_ids: SequenceNotStr[str] | None = None,
         model_revision_external_ids: SequenceNotStr[str] | None = None,
+        created_time: TimestampRange | None = None,
+        simulation_time: TimestampRange | None = None,
     ) -> SimulationRunList:
         """`Filter simulation runs <https://developer.cognite.com/api#tag/Simulation-Runs/operation/filter_simulation_runs_simulators_runs_list_post>`_
 
@@ -160,6 +173,8 @@ class SimulatorRunsAPI(APIClient):
             routine_external_ids (SequenceNotStr[str] | None): Filter by routine external ids
             routine_revision_external_ids (SequenceNotStr[str] | None): Filter by routine revision external ids
             model_revision_external_ids (SequenceNotStr[str] | None): Filter by model revision external ids
+            created_time (TimestampRange | None): Filter by created time
+            simulation_time (TimestampRange | None): Filter by simulation time
 
         Returns:
             SimulationRunList: List of simulation runs
@@ -175,6 +190,13 @@ class SimulatorRunsAPI(APIClient):
                 ...     simulator_external_ids=["PROSPER", "DWSIM"],
                 ...     status="success"
                 ... )
+
+            Filter runs by time ranges:
+                >>> from cognite.client.data_classes.shared import TimestampRange
+                >>> res = client.simulators.runs.list(
+                ...     created_time=TimestampRange(min=0, max=1000000),
+                ...     simulation_time=TimestampRange(min=0, max=1000000),
+                ... )
         """
 
         filter_runs = SimulatorRunsFilter(
@@ -186,6 +208,8 @@ class SimulatorRunsAPI(APIClient):
             routine_external_ids=routine_external_ids,
             routine_revision_external_ids=routine_revision_external_ids,
             model_revision_external_ids=model_revision_external_ids,
+            created_time=created_time,
+            simulation_time=simulation_time,
         )
         self._warning.warn()
         return self._list(

--- a/cognite/client/data_classes/simulators/filters.py
+++ b/cognite/client/data_classes/simulators/filters.py
@@ -63,6 +63,8 @@ class SimulatorRunsFilter(CogniteFilter):
         routine_external_ids: str | SequenceNotStr[str] | None = None,
         routine_revision_external_ids: str | SequenceNotStr[str] | None = None,
         model_revision_external_ids: str | SequenceNotStr[str] | None = None,
+        created_time: TimestampRange | None = None,
+        simulation_time: TimestampRange | None = None,
     ) -> None:
         self.model_external_ids = _parse_str_or_sequence(model_external_ids)
         self.simulator_integration_external_ids = _parse_str_or_sequence(simulator_integration_external_ids)
@@ -72,6 +74,8 @@ class SimulatorRunsFilter(CogniteFilter):
         self.model_revision_external_ids = _parse_str_or_sequence(model_revision_external_ids)
         self.status = status
         self.run_type = run_type
+        self.created_time = created_time
+        self.simulation_time = simulation_time
 
 
 class SimulatorRoutinesFilter(CogniteFilter):


### PR DESCRIPTION
## Description
This PR adds support for filtering simulation runs by `created_time` and `simulation_time` timestamp ranges, bringing the SDK in line with the Simulators API capabilities.

## Checklist:
- [x] Tests added/updated.
- [x] Documentation updated. Documentation is generated from docstrings - these must be updated according to your change.
  If a new method has been added it should be referenced in [cognite.rst](https://github.com/cognitedata/cognite-sdk-python/blob/master/docs/source/cognite.rst) in order to generate docs based on its docstring.
- [x] Changelog updated in [CHANGELOG.md](https://github.com/cognitedata/cognite-sdk-python/blob/master/CHANGELOG.md).
- [ ] Version bumped. If triggering a new release is desired, bump the version number in [_version.py](https://github.com/cognitedata/cognite-sdk-python/blob/master/cognite/client/_version.py) and [pyproject.toml](https://github.com/cognitedata/cognite-sdk-python/blob/master/pyproject.toml) per [semantic versioning](https://semver.org/).
