### PR TITLE
chore: Move release-type into workflow definition

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -12,3 +12,4 @@ jobs:
       - uses: google-github-actions/release-please-action@v4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+          release-type: python

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,8 +1,7 @@
 {
   "packages": {
     ".": {
-      "release-type": "python",
-      "package-name": "cognite-client",
+      "package-name": "cognite-sdk",
       "bump-files": [
         "pyproject.toml",
         {


### PR DESCRIPTION
Should fix the failing CD build