### PR TITLE
fix(agents): replace agentId with agentExternalId in chat API

### DIFF
--- a/cognite/client/_api/agents/agents.py
+++ b/cognite/client/_api/agents/agents.py
@@ -242,7 +242,7 @@ class AgentsAPI(APIClient):
 
     def chat(
         self,
-        agent_id: str,
+        agent_external_id: str,
         messages: Message | Sequence[Message],
         cursor: str | None = None,
     ) -> AgentChatResponse:
@@ -252,7 +252,7 @@ class AgentsAPI(APIClient):
         Users can ensure conversation continuity by including the cursor from the previous response in subsequent requests.
 
         Args:
-            agent_id (str): External ID that uniquely identifies the agent.
+            agent_external_id (str): External ID that uniquely identifies the agent.
             messages (Message | Sequence[Message]): A list of one or many input messages to the agent.
             cursor (str | None): The cursor to use for continuation of a conversation. Use this to
                 create multi-turn conversations, as the cursor will keep track of the conversation state.
@@ -268,7 +268,7 @@ class AgentsAPI(APIClient):
                 >>> from cognite.client.data_classes.agents import Message
                 >>> client = CogniteClient()
                 >>> response = client.agents.chat(
-                ...     agent_id="my_agent",
+                ...     agent_external_id="my_agent",
                 ...     messages=Message("What can you help me with?")
                 ... )
                 >>> print(response.text)
@@ -276,7 +276,7 @@ class AgentsAPI(APIClient):
             Continue a conversation using the cursor:
 
                 >>> follow_up = client.agents.chat(
-                ...     agent_id="my_agent",
+                ...     agent_external_id="my_agent",
                 ...     messages=Message("Tell me more about that"),
                 ...     cursor=response.cursor
                 ... )
@@ -284,7 +284,7 @@ class AgentsAPI(APIClient):
             Send multiple messages at once:
 
                 >>> response = client.agents.chat(
-                ...     agent_id="my_agent",
+                ...     agent_external_id="my_agent",
                 ...     messages=[
                 ...         Message("Help me find the 1st stage compressor."),
                 ...         Message("Once you have found it, find related time series.")
@@ -299,7 +299,7 @@ class AgentsAPI(APIClient):
 
         # Build request body
         body = {
-            "agentId": agent_id,
+            "agentExternalId": agent_external_id,
             "messages": MessageList(messages).dump(camel_case=True),
         }
 

--- a/cognite/client/data_classes/agents/chat.py
+++ b/cognite/client/data_classes/agents/chat.py
@@ -218,7 +218,7 @@ class AgentChatResponse(CogniteResource):
     """Response from agent chat.
 
     Args:
-        agent_id (str): The ID of the agent.
+        agent_external_id (str): The external ID of the agent.
         messages (AgentMessageList): The response messages from the agent.
         type (str): The response type.
         cursor (str | None): Cursor for conversation continuation.
@@ -226,19 +226,19 @@ class AgentChatResponse(CogniteResource):
 
     def __init__(
         self,
-        agent_id: str,
+        agent_external_id: str,
         messages: AgentMessageList,
         type: str,
         cursor: str | None = None,
     ) -> None:
-        self.agent_id = agent_id
+        self.agent_external_id = agent_external_id
         self.cursor = cursor
         self.messages = messages
         self.type = type
 
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         result = {
-            "agentId" if camel_case else "agent_id": self.agent_id,
+            "agentExternalId" if camel_case else "agent_external_id": self.agent_external_id,
             "response": {
                 "cursor": self.cursor,
                 "messages": [msg.dump(camel_case=camel_case) for msg in self.messages] if self.messages else [],
@@ -264,7 +264,7 @@ class AgentChatResponse(CogniteResource):
         messages_list = AgentMessageList(messages)
 
         instance = cls(
-            agent_id=data["agentId"],
+            agent_external_id=data["agentExternalId"],
             cursor=response_data.get("cursor"),
             messages=messages_list,
             type=response_data["type"],

--- a/tests/tests_integration/test_api/test_agents.py
+++ b/tests/tests_integration/test_api/test_agents.py
@@ -136,11 +136,11 @@ class TestAgentsAPI:
     def test_chat_minimal(self, cognite_client: CogniteClient, permanent_agent: Agent) -> None:
         """Minimal happy-path chat call to verify the endpoint works end-to-end."""
         response = cognite_client.agents.chat(
-            agent_id=permanent_agent.external_id,
+            agent_external_id=permanent_agent.external_id,
             messages=Message("Hello from SDK integration test"),
         )
 
         assert isinstance(response, AgentChatResponse)
-        assert response.agent_id == permanent_agent.external_id
+        assert response.agent_external_id == permanent_agent.external_id
         assert isinstance(response.type, str) and len(response.type) > 0
         assert response.messages is not None


### PR DESCRIPTION
[alpha] Align SDK with API specification by replacing agentId parameter with agentExternalId in the chat() method and AgentChatResponse class.

This is a breaking change for alpha users, but alpha features are subject to breaking changes without prior notice.

## Description
Please describe the change you have made.

## Checklist:
- [x] Tests added/updated.
- [x] Documentation updated. Documentation is generated from docstrings - these must be updated according to your change. If a new method has been added it should be referenced in [cognite.rst](https://github.com/cognitedata/cognite-sdk-python/blob/master/docs/source/cognite.rst) in order to generate docs based on its docstring.
- [x] The PR title follows the [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) spec.
