### PR TITLE
fix: add last_called to TIME_ATTRIBUTES for datetime rendering

### DIFF
--- a/cognite/client/utils/_time.py
+++ b/cognite/client/utils/_time.py
@@ -293,6 +293,7 @@ TIME_ATTRIBUTES = {
     "deleted_time",
     "end_time",
     "expiration_time",
+    "last_called",
     "last_failure",
     "last_indexed_time",
     "last_seen",

--- a/tests/tests_unit/test_utils/test_time.py
+++ b/tests/tests_unit/test_utils/test_time.py
@@ -335,6 +335,8 @@ class TestObjectTimeConversion:
             ({"simulation_time": 1609459200000}, {"simulation_time": "2021-01-01 00:00:00.000+00:00"}),
             ({"runTime": 1609459200000}, {"runTime": "2021-01-01 00:00:00.000+00:00"}),
             ({"simulationTime": 1609459200000}, {"simulationTime": "2021-01-01 00:00:00.000+00:00"}),
+            ({"last_called": 0}, {"last_called": "1970-01-01 00:00:00.000+00:00"}),
+            ({"lastCalled": 0}, {"lastCalled": "1970-01-01 00:00:00.000+00:00"}),
         ],
     )
     def test_convert_and_isoformat_time_attrs(self, item: dict[str, int], expected_output: dict[str, str]) -> None:


### PR DESCRIPTION
## Summary
- Adds `last_called` to `TIME_ATTRIBUTES` so the field is rendered as a human-readable datetime instead of a raw millisecond timestamp.

Fixes [FUN-795](https://cognitedata.atlassian.net/browse/FUN-795)


[FUN-795]: https://cognitedata.atlassian.net/browse/FUN-795?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ