### PR TITLE
perf(functions): Use exponential instead of constant backoff for FunctionCall:wait

### DIFF
--- a/cognite/client/data_classes/functions.py
+++ b/cognite/client/data_classes/functions.py
@@ -17,6 +17,7 @@ from cognite.client.data_classes._base import (
     WriteableCogniteResourceList,
 )
 from cognite.client.data_classes.shared import TimestampRange
+from cognite.client.utils._retry import Backoff
 from cognite.client.utils._time import ms_to_datetime
 
 if TYPE_CHECKING:
@@ -685,9 +686,10 @@ class FunctionCall(CogniteResource):
         return call_id, function_id
 
     def wait(self) -> None:
+        backoff = Backoff(max_wait=5, base=1)
         while self.status == "Running":
             self.update()
-            time.sleep(1.0)
+            time.sleep(next(backoff))
 
 
 class FunctionCallList(CogniteResourceList[FunctionCall], InternalIdTransformerMixin):


### PR DESCRIPTION
## Description
Please describe the change you have made.

## Checklist:
- [ ] Tests added/updated.
- [ ] Documentation updated. Documentation is generated from docstrings - these must be updated according to your change.
  If a new method has been added it should be referenced in [cognite.rst](https://github.com/cognitedata/cognite-sdk-python/blob/master/docs/source/cognite.rst) in order to generate docs based on its docstring.
- [ ] The PR title follows the [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) spec.
