### PR TITLE
feat(agents): add timeout parameter to chat method

### DIFF
--- a/cognite/client/_api/agents/agents.py
+++ b/cognite/client/_api/agents/agents.py
@@ -281,7 +281,7 @@ class AgentsAPI(APIClient):
                 >>> from cognite.client.data_classes.agents import Message
                 >>> client = CogniteClient()
                 >>> response = client.agents.chat(
-                ...     agent_id="my_agent",
+                ...     agent_external_id="my_agent",
                 ...     messages=Message("What can you help me with?")
                 ... )
                 >>> print(response.text)
@@ -289,7 +289,7 @@ class AgentsAPI(APIClient):
             Continue a conversation using the cursor:
 
                 >>> follow_up = client.agents.chat(
-                ...     agent_id="my_agent",
+                ...     agent_external_id="my_agent",
                 ...     messages=Message("Tell me more about that"),
                 ...     cursor=response.cursor
                 ... )
@@ -297,7 +297,7 @@ class AgentsAPI(APIClient):
             Send multiple messages at once:
 
                 >>> response = client.agents.chat(
-                ...     agent_id="my_agent",
+                ...     agent_external_id="my_agent",
                 ...     messages=[
                 ...         Message("Help me find the 1st stage compressor."),
                 ...         Message("Once you have found it, find related time series.")

--- a/cognite/client/_api/agents/agents.py
+++ b/cognite/client/_api/agents/agents.py
@@ -281,7 +281,7 @@ class AgentsAPI(APIClient):
                 >>> from cognite.client.data_classes.agents import Message
                 >>> client = CogniteClient()
                 >>> response = client.agents.chat(
-                ...     agent_external_id="my_agent",
+                ...     agent_id="my_agent",
                 ...     messages=Message("What can you help me with?")
                 ... )
                 >>> print(response.text)
@@ -289,7 +289,7 @@ class AgentsAPI(APIClient):
             Continue a conversation using the cursor:
 
                 >>> follow_up = client.agents.chat(
-                ...     agent_external_id="my_agent",
+                ...     agent_id="my_agent",
                 ...     messages=Message("Tell me more about that"),
                 ...     cursor=response.cursor
                 ... )
@@ -297,7 +297,7 @@ class AgentsAPI(APIClient):
             Send multiple messages at once:
 
                 >>> response = client.agents.chat(
-                ...     agent_external_id="my_agent",
+                ...     agent_id="my_agent",
                 ...     messages=[
                 ...         Message("Help me find the 1st stage compressor."),
                 ...         Message("Once you have found it, find related time series.")
@@ -320,7 +320,7 @@ class AgentsAPI(APIClient):
                 ...     }
                 ... )
                 >>> response = client.agents.chat(
-                ...     agent_external_id="my_agent",
+                ...     agent_id="my_agent",
                 ...     messages=Message("What is 42 plus 58?"),
                 ...     actions=[add_numbers_action]
                 ... )
@@ -330,7 +330,7 @@ class AgentsAPI(APIClient):
                 ...         result = call.arguments["a"] + call.arguments["b"]
                 ...         # Send result back
                 ...         response = client.agents.chat(
-                ...             agent_external_id="my_agent",
+                ...             agent_id="my_agent",
                 ...             messages=ClientToolResult(
                 ...                 action_id=call.action_id,
                 ...                 content=f"The result is {result}"

--- a/cognite/client/_api/agents/agents.py
+++ b/cognite/client/_api/agents/agents.py
@@ -258,7 +258,7 @@ class AgentsAPI(APIClient):
         Users can ensure conversation continuity by including the cursor from the previous response in subsequent requests.
 
         Note:
-            Agents can take time to execute and may not finish within the default timeout (30 seconds).
+            Agents can take time to execute and may not finish within the default timeout.
             If you experience timeout errors, you can increase the timeout by setting:
 
                 >>> client.config.timeout = 60  # Set timeout to 60 seconds

--- a/cognite/client/_api/agents/agents.py
+++ b/cognite/client/_api/agents/agents.py
@@ -257,6 +257,12 @@ class AgentsAPI(APIClient):
         Given a user query, the Atlas AI agent responds by reasoning and using the tools associated with it.
         Users can ensure conversation continuity by including the cursor from the previous response in subsequent requests.
 
+        Note:
+            Agents can take time to execute and may not finish within the default timeout (30 seconds).
+            If you experience timeout errors, you can increase the timeout by setting:
+
+                >>> client.config.timeout = 60  # Set timeout to 60 seconds
+
         Args:
             agent_external_id (str): External ID that uniquely identifies the agent.
             messages (Message | ActionResult | Sequence[Message | ActionResult]): A list of one or many input messages to the agent. Can include regular messages and action results.

--- a/tests/tests_unit/test_api/test_agents_chat.py
+++ b/tests/tests_unit/test_api/test_agents_chat.py
@@ -59,7 +59,7 @@ def chat_response_body() -> dict:
 class TestAgentChat:
     def test_chat_simple_message(self, cognite_client: CogniteClient, chat_response_body: dict) -> None:
         # Mock the API response
-        cognite_client.agents._post = MagicMock(return_value=MagicMock(json=lambda: chat_response_body))
+        cognite_client.agents._do_request = MagicMock(return_value=MagicMock(json=lambda: chat_response_body))
 
         # Test with simple string message
         response = cognite_client.agents.chat(
@@ -67,9 +67,11 @@ class TestAgentChat:
         )
 
         # Verify the request
-        cognite_client.agents._post.assert_called_once()
-        call_args = cognite_client.agents._post.call_args
+        cognite_client.agents._do_request.assert_called_once()
+        call_args = cognite_client.agents._do_request.call_args
+        assert call_args[0][0] == "POST"
         assert call_args[1]["url_path"] == "/ai/agents/chat"
+        assert call_args[1]["timeout"] == 60  # Verify default timeout
         assert call_args[1]["json"]["agentExternalId"] == "my_agent"
         assert len(call_args[1]["json"]["messages"]) == 1
         assert call_args[1]["json"]["messages"][0]["content"]["text"] == "What can you help me with?"
@@ -107,7 +109,7 @@ class TestAgentChat:
         assert response.text == "I can help you with various tasks related to your industrial data."
 
     def test_chat_with_cursor(self, cognite_client: CogniteClient, chat_response_body: dict) -> None:
-        cognite_client.agents._post = MagicMock(return_value=MagicMock(json=lambda: chat_response_body))
+        cognite_client.agents._do_request = MagicMock(return_value=MagicMock(json=lambda: chat_response_body))
 
         # Test with cursor
         cognite_client.agents.chat(
@@ -117,11 +119,11 @@ class TestAgentChat:
         )
 
         # Verify cursor was included in request
-        call_args = cognite_client.agents._post.call_args
+        call_args = cognite_client.agents._do_request.call_args
         assert call_args[1]["json"]["cursor"] == "previous_cursor_123"
 
     def test_chat_multiple_messages(self, cognite_client: CogniteClient, chat_response_body: dict) -> None:
-        cognite_client.agents._post = MagicMock(return_value=MagicMock(json=lambda: chat_response_body))
+        cognite_client.agents._do_request = MagicMock(return_value=MagicMock(json=lambda: chat_response_body))
 
         # Test with multiple messages
         messages = [
@@ -131,7 +133,7 @@ class TestAgentChat:
         cognite_client.agents.chat(agent_external_id="my_agent", messages=messages)
 
         # Verify multiple messages were sent
-        call_args = cognite_client.agents._post.call_args
+        call_args = cognite_client.agents._do_request.call_args
         assert len(call_args[1]["json"]["messages"]) == 2
         assert call_args[1]["json"]["messages"][0]["content"]["text"] == "I need help with time series data"
         assert call_args[1]["json"]["messages"][1]["content"]["text"] == "Specifically about temperature sensors"
@@ -155,7 +157,7 @@ class TestAgentChat:
             },
         }
 
-        cognite_client.agents._post = MagicMock(return_value=MagicMock(json=lambda: minimal_response))
+        cognite_client.agents._do_request = MagicMock(return_value=MagicMock(json=lambda: minimal_response))
 
         response = cognite_client.agents.chat(agent_external_id="my_agent", messages=Message("Hello"))
 
@@ -163,6 +165,20 @@ class TestAgentChat:
         assert response.messages[0].data is None
         assert response.messages[0].reasoning is None
         assert response.text == "Simple response"
+
+    def test_chat_with_custom_timeout(self, cognite_client: CogniteClient, chat_response_body: dict) -> None:
+        cognite_client.agents._do_request = MagicMock(return_value=MagicMock(json=lambda: chat_response_body))
+
+        # Test with custom timeout
+        cognite_client.agents.chat(
+            agent_external_id="my_agent",
+            messages=Message("Perform a complex analysis"),
+            timeout=120,
+        )
+
+        # Verify custom timeout was passed
+        call_args = cognite_client.agents._do_request.call_args
+        assert call_args[1]["timeout"] == 120
 
     def test_message_creation_from_string(self) -> None:
         # Test that string is automatically converted to TextContent


### PR DESCRIPTION
Adds a `timeout` parameter to the `agents.chat()` method to handle long-running agent executions. The method now uses `_do_request()` with a default timeout of 60 seconds, allowing endpoint-specific timeout configuration instead of relying solely on global client timeout settings.