### PR TITLE
Udpate toolkit modules

### DIFF
--- a/scripts/toolkit/cdf.toml
+++ b/scripts/toolkit/cdf.toml
@@ -7,4 +7,4 @@ run = true
 [modules]
 # This is the version of the modules. It should not be changed manually.
 # It will be updated by the 'cdf module upgrade' command.
-version = "0.4.9"
+version = "0.6.17"


### PR DESCRIPTION
## Description

Currently the tests are failing for updating the contributor read/write groups. This is because there is a mismatch of the Toolkit modules and the CI/CD version of Toolkit in use. This update the toolkit modules.


## Checklist:
- [ ] Tests added/updated.
- [ ] Documentation updated. Documentation is generated from docstrings - these must be updated according to your change.
  If a new method has been added it should be referenced in [cognite.rst](https://github.com/cognitedata/cognite-sdk-python/blob/master/docs/source/cognite.rst) in order to generate docs based on its docstring.
- [ ] The PR title follows the [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) spec.
