### PR TITLE
feat(agents): update agents SDK to use beta API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ As of 2025-08-29, changes are grouped as follows
 
 ## [Unreleased]
 ### Changed
-- [beta] Updated agents API to use beta version instead of alpha. API maturity changed from alpha to beta while SDK implementation remains alpha.
+- [beta] Updated agents API to use beta version instead of alpha. Both API maturity and SDK maturity changed from alpha to beta.
 - [beta] Updated warning system to show beta warnings for agents instead of alpha warnings, reflecting the API's promotion to beta status.
 
 ## [7.83.0] - 2025-08-28

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@ As of 2025-08-29, changes are grouped as follows
 - 🐛 Bug Fixes: Bug fixes.
 - ⚡ Improvements: Transparent changes, e.g. better performance.
 
+## [Unreleased]
+### Changed
+- [beta] Updated agents API to use beta version instead of alpha. API maturity changed from alpha to beta while SDK implementation remains alpha.
+- [beta] Updated warning system to show beta warnings for agents instead of alpha warnings, reflecting the API's promotion to beta status.
+
 ## [7.83.0] - 2025-08-28
 ### Added
 - Add `timezone` as an optional param to the WorkflowScheduledTriggerRule.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,6 @@ As of 2025-08-29, changes are grouped as follows
 ## [Unreleased]
 ### Changed
 - [beta] Updated agents API to use beta version instead of alpha. API maturity changed from alpha to beta while SDK implementation remains alpha.
-- [beta] Updated warning system to show beta warnings for agents instead of alpha warnings, reflecting the API's promotion to beta status.
 
 ## [7.83.0] - 2025-08-28
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ As of 2025-08-29, changes are grouped as follows
 
 ## [Unreleased]
 ### Changed
-- [beta] Updated agents API to use beta version instead of alpha. Both API maturity and SDK maturity changed from alpha to beta.
+- [beta] Updated agents API to use beta version instead of alpha. API maturity changed from alpha to beta while SDK implementation remains alpha.
 - [beta] Updated warning system to show beta warnings for agents instead of alpha warnings, reflecting the API's promotion to beta status.
 
 ## [7.83.0] - 2025-08-28

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ As of 2025-08-29, changes are grouped as follows
 - 🐛 Bug Fixes: Bug fixes.
 - ⚡ Improvements: Transparent changes, e.g. better performance.
 
-## [7.84.0] - 2025-08-30
+## [7.83.1] - 2025-08-30
 ### Changed
 - [beta] Agents API updated to beta maturity (SDK implementation remains alpha).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,9 +13,9 @@ As of 2025-08-29, changes are grouped as follows
 - 🐛 Bug Fixes: Bug fixes.
 - ⚡ Improvements: Transparent changes, e.g. better performance.
 
-## [Unreleased]
+## [7.84.0] - 2025-08-30
 ### Changed
-- [beta] Updated agents API to use beta version instead of alpha. API maturity changed from alpha to beta while SDK implementation remains alpha.
+- [beta] Agents API updated to beta maturity (SDK implementation remains alpha).
 
 ## [7.83.0] - 2025-08-28
 ### Added

--- a/cognite/client/_api/agents/agents.py
+++ b/cognite/client/_api/agents/agents.py
@@ -20,7 +20,7 @@ class AgentsAPI(APIClient):
 
     def __init__(self, config: ClientConfig, api_version: str | None, cognite_client: CogniteClient) -> None:
         super().__init__(config, api_version, cognite_client)
-        self._warnings = FeaturePreviewWarning(api_maturity="beta", sdk_maturity="alpha", feature_name="Agents")
+        self._warnings = FeaturePreviewWarning(api_maturity="beta", sdk_maturity="beta", feature_name="Agents")
         self._api_subversion = "beta"
         self._CREATE_LIMIT = 1
         self._DELETE_LIMIT = 1

--- a/cognite/client/_api/agents/agents.py
+++ b/cognite/client/_api/agents/agents.py
@@ -20,8 +20,8 @@ class AgentsAPI(APIClient):
 
     def __init__(self, config: ClientConfig, api_version: str | None, cognite_client: CogniteClient) -> None:
         super().__init__(config, api_version, cognite_client)
-        self._warnings = FeaturePreviewWarning(api_maturity="alpha", sdk_maturity="alpha", feature_name="Agents")
-        self._api_subversion = "alpha"
+        self._warnings = FeaturePreviewWarning(api_maturity="beta", sdk_maturity="alpha", feature_name="Agents")
+        self._api_subversion = "beta"
         self._CREATE_LIMIT = 1
         self._DELETE_LIMIT = 1
 
@@ -32,7 +32,7 @@ class AgentsAPI(APIClient):
     def upsert(self, agents: Sequence[AgentUpsert]) -> AgentList: ...
 
     def upsert(self, agents: AgentUpsert | Sequence[AgentUpsert]) -> Agent | AgentList:
-        """`Create or update (upsert) one or more agents. <https://api-docs.cognite.com/20230101-alpha/tag/Agents/operation/main_api_v1_projects__projectName__ai_agents_post>`_
+        """`Create or update (upsert) one or more agents. <https://api-docs.cognite.com/20230101-beta/tag/Agents/operation/main_api_v1_projects__projectName__ai_agents_post>`_
 
         Args:
             agents (AgentUpsert | Sequence[AgentUpsert]): Agent or list of agents to create or update.
@@ -168,7 +168,7 @@ class AgentsAPI(APIClient):
     def retrieve(
         self, external_ids: str | SequenceNotStr[str], ignore_unknown_ids: bool = False
     ) -> Agent | AgentList | None:
-        """`Retrieve one or more agents by external ID. <https://api-docs.cognite.com/20230101-alpha/tag/Agents/operation/get_agents_by_ids_api_v1_projects__projectName__ai_agents_byids_post>`_
+        """`Retrieve one or more agents by external ID. <https://api-docs.cognite.com/20230101-beta/tag/Agents/operation/get_agents_by_ids_api_v1_projects__projectName__ai_agents_byids_post>`_
 
         Args:
             external_ids (str | SequenceNotStr[str]): The external id of the agent(s) to retrieve.
@@ -199,7 +199,7 @@ class AgentsAPI(APIClient):
         )
 
     def delete(self, external_ids: str | SequenceNotStr[str], ignore_unknown_ids: bool = False) -> None:
-        """`Delete one or more agents. <https://api-docs.cognite.com/20230101-alpha/tag/Agents/operation/agent_delete_api_v1_projects__projectName__ai_agents_delete_post>`_
+        """`Delete one or more agents. <https://api-docs.cognite.com/20230101-beta/tag/Agents/operation/agent_delete_api_v1_projects__projectName__ai_agents_delete_post>`_
 
         Args:
             external_ids (str | SequenceNotStr[str]): External ID of the agent or a list of external ids.
@@ -222,7 +222,7 @@ class AgentsAPI(APIClient):
         )
 
     def list(self) -> AgentList:  # The API does not yet support limit or pagination
-        """`List agents. <https://api-docs.cognite.com/20230101-alpha/tag/Agents/operation/agent_list_api_v1_projects__projectName__ai_agents_get>`_
+        """`List agents. <https://api-docs.cognite.com/20230101-beta/tag/Agents/operation/agent_list_api_v1_projects__projectName__ai_agents_get>`_
 
         Returns:
             AgentList: The list of agents.
@@ -246,7 +246,7 @@ class AgentsAPI(APIClient):
         messages: Message | Sequence[Message],
         cursor: str | None = None,
     ) -> AgentChatResponse:
-        """`Chat with an agent. <https://api-docs.cognite.com/20230101-alpha/tag/Agents/operation/agent_session_api_v1_projects__projectName__ai_agents_chat_post>`_
+        """`Chat with an agent. <https://api-docs.cognite.com/20230101-beta/tag/Agents/operation/agent_session_api_v1_projects__projectName__ai_agents_chat_post>`_
 
         Given a user query, the Atlas AI agent responds by reasoning and using the tools associated with it.
         Users can ensure conversation continuity by including the cursor from the previous response in subsequent requests.

--- a/cognite/client/_api/agents/agents.py
+++ b/cognite/client/_api/agents/agents.py
@@ -32,7 +32,7 @@ class AgentsAPI(APIClient):
     def upsert(self, agents: Sequence[AgentUpsert]) -> AgentList: ...
 
     def upsert(self, agents: AgentUpsert | Sequence[AgentUpsert]) -> Agent | AgentList:
-        """`Create or update (upsert) one or more agents. <https://api-docs.cognite.com/20230101-beta/tag/Agents/operation/main_api_v1_projects__projectName__ai_agents_post>`_
+        """`Create or update (upsert) one or more agents. <https://api-docs.cognite.com/20230101-beta/tag/Agents/operation/main_ai_agents_post/>`_
 
         Args:
             agents (AgentUpsert | Sequence[AgentUpsert]): Agent or list of agents to create or update.
@@ -168,7 +168,7 @@ class AgentsAPI(APIClient):
     def retrieve(
         self, external_ids: str | SequenceNotStr[str], ignore_unknown_ids: bool = False
     ) -> Agent | AgentList | None:
-        """`Retrieve one or more agents by external ID. <https://api-docs.cognite.com/20230101-beta/tag/Agents/operation/get_agents_by_ids_api_v1_projects__projectName__ai_agents_byids_post>`_
+        """`Retrieve one or more agents by external ID. <https://api-docs.cognite.com/20230101-beta/tag/Agents/operation/get_agents_by_ids_ai_agents_byids_post/>`_
 
         Args:
             external_ids (str | SequenceNotStr[str]): The external id of the agent(s) to retrieve.
@@ -199,7 +199,7 @@ class AgentsAPI(APIClient):
         )
 
     def delete(self, external_ids: str | SequenceNotStr[str], ignore_unknown_ids: bool = False) -> None:
-        """`Delete one or more agents. <https://api-docs.cognite.com/20230101-beta/tag/Agents/operation/agent_delete_api_v1_projects__projectName__ai_agents_delete_post>`_
+        """`Delete one or more agents. <https://api-docs.cognite.com/20230101-beta/tag/Agents/operation/agent_delete_ai_agents_delete_post/>`_
 
         Args:
             external_ids (str | SequenceNotStr[str]): External ID of the agent or a list of external ids.
@@ -222,7 +222,7 @@ class AgentsAPI(APIClient):
         )
 
     def list(self) -> AgentList:  # The API does not yet support limit or pagination
-        """`List agents. <https://api-docs.cognite.com/20230101-beta/tag/Agents/operation/agent_list_api_v1_projects__projectName__ai_agents_get>`_
+        """`List agents. <https://api-docs.cognite.com/20230101-beta/tag/Agents/operation/agent_list_ai_agents_get/>`_
 
         Returns:
             AgentList: The list of agents.
@@ -246,7 +246,7 @@ class AgentsAPI(APIClient):
         messages: Message | Sequence[Message],
         cursor: str | None = None,
     ) -> AgentChatResponse:
-        """`Chat with an agent. <https://api-docs.cognite.com/20230101-beta/tag/Agents/operation/agent_session_api_v1_projects__projectName__ai_agents_chat_post>`_
+        """`Chat with an agent. <https://api-docs.cognite.com/20230101-beta/tag/Agents/operation/agent_session_ai_agents_chat_post/>`_
 
         Given a user query, the Atlas AI agent responds by reasoning and using the tools associated with it.
         Users can ensure conversation continuity by including the cursor from the previous response in subsequent requests.

--- a/cognite/client/_api/agents/agents.py
+++ b/cognite/client/_api/agents/agents.py
@@ -20,7 +20,7 @@ class AgentsAPI(APIClient):
 
     def __init__(self, config: ClientConfig, api_version: str | None, cognite_client: CogniteClient) -> None:
         super().__init__(config, api_version, cognite_client)
-        self._warnings = FeaturePreviewWarning(api_maturity="beta", sdk_maturity="beta", feature_name="Agents")
+        self._warnings = FeaturePreviewWarning(api_maturity="beta", sdk_maturity="alpha", feature_name="Agents")
         self._api_subversion = "beta"
         self._CREATE_LIMIT = 1
         self._DELETE_LIMIT = 1

--- a/cognite/client/_version.py
+++ b/cognite/client/_version.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
 
-__version__ = "7.83.0"
+__version__ = "7.83.1"
 
 __api_subversion__ = "20230101"

--- a/cognite/client/utils/_experimental.py
+++ b/cognite/client/utils/_experimental.py
@@ -16,9 +16,15 @@ class FeaturePreviewWarning(FutureWarning):
         self.feature_name = feature_name
 
     def __str__(self) -> str:
-        if self.api_version == "alpha" or self.sdk_version == "alpha":
+        if self.api_version == "alpha":
             return (
                 f"{self.feature_name} is in alpha and is subject to breaking changes without prior notice. "
+                f"API maturity={self.api_version}, SDK maturity={self.sdk_version}. "
+                "See https://cognite-sdk-python.readthedocs-hosted.com/en/latest/appendix.html for more information."
+            )
+        elif self.api_version == "beta" or self.sdk_version == "alpha":
+            return (
+                f"{self.feature_name} is in beta, breaking changes may occur but will be preceded by a DeprecationWarning. "
                 f"API maturity={self.api_version}, SDK maturity={self.sdk_version}. "
                 "See https://cognite-sdk-python.readthedocs-hosted.com/en/latest/appendix.html for more information."
             )

--- a/cognite/client/utils/_experimental.py
+++ b/cognite/client/utils/_experimental.py
@@ -16,15 +16,9 @@ class FeaturePreviewWarning(FutureWarning):
         self.feature_name = feature_name
 
     def __str__(self) -> str:
-        if self.api_version == "alpha":
+        if self.api_version == "alpha" or self.sdk_version == "alpha":
             return (
                 f"{self.feature_name} is in alpha and is subject to breaking changes without prior notice. "
-                f"API maturity={self.api_version}, SDK maturity={self.sdk_version}. "
-                "See https://cognite-sdk-python.readthedocs-hosted.com/en/latest/appendix.html for more information."
-            )
-        elif self.api_version == "beta" or self.sdk_version == "alpha":
-            return (
-                f"{self.feature_name} is in beta, breaking changes may occur but will be preceded by a DeprecationWarning. "
                 f"API maturity={self.api_version}, SDK maturity={self.sdk_version}. "
                 "See https://cognite-sdk-python.readthedocs-hosted.com/en/latest/appendix.html for more information."
             )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "cognite-sdk"
-version = "7.84.0"
+version = "7.83.1"
 
 description = "Cognite Python SDK"
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "cognite-sdk"
-version = "7.83.0"
+version = "7.84.0"
 
 description = "Cognite Python SDK"
 readme = "README.md"


### PR DESCRIPTION
## Description
This PR updates the Agents SDK to reflect the agents API's transition from alpha to beta.

The primary motivations for these changes are:
1.  **Align with API Maturity**: The Agents API has been promoted to beta, so the SDK should send the appropriate `cdf-version: xxxx-beta` header for all agent-related requests.
2.  **Updated Documentation**: All internal API documentation links within the SDK have been updated to point to the beta API endpoints.

## Checklist:
- [ ] Tests added/updated.
- [x] Documentation updated. Documentation is generated from docstrings - these must be updated according to your change.
  If a new method has been added it should be referenced in [cognite.rst](https://github.com/cognitedata/cognite-sdk-python/blob/master/docs/source/cognite.rst) in order to generate docs based on its docstring.
- [x] The PR title follows the [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) spec.

---
<a href="https://cursor.com/background-agent?bcId=bc-b60dbcea-d43e-4b0c-9de6-cc024c38f518">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-b60dbcea-d43e-4b0c-9de6-cc024c38f518">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

