### PR TITLE
feat(signals): Add support for subscribeSignals ACL

### DIFF
--- a/cognite/client/data_classes/capabilities.py
+++ b/cognite/client/data_classes/capabilities.py
@@ -1197,6 +1197,21 @@ class StreamRecordsAcl(Capability):
 
 
 @dataclass
+class SubscribeSignalsAcl(Capability):
+    _capability_name = "subscribeSignalsAcl"
+    actions: Sequence[Action]
+    scope: AllScope | CurrentUserScope
+
+    class Action(Capability.Action):  # type: ignore [misc]
+        Read = "READ"
+        Write = "WRITE"
+
+    class Scope:
+        All = AllScope
+        CurrentUser = CurrentUserScope
+
+
+@dataclass
 class DataModelInstancesAcl(Capability):
     _capability_name = "dataModelInstancesAcl"
     actions: Sequence[Action]

--- a/scripts/toolkit/modules/access/auth/readonly.Group.yaml
+++ b/scripts/toolkit/modules/access/auth/readonly.Group.yaml
@@ -238,6 +238,11 @@ capabilities:
       - READ
       scope:
         all: {}
+  - subscribeSignalsAcl:
+      actions:
+      - READ
+      scope:
+        all: {}
   - templateGroupsAcl:
       actions:
       - READ

--- a/scripts/toolkit/modules/access/auth/readwrite.Group.yaml
+++ b/scripts/toolkit/modules/access/auth/readwrite.Group.yaml
@@ -293,6 +293,12 @@ capabilities:
       - DELETE
       scope:
         all: {}
+  - subscribeSignalsAcl:
+      actions:
+      - WRITE
+      - READ
+      scope:
+        all: {}
   - templateGroupsAcl:
       actions:
       - WRITE

--- a/tests/tests_unit/test_data_classes/test_capabilities.py
+++ b/tests/tests_unit/test_data_classes/test_capabilities.py
@@ -141,6 +141,8 @@ def all_acls():
                 "scope": {"spaceIdScope": {"spaceIds": ["space-1", "space-2", "prod-space"]}},
             }
         },
+        {"subscribeSignalsAcl": {"actions": ["READ", "WRITE"], "scope": {"all": {}}}},
+        {"subscribeSignalsAcl": {"actions": ["READ"], "scope": {"currentuserscope": {}}}},
         {"templateGroupsAcl": {"actions": ["READ", "WRITE"], "scope": {"all": {}}}},
         {"templateGroupsAcl": {"actions": ["READ", "WRITE"], "scope": {"datasetScope": {"ids": ["1", "42"]}}}},
         {"templateInstancesAcl": {"actions": ["READ", "WRITE"], "scope": {"datasetScope": {"ids": ["4", "365"]}}}},


### PR DESCRIPTION
## Description
Adds support for the subscribeSignalsAcl capability in the SDK, aligned with the SubscribeSignals ACL proto (READ/WRITE actions, All and CurrentUser scopes).

## Checklist:
- [x] Tests added/updated.
- [x] Documentation updated. Documentation is generated from docstrings - these must be updated according to your change.
  If a new method has been added it should be referenced in [cognite.rst](https://github.com/cognitedata/cognite-sdk-python/blob/master/docs/source/cognite.rst) in order to generate docs based on its docstring.
- [x] The PR title follows the [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) spec.
