### PR TITLE
docs: add data modelling debugging data classes to the docs

### DIFF
--- a/docs/source/data_modeling.rst
+++ b/docs/source/data_modeling.rst
@@ -319,7 +319,7 @@ Extractor Extensions
     :show-inheritance:
 
 Debugging Data Classes
-------------
+----------------------
 .. automodule:: cognite.client.data_classes.data_modeling.debug
     :members:
     :show-inheritance:


### PR DESCRIPTION
## Description
It is hard to know what the data modelling debugging classes mentioned in the docs are. See example below:
<img width="694" height="388" alt="image" src="https://github.com/user-attachments/assets/c72c7366-251c-45b6-b6b7-57f5e7ca7c73" />

When they are added to the docs, it will be possible to click on them to see their definition:

<img width="1678" height="892" alt="image" src="https://github.com/user-attachments/assets/da901f2f-0283-4769-a8bb-a6f45d58dc11" />


## Checklist:
- [ ] Tests added/updated.
- [x] Documentation updated. Documentation is generated from docstrings - these must be updated according to your change.
  If a new method has been added it should be referenced in [cognite.rst](https://github.com/cognitedata/cognite-sdk-python/blob/master/docs/source/cognite.rst) in order to generate docs based on its docstring.
- [x] The PR title follows the [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) spec.
