### PR TITLE
chore: Move release-type into workflow definition

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -12,3 +12,4 @@ jobs:
       - uses: google-github-actions/release-please-action@v4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+          release-type: python

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,8 +1,7 @@
 {
   "packages": {
     ".": {
-      "release-type": "python",
-      "package-name": "cognite-client",
+      "package-name": "cognite-sdk",
       "bump-files": [
         "pyproject.toml",
         {


### PR DESCRIPTION
Should fix the failing CD build

## Description
Please describe the change you have made.

## Checklist:
- [ ] Tests added/updated.
- [ ] Documentation updated. Documentation is generated from docstrings - these must be updated according to your change.
  If a new method has been added it should be referenced in [cognite.rst](https://github.com/cognitedata/cognite-sdk-python/blob/master/docs/source/cognite.rst) in order to generate docs based on its docstring.
- [ ] The PR title follows the [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) spec.
