### PR TITLE
chore: Update renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -13,6 +13,10 @@
     {
       "enabled": false,
       "matchPackageNames": ["mcr.microsoft.com/devcontainers/python"]
+    },
+    {
+      "enabled": false,
+      "matchPackageNames": ["cognite-toolkit"]
     }
   ],
   "vulnerabilityAlerts": {


### PR DESCRIPTION
## Description

Renovate is unsuited for updating cognite-toolkit as this also requires updating the Toolkit modules (configuration files used for tests data). Toolkit is only used to maintain the auth groups for contributors, thus it is low-risk to do this manually instead.

## Checklist:
- [ ] Tests added/updated.
- [ ] Documentation updated. Documentation is generated from docstrings - these must be updated according to your change.
  If a new method has been added it should be referenced in [cognite.rst](https://github.com/cognitedata/cognite-sdk-python/blob/master/docs/source/cognite.rst) in order to generate docs based on its docstring.
- [ ] The PR title follows the [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) spec.
