### PR TITLE
chore: bump requests-oauthlib to v2

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -2604,14 +2604,14 @@ use-chardet-on-py3 = ["chardet (>=3.0.2,<6)"]
 
 [[package]]
 name = "requests-oauthlib"
-version = "1.3.1"
+version = "2.0.0"
 description = "OAuthlib authentication support for Requests."
 optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+python-versions = ">=3.4"
 groups = ["main"]
 files = [
-    {file = "requests-oauthlib-1.3.1.tar.gz", hash = "sha256:75beac4a47881eeb94d5ea5d6ad31ef88856affe2332b9aafb52c6452ccf0d7a"},
-    {file = "requests_oauthlib-1.3.1-py2.py3-none-any.whl", hash = "sha256:2577c501a2fb8d05a304c09d090d6e47c306fef15809d102b327cf8364bddab5"},
+    {file = "requests-oauthlib-2.0.0.tar.gz", hash = "sha256:b3dffaebd884d8cd778494369603a9e7b58d29111bf6b41bdc2dcd87203af4e9"},
+    {file = "requests_oauthlib-2.0.0-py2.py3-none-any.whl", hash = "sha256:7dd8a5c40426b779b0868c404bdef9768deccf22749cde15852df527e6269b36"},
 ]
 
 [package.dependencies]
@@ -3446,4 +3446,4 @@ yaml = ["PyYAML"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.10"
-content-hash = "b468526b4e65f62fb6cc27177f73383467ae274c8831fabd4c84f91b02af0836"
+content-hash = "535e32415817498c724d9809a625ea485c46adc623dc11733f2cefd77e476f4d"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ fixable = ["E", "W", "F", "I", "T", "RUF", "TID", "UP"]
 python = "^3.10"
 
 requests = "^2.27"
-requests_oauthlib = "^1"
+requests_oauthlib = ">=1, <3"
 msal = "^1.31"
 protobuf = ">=4"
 packaging = ">=20"


### PR DESCRIPTION
v2 is pretty old - March 2024, time to upgrade?

https://github.com/requests/requests-oauthlib/milestone/7?closed=1
https://github.com/requests/requests-oauthlib/releases/tag/v2.0.0
