### PR TITLE
feat(limits): add Limits API SDK implementation

### DIFF
--- a/cognite/client/_basic_api_client.py
+++ b/cognite/client/_basic_api_client.py
@@ -19,6 +19,7 @@ from cognite.client.config import global_config
 from cognite.client.exceptions import (
     CogniteAPIError,
     CogniteDuplicatedError,
+    CogniteHTTPStatusError,
     CogniteNotFoundError,
     CogniteProjectAccessError,
 )
@@ -45,7 +46,7 @@ class FailedRequestHandler:
     headers: dict[str, str] | httpx.Headers
     response_headers: dict[str, str] | httpx.Headers
     extra: dict[str, Any]
-    cause: httpx.HTTPStatusError
+    cause: CogniteHTTPStatusError
     stream: bool
 
     def __post_init__(self) -> None:
@@ -53,7 +54,7 @@ class FailedRequestHandler:
         self.response_headers = BasicAsyncAPIClient._sanitize_headers(self.response_headers)
 
     @classmethod
-    async def from_status_error(cls, err: httpx.HTTPStatusError, stream: bool) -> Self:
+    async def from_status_error(cls, err: CogniteHTTPStatusError, stream: bool) -> Self:
         response = err.response
         error, missing, duplicated = {}, None, None
 
@@ -134,7 +135,7 @@ class FailedRequestHandler:
             x_request_id=self.x_request_id,
             maybe_projects=maybe_projects,
             cluster=cluster,
-        ) from None  # we don't surface the underlying httpx.HTTPStatusError
+        ) from None  # we don't surface the underlying CogniteHTTPStatusError
 
     def _raise_api_error(self, err_type: type[CogniteAPIError], cluster: str | None, project: str) -> NoReturn:
         raise err_type(
@@ -248,7 +249,7 @@ class BasicAsyncAPIClient:
             httpx.Response: The response from the server.
 
         Raises:
-            httpx.HTTPStatusError: If the response status code is 4xx or 5xx.
+            CogniteHTTPStatusError: If the response status code is 4xx or 5xx.
         """
         http_client = self._select_async_http_client(method in {"GET", "PUT", "HEAD"})
         if include_cdf_headers:
@@ -260,7 +261,7 @@ class BasicAsyncAPIClient:
             self._log_successful_request(res)
             return res
 
-        except httpx.HTTPStatusError as err:
+        except CogniteHTTPStatusError as err:
             handler = await FailedRequestHandler.from_status_error(err, stream=False)
             handler.log_failed_request()
             raise
@@ -293,7 +294,7 @@ class BasicAsyncAPIClient:
                 self._log_successful_request(resp, payload=json, stream=True)
                 yield resp
 
-        except httpx.HTTPStatusError as err:
+        except CogniteHTTPStatusError as err:
             await self._handle_status_error(err, payload=json, stream=True)
 
     async def _get(
@@ -317,7 +318,7 @@ class BasicAsyncAPIClient:
                 timeout=self._config.timeout,
                 semaphore=semaphore,
             )
-        except httpx.HTTPStatusError as err:
+        except CogniteHTTPStatusError as err:
             await self._handle_status_error(err)
 
         self._log_successful_request(res)
@@ -350,7 +351,7 @@ class BasicAsyncAPIClient:
                 timeout=self._config.timeout,
                 semaphore=semaphore,
             )
-        except httpx.HTTPStatusError as err:
+        except CogniteHTTPStatusError as err:
             await self._handle_status_error(err, payload=json)
 
         self._log_successful_request(res, payload=json)
@@ -384,7 +385,7 @@ class BasicAsyncAPIClient:
                 timeout=timeout or self._config.timeout,
                 semaphore=semaphore,
             )
-        except httpx.HTTPStatusError as err:
+        except CogniteHTTPStatusError as err:
             await self._handle_status_error(err, payload=json)
 
         self._log_successful_request(res, payload=json)
@@ -417,7 +418,7 @@ class BasicAsyncAPIClient:
         headers[auth_header_name] = auth_header_value
 
     async def _handle_status_error(
-        self, error: httpx.HTTPStatusError, payload: dict[str, Any] | None = None, stream: bool = False
+        self, error: CogniteHTTPStatusError, payload: dict[str, Any] | None = None, stream: bool = False
     ) -> NoReturn:
         """The response had an HTTP status code of 4xx or 5xx"""
         handler = await FailedRequestHandler.from_status_error(error, stream=stream)

--- a/cognite/client/_http_client.py
+++ b/cognite/client/_http_client.py
@@ -21,9 +21,11 @@ from typing import Any, Literal, TypeAlias
 import httpx
 
 from cognite.client.config import global_config
+from cognite.client.data_classes._response import CogniteSDKResponse
 from cognite.client.exceptions import (
     CogniteConnectionError,
     CogniteConnectionRefused,
+    CogniteHTTPStatusError,
     CogniteReadTimeout,
     CogniteRequestError,
 )
@@ -127,24 +129,41 @@ class AsyncHTTPClientWithRetryConfig:
 
 
 class RetryTracker:
-    def __init__(self, config: AsyncHTTPClientWithRetryConfig) -> None:
+    def __init__(self, url: str, config: AsyncHTTPClientWithRetryConfig) -> None:
+        self.url = url
         self.config = config
         self.status = self.read = self.connect = 0
-        self.last_failed_reason = ""
+        self.retry_causes: list[str] = []
+        self.total_time_in_backoff = 0.0
 
     @property
     def total(self) -> int:
         return self.status + self.read + self.connect
 
-    def get_backoff_time(self) -> float:
-        backoff_time = self.config.backoff_factor * 2**self.total
-        return random.random() * min(backoff_time, self.config.max_backoff_seconds)
+    @property
+    def last_failed_reason(self) -> str | None:
+        if self.retry_causes:
+            return self.retry_causes[-1]
+        return None
 
-    def back_off(self, url: str) -> None:
+    def get_backoff_time(self) -> float:
+        """
+        Computes the randomized delay (backoff time) before the next retry attempt.
+
+        This method implements the **Exponential Backoff with Full Jitter** strategy,
+        with one addition, a small "initial floor" to avoid immediate retries.
+        """
+        base = self.config.backoff_factor * 2**self.total
+        cap = min(base, self.config.max_backoff_seconds)
+        return 0.1 + random.uniform(0, cap)
+
+    def back_off(self) -> None:
         backoff_time = self.get_backoff_time()
+        self.total_time_in_backoff += backoff_time
+        # We put logging here, since this is always called before retrying
         logger.debug(
-            f"Retrying failed request, attempt #{self.total}, backoff time: {backoff_time=:.4f} sec, "
-            f"reason: {self.last_failed_reason!r}, url: {url}"
+            f"Retrying failed request, attempt #{self.total}, backoff wait: {backoff_time:.4f} sec "
+            f"(total: {self.total_time_in_backoff:.4f} sec), reason: {self.last_failed_reason!r}, url: {self.url}"
         )
         time.sleep(backoff_time)
 
@@ -154,23 +173,25 @@ class RetryTracker:
         # one of [status, read, connect] += 1. Said differently, do last retry when 'total = max':
         return self.total <= self.config.max_retries_total
 
-    def should_retry_status_code(self, status_code: int, is_auto_retryable: bool = False) -> bool:
+    def should_retry_status_code(self, err: httpx.HTTPStatusError, is_auto_retryable: bool = False) -> bool:
         self.status += 1
-        self.last_failed_reason = f"{status_code=}"
+        status_code = err.response.status_code
+        error_type = CogniteHTTPStatusError.get_error_type(status_code)
+        self.retry_causes.append(f"HTTPStatusError({status_code} - {error_type}: {err.response.reason_phrase})")
         return (
             self.should_retry_total
             and self.status <= self.config.max_retries_status
             and (is_auto_retryable or status_code in self.config.status_codes_to_retry)
         )
 
-    def should_retry_connect_error(self, error: httpx.RequestError) -> bool:
+    def should_retry_connect_error(self, error: httpx.TransportError | httpx.DecodingError) -> bool:
         self.connect += 1
-        self.last_failed_reason = type(error).__name__
+        self.retry_causes.append(f"{type(error).__name__}({error!s})")
         return self.should_retry_total and self.connect <= self.config.max_retries_connect
 
-    def should_retry_timeout(self, error: httpx.RequestError) -> bool:
+    def should_retry_timeout(self, error: httpx.TimeoutException) -> bool:
         self.read += 1
-        self.last_failed_reason = type(error).__name__
+        self.retry_causes.append(f"{type(error).__name__}({error!s})")
         return self.should_retry_total and self.read <= self.config.max_retries_read
 
 
@@ -254,7 +275,7 @@ class AsyncHTTPClientWithRetry:
             semaphore = get_global_semaphore()
 
         is_auto_retryable = False
-        retry_tracker = RetryTracker(self.config)
+        retry_tracker = RetryTracker(url, self.config)
         accepts_json = (headers or {}).get("accept") == "application/json"
         while True:
             try:
@@ -263,6 +284,7 @@ class AsyncHTTPClientWithRetry:
                     if headers is not None:
                         self.refresh_auth_header(headers)
                     response = await coro_factory()
+
                 if accepts_json:
                     # Cache .json() return value in order to avoid redecoding JSON if called multiple times
                     response.json = functools.cache(response.json)  # type: ignore [method-assign]
@@ -271,8 +293,12 @@ class AsyncHTTPClientWithRetry:
             except httpx.HTTPStatusError as err:
                 response = err.response
                 is_auto_retryable = response.headers.get("cdf-is-auto-retryable", False)
-                if not retry_tracker.should_retry_status_code(response.status_code, is_auto_retryable):
-                    raise
+                if not retry_tracker.should_retry_status_code(err, is_auto_retryable):
+                    raise CogniteHTTPStatusError(
+                        response.status_code,
+                        request=err.request,
+                        response=CogniteSDKResponse(response),
+                    ) from None
 
             except httpx.ConnectError as err:
                 if not retry_tracker.should_retry_connect_error(err):

--- a/cognite/client/data_classes/_response.py
+++ b/cognite/client/data_classes/_response.py
@@ -1,0 +1,138 @@
+from __future__ import annotations
+
+import typing
+from collections.abc import Iterator
+from datetime import timedelta
+from typing import Any, Final
+
+# We import the specific types used by httpx for accurate type hinting
+from httpx import URL, Cookies, Headers, HTTPStatusError
+from httpx import Request as HttpxRequest
+from httpx import Response as HttpxResponse
+
+
+class CogniteSDKResponse:
+    """
+    A wrapper class for httpx.Response to isolate the SDK from the
+    underlying HTTP library's public interface.
+    """
+
+    def __init__(self, response: HttpxResponse) -> None:
+        # Store the underlying response object privately
+        self._response: Final[HttpxResponse] = response
+
+    @property
+    def httpx_response(self) -> HttpxResponse:
+        """
+        Direct access to the Response object from the underlying http library (currently httpx).
+
+        Disclaimer: Usage is neither backwards- nor forwards-compatible.
+        """
+        return self._response
+
+    @property
+    def status_code(self) -> int:
+        return self._response.status_code
+
+    @property
+    def reason_phrase(self) -> str:
+        return self._response.reason_phrase
+
+    @property
+    def http_version(self) -> str:
+        return self._response.http_version
+
+    @property
+    def url(self) -> URL:
+        return self._response.url
+
+    @property
+    def headers(self) -> Headers:
+        return self._response.headers
+
+    @property
+    def cookies(self) -> Cookies:
+        # Note: httpx.Response.cookies returns httpx.Cookies, which is a wrapper around SimpleCookie
+        return self._response.cookies
+
+    @property
+    def history(self) -> list[CogniteSDKResponse]:
+        return [CogniteSDKResponse(r) for r in self._response.history]
+
+    @property
+    def request(self) -> HttpxRequest:
+        return self._response.request
+
+    @property
+    def content(self) -> bytes:
+        return self._response.content
+
+    @property
+    def text(self) -> str:
+        return self._response.text
+
+    @property
+    def encoding(self) -> str | None:
+        return self._response.encoding
+
+    @encoding.setter
+    def encoding(self, value: str) -> None:
+        self._response.encoding = value
+
+    @property
+    def is_success(self) -> bool:
+        return self._response.is_success
+
+    @property
+    def is_error(self) -> bool:
+        return self._response.is_error
+
+    @property
+    def elapsed(self) -> timedelta:
+        return self._response.elapsed
+
+    @property
+    def next_request(self) -> HttpxRequest | None:
+        return self._response.next_request
+
+    @property
+    def stream(self) -> typing.Any:
+        # 'stream' typing is tricky; we leave it at Any as users should consume from the stream
+        # using the provided methods like iter_bytes, iter_lines, iter_text, etc.
+        return self._response.stream
+
+    @property
+    def num_bytes_downloaded(self) -> int:
+        return self._response.num_bytes_downloaded
+
+    def json(self, **kwargs: Any) -> Any:
+        return self._response.json(**kwargs)
+
+    def raise_for_status(self) -> CogniteSDKResponse:
+        """
+        Raises a CogniteHTTPStatusError if the response status code is 4xx or 5xx.
+        If successful (2xx), returns the response object (self) for chaining.
+        """
+        from cognite.client.exceptions import CogniteHTTPStatusError
+
+        try:
+            self._response.raise_for_status()
+            return self
+        except HTTPStatusError as e:
+            message = e.args[0]  # We forward the original error message from httpx which is nice
+            raise CogniteHTTPStatusError(message, request=self.request, response=self) from None
+
+    def iter_bytes(self, chunk_size: int | None = None) -> Iterator[bytes]:
+        return self._response.iter_bytes(chunk_size)
+
+    def read(self) -> bytes:
+        return self._response.read()
+
+    def close(self) -> None:
+        self._response.close()
+
+    async def aread(self) -> bytes:
+        return await self._response.aread()
+
+    async def aclose(self) -> None:
+        await self._response.aclose()

--- a/tests/tests_unit/test_http_client.py
+++ b/tests/tests_unit/test_http_client.py
@@ -19,64 +19,91 @@ def default_config() -> AsyncHTTPClientWithRetryConfig:
     )
 
 
+URL = "https://example.com"
+
+
+def make_http_status_error(status_code: int) -> httpx.HTTPStatusError:
+    request = httpx.Request("GET", URL)
+    response = httpx.Response(status_code=status_code, request=request)
+    return httpx.HTTPStatusError(f"Error {status_code}", request=request, response=response)
+
+
 @pytest.fixture
-def example_error() -> httpx.RequestError:
-    return httpx.RequestError("nice error")
+def timeout_error() -> httpx.TimeoutException:
+    return httpx.ReadTimeout("read timeout")
+
+
+@pytest.fixture
+def connect_error() -> httpx.ConnectError:
+    return httpx.ConnectError("connection error")
+
+
+@pytest.fixture
+def status_error_429() -> httpx.HTTPStatusError:
+    return make_http_status_error(429)
 
 
 class TestRetryTracker:
-    def test_total_retries_exceeded(self, default_config: AsyncHTTPClientWithRetryConfig) -> None:
+    def test_total_retries_exceeded(
+        self, default_config: AsyncHTTPClientWithRetryConfig, status_error_429: httpx.HTTPStatusError
+    ) -> None:
         default_config._max_retries_total = 10
-        rt = RetryTracker(default_config)
+        rt = RetryTracker(URL, default_config)
         rt.status = 4
         rt.connect = 4
         rt.read = 4
 
         assert rt.total == 12
         assert rt.should_retry_total is False
-        assert rt.should_retry_status_code(429) is False
+        assert rt.should_retry_status_code(status_error_429) is False
 
-    def test_status_retries_exceeded(self, default_config: AsyncHTTPClientWithRetryConfig) -> None:
+    def test_status_retries_exceeded(
+        self, default_config: AsyncHTTPClientWithRetryConfig, status_error_429: httpx.HTTPStatusError
+    ) -> None:
         default_config._max_retries_status = 1
-        rt = RetryTracker(default_config)
+        rt = RetryTracker(URL, default_config)
         assert rt.should_retry_total is True
-        assert rt.should_retry_status_code(429) is True
-        assert rt.should_retry_status_code(429) is False
-        assert rt.last_failed_reason == "status_code=429"
+        assert rt.should_retry_status_code(status_error_429) is True
+        assert rt.should_retry_status_code(status_error_429) is False
+        assert rt.last_failed_reason is not None
+        assert "429" in rt.last_failed_reason
 
     def test_read_retries_exceeded(
-        self, default_config: AsyncHTTPClientWithRetryConfig, example_error: httpx.RequestError
+        self, default_config: AsyncHTTPClientWithRetryConfig, timeout_error: httpx.TimeoutException
     ) -> None:
         default_config._max_retries_read = 1
-        rt = RetryTracker(default_config)
-        assert rt.should_retry_timeout(example_error) is True
-        assert rt.should_retry_timeout(example_error) is False
-        assert rt.last_failed_reason == "RequestError"
+        rt = RetryTracker(URL, default_config)
+        assert rt.should_retry_timeout(timeout_error) is True
+        assert rt.should_retry_timeout(timeout_error) is False
+        assert rt.last_failed_reason is not None
+        assert "ReadTimeout" in rt.last_failed_reason
 
     def test_connect_retries_exceeded(
-        self, default_config: AsyncHTTPClientWithRetryConfig, example_error: httpx.RequestError
+        self, default_config: AsyncHTTPClientWithRetryConfig, connect_error: httpx.ConnectError
     ) -> None:
         default_config._max_retries_connect = 1
-        rt = RetryTracker(default_config)
-        assert rt.should_retry_connect_error(example_error) is True
-        assert rt.should_retry_connect_error(example_error) is False
+        rt = RetryTracker(URL, default_config)
+        assert rt.should_retry_connect_error(connect_error) is True
+        assert rt.should_retry_connect_error(connect_error) is False
+        assert rt.last_failed_reason is not None
+        assert "ConnectError" in rt.last_failed_reason
 
     def test_correct_retry_of_status(self, default_config: AsyncHTTPClientWithRetryConfig) -> None:
-        rt = RetryTracker(default_config)
-        assert rt.should_retry_status_code(500) is False
+        rt = RetryTracker(URL, default_config)
+        assert rt.should_retry_status_code(make_http_status_error(500)) is False
         rt.config.status_codes_to_retry.add(500)
-        assert rt.should_retry_status_code(500) is True
+        assert rt.should_retry_status_code(make_http_status_error(500)) is True
 
     def test_get_backoff_time(self, default_config: AsyncHTTPClientWithRetryConfig) -> None:
-        rt = RetryTracker(default_config)
+        rt = RetryTracker(URL, default_config)
         for i in range(10):
             rt.read += 1
             assert 0 <= rt.get_backoff_time() <= default_config.max_backoff_seconds
 
     def test_is_auto_retryable(self, default_config: AsyncHTTPClientWithRetryConfig) -> None:
         default_config._max_retries_status = 1
-        rt = RetryTracker(default_config)
+        rt = RetryTracker(URL, default_config)
 
         # 409 is not in the list of status codes to retry, but we set is_auto_retryable=True, which should override it
-        assert rt.should_retry_status_code(409, is_auto_retryable=True) is True
-        assert rt.should_retry_status_code(409, is_auto_retryable=False) is False
+        assert rt.should_retry_status_code(make_http_status_error(409), is_auto_retryable=True) is True
+        assert rt.should_retry_status_code(make_http_status_error(409), is_auto_retryable=False) is False


### PR DESCRIPTION
## Description

Adds SDK support for the Limits API to query and retrieve limit values from Cognite Data Fusion. 

API Docs: https://api-docs.cognite.com/20230101-alpha/tag/Limits/

**Key Features:**

- Data classes: `LimitValue`, `LimitValueList`, `LimitValueFilter`, `LimitValuePrefixFilter`
- API methods: `list()`, `list_advanced()`, `retrieve()`
- Integrated into `CogniteClient` as `client.limits`
- Uses `cdf-version: 20230101-alpha` header for all requests

## Checklist:
- [X ] Tests added/updated.
- [ X] Documentation updated. Documentation is generated from docstrings - these must be updated according to your change.
  If a new method has been added it should be referenced in [cognite.rst](https://github.com/cognitedata/cognite-sdk-python/blob/master/docs/source/cognite.rst) in order to generate docs based on its docstring.
- [X ] The PR title follows the [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) spec.
