### PR TITLE
chore(functions): Actually make FunctionCall:wait() backoff exponential

### DIFF
--- a/cognite/client/data_classes/functions.py
+++ b/cognite/client/data_classes/functions.py
@@ -686,7 +686,7 @@ class FunctionCall(CogniteResource):
         return call_id, function_id
 
     def wait(self) -> None:
-        backoff = Backoff(max_wait=5, base=1)
+        backoff = Backoff(max_wait=10, base=2, multiplier=0.3)
         while self.status == "Running":
             self.update()
             time.sleep(next(backoff))


### PR DESCRIPTION
With base 1, it's just random but constant at [0,1)

## Description
Please describe the change you have made.

## Checklist:
- [ ] Tests added/updated.
- [ ] Documentation updated. Documentation is generated from docstrings - these must be updated according to your change.
  If a new method has been added it should be referenced in [cognite.rst](https://github.com/cognitedata/cognite-sdk-python/blob/master/docs/source/cognite.rst) in order to generate docs based on its docstring.
- [ ] The PR title follows the [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) spec.
