### PR TITLE
chore: stop warnings from being raised from our custom linter

### DIFF
--- a/scripts/custom_checks/docstr_examples.py
+++ b/scripts/custom_checks/docstr_examples.py
@@ -80,5 +80,5 @@ def fix_single_file(path: Path) -> str | None:
         return "\n".join(was_fixed)
 
 
-def format_docstring_examples(files: list[Path]) -> str:
+def format_docstring_examples(files: tuple[Path, ...]) -> str:
     return "\n".join(filter(None, map(fix_single_file, files)))

--- a/scripts/custom_checks/docstrings.py
+++ b/scripts/custom_checks/docstrings.py
@@ -425,7 +425,7 @@ def format_docstring_function(fn) -> list[str]:
     return []
 
 
-def find_all_classes_and_funcs(files: list[Path]):
+def find_all_classes_and_funcs(files: tuple[Path, ...]):
     def predicate(obj):
         return inspect.isclass(obj) or inspect.isfunction(obj)
 
@@ -438,5 +438,5 @@ def find_all_classes_and_funcs(files: list[Path]):
     }
 
 
-def format_docstrings(files: list[Path]) -> str:
+def format_docstrings(files: tuple[Path, ...]) -> str:
     return "\n".join(itertools.chain.from_iterable(map(format_docstring, find_all_classes_and_funcs(files))))

--- a/scripts/run_checks.py
+++ b/scripts/run_checks.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import sys
 from pathlib import Path
 
+from cognite.client import global_config
 from scripts.custom_checks.docstr_examples import format_docstring_examples
 from scripts.custom_checks.docstrings import format_docstrings
 from scripts.custom_checks.version import (
@@ -12,8 +13,10 @@ from scripts.custom_checks.version import (
     version_number_and_date_is_increasing,
 )
 
+global_config.silence_feature_preview_warnings = True
 
-def run_checks(files: list[Path]) -> list[str | None]:
+
+def run_checks(files: tuple[Path, ...]) -> list[str | None]:
     return [
         pyproj_version_matches(),
         changelog_entry_version_matches(),


### PR DESCRIPTION
Description:
Stop warnings from being raised from our custom linter + fix a few type annotations.