### PR TITLE
chore: bump pyodide version used in verify-jupyter.yml

### DIFF
--- a/.github/workflows/verify-jupyter.yml
+++ b/.github/workflows/verify-jupyter.yml
@@ -23,7 +23,7 @@ jobs:
         with:
           node-version: "22"
       - name: Install dependencies
-        run: npm install pyodide@0.26.2 # JupyterLite currently using pyodide 0.26.2
+        run: npm install pyodide@0.27.6 # JupyterLite currently using pyodide 0.27.6
       - name: Install cognite-sdk in pyodide environment
         run: |
           whl_file=$(find dist -name "*.whl" | sed 's|^dist/||') # Find the built wheel file, remove dist/ prefix


### PR DESCRIPTION
Updating our CI check that tries to avoid breaking Fusion Notebooks for new SDK releases to match the version that is in use.