### PR TITLE
fix(sequences): accept list ids/external_ids in retrieve_last_row (#2266)

### DIFF
--- a/tests/tests_unit/test_api/test_sequences_data.py
+++ b/tests/tests_unit/test_api/test_sequences_data.py
@@ -1,0 +1,43 @@
+from types import SimpleNamespace
+
+from cognite.client.data_classes.sequences import SequenceRows, SequenceRowsList
+
+
+class _DummyRows(SequenceRows):
+    def __init__(self):
+        pass
+
+
+def test_retrieve_last_row_accepts_list_of_external_ids(monkeypatch, cognite_client):
+    api = cognite_client.sequences.data
+    calls = []
+
+    def fake_do_request(method, path, json):
+        calls.append(json)
+        return SimpleNamespace(json=lambda: {})
+
+    monkeypatch.setattr(api, "_do_request", fake_do_request, raising=True)
+    monkeypatch.setattr(SequenceRows, "_load", classmethod(lambda cls, payload: _DummyRows()), raising=True)
+
+    out = api.retrieve_last_row(external_id=["exA", "exB"])
+
+    assert isinstance(out, SequenceRowsList)
+    assert len(out) == 2
+    assert len(calls) == 2
+
+
+def test_retrieve_last_row_single_id_calls_once(monkeypatch, cognite_client):
+    api = cognite_client.sequences.data
+    calls = []
+
+    def fake_do_request(method, path, json):
+        calls.append(json)
+        return SimpleNamespace(json=lambda: {})
+
+    monkeypatch.setattr(api, "_do_request", fake_do_request, raising=True)
+    monkeypatch.setattr(SequenceRows, "_load", classmethod(lambda cls, payload: _DummyRows()), raising=True)
+
+    out = api.retrieve_last_row(id=42)
+
+    assert isinstance(out, SequenceRows)
+    assert len(calls) == 1


### PR DESCRIPTION
Fixes #2266.

## Summary
`SequencesDataAPI.retrieve_last_row` now accepts:
- `id: int | typing.Sequence[int] | None`
- `external_id: str | SequenceNotStr[str] | None`

Behavior:
- Single identifier → returns `SequenceRows`
- Multiple identifiers → aggregates into `SequenceRowsList`

## Rationale
Docs and docstring say lists are supported, but the implementation only handled single values. This aligns code with docs and mirrors the list semantics used elsewhere.

## Implementation notes
- Normalize identifiers via `IdentifierSequence.load(...)`
- For multiple identifiers, call `/sequences/data/latest` per identifier and aggregate using `execute_tasks(...)`
- Keep single-identifier path unchanged
- Updated docstring (types + return description)

## Testing done
- Unit tests added: `tests/tests_unit/test_api/test_sequences_data.py`
  - list of `external_id` → returns `SequenceRowsList`, 2 HTTP calls
  - single `id` → returns `SequenceRows`, 1 HTTP call
- Local checks:
  - `poetry run pytest -q tests/tests_unit -k retrieve_last_row`
  - `poetry run pre-commit run --all-files` (ruff, ruff-format, mypy, custom checks, pydoclint) all pass

> **Note** that the integration tests were not run locally; CI should cover these.

## Backwards compatibility
- No breaking changes: single-identifier behavior unchanged
- Expanded accepted types only

## Files changed
- `cognite/client/_api/sequences.py`
- `tests/tests_unit/test_api/test_sequences_data.py`

## Checklist
- [x] Tests added/updated
- [x] Docstring updated (docs are generated from docstrings)
