### PR TITLE
chore: include version configuration for agent TOOL

### DIFF
--- a/cognite/client/data_classes/agents/agent_tools.py
+++ b/cognite/client/data_classes/agents/agent_tools.py
@@ -166,10 +166,12 @@ class QueryKnowledgeGraphAgentToolConfiguration(WriteableCogniteResource):
     Args:
         data_models (Sequence[DataModelInfo] | None): The data models and views to query.
         instance_spaces (InstanceSpaces | None): The instance spaces to query.
+        version (str | None): The version of the query generation strategy to use. A higher number does not necessarily mean a better query.
     """
 
     data_models: Sequence[DataModelInfo] | None = None
     instance_spaces: InstanceSpaces | None = None
+    version: str | None = None
 
     @classmethod
     def _load(
@@ -186,6 +188,7 @@ class QueryKnowledgeGraphAgentToolConfiguration(WriteableCogniteResource):
         return cls(
             data_models=data_models,
             instance_spaces=instance_spaces,
+            version=resource.get("version"),
         )
 
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
@@ -196,6 +199,8 @@ class QueryKnowledgeGraphAgentToolConfiguration(WriteableCogniteResource):
         if self.instance_spaces:
             key = "instanceSpaces" if camel_case else "instance_spaces"
             result[key] = self.instance_spaces.dump(camel_case=camel_case)
+        if self.version:
+            result["version"] = self.version
         return result
 
     def as_write(self) -> QueryKnowledgeGraphAgentToolConfiguration:


### PR DESCRIPTION
## Description

Adding version to the `QueryKnowledgeGraphAgentToolConfiguration` to be on par with the API. Chose not to go with enum since string is more future-proof.

<img width="1106" height="900" alt="Screenshot 2025-09-08 at 12 13 05" src="https://github.com/user-attachments/assets/eee9c6b8-9ce3-4a89-87d3-2cc7e38e9eae" />


Please describe the change you have made.

## Checklist:
- [] Tests added/updated.
- [x] Documentation updated. Documentation is generated from docstrings - these must be updated according to your change.
  If a new method has been added it should be referenced in [cognite.rst](https://github.com/cognitedata/cognite-sdk-python/blob/master/docs/source/cognite.rst) in order to generate docs based on its docstring.
- [x] The PR title follows the [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) spec.
