### PR TITLE
refactor(simulators): Consolidate imports and use public API in integration tests

### DIFF
--- a/tests/tests_integration/test_api/test_simulators/conftest.py
+++ b/tests/tests_integration/test_api/test_simulators/conftest.py
@@ -10,15 +10,14 @@ import pytest
 from cognite.client._cognite_client import CogniteClient
 from cognite.client.data_classes.data_sets import DataSetWrite
 from cognite.client.data_classes.files import FileMetadata
-from cognite.client.data_classes.simulators import SimulatorModelWrite
-from cognite.client.data_classes.simulators.models import SimulatorModel
-from cognite.client.data_classes.simulators.routine_revisions import (
-    SimulatorRoutineRevision,
-    SimulatorRoutineRevisionWrite,
-)
-from cognite.client.data_classes.simulators.routines import (
+from cognite.client.data_classes.simulators import (
+    SimulatorModel,
+    SimulatorModelRevisionWrite,
+    SimulatorModelWrite,
     SimulatorRoutine,
     SimulatorRoutineList,
+    SimulatorRoutineRevision,
+    SimulatorRoutineRevisionWrite,
     SimulatorRoutineWrite,
 )
 from cognite.client.utils._text import to_snake_case
@@ -172,18 +171,13 @@ def seed_simulator_model_revisions(
 
     for revision in revisions:
         if not model_revisions.get(external_id=revision):
-            cognite_client.simulators._post(
-                "/simulators/models/revisions",
-                json={
-                    "items": [
-                        {
-                            "description": "test sim model revision description",
-                            "fileId": seed_model_revision_file.id,
-                            "modelExternalId": model_unique_external_id,
-                            "externalId": revision,
-                        }
-                    ]
-                },
+            cognite_client.simulators.models.revisions.create(
+                SimulatorModelRevisionWrite(
+                    external_id=revision,
+                    model_external_id=model_unique_external_id,
+                    file_id=seed_model_revision_file.id,
+                    description="test sim model revision description",
+                )
             )
 
 

--- a/tests/tests_integration/test_api/test_simulators/test_models.py
+++ b/tests/tests_integration/test_api/test_simulators/test_models.py
@@ -6,16 +6,14 @@ from cognite.client._cognite_client import CogniteClient
 from cognite.client.data_classes import TimestampRange
 from cognite.client.data_classes.files import FileMetadata
 from cognite.client.data_classes.simulators import (
+    PropertySort,
+    SimulatorFlowsheet,
     SimulatorModelDependencyFileId,
+    SimulatorModelRevision,
     SimulatorModelRevisionDependency,
+    SimulatorModelRevisionList,
     SimulatorModelRevisionWrite,
     SimulatorModelWrite,
-)
-from cognite.client.data_classes.simulators.filters import PropertySort
-from cognite.client.data_classes.simulators.models import (
-    SimulatorFlowsheet,
-    SimulatorModelRevision,
-    SimulatorModelRevisionList,
 )
 from cognite.client.utils._text import random_string
 from tests.tests_integration.test_api.test_simulators.conftest import upload_file

--- a/tests/tests_integration/test_api/test_simulators/test_routine_revisions.py
+++ b/tests/tests_integration/test_api/test_simulators/test_routine_revisions.py
@@ -2,13 +2,13 @@ import time
 
 from cognite.client import CogniteClient
 from cognite.client.data_classes.shared import TimestampRange
-from cognite.client.data_classes.simulators import PropertySort
-from cognite.client.data_classes.simulators.routine_revisions import (
+from cognite.client.data_classes.simulators import (
+    PropertySort,
+    SimulatorRoutine,
     SimulatorRoutineInputConstant,
     SimulatorRoutineRevision,
     SimulatorRoutineRevisionWrite,
 )
-from cognite.client.data_classes.simulators.routines import SimulatorRoutine
 from cognite.client.utils._time import timestamp_to_ms
 from tests.tests_integration.test_api.test_simulators.seed.data import (
     SIMULATOR_ROUTINE_REVISION,

--- a/tests/tests_integration/test_api/test_simulators/test_routines.py
+++ b/tests/tests_integration/test_api/test_simulators/test_routines.py
@@ -3,9 +3,12 @@ from itertools import pairwise
 import pytest
 
 from cognite.client._cognite_client import CogniteClient
-from cognite.client.data_classes.simulators.filters import PropertySort
-from cognite.client.data_classes.simulators.routine_revisions import SimulatorRoutineRevision
-from cognite.client.data_classes.simulators.routines import SimulatorRoutine, SimulatorRoutineWrite
+from cognite.client.data_classes.simulators import (
+    PropertySort,
+    SimulatorRoutine,
+    SimulatorRoutineRevision,
+    SimulatorRoutineWrite,
+)
 from cognite.client.utils._text import random_string
 from tests.tests_integration.test_api.test_simulators.seed.data import (
     ResourceNames,

--- a/tests/tests_integration/test_api/test_simulators/test_runs.py
+++ b/tests/tests_integration/test_api/test_simulators/test_runs.py
@@ -6,11 +6,11 @@ import pytest
 
 from cognite.client._cognite_client import CogniteClient
 from cognite.client.data_classes import TimestampRange
-from cognite.client.data_classes.simulators.filters import SimulationRunsSort
-from cognite.client.data_classes.simulators.runs import (
+from cognite.client.data_classes.simulators import (
     SimulationInput,
     SimulationOutput,
     SimulationRun,
+    SimulationRunsSort,
     SimulationRunWrite,
     SimulationValueUnitName,
 )

--- a/tests/tests_integration/test_api/test_simulators/test_simulators.py
+++ b/tests/tests_integration/test_api/test_simulators/test_simulators.py
@@ -1,7 +1,7 @@
 import pytest
 
 from cognite.client._cognite_client import CogniteClient
-from cognite.client.data_classes.simulators.simulators import Simulator
+from cognite.client.data_classes.simulators import Simulator
 
 
 @pytest.mark.usefixtures("seed_simulator")


### PR DESCRIPTION
## Description
This PR refactors the simulators integration tests to improve consistency and maintainability:

- Updated all test files to import simulator classes directly from the top-level `cognite.client.data_classes.simulators` module instead of sub submodules (`models`, `routines`, `routine_revisions`, `filters`)
- Replaced internal `_post()` call with the public `simulators.models.revisions.create()` method in test fixture

## Checklist:
- [x] Tests added/updated.
- [ ] Documentation updated. Documentation is generated from docstrings - these must be updated according to your change.
  If a new method has been added it should be referenced in [cognite.rst](https://github.com/cognitedata/cognite-sdk-python/blob/master/docs/source/cognite.rst) in order to generate docs based on its docstring.
- [x] The PR title follows the [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) spec.
