### PR TITLE
fix: dont send null for system-managed props CogniteFile

### DIFF
--- a/tests/tests_unit/test_data_classes/test_data_models/test_cdm/test_v1.py
+++ b/tests/tests_unit/test_data_classes/test_data_models/test_cdm/test_v1.py
@@ -1,6 +1,9 @@
 from datetime import datetime
 
+import pytest
+
 from cognite.client.data_classes.data_modeling.cdm.v1 import Cognite3DModelApply, CogniteSourceableNodeApply
+from cognite.client.data_classes.data_modeling.extractor_extensions.v1 import CogniteExtractorFileApply
 
 
 class TestSourceable:
@@ -82,3 +85,36 @@ class TestModel3D:
         }
         dumped_and_loaded = Cognite3DModelApply.load(dumped)
         assert dumped_and_loaded == my_model
+
+
+def test_extractor_file_apply_warns_on_system_managed_fields() -> None:
+    file_apply = CogniteExtractorFileApply(
+        space="sp_data_space",
+        external_id="my_file",
+        is_uploaded=True,
+        uploaded_time=datetime.now(),
+    )
+    with pytest.warns(UserWarning, match="system-managed and cannot be modified"):
+        dumped = file_apply.dump()
+
+    sources = dumped["sources"]
+    assert len(sources) == 1
+    properties = sources[0]["properties"]
+    assert properties["isUploaded"] is True
+    assert isinstance(properties["uploadedTime"], str)
+
+
+def test_extractor_file_apply_skips_nulls() -> None:
+    file_apply = CogniteExtractorFileApply(
+        space="sp_data_space",
+        external_id="my_file",
+        is_uploaded=None,
+        uploaded_time=None,
+    )
+    dumped = file_apply.dump()
+
+    sources = dumped["sources"]
+    assert len(sources) == 1
+    properties = sources[0]["properties"]
+    assert "isUploaded" not in properties
+    assert "uploadedTime" not in properties


### PR DESCRIPTION
https://cognitedata.atlassian.net/browse/DM-3369

## Description
Unfortunately, the SDK sends full request bodies for all "unset" fields (or, they could have been set to None but we can't tell before v8).

This is a stop-gap to at least skip system-managed fields when null.

Raised from slack: https://cognitedata.slack.com/archives/C03G11UNHBJ/p1764156830780839