### PR TITLE
feat: data classes for debug notices

### DIFF
--- a/cognite/client/data_classes/data_modeling/__init__.py
+++ b/cognite/client/data_classes/data_modeling/__init__.py
@@ -40,6 +40,10 @@ from cognite.client.data_classes.data_modeling.data_types import (
     TimeSeriesReference,
     Timestamp,
 )
+from cognite.client.data_classes.data_modeling.debug import (
+    DebugNotice,
+    DebugNoticeList,
+)
 from cognite.client.data_classes.data_modeling.ids import (
     ContainerId,
     ContainerIdentifier,
@@ -127,6 +131,8 @@ __all__ = [
     "DataModelingId",
     "DataModelsSort",
     "Date",
+    "DebugNotice",
+    "DebugNoticeList",
     "DirectRelation",
     "DirectRelationReference",
     "Edge",

--- a/cognite/client/data_classes/data_modeling/debug.py
+++ b/cognite/client/data_classes/data_modeling/debug.py
@@ -1,0 +1,475 @@
+from __future__ import annotations
+
+from abc import ABC
+from dataclasses import dataclass
+from functools import cache
+from typing import TYPE_CHECKING, Any, Literal, NoReturn, cast, get_args, get_type_hints
+
+from typing_extensions import Self
+
+from cognite.client.data_classes._base import CogniteResource, CogniteResourceList
+from cognite.client.data_classes.data_modeling.ids import ContainerId
+from cognite.client.data_classes.data_modeling.instances import InstanceSort
+from cognite.client.utils._auxiliary import all_concrete_subclasses
+
+if TYPE_CHECKING:
+    from cognite.client import CogniteClient
+
+
+@dataclass(kw_only=True)
+class DebugParameters:
+    """
+    Debug parameters for debugging and analyzing queries.
+
+    Args:
+        emit_results (bool): Include the query result in the response. emit_results=False is required for advanced query analysis features.
+        timeout (int | None): Query timeout in milliseconds. Can be used to override the default timeout when analysing queries. Requires emit_results=False.
+        profile (bool): Most thorough level of query analysis. Requires emit_results=False.
+    """
+
+    emit_results: bool = True
+    timeout: int | None = None
+    profile: bool = False
+
+    def dump(self, camel_case: bool = True) -> dict[str, bool | int]:
+        res: dict[str, bool | int] = {
+            "emitResults" if camel_case else "emit_results": self.emit_results,
+            "profile": self.profile,
+        }
+        if self.timeout is not None:
+            res["timeout"] = self.timeout
+        return res
+
+
+@dataclass
+class DebugNotice(CogniteResource, ABC):
+    """
+    A notice that provides insight into the query's execution. It can highlight potential performance issues,
+    offer an optimization suggestion, or explain an aspect of the query processing. Each notice falls into a
+    category, such as indexing, sorting, filtering, or cursoring, to help identify areas for improvement.
+    """
+
+    category: str
+    code: str
+    hint: str
+    level: str
+
+    @classmethod
+    def _load(cls, data: dict[str, Any], cognite_client: CogniteClient | None = None) -> DebugNotice:
+        subclass_lookup = _create_debug_notice_subclass_map()
+        try:
+            key = (data["code"], data["category"])
+            return subclass_lookup[key]._load(data)
+        except KeyError:
+            return cast(DebugNotice, UnknownDebugNotice._load(data))
+
+    def dump(self, camel_case: bool = True) -> dict[str, Any]:
+        return {
+            "category": self.category,
+            "code": self.code,
+            "hint": self.hint,
+            "level": self.level,
+        }
+
+
+@dataclass
+class InvalidDebugOptionsNotice(DebugNotice, ABC):
+    pass
+
+
+@dataclass
+class ExcessiveTimeoutNotice(InvalidDebugOptionsNotice):
+    code: Literal["excessiveTimeout"]
+    category: Literal["invalidDebugOptions"]
+    level: Literal["warning"]
+    hint: Literal["Cannot specify too large timeout"]
+    timeout: int
+
+    @classmethod
+    def _load(cls, data: dict[str, Any], cognite_client: CogniteClient | None = None) -> Self:
+        return cls(
+            code=data["code"],
+            category=data["category"],
+            level=data["level"],
+            hint=data["hint"],
+            timeout=data["timeout"],
+        )
+
+    def dump(self, camel_case: bool = True) -> dict[str, Any]:
+        obj = super().dump(camel_case=camel_case)
+        obj["timeout"] = self.timeout
+        return obj
+
+
+@dataclass
+class NoTimeoutWithResultsNotice(InvalidDebugOptionsNotice):
+    code: Literal["noTimeoutWithResults"]
+    category: Literal["invalidDebugOptions"]
+    level: Literal["warning"]
+    hint: Literal["Ignoring timeout setting since emitResults=true"]
+
+    @classmethod
+    def _load(cls, data: dict[str, Any], cognite_client: CogniteClient | None = None) -> Self:
+        return cls(
+            code=data["code"],
+            category=data["category"],
+            level=data["level"],
+            hint=data["hint"],
+        )
+
+
+@dataclass
+class CursoringNotice(DebugNotice, ABC):
+    pass
+
+
+@dataclass
+class IntractableDirectRelationsCursorNotice(CursoringNotice):
+    code: Literal["intractableDirectRelationsCursor"]
+    category: Literal["cursoring"]
+    level: Literal["warning"]
+    grade: Literal["D"]
+    hint: Literal[
+        "Cursoring combined with chaining to a list of direct relations requires a run-time sort and is therefore inherently intractable."
+    ]
+    result_expression: str
+
+    @classmethod
+    def _load(cls, data: dict[str, Any], cognite_client: CogniteClient | None = None) -> Self:
+        return cls(
+            code=data["code"],
+            category=data["category"],
+            level=data["level"],
+            grade=data["grade"],
+            hint=data["hint"],
+            result_expression=data["resultExpression"],
+        )
+
+    def dump(self, camel_case: bool = True) -> dict[str, Any]:
+        obj = super().dump(camel_case=camel_case)
+        obj["grade"] = self.grade
+        obj["resultExpression" if camel_case else "result_expression"] = self.result_expression
+        return obj
+
+
+@dataclass
+class IndexingNotice(DebugNotice, ABC):
+    pass
+
+
+@dataclass
+class UnindexedThroughNotice(IndexingNotice):
+    code: Literal["unindexedThrough"]
+    category: Literal["indexing"]
+    level: Literal["warning"]
+    grade: Literal["E"]
+    hint: Literal[
+        "The result expression has a `through` on an unindexed direct relation. This will become untenable when the container grows."
+    ]
+    result_expression: str
+    property: list[str]
+
+    @classmethod
+    def _load(cls, data: dict[str, Any], cognite_client: CogniteClient | None = None) -> Self:
+        return cls(
+            code=data["code"],
+            category=data["category"],
+            level=data["level"],
+            grade=data["grade"],
+            hint=data["hint"],
+            result_expression=data["resultExpression"],
+            property=data["property"],
+        )
+
+    def dump(self, camel_case: bool = True) -> dict[str, Any]:
+        obj = super().dump(camel_case=camel_case)
+        obj.update(
+            {
+                "resultExpression" if camel_case else "result_expression": self.result_expression,
+                "grade": self.grade,
+                "property": self.property,
+            }
+        )
+        return obj
+
+
+@dataclass
+class ContainersWithoutIndexesInvolvedNotice(IndexingNotice):
+    code: Literal["containersWithoutIndexesInvolved"]
+    category: Literal["indexing"]
+    level: Literal["warning"]
+    grade: Literal["C"]
+    hint: Literal["The query is using one or more containers that doesn't have any indexes declared."]
+    result_expression: str | None
+    containers: list[ContainerId]
+
+    @classmethod
+    def _load(cls, data: dict[str, Any], cognite_client: CogniteClient | None = None) -> Self:
+        return cls(
+            code=data["code"],
+            category=data["category"],
+            level=data["level"],
+            grade=data["grade"],
+            hint=data["hint"],
+            result_expression=data.get("resultExpression"),
+            containers=[ContainerId.load(c) for c in data["containers"]],
+        )
+
+    def dump(self, camel_case: bool = True) -> dict[str, Any]:
+        obj = super().dump(camel_case=camel_case)
+        obj.update(
+            {
+                "grade": self.grade,
+                "containers": [c.dump(camel_case=camel_case) for c in self.containers],
+                "resultExpression" if camel_case else "result_expression": self.result_expression,
+            }
+        )
+        return obj
+
+
+@dataclass
+class FilteringNotice(DebugNotice, ABC):
+    pass
+
+
+@dataclass
+class SelectiveExternalIDFilterNotice(FilteringNotice):
+    code: Literal["selectiveExternalIDFilter"]
+    category: Literal["filtering"]
+    level: Literal["info"]
+    grade: Literal["A"]
+    hint: Literal["The filter on the instances' primary key should always be selective."]
+    result_expression: str
+    via_from: str | None
+
+    @classmethod
+    def _load(cls, data: dict[str, Any], cognite_client: CogniteClient | None = None) -> Self:
+        return cls(
+            code=data["code"],
+            category=data["category"],
+            level=data["level"],
+            grade=data["grade"],
+            hint=data["hint"],
+            result_expression=data["resultExpression"],
+            via_from=data.get("viaFrom"),
+        )
+
+    def dump(self, camel_case: bool = True) -> dict[str, Any]:
+        obj = super().dump(camel_case=camel_case)
+        obj.update(
+            {
+                "resultExpression" if camel_case else "result_expression": self.result_expression,
+                "viaFrom" if camel_case else "via_from": self.via_from,
+                "grade": self.grade,
+            }
+        )
+        return obj
+
+
+@dataclass
+class SignificantHasDataFiltersNotice(FilteringNotice):
+    code: Literal["significantHasDataFiltering"]
+    category: Literal["filtering"]
+    level: Literal["warning"]
+    grade: Literal["C"]
+    hint: Literal[
+        "The provided `hasData` filters expand to several joins, which can be problematic depending on data distribution. Consider `requires` constraints, which can enable query time join pruning."
+    ]
+    result_expression: str
+    containers: list[ContainerId]
+
+    @classmethod
+    def _load(cls, data: dict[str, Any], cognite_client: CogniteClient | None = None) -> Self:
+        return cls(
+            code=data["code"],
+            category=data["category"],
+            level=data["level"],
+            grade=data["grade"],
+            hint=data["hint"],
+            result_expression=data["resultExpression"],
+            containers=[ContainerId.load(c) for c in data["containers"]],
+        )
+
+    def dump(self, camel_case: bool = True) -> dict[str, Any]:
+        obj = super().dump(camel_case=camel_case)
+        obj.update(
+            {
+                "grade": self.grade,
+                "resultExpression" if camel_case else "result_expression": self.result_expression,
+                "containers": [c.dump(camel_case=camel_case) for c in self.containers],
+            }
+        )
+        return obj
+
+
+@dataclass
+class SignificantPostFilteringNotice(FilteringNotice):
+    code: Literal["significantPostFiltering"]
+    category: Literal["filtering"]
+    level: Literal["warning"]
+    grade: Literal["C"]
+    hint: Literal["A lot more rows than selected by the expression are involved to compute the result."]
+    result_expression: str
+    limit: int
+    max_involved_rows: int
+
+    @classmethod
+    def _load(cls, data: dict[str, Any], cognite_client: CogniteClient | None = None) -> Self:
+        return cls(
+            code=data["code"],
+            category=data["category"],
+            level=data["level"],
+            grade=data["grade"],
+            hint=data["hint"],
+            result_expression=data["resultExpression"],
+            limit=data["limit"],
+            max_involved_rows=data["maxInvolvedRows"],
+        )
+
+    def dump(self, camel_case: bool = True) -> dict[str, Any]:
+        obj = super().dump(camel_case=camel_case)
+        obj.update(
+            {
+                "grade": self.grade,
+                "resultExpression" if camel_case else "result_expression": self.result_expression,
+                "limit": self.limit,
+                "maxInvolvedRows" if camel_case else "max_involved_rows": self.max_involved_rows,
+            }
+        )
+        return obj
+
+
+@dataclass
+class SortingNotice(DebugNotice, ABC):
+    pass
+
+
+@dataclass
+class SortNotBackedByIndexNotice(SortingNotice):
+    code: Literal["sortNotBackedByIndex"]
+    category: Literal["sorting"]
+    level: Literal["warning"]
+    grade: Literal["C"]
+    hint: Literal[
+        "The sort is not backed by a cursorable index, which means query time sorting is necessary, which in turn means a lot more data must be read. Consider whether a cursorable index is a good fit."
+    ]
+    result_expression: str
+    sort: list[InstanceSort]
+
+    @classmethod
+    def _load(cls, data: dict[str, Any], cognite_client: CogniteClient | None = None) -> Self:
+        return cls(
+            code=data["code"],
+            category=data["category"],
+            level=data["level"],
+            grade=data["grade"],
+            hint=data["hint"],
+            result_expression=data["resultExpression"],
+            sort=[InstanceSort.load(s) for s in data["sort"]],
+        )
+
+    def dump(self, camel_case: bool = True) -> dict[str, Any]:
+        obj = super().dump(camel_case=camel_case)
+        obj.update(
+            {
+                "grade": self.grade,
+                "resultExpression" if camel_case else "result_expression": self.result_expression,
+                "sort": [s.dump(camel_case=camel_case) for s in self.sort],
+            }
+        )
+        return obj
+
+
+@dataclass
+class FilterMatchesCursorableSortNotice(SortingNotice):
+    code: Literal["filterMatchesCursorableSort"]
+    category: Literal["sorting"]
+    level: Literal["info"]
+    grade: Literal["A", "B"]
+    hint: Literal["The provided filter and sort combination appear to match a backing index."]
+    result_expression: str
+    sort: list[InstanceSort]
+
+    @classmethod
+    def _load(cls, data: dict[str, Any], cognite_client: CogniteClient | None = None) -> Self:
+        return cls(
+            code=data["code"],
+            category=data["category"],
+            level=data["level"],
+            grade=data["grade"],
+            hint=data["hint"],
+            result_expression=data["resultExpression"],
+            sort=[InstanceSort.load(s) for s in data["sort"]],
+        )
+
+    def dump(self, camel_case: bool = True) -> dict[str, Any]:
+        obj = super().dump(camel_case=camel_case)
+        obj.update(
+            {
+                "grade": self.grade,
+                "resultExpression" if camel_case else "result_expression": self.result_expression,
+                "sort": [s.dump(camel_case=camel_case) for s in self.sort],
+            }
+        )
+        return obj
+
+
+@dataclass
+class UnknownDebugNotice(DebugNotice):
+    category: str | None  # type: ignore [assignment]
+    code: str | None  # type: ignore [assignment]
+    hint: str | None  # type: ignore [assignment]
+    level: str | None  # type: ignore [assignment]
+    data: dict[str, Any]
+
+    @classmethod
+    def _load(cls, data: dict[str, Any], cognite_client: CogniteClient | None = None) -> Self:
+        data = data.copy()
+        category = data.pop("category", None)
+        code = data.pop("code", None)
+        hint = data.pop("hint", None)
+        level = data.pop("level", None)
+        return cls(category=category, code=code, hint=hint, level=level, data=data)
+
+    def dump(self, camel_case: bool = True) -> dict[str, Any]:
+        if camel_case is False:
+            import warnings
+
+            warnings.warn(
+                f"{type(self).__name__}.dump(...) does not support 'camel_case=False', returning original data. "
+                "Please raise an issue on Github to add support for this debug notice type.",
+                stacklevel=2,
+            )
+        output = {}
+        if self.category is not None:
+            output["category"] = self.category
+        if self.code is not None:
+            output["code"] = self.code
+        if self.hint is not None:
+            output["hint"] = self.hint
+        if self.level is not None:
+            output["level"] = self.level
+        return output | self.data.copy()
+
+
+class DebugNoticeList(CogniteResourceList[DebugNotice]):
+    _RESOURCE = DebugNotice
+
+    def get(self, *a: Any, **kw: Any) -> NoReturn:
+        raise NotImplementedError
+
+
+@cache
+def _create_debug_notice_subclass_map() -> dict[tuple[str, str], type[DebugNotice]]:
+    from cognite.client import CogniteClient
+
+    lookup = {}
+    subclasses: set[type[DebugNotice]] = all_concrete_subclasses(DebugNotice)
+    for sub_cls in subclasses:
+        # When we do 'get_type_hints', we evaluate forward refs., and we reference InstanceSort in a file
+        # that only imports CogniteClient while TYPE_CHECKING, so it is not available at runtime which we need:
+        annots = get_type_hints(sub_cls, globalns=globals() | {"CogniteClient": CogniteClient})
+        code = get_args(annots["code"])[0]
+        category = get_args(annots["category"])[0]
+        lookup[code, category] = sub_cls
+    return lookup

--- a/cognite/client/utils/_auxiliary.py
+++ b/cognite/client/utils/_auxiliary.py
@@ -4,7 +4,9 @@ import functools
 import math
 import platform
 import warnings
+from abc import ABC
 from collections.abc import Hashable, Iterable, Iterator, Sequence
+from inspect import isabstract
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -31,6 +33,18 @@ if TYPE_CHECKING:
 T = TypeVar("T")
 K = TypeVar("K")
 THashable = TypeVar("THashable", bound=Hashable)
+
+
+def all_subclasses(base: type[T], exclude: set[type[T]] | None = None) -> set[type[T]]:
+    """Recursively find all subclasses of a given class."""
+    return set(base.__subclasses__()).union(s for c in base.__subclasses__() for s in all_subclasses(c)) - (
+        exclude or set()
+    )
+
+
+def all_concrete_subclasses(base: type[T], exclude: set[type[T]] | None = None) -> set[type[T]]:
+    """Recursively find all non-abstract subclasses of a given class."""
+    return {cls for cls in all_subclasses(base, exclude) if ABC not in cls.__bases__ and not isabstract(cls)}
 
 
 def no_op(x: T) -> T:

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -20,6 +20,7 @@ from types import UnionType
 from typing import TYPE_CHECKING, Any, Literal, TypeVar, cast, get_args, get_origin, get_type_hints
 from zoneinfo import ZoneInfo
 
+import cognite.client.utils._auxiliary
 from cognite.client import CogniteClient
 from cognite.client._api_client import APIClient
 from cognite.client._constants import MAX_VALID_INTERNAL_ID
@@ -90,8 +91,7 @@ def all_subclasses(base: T_Type, exclude: set[type] | None = None) -> list[T_Typ
     return sorted(
         filter(
             lambda sub: sub.__module__.startswith("cognite.client"),
-            set(base.__subclasses__()).union(s for c in base.__subclasses__() for s in all_subclasses(c))
-            - (exclude or set()),
+            cognite.client.utils._auxiliary.all_subclasses(base, exclude=exclude),
         ),
         key=str,
     )
@@ -101,7 +101,7 @@ def all_concrete_subclasses(base: T_Type, exclude: set[type] | None = None) -> l
     return [
         sub
         for sub in all_subclasses(base, exclude=exclude)
-        if all(base is not abc.ABC for base in sub.__bases__)
+        if abc.ABC not in sub.__bases__
         and not inspect.isabstract(sub)
         # The FakeCogniteResourceGenerator does not support descriptors, so we exclude the Typed classes
         # as these use the PropertyOptions descriptor.


### PR DESCRIPTION
https://cognitedata.atlassian.net/browse/DM-3058

## Description
Part one of adding debug notice support to the SDK: All necessary data classes.

Risk review note: Subclasses of CogniteResource are automatically picked up and tested. Don't believe me, run `pytest tests/tests_unit/test_base.py` after introducing a random error somewhere 😉 