### PR TITLE
feat(agents): add actions support for custom tool calls in chat endpoint

### DIFF
--- a/cognite/client/data_classes/agents/__init__.py
+++ b/cognite/client/data_classes/agents/__init__.py
@@ -32,6 +32,11 @@ from cognite.client.data_classes.agents.chat import (
     TextContent,
     UnknownContent,
 )
+from cognite.client.data_classes.agents.client_tools import (
+    ClientTool,
+    ClientToolList,
+    ClientToolParameters,
+)
 
 __all__ = [
     "Agent",
@@ -49,6 +54,9 @@ __all__ = [
     "AgentUpsertList",
     "AskDocumentAgentTool",
     "AskDocumentAgentToolUpsert",
+    "ClientTool",
+    "ClientToolList",
+    "ClientToolParameters",
     "DataModelInfo",
     "InstanceSpaces",
     "Message",

--- a/cognite/client/data_classes/agents/client_tools.py
+++ b/cognite/client/data_classes/agents/client_tools.py
@@ -1,0 +1,117 @@
+"""Client tool data classes for agent actions."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from cognite.client.data_classes._base import CogniteResource
+
+
+class ClientToolParameters(CogniteResource):
+    """Parameters for a client tool call.
+
+    Args:
+        type (str): The type of the parameter, must be "object".
+        properties (dict[str, Any] | None): Properties defining the parameter schema.
+        required (list[str] | None): List of required property names.
+        property_ordering (list[str] | None): Order of properties.
+        description (str | None): Description of the parameter.
+    """
+
+    def __init__(
+        self,
+        type: str = "object",
+        properties: dict[str, Any] | None = None,
+        required: list[str] | None = None,
+        property_ordering: list[str] | None = None,
+        description: str | None = None,
+    ) -> None:
+        self.type = type
+        self.properties = properties or {}
+        self.required = required or []
+        self.property_ordering = property_ordering or []
+        self.description = description
+
+    def dump(self, camel_case: bool = True) -> dict[str, Any]:
+        """Dump the parameters to a dictionary."""
+        result = {
+            "type": self.type,
+            "properties": self.properties,
+            "required": self.required,
+            "propertyOrdering" if camel_case else "property_ordering": self.property_ordering,
+        }
+        if self.description:
+            result["description"] = self.description
+        return result
+
+    @classmethod
+    def _load(cls, data: dict[str, Any], cognite_client: Any = None) -> ClientToolParameters:
+        """Load parameters from a dictionary."""
+        return cls(
+            type=data.get("type", "object"),
+            properties=data.get("properties", {}),
+            required=data.get("required", []),
+            property_ordering=data.get("propertyOrdering", data.get("property_ordering", [])),
+            description=data.get("description"),
+        )
+
+
+class ClientTool(CogniteResource):
+    """A client tool that can be called by the agent.
+
+    Args:
+        name (str): The name of the client tool to call.
+        parameters (ClientToolParameters): The parameters the function accepts.
+        description (str | None): A description of what the function does.
+        type (str): The type of client action, always "clientTool".
+    """
+
+    def __init__(
+        self,
+        name: str,
+        parameters: ClientToolParameters,
+        description: str | None = None,
+        type: str = "clientTool",
+    ) -> None:
+        self.name = name
+        self.description = description
+        self.parameters = parameters
+        self.type = type
+
+    def dump(self, camel_case: bool = True) -> dict[str, Any]:
+        """Dump the client tool to a dictionary."""
+        result = {
+            "name": self.name,
+            "type": self.type,
+            "parameters": self.parameters.dump(camel_case=camel_case),
+        }
+        if self.description:
+            result["description"] = self.description
+        return result
+
+    @classmethod
+    def _load(cls, data: dict[str, Any], cognite_client: Any = None) -> ClientTool:
+        """Load a client tool from a dictionary."""
+        return cls(
+            name=data["name"],
+            description=data.get("description"),
+            parameters=ClientToolParameters._load(data["parameters"]),
+            type=data.get("type", "clientTool"),
+        )
+
+
+class ClientToolList:
+    """List of client tools."""
+
+    def __init__(self, tools: list[ClientTool]) -> None:
+        self.tools = tools
+
+    def dump(self, camel_case: bool = True) -> list[dict[str, Any]]:
+        """Dump the client tools to a list of dictionaries."""
+        return [tool.dump(camel_case=camel_case) for tool in self.tools]
+
+    @classmethod
+    def _load(cls, data: list[dict[str, Any]], cognite_client: Any = None) -> ClientToolList:
+        """Load client tools from a list of dictionaries."""
+        tools = [ClientTool._load(tool_data) for tool_data in data]
+        return cls(tools=tools)

--- a/tests/tests_unit/test_data_classes/test_client_tools.py
+++ b/tests/tests_unit/test_data_classes/test_client_tools.py
@@ -1,0 +1,266 @@
+"""Tests for client tool data classes."""
+
+from __future__ import annotations
+
+from cognite.client.data_classes.agents.client_tools import ClientTool, ClientToolList, ClientToolParameters
+
+
+class TestClientToolParameters:
+    def test_init_defaults(self) -> None:
+        """Test ClientToolParameters initialization with defaults."""
+        params = ClientToolParameters()
+        assert params.type == "object"
+        assert params.properties == {}
+        assert params.required == []
+        assert params.property_ordering == []
+        assert params.description is None
+
+    def test_init_with_values(self) -> None:
+        """Test ClientToolParameters initialization with values."""
+        properties = {"location": {"type": "string", "description": "City name"}}
+        required = ["location"]
+        property_ordering = ["location"]
+        description = "Parameters for weather tool"
+
+        params = ClientToolParameters(
+            type="object",
+            properties=properties,
+            required=required,
+            property_ordering=property_ordering,
+            description=description,
+        )
+
+        assert params.type == "object"
+        assert params.properties == properties
+        assert params.required == required
+        assert params.property_ordering == property_ordering
+        assert params.description == description
+
+    def test_dump_camel_case(self) -> None:
+        """Test dumping ClientToolParameters with camel case."""
+        params = ClientToolParameters(
+            properties={"location": {"type": "string"}},
+            required=["location"],
+            property_ordering=["location"],
+            description="Test parameters",
+        )
+
+        result = params.dump(camel_case=True)
+        expected = {
+            "type": "object",
+            "properties": {"location": {"type": "string"}},
+            "required": ["location"],
+            "propertyOrdering": ["location"],
+            "description": "Test parameters",
+        }
+        assert result == expected
+
+    def test_dump_snake_case(self) -> None:
+        """Test dumping ClientToolParameters with snake case."""
+        params = ClientToolParameters(
+            properties={"location": {"type": "string"}},
+            required=["location"],
+            property_ordering=["location"],
+            description="Test parameters",
+        )
+
+        result = params.dump(camel_case=False)
+        expected = {
+            "type": "object",
+            "properties": {"location": {"type": "string"}},
+            "required": ["location"],
+            "property_ordering": ["location"],
+            "description": "Test parameters",
+        }
+        assert result == expected
+
+    def test_load_from_dict(self) -> None:
+        """Test loading ClientToolParameters from dictionary."""
+        data = {
+            "type": "object",
+            "properties": {"location": {"type": "string"}},
+            "required": ["location"],
+            "propertyOrdering": ["location"],
+            "description": "Test parameters",
+        }
+
+        params = ClientToolParameters._load(data)
+        assert params.type == "object"
+        assert params.properties == {"location": {"type": "string"}}
+        assert params.required == ["location"]
+        assert params.property_ordering == ["location"]
+        assert params.description == "Test parameters"
+
+    def test_load_from_dict_snake_case(self) -> None:
+        """Test loading ClientToolParameters from dictionary with snake case."""
+        data = {
+            "type": "object",
+            "properties": {"location": {"type": "string"}},
+            "required": ["location"],
+            "property_ordering": ["location"],
+            "description": "Test parameters",
+        }
+
+        params = ClientToolParameters._load(data)
+        assert params.type == "object"
+        assert params.properties == {"location": {"type": "string"}}
+        assert params.required == ["location"]
+        assert params.property_ordering == ["location"]
+        assert params.description == "Test parameters"
+
+
+class TestClientTool:
+    def test_init_defaults(self) -> None:
+        """Test ClientTool initialization with defaults."""
+        parameters = ClientToolParameters()
+        tool = ClientTool(name="test_tool", parameters=parameters)
+        assert tool.name == "test_tool"
+        assert tool.parameters is parameters
+        assert tool.type == "clientTool"
+        assert tool.description is None
+
+    def test_init_with_values(self) -> None:
+        """Test ClientTool initialization with values."""
+        parameters = ClientToolParameters(properties={"location": {"type": "string"}})
+        description = "A test tool"
+        tool_type = "clientTool"
+
+        tool = ClientTool(
+            name="test_tool",
+            parameters=parameters,
+            description=description,
+            type=tool_type,
+        )
+
+        assert tool.name == "test_tool"
+        assert tool.parameters is parameters
+        assert tool.type == tool_type
+        assert tool.description == description
+
+    def test_dump_camel_case(self) -> None:
+        """Test dumping ClientTool with camel case."""
+        parameters = ClientToolParameters(
+            properties={"location": {"type": "string"}},
+            required=["location"],
+        )
+        tool = ClientTool(
+            name="test_tool",
+            parameters=parameters,
+            description="A test tool",
+        )
+
+        result = tool.dump(camel_case=True)
+        expected = {
+            "name": "test_tool",
+            "type": "clientTool",
+            "description": "A test tool",
+            "parameters": {
+                "type": "object",
+                "properties": {"location": {"type": "string"}},
+                "required": ["location"],
+                "propertyOrdering": [],
+            },
+        }
+        assert result == expected
+
+    def test_dump_without_description(self) -> None:
+        """Test dumping ClientTool without description."""
+        parameters = ClientToolParameters()
+        tool = ClientTool(name="test_tool", parameters=parameters)
+
+        result = tool.dump(camel_case=True)
+        expected = {
+            "name": "test_tool",
+            "type": "clientTool",
+            "parameters": {
+                "type": "object",
+                "properties": {},
+                "required": [],
+                "propertyOrdering": [],
+            },
+        }
+        assert result == expected
+
+    def test_load_from_dict(self) -> None:
+        """Test loading ClientTool from dictionary."""
+        data = {
+            "name": "test_tool",
+            "type": "clientTool",
+            "description": "A test tool",
+            "parameters": {
+                "type": "object",
+                "properties": {"location": {"type": "string"}},
+                "required": ["location"],
+                "propertyOrdering": [],
+            },
+        }
+
+        tool = ClientTool._load(data)
+        assert tool.name == "test_tool"
+        assert tool.type == "clientTool"
+        assert tool.description == "A test tool"
+        assert isinstance(tool.parameters, ClientToolParameters)
+        assert tool.parameters.properties == {"location": {"type": "string"}}
+        assert tool.parameters.required == ["location"]
+
+
+class TestClientToolList:
+    def test_init(self) -> None:
+        """Test ClientToolList initialization."""
+        tool1 = ClientTool(name="tool1", parameters=ClientToolParameters())
+        tool2 = ClientTool(name="tool2", parameters=ClientToolParameters())
+        tools = [tool1, tool2]
+
+        tool_list = ClientToolList(tools)
+        assert tool_list.tools == tools
+
+    def test_dump_camel_case(self) -> None:
+        """Test dumping ClientToolList with camel case."""
+        tool1 = ClientTool(
+            name="tool1",
+            parameters=ClientToolParameters(properties={"param1": {"type": "string"}}),
+        )
+        tool2 = ClientTool(
+            name="tool2",
+            parameters=ClientToolParameters(properties={"param2": {"type": "integer"}}),
+        )
+        tool_list = ClientToolList([tool1, tool2])
+
+        result = tool_list.dump(camel_case=True)
+        assert len(result) == 2
+        assert result[0]["name"] == "tool1"
+        assert result[1]["name"] == "tool2"
+        assert result[0]["parameters"]["properties"]["param1"]["type"] == "string"
+        assert result[1]["parameters"]["properties"]["param2"]["type"] == "integer"
+
+    def test_load_from_list(self) -> None:
+        """Test loading ClientToolList from list of dictionaries."""
+        data = [
+            {
+                "name": "tool1",
+                "type": "clientTool",
+                "parameters": {
+                    "type": "object",
+                    "properties": {"param1": {"type": "string"}},
+                    "required": [],
+                    "propertyOrdering": [],
+                },
+            },
+            {
+                "name": "tool2",
+                "type": "clientTool",
+                "parameters": {
+                    "type": "object",
+                    "properties": {"param2": {"type": "integer"}},
+                    "required": [],
+                    "propertyOrdering": [],
+                },
+            },
+        ]
+
+        tool_list = ClientToolList._load(data)
+        assert len(tool_list.tools) == 2
+        assert tool_list.tools[0].name == "tool1"
+        assert tool_list.tools[1].name == "tool2"
+        assert isinstance(tool_list.tools[0], ClientTool)
+        assert isinstance(tool_list.tools[1], ClientTool)


### PR DESCRIPTION
- Add ClientTool, ClientToolParameters, and ClientToolList data classes
- Update agents.chat() method to accept actions parameter
- Support single ClientTool or sequence of ClientTool objects
- Add comprehensive tests for new functionality
- Update documentation with examples
- Maintain backward compatibility with existing chat functionality

The actions parameter allows clients to inject custom tool calls that agents can use during conversations, following the JSON Schema specification for parameter definitions.

## Description
Please describe the change you have made.

## Checklist:
- [ ] Tests added/updated.
- [ ] Documentation updated. Documentation is generated from docstrings - these must be updated according to your change.
  If a new method has been added it should be referenced in [cognite.rst](https://github.com/cognitedata/cognite-sdk-python/blob/master/docs/source/cognite.rst) in order to generate docs based on its docstring.
- [ ] The PR title follows the [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) spec.
