### PR TITLE
fix(simulators): make SimulatorModelRevision.get_data() return single item for consistency

### DIFF
--- a/cognite/client/data_classes/simulators/models.py
+++ b/cognite/client/data_classes/simulators/models.py
@@ -165,10 +165,19 @@ class SimulatorModelRevision(SimulatorModelRevisionCore):
             description=self.description,
         )
 
-    def get_data(self) -> SimulatorModelRevisionDataList:
-        return self._cognite_client.simulators.models.revisions.retrieve_data(
+    def get_data(self) -> SimulatorModelRevisionData | None:
+        """`Retrieve data associated with this simulator model revision. <https://developer.cognite.com/api#tag/Simulator-Models/operation/retrieve_simulator_model_revision_data>`_
+
+        Returns:
+            SimulatorModelRevisionData | None: Data for the simulator model revision.
+        """
+        data = self._cognite_client.simulators.models.revisions.retrieve_data(
             model_revision_external_id=self.external_id
         )
+        if data:
+            return data[0]
+
+        return None
 
 
 class SimulatorModelCore(WriteableCogniteResource["SimulatorModelWrite"], ABC):

--- a/tests/tests_integration/test_api/test_simulators/test_models.py
+++ b/tests/tests_integration/test_api/test_simulators/test_models.py
@@ -313,15 +313,13 @@ class TestSimulatorModels:
             model_external_ids=seed_resource_names.simulator_model_external_id
         )
 
-        model_revision_data = model_revisions[0].get_data()
-        assert model_revision_data is not None
+        model_revision_data_item = model_revisions[0].get_data()
+        assert model_revision_data_item is not None
 
         model_revision_data_list = cognite_client.simulators.models.revisions.retrieve_data(
             model_revision_external_id=model_revisions[0].external_id
         )
-        assert model_revision_data == model_revision_data_list
-
-        model_revision_data_item = model_revision_data[0]
+        assert model_revision_data_item == model_revision_data_list[0]
         assert model_revision_data_item.flowsheets is not None
         assert (
             model_revision_data_item.flowsheets[0].dump()


### PR DESCRIPTION
## Description
- Changes `SimulatorModelRevision.get_data()` return type from `SimulatorModelRevisionDataList` to `SimulatorModelRevisionData | None`
- Updates integration test to handle the new return type
- Makes the method consistent with `SimulationRun.get_data()` which already returns a single item

## Checklist:
- [x] Tests added/updated.
- [x] Documentation updated. Documentation is generated from docstrings - these must be updated according to your change.
  If a new method has been added it should be referenced in [cognite.rst](https://github.com/cognitedata/cognite-sdk-python/blob/master/docs/source/cognite.rst) in order to generate docs based on its docstring.
- [x] The PR title follows the [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) spec.
