### PR TITLE
feat: add query knowledge graph tool version configuration to agents

### DIFF
--- a/cognite/client/data_classes/agents/agent_tools.py
+++ b/cognite/client/data_classes/agents/agent_tools.py
@@ -14,6 +14,9 @@ from cognite.client.data_classes._base import (
     WriteableCogniteResourceList,
 )
 
+# Constants
+DEFAULT_QKG_VERSION = "v2"
+
 
 @dataclass
 class AgentToolCore(WriteableCogniteResource["AgentToolUpsert"], ABC):
@@ -167,12 +170,12 @@ class QueryKnowledgeGraphAgentToolConfiguration(WriteableCogniteResource):
         data_models (Sequence[DataModelInfo] | None): The data models and views to query.
         instance_spaces (InstanceSpaces | None): The instance spaces to query.
         version (Literal["v1", "v2"]): The version of the QKG tool to use.
-            Defaults to "v2".
+            Defaults to DEFAULT_QKG_VERSION ("v2").
     """
 
     data_models: Sequence[DataModelInfo] | None = None
     instance_spaces: InstanceSpaces | None = None
-    version: Literal["v1", "v2"] = "v2"
+    version: Literal["v1", "v2"] = DEFAULT_QKG_VERSION
 
     @classmethod
     def _load(
@@ -186,7 +189,7 @@ class QueryKnowledgeGraphAgentToolConfiguration(WriteableCogniteResource):
         if "instanceSpaces" in resource:
             instance_spaces = InstanceSpaces._load(resource["instanceSpaces"])
 
-        version = resource.get("version", "v2")
+        version = resource.get("version", DEFAULT_QKG_VERSION)
 
         return cls(
             data_models=data_models,

--- a/tests/tests_unit/test_data_classes/test_agents/test_agent_tools.py
+++ b/tests/tests_unit/test_data_classes/test_agents/test_agent_tools.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import pytest
 
 from cognite.client.data_classes.agents.agent_tools import (
+    DEFAULT_QKG_VERSION,
     AgentTool,
     AskDocumentAgentTool,
     QueryKnowledgeGraphAgentTool,
@@ -59,7 +60,7 @@ qkg_example_with_v2 = {
             {"space": "cdf_cdm", "externalId": "CogniteCore", "version": "v1", "viewExternalIds": ["CogniteAsset"]}
         ],
         "instanceSpaces": {"type": "manual", "spaces": ["my_space"]},
-        "version": "v2",
+        "version": DEFAULT_QKG_VERSION,
     },
 }
 
@@ -123,7 +124,7 @@ class TestAgentToolLoad:
                 # Version field is added automatically if not present, so we need to account for it
                 expected_config = tool_data["configuration"].copy()
                 if "version" not in expected_config:
-                    expected_config["version"] = "v2"  # Default version
+                    expected_config["version"] = DEFAULT_QKG_VERSION  # Default version
                 assert loaded_tool.configuration.dump(camel_case=True) == expected_config
             else:
                 # For other tools (like UnknownAgentTool), configuration should be a dict
@@ -183,7 +184,7 @@ class TestAgentToolDump:
         
         # Check configuration components individually since version is now added automatically
         expected_config = qkg_example["configuration"].copy()
-        expected_config["version"] = "v2"  # Default version is added during load/dump
+        expected_config["version"] = DEFAULT_QKG_VERSION  # Default version is added during load/dump
         assert dumped_tool["configuration"] == expected_config
 
 
@@ -221,11 +222,11 @@ class TestQueryKnowledgeGraphAgentToolVersions:
 
         assert isinstance(loaded_tool, QueryKnowledgeGraphAgentTool)
         assert loaded_tool.configuration is not None
-        assert loaded_tool.configuration.version == "v2"
+        assert loaded_tool.configuration.version == DEFAULT_QKG_VERSION
 
         # Test that it dumps correctly
         dumped_tool = loaded_tool.dump(camel_case=True)
-        assert dumped_tool["configuration"]["version"] == "v2"
+        assert dumped_tool["configuration"]["version"] == DEFAULT_QKG_VERSION
 
     def test_qkg_tool_with_explicit_v1_version(self) -> None:
         """Test QKG tool with explicit v1 version."""
@@ -245,11 +246,11 @@ class TestQueryKnowledgeGraphAgentToolVersions:
 
         assert isinstance(loaded_tool, QueryKnowledgeGraphAgentTool)
         assert loaded_tool.configuration is not None
-        assert loaded_tool.configuration.version == "v2"
+        assert loaded_tool.configuration.version == DEFAULT_QKG_VERSION
 
         # Test that it dumps correctly with default version
         dumped_tool = loaded_tool.dump(camel_case=True)
-        assert dumped_tool["configuration"]["version"] == "v2"
+        assert dumped_tool["configuration"]["version"] == DEFAULT_QKG_VERSION
 
     def test_qkg_tool_upsert_preserves_version(self) -> None:
         """Test that QKG tool upsert preserves version information."""


### PR DESCRIPTION
Closes [AAA-3112]
## Description
This PR introduces a `version` configuration option for the `QueryKnowledgeGraphAgentTool`.

**Why this change?**
Users need the ability to specify which version of the QKG tool (`v1` or `v2`) their agent deployment should use. This change allows for explicit selection while setting `v2` as the default, aligning with the latest QKG tool capabilities.

**What was changed?**
- Added a `version: Literal["v1", "v2"] = "v2"` field to `QueryKnowledgeGraphAgentToolConfiguration`.
- Updated the `_load` and `dump` methods to handle the new `version` field, ensuring proper serialization and deserialization with `v2` as the default.

## Checklist:
- [x] Tests added/updated.
- [x] Documentation updated. Documentation is generated from docstrings - these must be updated according to your change.
  If a new method has been added it should be referenced in [cognite.rst](https://github.com/cognitedata/cognite-sdk-python/blob/master/docs/source/cognite.rst) in order to generate docs based on its docstring.
- [x] The PR title follows the [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) spec.

---
<a href="https://cursor.com/background-agent?bcId=bc-76fc3487-b1b9-4aad-8593-f5fccdfdbaa8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-76fc3487-b1b9-4aad-8593-f5fccdfdbaa8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>



[AAA-3112]: https://cognitedata.atlassian.net/browse/AAA-3112?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ