### PR TITLE
feat(simint-alpha): change mouthfull class names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ Changes are grouped as follows
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
+## [7.83.1] - 2025-08-29
+### Changed
+- [alpha] Breaking change: rename `SimulatorModelRevisionExternalDependency` to `SimulatorModelRevisionDependency`, `SimulatorExternalDependencyFileInternalId` to `SimulatorModelDependencyFileId` in `external_dependencies` field in `SimulatorModelRevision`.
+
 ## [7.83.0] - 2025-08-28
 ### Added
 - Add `timezone` as an optional param to the WorkflowScheduledTriggerRule.

--- a/cognite/client/_api/simulators/models_revisions.py
+++ b/cognite/client/_api/simulators/models_revisions.py
@@ -247,8 +247,7 @@ class SimulatorModelRevisionsAPI(APIClient):
         Examples:
             Create new simulator model revisions:
                 >>> from cognite.client import CogniteClient
-                >>> from cognite.client.data_classes.simulators import SimulatorModelRevisionWrite
-                >>> from cognite.client.data_classes.simulators.models import SimulatorExternalDependencyFileInternalId, SimulatorModelRevisionExternalDependency
+                >>> from cognite.client.data_classes.simulators import SimulatorModelRevisionWrite, SimulatorModelDependencyFileId, SimulatorModelRevisionDependency
                 >>> client = CogniteClient()
                 >>> revisions = [
                 ...     SimulatorModelRevisionWrite(
@@ -261,8 +260,8 @@ class SimulatorModelRevisionsAPI(APIClient):
                 ...         file_id=2,
                 ...         model_external_id="a_2",
                 ...         external_dependencies = [
-                ...             SimulatorModelRevisionExternalDependency(
-                ...                 file=SimulatorExternalDependencyFileInternalId(id=123),
+                ...             SimulatorModelRevisionDependency(
+                ...                 file=SimulatorModelDependencyFileId(id=123),
                 ...                 arguments={
                 ...                     "fieldA": "value1",
                 ...                     "fieldB": "value2",

--- a/cognite/client/_version.py
+++ b/cognite/client/_version.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
 
-__version__ = "7.83.0"
+__version__ = "7.83.1"
 
 __api_subversion__ = "20230101"

--- a/cognite/client/data_classes/simulators/__init__.py
+++ b/cognite/client/data_classes/simulators/__init__.py
@@ -8,10 +8,15 @@ from cognite.client.data_classes.simulators.filters import (
 )
 from cognite.client.data_classes.simulators.models import (
     SimulatorModel,
+    SimulatorModelDependencyFileId,
+    SimulatorModelDependencyFileReference,
     SimulatorModelList,
     SimulatorModelRevision,
+    SimulatorModelRevisionDependency,
     SimulatorModelRevisionList,
     SimulatorModelRevisionWrite,
+    SimulatorModelRevisionWriteList,
+    SimulatorModelUpdate,
     SimulatorModelWrite,
 )
 from cognite.client.data_classes.simulators.runs import (
@@ -44,11 +49,16 @@ __all__ = [
     "SimulatorIntegrationList",
     "SimulatorList",
     "SimulatorModel",
+    "SimulatorModelDependencyFileId",
+    "SimulatorModelDependencyFileReference",
     "SimulatorModelList",
     "SimulatorModelRevision",
+    "SimulatorModelRevisionDependency",
     "SimulatorModelRevisionList",
     "SimulatorModelRevisionWrite",
+    "SimulatorModelRevisionWriteList",
     "SimulatorModelRevisionsFilter",
+    "SimulatorModelUpdate",
     "SimulatorModelWrite",
     "SimulatorModelsFilter",
     "SimulatorStep",

--- a/cognite/client/data_classes/simulators/models.py
+++ b/cognite/client/data_classes/simulators/models.py
@@ -30,7 +30,7 @@ class SimulatorModelRevisionCore(WriteableCogniteResource["SimulatorModelRevisio
         model_external_id: str,
         file_id: int,
         description: str | None = None,
-        external_dependencies: list[SimulatorModelRevisionExternalDependency] | None = None,
+        external_dependencies: list[SimulatorModelRevisionDependency] | None = None,
     ) -> None:
         self.external_id = external_id
         self.model_external_id = model_external_id
@@ -45,7 +45,7 @@ class SimulatorModelRevisionCore(WriteableCogniteResource["SimulatorModelRevisio
             model_external_id=resource["modelExternalId"],
             file_id=resource["fileId"],
             description=resource.get("description"),
-            external_dependencies=SimulatorModelRevisionExternalDependency._load_list(
+            external_dependencies=SimulatorModelRevisionDependency._load_list(
                 resource["externalDependencies"], cognite_client
             )
             if "externalDependencies" in resource
@@ -74,7 +74,7 @@ class SimulatorModelRevisionWrite(SimulatorModelRevisionCore):
             model_external_id=resource["modelExternalId"],
             file_id=resource["fileId"],
             description=resource.get("description"),
-            external_dependencies=SimulatorModelRevisionExternalDependency._load_list(
+            external_dependencies=SimulatorModelRevisionDependency._load_list(
                 resource["externalDependencies"], cognite_client
             )
             if "externalDependencies" in resource
@@ -103,7 +103,7 @@ class SimulatorModelRevision(SimulatorModelRevisionCore):
         log_id (int): The id of the log associated with the simulator model revision
         description (str | None): The description of the simulator model revision
         status_message (str | None): The current status message of the simulator model revision
-        external_dependencies (list[SimulatorModelRevisionExternalDependency] | None): A list of external dependencies for the simulator model revision
+        external_dependencies (list[SimulatorModelRevisionDependency] | None): A list of external dependencies for the simulator model revision
     """
 
     def __init__(
@@ -122,7 +122,7 @@ class SimulatorModelRevision(SimulatorModelRevisionCore):
         log_id: int,
         description: str | None = None,
         status_message: str | None = None,
-        external_dependencies: list[SimulatorModelRevisionExternalDependency] | None = None,
+        external_dependencies: list[SimulatorModelRevisionDependency] | None = None,
     ) -> None:
         super().__init__(
             external_id=external_id,
@@ -159,7 +159,7 @@ class SimulatorModelRevision(SimulatorModelRevisionCore):
             log_id=resource["logId"],
             description=resource.get("description"),
             status_message=resource.get("statusMessage"),
-            external_dependencies=SimulatorModelRevisionExternalDependency._load_list(
+            external_dependencies=SimulatorModelRevisionDependency._load_list(
                 resource["externalDependencies"], cognite_client
             )
             if "externalDependencies" in resource
@@ -355,11 +355,11 @@ class SimulatorModelUpdate(CogniteUpdate):
 
 
 @dataclass
-class SimulatorExternalDependencyFileReference(CogniteObject): ...
+class SimulatorModelDependencyFileReference(CogniteObject): ...
 
 
 @dataclass
-class SimulatorExternalDependencyFileInternalId(SimulatorExternalDependencyFileReference):
+class SimulatorModelDependencyFileId(SimulatorModelDependencyFileReference):
     id: int
 
     @classmethod
@@ -370,7 +370,7 @@ class SimulatorExternalDependencyFileInternalId(SimulatorExternalDependencyFileR
 
 
 @dataclass
-class SimulatorModelRevisionExternalDependency(CogniteObject):
+class SimulatorModelRevisionDependency(CogniteObject):
     """
     Represents an external dependency for a simulator model revision.
     Args:
@@ -378,13 +378,13 @@ class SimulatorModelRevisionExternalDependency(CogniteObject):
         arguments (dict[str, str]): A dictionary that contains the key-value pairs (fields) for the external dependency.
     """
 
-    file: SimulatorExternalDependencyFileReference
+    file: SimulatorModelDependencyFileReference
     arguments: dict[str, str]
 
     @classmethod
     def _load(cls, resource: dict[str, Any], cognite_client: CogniteClient | None = None) -> Self:
         return cls(
-            file=SimulatorExternalDependencyFileInternalId.load(resource["file"])
+            file=SimulatorModelDependencyFileId.load(resource["file"])
             if "id" in resource["file"]
             else resource["file"],
             arguments=resource["arguments"],
@@ -394,7 +394,7 @@ class SimulatorModelRevisionExternalDependency(CogniteObject):
         output = super().dump(camel_case=camel_case)
         output["file"] = (
             self.file.dump(camel_case=camel_case)
-            if isinstance(self.file, SimulatorExternalDependencyFileReference)
+            if isinstance(self.file, SimulatorModelDependencyFileReference)
             else self.file
         )
         return output
@@ -402,5 +402,5 @@ class SimulatorModelRevisionExternalDependency(CogniteObject):
     @classmethod
     def _load_list(
         cls, resource: list[dict[str, Any]], cognite_client: CogniteClient | None = None
-    ) -> list[SimulatorModelRevisionExternalDependency]:
+    ) -> list[SimulatorModelRevisionDependency]:
         return [cls._load(item, cognite_client) for item in resource]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "cognite-sdk"
-version = "7.83.0"
+version = "7.83.1"
 
 description = "Cognite Python SDK"
 readme = "README.md"

--- a/tests/tests_integration/test_api/test_simulators/conftest.py
+++ b/tests/tests_integration/test_api/test_simulators/conftest.py
@@ -11,7 +11,7 @@ import pytest
 from cognite.client._cognite_client import CogniteClient
 from cognite.client.data_classes.data_sets import DataSetWrite
 from cognite.client.data_classes.files import FileMetadata
-from cognite.client.data_classes.simulators.models import SimulatorModelWrite
+from cognite.client.data_classes.simulators import SimulatorModelWrite
 from cognite.client.data_classes.simulators.routine_revisions import SimulatorRoutineRevisionWrite
 from cognite.client.data_classes.simulators.routines import SimulatorRoutineWrite
 from tests.tests_integration.test_api.test_simulators.seed.data import (

--- a/tests/tests_integration/test_api/test_simulators/test_models.py
+++ b/tests/tests_integration/test_api/test_simulators/test_models.py
@@ -5,13 +5,13 @@ import pytest
 from cognite.client._cognite_client import CogniteClient
 from cognite.client.data_classes import TimestampRange
 from cognite.client.data_classes.files import FileMetadata
-from cognite.client.data_classes.simulators.filters import PropertySort
-from cognite.client.data_classes.simulators.models import (
-    SimulatorExternalDependencyFileInternalId,
-    SimulatorModelRevisionExternalDependency,
+from cognite.client.data_classes.simulators import (
+    SimulatorModelDependencyFileId,
+    SimulatorModelRevisionDependency,
     SimulatorModelRevisionWrite,
     SimulatorModelWrite,
 )
+from cognite.client.data_classes.simulators.filters import PropertySort
 from cognite.client.utils._text import random_string
 from tests.tests_integration.test_api.test_simulators.conftest import upload_file
 from tests.tests_integration.test_api.test_simulators.seed.data import ResourceNames
@@ -231,8 +231,8 @@ class TestSimulatorModels:
             )
 
             external_dependencies = [
-                SimulatorModelRevisionExternalDependency(
-                    file=SimulatorExternalDependencyFileInternalId(id=seed_external_dependency_file.id),
+                SimulatorModelRevisionDependency(
+                    file=SimulatorModelDependencyFileId(id=seed_external_dependency_file.id),
                     arguments={
                         "fieldA": "value1",
                         "fieldB": "value2",
@@ -251,9 +251,7 @@ class TestSimulatorModels:
 
             assert model_revision_created is not None
             assert model_revision_created.external_id == model_revision_external_id
-            assert isinstance(
-                model_revision_created.external_dependencies[0].file, SimulatorExternalDependencyFileInternalId
-            )
+            assert isinstance(model_revision_created.external_dependencies[0].file, SimulatorModelDependencyFileId)
             assert model_revision_created.external_dependencies[0].file.id == external_dependencies[0].file.id
         finally:
             cognite_client.simulators.models.delete(external_ids=[model_external_id])

--- a/tests/tests_unit/test_data_classes/test_simulators.py
+++ b/tests/tests_unit/test_data_classes/test_simulators.py
@@ -1,12 +1,12 @@
 import pytest
 
 from cognite.client.data_classes.simulators.models import (
-    SimulatorExternalDependencyFileInternalId,
-    SimulatorModelRevisionExternalDependency,
+    SimulatorModelDependencyFileId,
+    SimulatorModelRevisionDependency,
 )
 
 
-class TestSimulatorModelRevisionExternalDependency:
+class TestSimulatorModelRevisionDependency:
     @pytest.mark.parametrize(
         ["input_data"],
         [
@@ -19,12 +19,12 @@ class TestSimulatorModelRevisionExternalDependency:
         ],
     )
     def test_load_list(self, input_data):
-        result = SimulatorModelRevisionExternalDependency._load_list(input_data)
+        result = SimulatorModelRevisionDependency._load_list(input_data)
         assert isinstance(result, list)
-        assert all(isinstance(item, SimulatorModelRevisionExternalDependency) for item in result)
+        assert all(isinstance(item, SimulatorModelRevisionDependency) for item in result)
         assert len(result) == 2
-        assert isinstance(result[0].file, SimulatorExternalDependencyFileInternalId)
+        assert isinstance(result[0].file, SimulatorModelDependencyFileId)
         assert result[0].file.id == 1111
         assert result[0].arguments == {"fieldA": "valueA"}
-        assert isinstance(result[0].file, SimulatorExternalDependencyFileInternalId)
+        assert isinstance(result[0].file, SimulatorModelDependencyFileId)
         assert result[1].file.id == 2222


### PR DESCRIPTION
This change is primarily a UX improvement


1. This makes the class names slightly shorter for the recent API features we introduced.
2. Added type export from the simulators module
## Description
Please describe the change you have made.

## Checklist:
- [ ] Tests added/updated.
- [ ] Documentation updated. Documentation is generated from docstrings - these must be updated according to your change.
  If a new method has been added it should be referenced in [cognite.rst](https://github.com/cognitedata/cognite-sdk-python/blob/master/docs/source/cognite.rst) in order to generate docs based on its docstring.
- [ ] Changelog updated in [CHANGELOG.md](https://github.com/cognitedata/cognite-sdk-python/blob/master/CHANGELOG.md).
- [ ] Version bumped. If triggering a new release is desired, bump the version number in [_version.py](https://github.com/cognitedata/cognite-sdk-python/blob/master/cognite/client/_version.py) and [pyproject.toml](https://github.com/cognitedata/cognite-sdk-python/blob/master/pyproject.toml) per [semantic versioning](https://semver.org/).
