### PR TITLE
feat(data_modeling): add 'record' value to Container 'used_for' field

### DIFF
--- a/cognite/client/data_classes/data_modeling/containers.py
+++ b/cognite/client/data_classes/data_modeling/containers.py
@@ -82,7 +82,7 @@ class ContainerApply(ContainerCore):
         properties (dict[str, ContainerProperty]): We index the property by a local unique identifier.
         description (str | None): Textual description of the container
         name (str | None): Human readable name for the container.
-        used_for (Literal['node', 'edge', 'all'] | None): Should this operation apply to nodes, edges or both.
+        used_for (Literal['node', 'edge', 'all', 'record'] | None): Should this operation apply to nodes, edges, all (nodes and edges) or records.
         constraints (dict[str, Constraint] | None): Set of constraints to apply to the container
         indexes (dict[str, Index] | None): Set of indexes to apply to the container.
     """
@@ -94,7 +94,7 @@ class ContainerApply(ContainerCore):
         properties: dict[str, ContainerProperty],
         description: str | None = None,
         name: str | None = None,
-        used_for: Literal["node", "edge", "all"] | None = None,
+        used_for: Literal["node", "edge", "all", "record"] | None = None,
         constraints: dict[str, Constraint] | None = None,
         indexes: dict[str, Index] | None = None,
     ) -> None:
@@ -134,7 +134,7 @@ class Container(ContainerCore):
         created_time (int): The number of milliseconds since 00:00:00 Thursday, 1 January 1970, Coordinated Universal Time (UTC), minus leap seconds.
         description (str | None): Textual description of the container
         name (str | None): Human readable name for the container.
-        used_for (Literal['node', 'edge', 'all']): Should this operation apply to nodes, edges or both.
+        used_for (Literal['node', 'edge', 'all', 'record']): Should this operation apply to nodes, edges, all (nodes and edges) or records.
         constraints (dict[str, Constraint] | None): Set of constraints to apply to the container
         indexes (dict[str, Index] | None): Set of indexes to apply to the container.
     """
@@ -149,7 +149,7 @@ class Container(ContainerCore):
         created_time: int,
         description: str | None,
         name: str | None,
-        used_for: Literal["node", "edge", "all"],
+        used_for: Literal["node", "edge", "all", "record"],
         constraints: dict[str, Constraint] | None,
         indexes: dict[str, Index] | None,
     ) -> None:


### PR DESCRIPTION
## Description
Add support for the 'record' value in the `used_for` field for both `Container` and `ContainerApply` classes in the data modeling API.

Existing tests already provide adequate coverage for this change, as no tests explicitly validate the list of allowed `used_for` values and the new value is additive and doesn't break existing functionality.

## Checklist:
- [ ] Tests added/updated.
- [ ] Documentation updated. Documentation is generated from docstrings - these must be updated according to your change.
  If a new method has been added it should be referenced in [cognite.rst](https://github.com/cognitedata/cognite-sdk-python/blob/master/docs/source/cognite.rst) in order to generate docs based on its docstring.
- [x] The PR title follows the [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) spec.
