### PR TITLE
fix: filters now accept DirectRelationReference as instance identifier

### DIFF
--- a/cognite/client/data_classes/filters.py
+++ b/cognite/client/data_classes/filters.py
@@ -7,13 +7,13 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Literal, NoReturn, TypeAlias, cast, final
 
 from cognite.client.data_classes._base import EnumProperty, Geometry
+from cognite.client.data_classes.data_modeling.data_types import DirectRelationReference
 from cognite.client.data_classes.labels import Label
 from cognite.client.utils._identifier import InstanceId
 from cognite.client.utils._text import convert_all_keys_to_camel_case, to_camel_case
 from cognite.client.utils.useful_types import SequenceNotStr, is_sequence_not_str
 
 if TYPE_CHECKING:
-    from cognite.client.data_classes.data_modeling import DirectRelationReference
     from cognite.client.data_classes.data_modeling.ids import ContainerId, ViewId
 
 
@@ -30,12 +30,9 @@ class ParameterValue:
     parameter: str
 
 
-if TYPE_CHECKING:
-    RawValue: TypeAlias = (
-        str | float | bool | Sequence | Mapping[str, Any] | Label | InstanceId | DirectRelationReference
-    )
-    FilterValue: TypeAlias = RawValue | PropertyReferenceValue | ParameterValue
-    FilterValueList: TypeAlias = Sequence[RawValue] | PropertyReferenceValue | ParameterValue
+RawValue: TypeAlias = str | float | bool | Sequence | Mapping[str, Any] | Label | InstanceId | DirectRelationReference
+FilterValue: TypeAlias = RawValue | PropertyReferenceValue | ParameterValue
+FilterValueList: TypeAlias = Sequence[RawValue] | PropertyReferenceValue | ParameterValue
 
 
 def _dump_filter_value(value: FilterValueList | FilterValue) -> Any:

--- a/cognite/client/data_classes/filters.py
+++ b/cognite/client/data_classes/filters.py
@@ -7,6 +7,7 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Literal, NoReturn, TypeAlias, cast, final
 
 from cognite.client.data_classes._base import EnumProperty, Geometry
+from cognite.client.data_classes.data_modeling import DirectRelationReference
 from cognite.client.data_classes.labels import Label
 from cognite.client.utils._identifier import InstanceId
 from cognite.client.utils._text import convert_all_keys_to_camel_case, to_camel_case
@@ -18,7 +19,7 @@ if TYPE_CHECKING:
 
 PropertyReference: TypeAlias = str | SequenceNotStr[str] | EnumProperty
 
-RawValue: TypeAlias = str | float | bool | Sequence | Mapping[str, Any] | Label | InstanceId
+RawValue: TypeAlias = str | float | bool | Sequence | Mapping[str, Any] | Label | InstanceId | DirectRelationReference
 
 
 @dataclass

--- a/cognite/client/data_classes/filters.py
+++ b/cognite/client/data_classes/filters.py
@@ -7,19 +7,17 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Literal, NoReturn, TypeAlias, cast, final
 
 from cognite.client.data_classes._base import EnumProperty, Geometry
-from cognite.client.data_classes.data_modeling import DirectRelationReference
 from cognite.client.data_classes.labels import Label
 from cognite.client.utils._identifier import InstanceId
 from cognite.client.utils._text import convert_all_keys_to_camel_case, to_camel_case
 from cognite.client.utils.useful_types import SequenceNotStr, is_sequence_not_str
 
 if TYPE_CHECKING:
+    from cognite.client.data_classes.data_modeling import DirectRelationReference
     from cognite.client.data_classes.data_modeling.ids import ContainerId, ViewId
 
 
 PropertyReference: TypeAlias = str | SequenceNotStr[str] | EnumProperty
-
-RawValue: TypeAlias = str | float | bool | Sequence | Mapping[str, Any] | Label | InstanceId | DirectRelationReference
 
 
 @dataclass
@@ -32,8 +30,12 @@ class ParameterValue:
     parameter: str
 
 
-FilterValue: TypeAlias = RawValue | PropertyReferenceValue | ParameterValue
-FilterValueList: TypeAlias = Sequence[RawValue] | PropertyReferenceValue | ParameterValue
+if TYPE_CHECKING:
+    RawValue: TypeAlias = (
+        str | float | bool | Sequence | Mapping[str, Any] | Label | InstanceId | DirectRelationReference
+    )
+    FilterValue: TypeAlias = RawValue | PropertyReferenceValue | ParameterValue
+    FilterValueList: TypeAlias = Sequence[RawValue] | PropertyReferenceValue | ParameterValue
 
 
 def _dump_filter_value(value: FilterValueList | FilterValue) -> Any:

--- a/tests/tests_integration/test_api/test_data_modeling/test_instances.py
+++ b/tests/tests_integration/test_api/test_data_modeling/test_instances.py
@@ -509,7 +509,7 @@ class TestInstancesAPI:
         edge_type_class: type[NodeId, DirectRelationReference],
     ) -> None:
         edge_type = edge_type_class(
-            space=edge_type_filter_test_edge.space, external_id=edge_type_filter_test_edge.external_id
+            space=edge_type_filter_test_edge.type.space, external_id=edge_type_filter_test_edge.type.external_id
         )
 
         listed_edges = cognite_client.data_modeling.instances.list(

--- a/tests/tests_integration/test_api/test_data_modeling/test_instances.py
+++ b/tests/tests_integration/test_api/test_data_modeling/test_instances.py
@@ -147,7 +147,7 @@ def node_with_1_1_pressure_in_bar(
 
 @pytest.fixture
 def edge_type_filter_test_node(cognite_client: CogniteClient, integration_test_space: Space) -> CogniteDescribableNode:
-    return cognite_client.data_modeling.instances.apply(
+    node_result = cognite_client.data_modeling.instances.apply(
         nodes=[
             CogniteDescribableNodeApply(
                 space=integration_test_space.space,
@@ -156,6 +156,9 @@ def edge_type_filter_test_node(cognite_client: CogniteClient, integration_test_s
             )
         ]
     ).nodes[0]
+    return cognite_client.data_modeling.instances.retrieve_nodes(
+        nodes=[node_result.as_id()], node_cls=CogniteDescribableNode
+    )[0]
 
 
 @pytest.fixture
@@ -166,7 +169,7 @@ def edge_type_filter_test_edge(
         edge_type_filter_test_node.space, edge_type_filter_test_node.external_id
     )
 
-    return cognite_client.data_modeling.instances.apply(
+    edge_result = cognite_client.data_modeling.instances.apply(
         edges=[
             CogniteDescribableEdgeApply(
                 space=edge_type_filter_test_node.space,
@@ -178,6 +181,9 @@ def edge_type_filter_test_edge(
             )
         ]
     ).edges[0]
+    return cognite_client.data_modeling.instances.retrieve_edges(
+        edges=[edge_result.as_id()], edge_cls=CogniteDescribableEdge
+    )[0]
 
 
 class PrimitiveNullable(TypedNodeApply):
@@ -506,7 +512,7 @@ class TestInstancesAPI:
         self,
         cognite_client: CogniteClient,
         edge_type_filter_test_edge: CogniteDescribableEdge,
-        edge_type_class: type[NodeId, DirectRelationReference],
+        edge_type_class: type[NodeId] | type[DirectRelationReference],
     ) -> None:
         edge_type = edge_type_class(
             space=edge_type_filter_test_edge.type.space, external_id=edge_type_filter_test_edge.type.external_id

--- a/tests/tests_integration/test_api/test_data_modeling/test_instances.py
+++ b/tests/tests_integration/test_api/test_data_modeling/test_instances.py
@@ -45,6 +45,12 @@ from cognite.client.data_classes.data_modeling import (
     filters,
     query,
 )
+from cognite.client.data_classes.data_modeling.cdm.v1 import (
+    CogniteDescribableEdge,
+    CogniteDescribableEdgeApply,
+    CogniteDescribableNode,
+    CogniteDescribableNodeApply,
+)
 from cognite.client.data_classes.data_modeling.data_types import DirectRelation, Int64, UnitReference
 from cognite.client.data_classes.data_modeling.instances import (
     InstanceInspectResult,
@@ -66,7 +72,7 @@ from cognite.client.data_classes.data_modeling.query import (
     Union,
     UnionAll,
 )
-from cognite.client.data_classes.filters import Prefix
+from cognite.client.data_classes.filters import In, Prefix
 from cognite.client.exceptions import CogniteAPIError
 from cognite.client.utils._identifier import InstanceId
 from cognite.client.utils._text import random_string
@@ -137,6 +143,41 @@ def node_with_1_1_pressure_in_bar(
     )
     _ = cognite_client.data_modeling.instances.apply(node)
     return node
+
+
+@pytest.fixture
+def edge_type_filter_test_node(cognite_client: CogniteClient, integration_test_space: Space) -> CogniteDescribableNode:
+    return cognite_client.data_modeling.instances.apply(
+        nodes=[
+            CogniteDescribableNodeApply(
+                space=integration_test_space.space,
+                external_id="edge_filter_test_node",
+                name="edge_filter_test_node",
+            )
+        ]
+    ).nodes[0]
+
+
+@pytest.fixture
+def edge_type_filter_test_edge(
+    cognite_client: CogniteClient, edge_type_filter_test_node: CogniteDescribableNode
+) -> CogniteDescribableEdge:
+    direct_relation_reference = DirectRelationReference(
+        edge_type_filter_test_node.space, edge_type_filter_test_node.external_id
+    )
+
+    return cognite_client.data_modeling.instances.apply(
+        edges=[
+            CogniteDescribableEdgeApply(
+                space=edge_type_filter_test_node.space,
+                external_id="edge_filter_test_edge",
+                name="edge_filter_test_edge",
+                start_node=direct_relation_reference,
+                end_node=direct_relation_reference,
+                type=direct_relation_reference,
+            )
+        ]
+    ).edges[0]
 
 
 class PrimitiveNullable(TypedNodeApply):
@@ -457,6 +498,27 @@ class TestInstancesAPI:
 
         listed_edges = cognite_client.data_modeling.instances.list(limit=-1, instance_type="edge", filter=is_prefix)
         assert set(movie_edges.as_ids()) <= set(listed_edges.as_ids())
+
+    @pytest.mark.parametrize(
+        "edge_type_class", [NodeId, DirectRelationReference], ids=["NodeId", "DirectRelationReference"]
+    )
+    def test_filter_edges_by_type(
+        self,
+        cognite_client: CogniteClient,
+        edge_type_filter_test_edge: CogniteDescribableEdge,
+        edge_type_class: type[NodeId, DirectRelationReference],
+    ) -> None:
+        edge_type = edge_type_class(
+            space=edge_type_filter_test_edge.space, external_id=edge_type_filter_test_edge.external_id
+        )
+
+        listed_edges = cognite_client.data_modeling.instances.list(
+            instance_type=CogniteDescribableEdge,
+            filter=In(["edge", "type"], [edge_type]),
+        )
+
+        assert len(listed_edges) == 1
+        assert listed_edges[0].as_id() == edge_type_filter_test_edge.as_id()
 
     def test_list_nodes_with_properties(self, cognite_client: CogniteClient, person_view: View) -> None:
         person_nodes = cognite_client.data_modeling.instances.list(

--- a/tests/tests_integration/test_api/test_data_modeling/test_instances.py
+++ b/tests/tests_integration/test_api/test_data_modeling/test_instances.py
@@ -145,7 +145,7 @@ def node_with_1_1_pressure_in_bar(
     return node
 
 
-@pytest.fixture
+@pytest.fixture(scope="session")
 def edge_type_filter_test_node(cognite_client: CogniteClient, integration_test_space: Space) -> CogniteDescribableNode:
     node_result = cognite_client.data_modeling.instances.apply(
         nodes=[
@@ -161,7 +161,7 @@ def edge_type_filter_test_node(cognite_client: CogniteClient, integration_test_s
     )[0]
 
 
-@pytest.fixture
+@pytest.fixture(scope="session")
 def edge_type_filter_test_edge(
     cognite_client: CogniteClient, edge_type_filter_test_node: CogniteDescribableNode
 ) -> CogniteDescribableEdge:


### PR DESCRIPTION
## Description
When creating an edge, you need to use a DirectRelationReference for the type of the edge.
When you filter edges however, you can use InstanceId for the type, but DirectRelationReference is not covered by the type hint. Adding support for this, as I have seen that you can use them interchangeably in the filter. 

The annotation writer worker in the context-api is currently keeping two constants for the diagrams.FileLink, one direct relation reference and one node id. Being able to just have one is the motivation for this change. 


## Checklist:
- [ ] Tests added/updated.
- [ ] Documentation updated. Documentation is generated from docstrings - these must be updated according to your change.
  If a new method has been added it should be referenced in [cognite.rst](https://github.com/cognitedata/cognite-sdk-python/blob/master/docs/source/cognite.rst) in order to generate docs based on its docstring.
- [ ] The PR title follows the [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) spec.
