### PR TITLE
fix: re-enables the flaky workflow tests

### DIFF
--- a/tests/tests_integration/test_api/test_workflows.py
+++ b/tests/tests_integration/test_api/test_workflows.py
@@ -335,7 +335,7 @@ def _create_scheduled_trigger(version: WorkflowVersion, cron_expression: str) ->
 @pytest.fixture(scope="class")
 def permanent_scheduled_trigger(
     cognite_client: CogniteClient, permanent_workflow_for_triggers: WorkflowVersion
-) -> WorkflowTrigger:
+) -> Iterator[WorkflowTrigger]:
     version = permanent_workflow_for_triggers
     every_minute_expression = "* * * * *"
 


### PR DESCRIPTION
**Summary**

This PR fixes flaky workflow integration tests that fail when multiple CI runs execute concurrently against a shared environment.

*Root cause*
The test setup cleans up stale resources older than 30 minutes, but it was filtering by `created_time`. A resource created by a parallel run and still actively in use could be old enough by creation time yet still
  needed. Switching to `last_updated_time` ensures resources that are actively being touched by another run are left alone, eliminating the race condition.

*Secondary*
Fix to the same flakiness theme: The trigger fixtures previously had a defensive check-then-act pattern (list all triggers, check if ours exists, create only if missing). This was replaced with a single upsert
  call, which is idempotent and eliminates the TOCTOU race window between the existence check and the create call. This is both simpler and more correct.

*Incidental*
Uncovered while re-enabling a skipped test: The version assertion ("1" vs "v1") was wrong but never caught because the test was permanently skipped. The equality assertion on WorkflowDataModelingTriggerRule was changed to compare serialized .dump() dicts, likely because the server returns additional/normalized fields that cause direct object equality to fail.
