### PR TITLE
fix(simint): retrieve(..) overloads and enable mypy checks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,12 +29,15 @@ repos:
     hooks:
       - id: mypy
         name: mypy
-      # Eventually we want to run mypy on the whole test code base. But for now we only enable it for data modeling tests.
+      # Eventually we want to run mypy on the whole test code base. But for now we only enable it for data modeling, simulators and datapoints
         entry: |
           poetry run dmypy run -- cognite tests/tests_integration/test_api/test_data_modeling
           tests/tests_unit/test_data_classes/test_data_models
           tests/tests_unit/test_utils/test_time.py
           tests/tests_integration/test_api/test_datapoints.py
+          tests/tests_integration/test_api/test_simulators
+          tests/tests_unit/test_api/test_simulators
+          tests/tests_unit/test_data_classes/test_simulators.py
         files: ^.*.(py|pyi)$
         language: system
         pass_filenames: false

--- a/cognite/client/_api/simulators/__init__.py
+++ b/cognite/client/_api/simulators/__init__.py
@@ -70,11 +70,11 @@ class SimulatorsAPI(APIClient):
             limit=limit,
         )
 
-    def list(self, limit: int = DEFAULT_LIMIT_READ) -> SimulatorList:
+    def list(self, limit: int | None = DEFAULT_LIMIT_READ) -> SimulatorList:
         """`List all simulators <https://developer.cognite.com/api#tag/Simulators/operation/filter_simulators_simulators_list_post>`_
 
         Args:
-            limit (int): Maximum number of results to return. Defaults to 25. Set to -1, float(“inf”) or None to return all items.
+            limit (int | None): Maximum number of results to return. Defaults to 25. Set to -1, float(“inf”) or None to return all items.
 
         Returns:
             SimulatorList: List of simulators

--- a/cognite/client/_api/simulators/models.py
+++ b/cognite/client/_api/simulators/models.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Iterator, Sequence
-from typing import TYPE_CHECKING, NoReturn, overload
+from typing import TYPE_CHECKING, overload
 
 from cognite.client._api.simulators.models_revisions import SimulatorModelRevisionsAPI
 from cognite.client._api_client import APIClient
@@ -82,27 +82,20 @@ class SimulatorModelsAPI(APIClient):
         )
 
     @overload
-    def retrieve(self, ids: None = None, external_ids: None = None) -> NoReturn: ...
+    def retrieve(self, *, ids: int) -> SimulatorModel | None: ...
 
     @overload
-    def retrieve(self, ids: int, external_ids: None = None) -> SimulatorModel | None: ...
+    def retrieve(self, *, external_ids: str) -> SimulatorModel | None: ...
 
     @overload
-    def retrieve(
-        self,
-        ids: None = None,
-        external_ids: str = ...,
-    ) -> SimulatorModel | None: ...
+    def retrieve(self, *, ids: Sequence[int]) -> SimulatorModelList: ...
 
     @overload
-    def retrieve(
-        self,
-        ids: Sequence[int] | None = None,
-        external_ids: SequenceNotStr[str] | None = None,
-    ) -> SimulatorModelList | None: ...
+    def retrieve(self, *, external_ids: SequenceNotStr[str]) -> SimulatorModelList: ...
 
     def retrieve(
         self,
+        *,
         ids: int | Sequence[int] | None = None,
         external_ids: str | SequenceNotStr[str] | None = None,
     ) -> SimulatorModel | SimulatorModelList | None:

--- a/cognite/client/_api/simulators/models.py
+++ b/cognite/client/_api/simulators/models.py
@@ -90,8 +90,8 @@ class SimulatorModelsAPI(APIClient):
     @overload
     def retrieve(
         self,
-        ids: None,
-        external_ids: str,
+        ids: None = None,
+        external_ids: str = ...,
     ) -> SimulatorModel | None: ...
 
     @overload

--- a/cognite/client/_api/simulators/models.py
+++ b/cognite/client/_api/simulators/models.py
@@ -37,7 +37,7 @@ class SimulatorModelsAPI(APIClient):
 
     def list(
         self,
-        limit: int = DEFAULT_LIMIT_READ,
+        limit: int | None = DEFAULT_LIMIT_READ,
         simulator_external_ids: str | SequenceNotStr[str] | None = None,
         sort: PropertySort | None = None,
     ) -> SimulatorModelList:
@@ -46,7 +46,7 @@ class SimulatorModelsAPI(APIClient):
         Retrieves a list of simulator models that match the given criteria.
 
         Args:
-            limit (int): Maximum number of results to return. Defaults to 25. Set to -1, float(“inf”) or None to return all items.
+            limit (int | None): Maximum number of results to return. Defaults to 25. Set to -1, float(“inf”) or None to return all items.
             simulator_external_ids (str | SequenceNotStr[str] | None): Filter by simulator external id(s).
             sort (PropertySort | None): The criteria to sort by.
 

--- a/cognite/client/_api/simulators/models_revisions.py
+++ b/cognite/client/_api/simulators/models_revisions.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Iterator, Sequence
-from typing import TYPE_CHECKING, NoReturn, overload
+from typing import TYPE_CHECKING, overload
 
 from cognite.client._api_client import APIClient
 from cognite.client._constants import DEFAULT_LIMIT_READ
@@ -90,27 +90,20 @@ class SimulatorModelRevisionsAPI(APIClient):
         )
 
     @overload
-    def retrieve(self, ids: None = None, external_ids: None = None) -> NoReturn: ...
+    def retrieve(self, *, ids: int) -> SimulatorModelRevision | None: ...
 
     @overload
-    def retrieve(self, ids: int, external_ids: None = None) -> SimulatorModelRevision | None: ...
+    def retrieve(self, *, external_ids: str) -> SimulatorModelRevision | None: ...
 
     @overload
-    def retrieve(
-        self,
-        ids: None = None,
-        external_ids: str = ...,
-    ) -> SimulatorModelRevision | None: ...
+    def retrieve(self, *, ids: Sequence[int]) -> SimulatorModelRevisionList: ...
 
     @overload
-    def retrieve(
-        self,
-        ids: int | Sequence[int] | None = None,
-        external_ids: str | SequenceNotStr[str] | None = None,
-    ) -> SimulatorModelRevision | SimulatorModelRevisionList | None: ...
+    def retrieve(self, *, external_ids: SequenceNotStr[str]) -> SimulatorModelRevisionList: ...
 
     def retrieve(
         self,
+        *,
         ids: int | Sequence[int] | None = None,
         external_ids: str | SequenceNotStr[str] | None = None,
     ) -> SimulatorModelRevision | SimulatorModelRevisionList | None:

--- a/cognite/client/_api/simulators/models_revisions.py
+++ b/cognite/client/_api/simulators/models_revisions.py
@@ -98,8 +98,8 @@ class SimulatorModelRevisionsAPI(APIClient):
     @overload
     def retrieve(
         self,
-        ids: None,
-        external_ids: str,
+        ids: None = None,
+        external_ids: str = ...,
     ) -> SimulatorModelRevision | None: ...
 
     @overload

--- a/cognite/client/_api/simulators/routine_revisions.py
+++ b/cognite/client/_api/simulators/routine_revisions.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Iterator, Sequence
-from typing import TYPE_CHECKING, NoReturn, overload
+from typing import TYPE_CHECKING, overload
 
 from cognite.client._api_client import APIClient
 from cognite.client.data_classes.shared import TimestampRange
@@ -127,27 +127,20 @@ class SimulatorRoutineRevisionsAPI(APIClient):
         )
 
     @overload
-    def retrieve(self, ids: None = None, external_ids: None = None) -> NoReturn: ...
+    def retrieve(self, *, ids: int) -> SimulatorRoutineRevision | None: ...
 
     @overload
-    def retrieve(self, ids: int, external_ids: None = None) -> SimulatorRoutineRevision | None: ...
+    def retrieve(self, *, external_ids: str) -> SimulatorRoutineRevision | None: ...
 
     @overload
-    def retrieve(
-        self,
-        ids: None = None,
-        external_ids: str = ...,
-    ) -> SimulatorRoutineRevision | None: ...
+    def retrieve(self, *, ids: Sequence[int]) -> SimulatorRoutineRevisionList: ...
 
     @overload
-    def retrieve(
-        self,
-        ids: Sequence[int] | None = None,
-        external_ids: SequenceNotStr[str] | None = None,
-    ) -> SimulatorRoutineRevisionList | None: ...
+    def retrieve(self, *, external_ids: SequenceNotStr[str]) -> SimulatorRoutineRevisionList: ...
 
     def retrieve(
         self,
+        *,
         ids: int | Sequence[int] | None = None,
         external_ids: str | SequenceNotStr[str] | None = None,
     ) -> SimulatorRoutineRevision | SimulatorRoutineRevisionList | None:

--- a/cognite/client/_api/simulators/routine_revisions.py
+++ b/cognite/client/_api/simulators/routine_revisions.py
@@ -135,8 +135,8 @@ class SimulatorRoutineRevisionsAPI(APIClient):
     @overload
     def retrieve(
         self,
-        ids: None,
-        external_ids: str,
+        ids: None = None,
+        external_ids: str = ...,
     ) -> SimulatorRoutineRevision | None: ...
 
     @overload

--- a/tests/tests_integration/test_api/test_simulators/conftest.py
+++ b/tests/tests_integration/test_api/test_simulators/conftest.py
@@ -82,7 +82,7 @@ def seed_model_revision_file(
 @pytest.fixture(scope="session")
 def seed_simulator(cognite_client: CogniteClient, seed_resource_names: ResourceNames) -> None:
     simulator_external_id = seed_resource_names.simulator_external_id
-    simulators = cognite_client.simulators.list()
+    simulators = cognite_client.simulators.list(limit=None)
     seeded_simulator = simulators.get(external_id=simulator_external_id)
     fields_to_compare = ["fileExtensionTypes", "modelTypes", "modelDependencies", "stepFields", "unitQuantities"]
 
@@ -103,7 +103,7 @@ def seed_simulator_integration(
 ) -> None:
     log_id = None
     timestamp = int(time.time() * 1000)
-    simulator_integrations = cognite_client.simulators.integrations.list()
+    simulator_integrations = cognite_client.simulators.integrations.list(limit=None)
     existing_integration = simulator_integrations.get(external_id=seed_resource_names.simulator_integration_external_id)
     if not existing_integration:
         new_integration = {
@@ -136,7 +136,7 @@ def seed_simulator_models(
     cognite_client: CogniteClient, seed_simulator_integration: None, seed_resource_names: ResourceNames
 ) -> Iterator[SimulatorModel]:
     model_unique_external_id = seed_resource_names.simulator_model_external_id
-    models = cognite_client.simulators.models.list()
+    models = cognite_client.simulators.models.list(limit=None)
     model = models.get(external_id=model_unique_external_id)
 
     if not model:

--- a/tests/tests_integration/test_api/test_simulators/seed/data.py
+++ b/tests/tests_integration/test_api/test_simulators/seed/data.py
@@ -1,20 +1,13 @@
 # This file contains the data used to seed the test environment for the simulator tests
 from dataclasses import dataclass
 
+from cognite.client.data_classes.simulators.models import SimulatorModelWrite
 from cognite.client.data_classes.simulators.routine_revisions import (
-    SimulationValueUnitInput,
     SimulatorRoutineConfiguration,
-    SimulatorRoutineDataSampling,
-    SimulatorRoutineInputConstant,
-    SimulatorRoutineLogicalCheck,
-    SimulatorRoutineOutput,
     SimulatorRoutineRevisionWrite,
-    SimulatorRoutineSchedule,
     SimulatorRoutineStage,
-    SimulatorRoutineSteadyStateDetection,
-    SimulatorRoutineStep,
-    SimulatorRoutineStepArguments,
 )
+from cognite.client.data_classes.simulators.routines import SimulatorRoutineWrite
 from cognite.client.utils._text import random_string
 
 data_set_external_id = "sdk_tests_dwsim1"
@@ -30,7 +23,7 @@ class ResourceNames:
     simulator_model_revision_external_id: str
     simulator_model_file_external_id: str
     simulator_routine_external_id: str
-    simulator_test_data_set_id: str | None
+    simulator_test_data_set_id: int
     simulator_test_data_set_external_id: str
     simulator_model_external_dependency_file_external_id: str
 
@@ -42,12 +35,12 @@ RESOURCES = ResourceNames(
     simulator_model_revision_external_id=f"py_sdk_integration_tests_model_{random_str}_v1",
     simulator_model_file_external_id="ShowerMixer_simulator_model_file_5",
     simulator_routine_external_id=f"pysdk_routine_{random_str}",
-    simulator_test_data_set_id=None,
+    simulator_test_data_set_id=0,  # is set by fixture
     simulator_test_data_set_external_id=data_set_external_id,
     simulator_model_external_dependency_file_external_id="ExtDependency_simulator_model_external_dependency_file",
 )
 
-SIMULATOR = {
+SIMULATOR: dict = {
     "name": RESOURCES.simulator_external_id,
     "externalId": RESOURCES.simulator_external_id,
     "fileExtensionTypes": ["txt"],
@@ -245,7 +238,7 @@ SIMULATOR = {
     ],
 }
 
-SIMULATOR_INTEGRATION = {
+SIMULATOR_INTEGRATION: dict = {
     "externalId": RESOURCES.simulator_integration_external_id,
     "simulatorExternalId": RESOURCES.simulator_external_id,
     "heartbeat": 0,
@@ -258,128 +251,138 @@ SIMULATOR_INTEGRATION = {
     "connectorStatusUpdatedTime": 0,
 }
 
-SIMULATOR_MODEL = {
-    "externalId": RESOURCES.simulator_model_external_id,
-    "simulatorExternalId": RESOURCES.simulator_external_id,
-    "name": "Test Simulator Model",
-    "description": "Test Simulator Model Desc",
-    "dataSetId": RESOURCES.simulator_test_data_set_id,
-    "type": "SteadyState",
-}
 
-
-SIMULATOR_ROUTINE = {
-    "externalId": RESOURCES.simulator_routine_external_id,
-    "modelExternalId": RESOURCES.simulator_model_external_id,
-    "simulatorIntegrationExternalId": RESOURCES.simulator_integration_external_id,
-    "name": "Simulator Routine - Test",
-    "description": "Simulator Routine - Description Test",
-}
-
-SIMULATOR_ROUTINE_REVISION_CONFIG_OBJ = {
-    "schedule": {"enabled": True, "cronExpression": "*/10 * * * *"},
-    "dataSampling": {"enabled": True, "samplingWindow": 15, "granularity": 1, "validationWindow": 5},
-    "logicalCheck": [
-        {
-            "enabled": True,
-            "aggregate": "average",
-            "operator": "lt",
-            "value": 75.8,
-            "timeseriesExternalId": "VAL-45-PT-92608_test",
-        }
-    ],
-    "steadyStateDetection": [
-        {
-            "enabled": True,
-            "aggregate": "average",
-            "minSectionSize": 1,
-            "varThreshold": 3.5,
-            "slopeThreshold": -7.5,
-            "timeseriesExternalId": "VAL-45-PT-92608",
-        }
-    ],
-    "inputs": [
-        {
-            "name": "Cold Water Temperature",
-            "referenceId": "CWT",
-            "value": 10.0,
-            "valueType": "DOUBLE",
-            "unit": {"name": "C", "quantity": "temperature"},
-            "saveTimeseriesExternalId": "TEST-ROUTINE-INPUT-CWT",
-        },
-        {
-            "name": "Cold Water Pressure",
-            "referenceId": "CWP",
-            "value": [3.6],
-            "valueType": "DOUBLE_ARRAY",
-            "unit": {"name": "bar", "quantity": "pressure"},
-        },
-    ],
-    "outputs": [
-        {
-            "name": "Shower Temperature",
-            "referenceId": "ST",
-            "unit": {"name": "C", "quantity": "temperature"},
-            "valueType": "DOUBLE",
-            "saveTimeseriesExternalId": "TEST-ROUTINE-OUTPUT-ST",
-        },
-        {
-            "name": "Shower Pressure",
-            "referenceId": "SP",
-            "unit": {"name": "bar", "quantity": "pressure"},
-            "valueType": "DOUBLE",
-        },
-    ],
-}
-
-SIMULATOR_ROUTINE_REVISION_SCRIPT_OBJ = [
+SIMULATOR_MODEL = SimulatorModelWrite.load(
     {
-        "order": 1,
-        "description": "Set Inputs",
-        "steps": [
+        "externalId": RESOURCES.simulator_model_external_id,
+        "simulatorExternalId": RESOURCES.simulator_external_id,
+        "name": "Test Simulator Model",
+        "description": "Test Simulator Model Desc",
+        "dataSetId": RESOURCES.simulator_test_data_set_id,
+        "type": "SteadyState",
+    }
+)
+
+
+SIMULATOR_ROUTINE = SimulatorRoutineWrite.load(
+    {
+        "externalId": RESOURCES.simulator_routine_external_id,
+        "modelExternalId": RESOURCES.simulator_model_external_id,
+        "simulatorIntegrationExternalId": RESOURCES.simulator_integration_external_id,
+        "name": "Simulator Routine - Test",
+        "description": "Simulator Routine - Description Test",
+    }
+)
+
+SIMULATOR_ROUTINE_REVISION_CONFIG = SimulatorRoutineConfiguration.load(
+    {
+        "schedule": {"enabled": True, "cronExpression": "*/10 * * * *"},
+        "dataSampling": {"enabled": True, "samplingWindow": 15, "granularity": 1, "validationWindow": 5},
+        "logicalCheck": [
             {
-                "order": 1,
-                "stepType": "Set",
-                "description": "Set Cold Water Temperature",
-                "arguments": {"referenceId": "CWT", "objectName": "Cold water", "objectProperty": "Temperature"},
+                "enabled": True,
+                "aggregate": "average",
+                "operator": "lt",
+                "value": 75.8,
+                "timeseriesExternalId": "VAL-45-PT-92608_test",
+            }
+        ],
+        "steadyStateDetection": [
+            {
+                "enabled": True,
+                "aggregate": "average",
+                "minSectionSize": 1,
+                "varThreshold": 3.5,
+                "slopeThreshold": -7.5,
+                "timeseriesExternalId": "VAL-45-PT-92608",
+            }
+        ],
+        "inputs": [
+            {
+                "name": "Cold Water Temperature",
+                "referenceId": "CWT",
+                "value": 10.0,
+                "valueType": "DOUBLE",
+                "unit": {"name": "C", "quantity": "temperature"},
+                "saveTimeseriesExternalId": "TEST-ROUTINE-INPUT-CWT",
             },
             {
-                "order": 2,
-                "stepType": "Set",
-                "description": "Set Cold Water Pressure",
-                "arguments": {"referenceId": "CWP", "objectName": "Cold water", "objectProperty": "Pressure"},
+                "name": "Cold Water Pressure",
+                "referenceId": "CWP",
+                "value": [3.6],
+                "valueType": "DOUBLE_ARRAY",
+                "unit": {"name": "bar", "quantity": "pressure"},
             },
         ],
-    },
-    {
-        "order": 2,
-        "description": "Solve the flowsheet",
-        "steps": [{"order": 1, "stepType": "Command", "arguments": {"command": "Solve"}}],
-    },
-    {
-        "order": 3,
-        "description": "Set simulation outputs",
-        "steps": [
+        "outputs": [
             {
-                "order": 1,
-                "stepType": "Get",
-                "arguments": {"referenceId": "ST", "objectName": "Shower", "objectProperty": "Temperature"},
+                "name": "Shower Temperature",
+                "referenceId": "ST",
+                "unit": {"name": "C", "quantity": "temperature"},
+                "valueType": "DOUBLE",
+                "saveTimeseriesExternalId": "TEST-ROUTINE-OUTPUT-ST",
             },
             {
-                "order": 2,
-                "stepType": "Get",
-                "arguments": {"referenceId": "SP", "objectName": "Shower", "objectProperty": "Pressure"},
+                "name": "Shower Pressure",
+                "referenceId": "SP",
+                "unit": {"name": "bar", "quantity": "pressure"},
+                "valueType": "DOUBLE",
             },
         ],
-    },
+    }
+)
+
+SIMULATOR_ROUTINE_REVISION_SCRIPT = [
+    SimulatorRoutineStage.load(stage)
+    for stage in [
+        {
+            "order": 1,
+            "description": "Set Inputs",
+            "steps": [
+                {
+                    "order": 1,
+                    "stepType": "Set",
+                    "description": "Set Cold Water Temperature",
+                    "arguments": {"referenceId": "CWT", "objectName": "Cold water", "objectProperty": "Temperature"},
+                },
+                {
+                    "order": 2,
+                    "stepType": "Set",
+                    "description": "Set Cold Water Pressure",
+                    "arguments": {"referenceId": "CWP", "objectName": "Cold water", "objectProperty": "Pressure"},
+                },
+            ],
+        },
+        {
+            "order": 2,
+            "description": "Solve the flowsheet",
+            "steps": [{"order": 1, "stepType": "Command", "arguments": {"command": "Solve"}}],
+        },
+        {
+            "order": 3,
+            "description": "Set simulation outputs",
+            "steps": [
+                {
+                    "order": 1,
+                    "stepType": "Get",
+                    "arguments": {"referenceId": "ST", "objectName": "Shower", "objectProperty": "Temperature"},
+                },
+                {
+                    "order": 2,
+                    "stepType": "Get",
+                    "arguments": {"referenceId": "SP", "objectName": "Shower", "objectProperty": "Pressure"},
+                },
+            ],
+        },
+    ]
 ]
 
-SIMULATOR_ROUTINE_REVISION_OBJ = {
-    "externalId": None,
-    "routineExternalId": RESOURCES.simulator_routine_external_id,
-    "configuration": SIMULATOR_ROUTINE_REVISION_CONFIG_OBJ,
-    "script": SIMULATOR_ROUTINE_REVISION_SCRIPT_OBJ,
-}
+SIMULATOR_ROUTINE_REVISION = SimulatorRoutineRevisionWrite(
+    external_id=RESOURCES.simulator_routine_external_id + "_rev1",
+    routine_external_id=RESOURCES.simulator_routine_external_id,
+    configuration=SIMULATOR_ROUTINE_REVISION_CONFIG,
+    script=SIMULATOR_ROUTINE_REVISION_SCRIPT,
+)
 
 
 def create_simulator_routine_revision(
@@ -390,76 +393,6 @@ def create_simulator_routine_revision(
     return SimulatorRoutineRevisionWrite(
         external_id=external_id,
         routine_external_id=routine_external_id,
-        configuration=SimulatorRoutineConfiguration(
-            schedule=SimulatorRoutineSchedule(
-                cron_expression=SIMULATOR_ROUTINE_REVISION_CONFIG_OBJ["schedule"]["cronExpression"],
-            ),
-            data_sampling=SimulatorRoutineDataSampling(
-                sampling_window=SIMULATOR_ROUTINE_REVISION_CONFIG_OBJ["dataSampling"]["samplingWindow"],
-                granularity=SIMULATOR_ROUTINE_REVISION_CONFIG_OBJ["dataSampling"]["granularity"],
-                validation_window=SIMULATOR_ROUTINE_REVISION_CONFIG_OBJ["dataSampling"]["validationWindow"],
-            ),
-            logical_check=[
-                SimulatorRoutineLogicalCheck(
-                    aggregate=logical_check["aggregate"],
-                    operator=logical_check["operator"],
-                    value=logical_check["value"],
-                    timeseries_external_id=logical_check["timeseriesExternalId"],
-                )
-                for logical_check in SIMULATOR_ROUTINE_REVISION_CONFIG_OBJ["logicalCheck"]
-            ],
-            steady_state_detection=[
-                SimulatorRoutineSteadyStateDetection(
-                    aggregate=steady_state_detection["aggregate"],
-                    min_section_size=steady_state_detection["minSectionSize"],
-                    var_threshold=steady_state_detection["varThreshold"],
-                    slope_threshold=steady_state_detection["slopeThreshold"],
-                    timeseries_external_id=steady_state_detection["timeseriesExternalId"],
-                )
-                for steady_state_detection in SIMULATOR_ROUTINE_REVISION_CONFIG_OBJ["steadyStateDetection"]
-            ],
-            inputs=[
-                SimulatorRoutineInputConstant(
-                    name=input_cfg["name"],
-                    reference_id=input_cfg["referenceId"],
-                    value=input_cfg["value"],
-                    value_type=input_cfg["valueType"],
-                    unit=SimulationValueUnitInput(
-                        name=input_cfg["unit"]["name"],
-                        quantity=input_cfg["unit"]["quantity"],
-                    ),
-                    save_timeseries_external_id=input_cfg.get("saveTimeseriesExternalId"),
-                )
-                for input_cfg in SIMULATOR_ROUTINE_REVISION_CONFIG_OBJ["inputs"]
-            ],
-            outputs=[
-                SimulatorRoutineOutput(
-                    name=output_cfg["name"],
-                    reference_id=output_cfg["referenceId"],
-                    unit=SimulationValueUnitInput(
-                        name=output_cfg["unit"]["name"],
-                        quantity=output_cfg["unit"]["quantity"],
-                    ),
-                    value_type=output_cfg["valueType"],
-                    save_timeseries_external_id=output_cfg.get("saveTimeseriesExternalId"),
-                )
-                for output_cfg in SIMULATOR_ROUTINE_REVISION_CONFIG_OBJ["outputs"]
-            ],
-        ),
-        script=[
-            SimulatorRoutineStage(
-                order=stage_cfg["order"],
-                description=stage_cfg["description"],
-                steps=[
-                    SimulatorRoutineStep(
-                        order=step_cfg["order"],
-                        step_type=step_cfg["stepType"],
-                        description=step_cfg.get("description"),
-                        arguments=SimulatorRoutineStepArguments(step_cfg["arguments"]),
-                    )
-                    for step_cfg in stage_cfg["steps"]
-                ],
-            )
-            for stage_cfg in SIMULATOR_ROUTINE_REVISION_SCRIPT_OBJ
-        ],
+        configuration=SIMULATOR_ROUTINE_REVISION_CONFIG,
+        script=SIMULATOR_ROUTINE_REVISION_SCRIPT,
     )

--- a/tests/tests_integration/test_api/test_simulators/seed/resources.py
+++ b/tests/tests_integration/test_api/test_simulators/seed/resources.py
@@ -190,7 +190,9 @@ def ensure_workflow_simint_routine(cognite_client: CogniteClient) -> str:
         assert isinstance(uploaded_file, FileMetadata)
         file = uploaded_file
 
-    integration = cognite_client.simulators.integrations.list().get(external_id="integration_tests_workflow_connector")
+    integration = cognite_client.simulators.integrations.list(limit=None).get(
+        external_id="integration_tests_workflow_connector"
+    )
 
     seed_data = get_workflow_seed_data(data_set.id, file.id)
     if integration is None:
@@ -203,7 +205,9 @@ def ensure_workflow_simint_routine(cognite_client: CogniteClient) -> str:
             except CogniteAPIError:
                 pass
 
-    integration = cognite_client.simulators.integrations.list().get(external_id="integration_tests_workflow_connector")
+    integration = cognite_client.simulators.integrations.list(limit=None).get(
+        external_id="integration_tests_workflow_connector"
+    )
     assert integration is not None
     update_seed_integration(cognite_client, integration.id)
 

--- a/tests/tests_integration/test_api/test_simulators/test_routine_revisions.py
+++ b/tests/tests_integration/test_api/test_simulators/test_routine_revisions.py
@@ -23,7 +23,7 @@ class TestSimulatorRoutineRevisions:
     def test_list_and_filtering_routine_revisions(
         self,
         cognite_client: CogniteClient,
-        seed_simulator_routine_revisions: list[SimulatorRoutineRevision],
+        seed_simulator_routine_revisions: tuple[SimulatorRoutineRevision, SimulatorRoutineRevision],
         seed_resource_names: ResourceNames,
     ) -> None:
         simulator_routine_external_id = seed_resource_names.simulator_routine_external_id
@@ -70,7 +70,7 @@ class TestSimulatorRoutineRevisions:
     def test_retrieve_routine_revision(
         self,
         cognite_client: CogniteClient,
-        seed_simulator_routine_revisions: list[SimulatorRoutineRevision],
+        seed_simulator_routine_revisions: tuple[SimulatorRoutineRevision, SimulatorRoutineRevision],
         seed_resource_names: ResourceNames,
     ) -> None:
         simulator_routine_external_id = seed_resource_names.simulator_routine_external_id

--- a/tests/tests_integration/test_api/test_simulators/test_routine_revisions.py
+++ b/tests/tests_integration/test_api/test_simulators/test_routine_revisions.py
@@ -1,5 +1,4 @@
 import time
-from typing import Any
 
 from cognite.client import CogniteClient
 from cognite.client.data_classes.shared import TimestampRange
@@ -9,11 +8,12 @@ from cognite.client.data_classes.simulators.routine_revisions import (
     SimulatorRoutineRevision,
     SimulatorRoutineRevisionWrite,
 )
+from cognite.client.data_classes.simulators.routines import SimulatorRoutine
 from cognite.client.utils._time import timestamp_to_ms
 from tests.tests_integration.test_api.test_simulators.seed.data import (
-    SIMULATOR_ROUTINE_REVISION_CONFIG_OBJ,
-    SIMULATOR_ROUTINE_REVISION_OBJ,
-    SIMULATOR_ROUTINE_REVISION_SCRIPT_OBJ,
+    SIMULATOR_ROUTINE_REVISION,
+    SIMULATOR_ROUTINE_REVISION_CONFIG,
+    SIMULATOR_ROUTINE_REVISION_SCRIPT,
     ResourceNames,
     create_simulator_routine_revision,
 )
@@ -23,7 +23,7 @@ class TestSimulatorRoutineRevisions:
     def test_list_and_filtering_routine_revisions(
         self,
         cognite_client: CogniteClient,
-        seed_simulator_routine_revisions: list[dict[str, Any]],
+        seed_simulator_routine_revisions: list[SimulatorRoutineRevision],
         seed_resource_names: ResourceNames,
     ) -> None:
         simulator_routine_external_id = seed_resource_names.simulator_routine_external_id
@@ -61,20 +61,16 @@ class TestSimulatorRoutineRevisions:
         last_revision = revisions_by_model[1]
         assert last_revision.external_id == seed_resource_names.simulator_routine_external_id + "_v2"
 
-        last_revision_script_json = [item.dump() for item in last_revision.script]
-        assert last_revision_script_json == seed_rev2["script"]
-        assert (
-            last_revision.script[0].steps[0].arguments["referenceId"]
-            == seed_rev2["script"][0]["steps"][0]["arguments"]["referenceId"]
-        )
+        assert last_revision.script is not None
+        assert last_revision.script == seed_rev2.script
 
-        last_revision_config_json = last_revision.configuration.dump()
-        assert last_revision_config_json == seed_rev2["configuration"]
+        assert last_revision.configuration is not None
+        assert last_revision.configuration == seed_rev2.configuration
 
     def test_retrieve_routine_revision(
         self,
         cognite_client: CogniteClient,
-        seed_simulator_routine_revisions: list[dict[str, Any]],
+        seed_simulator_routine_revisions: list[SimulatorRoutineRevision],
         seed_resource_names: ResourceNames,
     ) -> None:
         simulator_routine_external_id = seed_resource_names.simulator_routine_external_id
@@ -97,9 +93,9 @@ class TestSimulatorRoutineRevisions:
     def test_create_routine_revision(
         self,
         cognite_client: CogniteClient,
-        seed_simulator_routines: dict[str, Any],
+        seed_simulator_routines: list[SimulatorRoutine],
         seed_resource_names: ResourceNames,
-    ):
+    ) -> None:
         routine_external_id = seed_resource_names.simulator_routine_external_id
 
         revisions = cognite_client.simulators.routines.revisions.create(
@@ -110,7 +106,7 @@ class TestSimulatorRoutineRevisions:
                 ),
                 SimulatorRoutineRevisionWrite.load(
                     {
-                        **SIMULATOR_ROUTINE_REVISION_OBJ,
+                        **SIMULATOR_ROUTINE_REVISION.dump(),
                         "externalId": f"{routine_external_id}_1_v1",
                         "routineExternalId": f"{routine_external_id}_1",
                     }
@@ -122,15 +118,20 @@ class TestSimulatorRoutineRevisions:
         revision_1 = revisions[0]
         assert revision_1 is not None
         assert revision_1.external_id == f"{routine_external_id}_v3"
-        assert revision_1.configuration.dump() == SIMULATOR_ROUTINE_REVISION_CONFIG_OBJ
-        assert [item.dump(camel_case=True) for item in revision_1.script] == SIMULATOR_ROUTINE_REVISION_SCRIPT_OBJ
+        assert revision_1.configuration is not None
+        assert revision_1.configuration == SIMULATOR_ROUTINE_REVISION_CONFIG
+        assert revision_1.script == SIMULATOR_ROUTINE_REVISION_SCRIPT
         assert revision_1.created_time
         assert revision_1.created_time > int(time.time() - 60) * 1000
 
         revision_2 = revisions[1]
         assert revision_2 is not None
         assert revision_2.external_id == f"{routine_external_id}_1_v1"
+        assert revision_2.configuration is not None
+        assert revision_2.configuration.inputs is not None
         assert revision_2.configuration.inputs[0].reference_id == "CWT"
         assert type(revision_2.configuration.inputs[0]) is SimulatorRoutineInputConstant
+        assert revision_2.configuration.outputs is not None
         assert revision_2.configuration.outputs[0].reference_id == "ST"
+        assert revision_2.script is not None
         assert revision_2.script[0].steps[0].arguments["referenceId"] == "CWT"

--- a/tests/tests_integration/test_api/test_simulators/test_routines.py
+++ b/tests/tests_integration/test_api/test_simulators/test_routines.py
@@ -2,7 +2,7 @@ import pytest
 
 from cognite.client._cognite_client import CogniteClient
 from cognite.client.data_classes.simulators.filters import PropertySort
-from cognite.client.data_classes.simulators.routines import SimulatorRoutineWrite
+from cognite.client.data_classes.simulators.routines import SimulatorRoutine, SimulatorRoutineWrite
 from cognite.client.utils._text import random_string
 from tests.tests_integration.test_api.test_simulators.seed.data import ResourceNames
 
@@ -37,7 +37,10 @@ class TestSimulatorRoutines:
             cognite_client.simulators.routines.delete(external_ids=[routine_to_create.external_id])
 
     def test_sort(
-        self, cognite_client: CogniteClient, seed_resource_names: ResourceNames, seed_simulator_routines
+        self,
+        cognite_client: CogniteClient,
+        seed_resource_names: ResourceNames,
+        seed_simulator_routines: list[SimulatorRoutine],
     ) -> None:
         simulator_integration_unique_external_id = seed_resource_names.simulator_integration_external_id
 

--- a/tests/tests_integration/test_api/test_simulators/test_runs.py
+++ b/tests/tests_integration/test_api/test_simulators/test_runs.py
@@ -5,6 +5,7 @@ import pytest
 
 from cognite.client._cognite_client import CogniteClient
 from cognite.client.data_classes import TimestampRange
+from cognite.client.data_classes.simulators.routine_revisions import SimulatorRoutineRevision
 from cognite.client.data_classes.simulators.runs import (
     SimulationInput,
     SimulationOutput,
@@ -113,7 +114,7 @@ class TestSimulatorRuns:
     def test_create_run(
         self,
         cognite_client: CogniteClient,
-        seed_simulator_routine_revisions: list[dict],
+        seed_simulator_routine_revisions: tuple[SimulatorRoutineRevision, SimulatorRoutineRevision],
         seed_resource_names: ResourceNames,
     ) -> None:
         routine_external_id = seed_resource_names.simulator_routine_external_id

--- a/tests/tests_integration/test_api/test_simulators/test_runs.py
+++ b/tests/tests_integration/test_api/test_simulators/test_runs.py
@@ -95,12 +95,14 @@ class TestSimulatorRuns:
         created_run = await run_task
 
         retrieved_run = cognite_client.simulators.runs.retrieve(ids=created_run.id)
+        assert retrieved_run is not None
         assert created_run.id == retrieved_run.id
 
         logs_res = retrieved_run.get_logs()
         logs_res2 = cognite_client.simulators.logs.retrieve(ids=created_run.log_id)
 
         assert logs_res is not None
+        assert logs_res2 is not None
         assert logs_res.dump() == logs_res2.dump()
 
         data_res = retrieved_run.get_data()
@@ -109,7 +111,10 @@ class TestSimulatorRuns:
         assert data_res.dump() == data_res2.dump()
 
     def test_create_run(
-        self, cognite_client: CogniteClient, seed_simulator_routine_revisions, seed_resource_names: ResourceNames
+        self,
+        cognite_client: CogniteClient,
+        seed_simulator_routine_revisions: list[dict],
+        seed_resource_names: ResourceNames,
     ) -> None:
         routine_external_id = seed_resource_names.simulator_routine_external_id
         created_runs = cognite_client.simulators.runs.create(
@@ -193,7 +198,7 @@ class TestSimulatorRuns:
                 value=18.5,
                 value_type="DOUBLE",
                 unit=SimulationValueUnitName(name="C"),
-            ).dump(),
+            ),
         ]
 
         inputs = [
@@ -203,14 +208,14 @@ class TestSimulatorRuns:
                 value_type="DOUBLE",
                 overridden=True,
                 unit=SimulationValueUnitName(name="C"),
-            ).dump(),
+            ),
             SimulationInput(
                 reference_id="CWP",
                 overridden=True,
                 value=[5.0],
                 value_type="DOUBLE_ARRAY",
                 unit=SimulationValueUnitName(name="bar"),
-            ).dump(),
+            ),
         ]
 
         cognite_client.simulators._post(
@@ -227,11 +232,15 @@ class TestSimulatorRuns:
             },
         )
 
-        get_run_data = cognite_client.simulators.runs.list_run_data(
+        run_data_res = cognite_client.simulators.runs.list_run_data(
             run_id=created_run[0].id,
         )
 
-        assert len(get_run_data) == 1
-        assert get_run_data[0].run_id == created_run[0].id
-        assert get_run_data[0].inputs[0].dump() == inputs[0]
-        assert get_run_data[0].outputs[0].dump() == outputs[0]
+        assert len(run_data_res) == 1
+        assert run_data_res[0].run_id == created_run[0].id
+
+        def sort_by_ref_id(x: SimulationInput | SimulationOutput) -> str:
+            return x.reference_id
+
+        assert sorted(run_data_res[0].inputs, key=sort_by_ref_id) == sorted(inputs, key=sort_by_ref_id)
+        assert sorted(run_data_res[0].outputs, key=sort_by_ref_id) == sorted(outputs, key=sort_by_ref_id)

--- a/tests/tests_integration/test_api/test_simulators/utils.py
+++ b/tests/tests_integration/test_api/test_simulators/utils.py
@@ -1,4 +1,6 @@
-from cognite.client._cognite_client import CogniteClient, Response
+from requests import Response
+
+from cognite.client._cognite_client import CogniteClient
 
 
 def update_logs(cognite_client: CogniteClient, log_id: int, payload: list[dict]) -> Response:

--- a/tests/tests_unit/test_api/test_simulators/test_run_data.py
+++ b/tests/tests_unit/test_api/test_simulators/test_run_data.py
@@ -10,7 +10,7 @@ from cognite.client.data_classes.simulators.runs import (
 
 @pytest.mark.dsl
 class TestSimulationRunDataItemPandasIntegration:
-    def test_to_pandas(self):
+    def test_to_pandas(self) -> None:
         import pandas as pd
 
         # Create sample data

--- a/tests/tests_unit/test_data_classes/test_simulators.py
+++ b/tests/tests_unit/test_data_classes/test_simulators.py
@@ -23,7 +23,10 @@ class TestSimulatorModelRevisionDependency:
             )
         ],
     )
-    def test_load_list(self, input_data):
+    def test_load_list(
+        self,
+        input_data: list[dict[str, dict]],
+    ) -> None:
         result = SimulatorModelRevisionDependency._load_list(input_data)
         assert isinstance(result, list)
         assert all(isinstance(item, SimulatorModelRevisionDependency) for item in result)
@@ -31,13 +34,13 @@ class TestSimulatorModelRevisionDependency:
         assert isinstance(result[0].file, SimulatorModelDependencyFileId)
         assert result[0].file.id == 1111
         assert result[0].arguments == {"fieldA": "valueA"}
-        assert isinstance(result[0].file, SimulatorModelDependencyFileId)
+        assert isinstance(result[1].file, SimulatorModelDependencyFileId)
         assert result[1].file.id == 2222
 
 
 class TestSimulator:
     @pytest.fixture
-    def simulator_with_quantities(self):
+    def simulator_with_quantities(self) -> Simulator:
         """Create a simulator with unit quantities for testing."""
         unit_m = SimulatorUnitEntry(label="Meters", name="m")
         unit_ft = SimulatorUnitEntry(label="Feet", name="ft")
@@ -59,7 +62,7 @@ class TestSimulator:
         )
 
     @pytest.fixture
-    def simulator_without_quantities(self):
+    def simulator_without_quantities(self) -> Simulator:
         """Create a simulator without unit quantities for testing."""
         return Simulator(
             external_id="empty-simulator",
@@ -69,20 +72,20 @@ class TestSimulator:
             unit_quantities=None,
         )
 
-    def test_get_quantities_with_data(self, simulator_with_quantities):
+    def test_get_quantities_with_data(self, simulator_with_quantities: Simulator) -> None:
         """Test get_quantities returns correct list when quantities exist."""
         quantities = simulator_with_quantities.get_quantities()
         assert quantities == ["length", "mass", "temperature"]
         assert len(quantities) == 3
         assert all(isinstance(q, str) for q in quantities)
 
-    def test_get_quantities_empty(self, simulator_without_quantities):
+    def test_get_quantities_empty(self, simulator_without_quantities: Simulator) -> None:
         """Test get_quantities returns empty list when no quantities exist."""
         quantities = simulator_without_quantities.get_quantities()
         assert quantities == []
         assert len(quantities) == 0
 
-    def test_get_units_valid_quantity(self, simulator_with_quantities):
+    def test_get_units_valid_quantity(self, simulator_with_quantities: Simulator) -> None:
         """Test get_units returns correct units for valid quantities."""
         # Test length units
         length_units = simulator_with_quantities.get_units("length")
@@ -99,7 +102,7 @@ class TestSimulator:
         assert temp_units == ["C", "F"]
         assert len(temp_units) == 2
 
-    def test_get_units_invalid_quantity(self, simulator_with_quantities):
+    def test_get_units_invalid_quantity(self, simulator_with_quantities: Simulator) -> None:
         """Test get_units raises ValueError for non-existent quantity."""
         with pytest.raises(ValueError) as exc_info:
             simulator_with_quantities.get_units("pressure")
@@ -108,7 +111,7 @@ class TestSimulator:
         assert "Quantity 'pressure' not found" in error_msg
         assert "Available quantities: length, mass, temperature" in error_msg
 
-    def test_get_units_no_quantities(self, simulator_without_quantities):
+    def test_get_units_no_quantities(self, simulator_without_quantities: Simulator) -> None:
         """Test get_units raises ValueError when simulator has no quantities."""
         with pytest.raises(ValueError) as exc_info:
             simulator_without_quantities.get_units("any_quantity")
@@ -117,7 +120,7 @@ class TestSimulator:
         assert "Quantity 'any_quantity' not found" in error_msg
         assert "This simulator has no unit quantities defined" in error_msg
 
-    def test_get_units_empty_units_list(self):
+    def test_get_units_empty_units_list(self) -> None:
         """Test get_units with quantity that has empty units list."""
         empty_quantity = SimulatorQuantity(name="empty", label="Empty Quantity", units=[])
 


### PR DESCRIPTION
## Description
Enabled mypy for simint tests, some refactor / minor typing changes to make mypy happy.

Biggest changes:
- fixed overloads for the models, routines and their revisions
- moved from using dictionaries in seed data to actual simulator objects (where possible)
- typed params / return types for test cases


## Checklist:
- [x] Tests added/updated.
- [x] The PR title follows the [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) spec.
