### PR TITLE
fix: do not throw UserWarning from SDK code

### DIFF
--- a/cognite/client/_api/data_modeling/instances.py
+++ b/cognite/client/_api/data_modeling/instances.py
@@ -1185,7 +1185,7 @@ class InstancesAPI(APIClient):
             body["properties"] = properties
         if include_typing:
             body["includeTyping"] = include_typing
-        if filter:
+        if filter is not None:
             body["filter"] = filter.dump(camel_case_property=False) if isinstance(filter, Filter) else filter
         if target_units:
             body["targetUnits"] = [unit.dump(camel_case=True) for unit in target_units]
@@ -1309,7 +1309,7 @@ class InstancesAPI(APIClient):
         ]
         if group_by:
             body["groupBy"] = [group_by] if isinstance(group_by, str) else group_by
-        if filter:
+        if filter is not None:
             body["filter"] = filter.dump(camel_case_property=False) if isinstance(filter, Filter) else filter
         if query:
             body["query"] = query
@@ -1416,7 +1416,7 @@ class InstancesAPI(APIClient):
                 raise TypeError(f"Not a histogram: {histogram}")
 
         body["aggregates"] = [histogram.dump(camel_case=True) for histogram in histogram_seq]
-        if filter:
+        if filter is not None:
             body["filter"] = filter.dump(camel_case_property=False) if isinstance(filter, Filter) else filter
         if query:
             body["query"] = query

--- a/cognite/client/_api/documents.py
+++ b/cognite/client/_api/documents.py
@@ -599,7 +599,7 @@ class DocumentsAPI(APIClient):
         """
         self._validate_filter(filter)
         body: dict[str, str | int | bool | dict | list] = {"search": {"query": query}}
-        if filter:
+        if filter is not None:
             body["filter"] = filter.dump() if isinstance(filter, Filter) else filter
         if sort:
             body["sort"] = [DocumentSort.load(sort).dump()]

--- a/cognite/client/_api_client.py
+++ b/cognite/client/_api_client.py
@@ -565,7 +565,7 @@ class APIClient:
             body: dict[str, Any] = {}
             if filter:
                 body["filter"] = filter
-            if advanced_filter:
+            if advanced_filter is not None:
                 if isinstance(advanced_filter, Filter):
                     # TODO: Does our json.dumps now understand Filter?
                     body["advancedFilter"] = advanced_filter.dump(camel_case_property=True)
@@ -697,7 +697,7 @@ class APIClient:
                         "partition": partition,
                         **(other_params or {}),
                     }
-                    if advanced_filter:
+                    if advanced_filter is not None:
                         body["advancedFilter"] = (
                             advanced_filter.dump(camel_case_property=True)
                             if isinstance(advanced_filter, Filter)

--- a/cognite/client/data_classes/data_modeling/query.py
+++ b/cognite/client/data_classes/data_modeling/query.py
@@ -481,9 +481,9 @@ class EdgeResultSetExpression(NodeOrEdgeResultSetExpression):
             edges["direction"] = self.direction
         if self.filter is not None:
             edges["filter"] = self.filter.dump()
-        if self.node_filter:
+        if self.node_filter is not None:
             edges["nodeFilter" if camel_case else "node_filter"] = self.node_filter.dump()
-        if self.termination_filter:
+        if self.termination_filter is not None:
             edges["terminationFilter" if camel_case else "termination_filter"] = self.termination_filter.dump()
         if self.limit_each:
             edges["limitEach" if camel_case else "limit_each"] = self.limit_each

--- a/cognite/client/data_classes/data_modeling/query.py
+++ b/cognite/client/data_classes/data_modeling/query.py
@@ -370,7 +370,7 @@ class NodeResultSetExpression(NodeOrEdgeResultSetExpression):
         nodes: dict[str, Any] = {}
         if self.from_:
             nodes["from"] = self.from_
-        if self.filter:
+        if self.filter is not None:
             nodes["filter"] = self.filter.dump()
         if self.through:
             nodes["through"] = self.through.dump(camel_case=camel_case)
@@ -479,7 +479,7 @@ class EdgeResultSetExpression(NodeOrEdgeResultSetExpression):
             edges["maxDistance" if camel_case else "max_distance"] = self.max_distance
         if self.direction:
             edges["direction"] = self.direction
-        if self.filter:
+        if self.filter is not None:
             edges["filter"] = self.filter.dump()
         if self.node_filter:
             edges["nodeFilter" if camel_case else "node_filter"] = self.node_filter.dump()

--- a/cognite/client/data_classes/data_modeling/views.py
+++ b/cognite/client/data_classes/data_modeling/views.py
@@ -50,7 +50,7 @@ class ViewCore(DataModelingSchemaResource["ViewApply"], ABC):
 
         if self.implements:
             output["implements"] = [v.dump(camel_case) for v in self.implements]
-        if self.filter:
+        if self.filter is not None:
             output["filter"] = self.filter.dump()
 
         return output

--- a/pytest.ini
+++ b/pytest.ini
@@ -12,6 +12,8 @@ filterwarnings =
     ignore::DeprecationWarning:cognite.client
     ignore::DeprecationWarning:test
     ignore::cognite.client.utils._experimental.FeaturePreviewWarning
+    # Raise if we ever see this warning coming from the SDK itself:
+    error:You may be trying to combine two \(or more\) filters using 'and' or 'or'.*:UserWarning
 
 testpaths =
     tests

--- a/tests/tests_unit/test_data_classes/test_data_models/test_filters.py
+++ b/tests/tests_unit/test_data_classes/test_data_models/test_filters.py
@@ -340,7 +340,7 @@ def test_compound_filters_require_at_least_one_filter(compound_flt: type[f.Compo
 def test_merge_space_into_filter(
     space: str | list[str] | None, user_filter: f.Filter | None, pass_as_dict: bool
 ) -> None:
-    flt_used = user_filter.dump() if pass_as_dict and user_filter else user_filter
+    flt_used = user_filter.dump() if pass_as_dict and user_filter is not None else user_filter
     res = InstancesAPI._merge_space_into_filter(
         instance_type="node",
         space=space,


### PR DESCRIPTION
(and make sure it doesn't happen again)

## Description
Follow-up from #2330 - apparently we use `if filter` a lot in the SDK codebase (and we don't want to do this of course).

Pytest will now error out if it ever sees this warning again when running tests to ensure we don't repeat this.

Also noted on slack: https://cognitedata.slack.com/archives/CG10VQPFX/p1758651269707159
