### PR TITLE
docs: fix agent_id to agent_external_id in chat() docstring examples

### DIFF
--- a/cognite/client/_api/agents/agents.py
+++ b/cognite/client/_api/agents/agents.py
@@ -314,7 +314,7 @@ class AgentsAPI(APIClient):
                 ...     }
                 ... )
                 >>> response = client.agents.chat(
-                ...     agent_id="my_agent",
+                ...     agent_external_id="my_agent",
                 ...     messages=Message("What is 42 plus 58?"),
                 ...     actions=[add_numbers_action]
                 ... )
@@ -324,7 +324,7 @@ class AgentsAPI(APIClient):
                 ...         result = call.arguments["a"] + call.arguments["b"]
                 ...         # Send result back
                 ...         response = client.agents.chat(
-                ...             agent_id="my_agent",
+                ...             agent_external_id="my_agent",
                 ...             messages=ClientToolResult(
                 ...                 action_id=call.action_id,
                 ...                 content=f"The result is {result}"


### PR DESCRIPTION
Fixes incorrect parameter name in the AgentsAPI.chat method docstring examples. The parameter was documented as agent_id but should be agent_external_id to match the actual method signature.