### PR TITLE
fix: DMS triggers tests: set explicit _with limit when referenced from select

### DIFF
--- a/tests/tests_integration/test_api/test_workflows.py
+++ b/tests/tests_integration/test_api/test_workflows.py
@@ -358,7 +358,7 @@ def permanent_data_modeling_trigger(cognite_client: CogniteClient, permanent_wor
         external_id=f"data-modeling-trigger_{version.workflow_external_id}",
         trigger_rule=WorkflowDataModelingTriggerRule(
             data_modeling_query=WorkflowTriggerDataModelingQuery(
-                with_={"timeseries": NodeResultSetExpression(limit = 500)},
+                with_={"timeseries": NodeResultSetExpression(limit=500)},
                 select={
                     "timeseries": Select(
                         sources=[SourceSelector(ViewId("cdf_cdm", "CogniteTimeSeries", "v1"), ["name"])]
@@ -671,7 +671,7 @@ class TestWorkflowTriggers:
         assert permanent_data_modeling_trigger.external_id.startswith("data-modeling-trigger_integration_test-workflow")
         assert permanent_data_modeling_trigger.trigger_rule == WorkflowDataModelingTriggerRule(
             data_modeling_query=WorkflowTriggerDataModelingQuery(
-                with_={"timeseries": NodeResultSetExpression(limit = 500)},
+                with_={"timeseries": NodeResultSetExpression(limit=500)},
                 select={
                     "timeseries": Select(
                         sources=[SourceSelector(ViewId("cdf_cdm", "CogniteTimeSeries", "v1"), ["name"])]
@@ -690,7 +690,7 @@ class TestWorkflowTriggers:
                 external_id=permanent_data_modeling_trigger.external_id,
                 trigger_rule=WorkflowDataModelingTriggerRule(
                     data_modeling_query=WorkflowTriggerDataModelingQuery(
-                        with_={"timeseries": NodeResultSetExpression(limit = 100)},
+                        with_={"timeseries": NodeResultSetExpression(limit=100)},
                         select={
                             "timeseries": Select(
                                 sources=[SourceSelector(ViewId("cdf_cdm", "CogniteTimeSeries", "v1"), ["name"])]
@@ -708,7 +708,7 @@ class TestWorkflowTriggers:
         assert updated_trigger.external_id == permanent_data_modeling_trigger.external_id
         assert updated_trigger.trigger_rule == WorkflowDataModelingTriggerRule(
             data_modeling_query=WorkflowTriggerDataModelingQuery(
-                with_={"timeseries": NodeResultSetExpression(limit = 100)},
+                with_={"timeseries": NodeResultSetExpression(limit=100)},
                 select={
                     "timeseries": Select(
                         sources=[SourceSelector(ViewId("cdf_cdm", "CogniteTimeSeries", "v1"), ["name"])]


### PR DESCRIPTION
## Description
Need an explicit limit (== to the batchSize) on the `_with` clause if referenced from a select.