### PR TITLE
feat: add support for the Streams API

### DIFF
--- a/cognite/client/_api/data_modeling/__init__.py
+++ b/cognite/client/_api/data_modeling/__init__.py
@@ -9,6 +9,7 @@ from cognite.client._api.data_modeling.graphql import DataModelingGraphQLAPI
 from cognite.client._api.data_modeling.instances import InstancesAPI
 from cognite.client._api.data_modeling.spaces import SpacesAPI
 from cognite.client._api.data_modeling.statistics import StatisticsAPI
+from cognite.client._api.data_modeling.streams import StreamsAPI
 from cognite.client._api.data_modeling.views import ViewsAPI
 from cognite.client._api_client import APIClient
 
@@ -27,6 +28,7 @@ class DataModelingAPI(APIClient):
         self.instances = InstancesAPI(config, api_version, cognite_client)
         self.graphql = DataModelingGraphQLAPI(config, api_version, cognite_client)
         self.statistics = StatisticsAPI(config, api_version, cognite_client)
+        self.streams = StreamsAPI(config, api_version, cognite_client)
 
     def _get_semaphore(
         self, operation: Literal["read", "write", "delete", "search", "read_schema", "write_schema"]

--- a/cognite/client/_api/data_modeling/streams.py
+++ b/cognite/client/_api/data_modeling/streams.py
@@ -52,7 +52,9 @@ class StreamsAPI(APIClient):
 
             Retrieve a stream with statistics:
 
-                >>> res = client.data_modeling.streams.retrieve(external_id="my_stream", include_statistics=True)
+                >>> res = client.data_modeling.streams.retrieve(
+                ...     external_id="my_stream", include_statistics=True
+                ... )
 
         """
         self._warning.warn()
@@ -111,7 +113,7 @@ class StreamsAPI(APIClient):
             Iterate over the returned list:
 
                 >>> for stream in stream_list:
-                ...     stream # do something with the stream
+                ...     stream  # do something with the stream
         """
         self._warning.warn()
         return await self._list(
@@ -136,12 +138,15 @@ class StreamsAPI(APIClient):
             Create a new stream:
 
                 >>> from cognite.client import CogniteClient, AsyncCogniteClient
-                >>> from cognite.client.data_classes.data_modeling import StreamWrite, StreamWriteSettings
+                >>> from cognite.client.data_classes.data_modeling import (
+                ...     StreamWrite,
+                ...     StreamWriteSettings,
+                ... )
                 >>> client = CogniteClient()
                 >>> # async_client = AsyncCogniteClient()  # another option
                 >>> stream = StreamWrite(
                 ...     external_id="my_stream",
-                ...     settings=StreamWriteSettings(template_name="ImmutableTestStream")
+                ...     settings=StreamWriteSettings(template_name="ImmutableTestStream"),
                 ... )
                 >>> res = client.data_modeling.streams.create(stream)
         """

--- a/cognite/client/_api/data_modeling/streams.py
+++ b/cognite/client/_api/data_modeling/streams.py
@@ -1,0 +1,155 @@
+from __future__ import annotations
+
+import asyncio
+from typing import TYPE_CHECKING, Literal
+
+from cognite.client._api_client import APIClient
+from cognite.client.data_classes.data_modeling.streams import Stream, StreamList, StreamWrite
+from cognite.client.exceptions import CogniteAPIError
+from cognite.client.utils._experimental import FeaturePreviewWarning
+
+if TYPE_CHECKING:
+    from cognite.client import AsyncCogniteClient
+    from cognite.client.config import ClientConfig
+
+
+class StreamsAPI(APIClient):
+    _RESOURCE_PATH = "/streams"
+
+    def __init__(self, config: ClientConfig, api_version: str | None, cognite_client: AsyncCogniteClient) -> None:
+        super().__init__(config, api_version, cognite_client)
+        self._CREATE_LIMIT = 1
+        self._warning = FeaturePreviewWarning(
+            api_maturity="General Availability", sdk_maturity="alpha", feature_name="Streams API"
+        )
+
+    def _get_semaphore(self, operation: Literal["read", "write", "delete"]) -> asyncio.BoundedSemaphore:
+        from cognite.client import global_config
+
+        assert operation not in ("read_schema", "write_schema"), "Streams API should not use schema semaphores"
+        return global_config.concurrency_settings.data_modeling._semaphore_factory(
+            operation, project=self._cognite_client.config.project
+        )
+
+    async def retrieve(self, external_id: str, include_statistics: bool = False) -> Stream | None:
+        """`Retrieve a stream by external ID. <https://api-docs.cognite.com/20230101/tag/Streams/operation/getStream>`_
+
+        Args:
+            external_id (str): Stream external ID
+            include_statistics (bool): If set to True, usage statistics will be returned together with stream settings. Defaults to False.
+
+        Returns:
+            Stream | None: Requested stream or None if it does not exist.
+
+        Examples:
+
+            Retrieve a single stream by external id:
+
+                >>> from cognite.client import CogniteClient, AsyncCogniteClient
+                >>> client = CogniteClient()
+                >>> # async_client = AsyncCogniteClient()  # another option
+                >>> res = client.data_modeling.streams.retrieve(external_id="my_stream")
+
+            Retrieve a stream with statistics:
+
+                >>> res = client.data_modeling.streams.retrieve(external_id="my_stream", include_statistics=True)
+
+        """
+        self._warning.warn()
+        params = {"includeStatistics": "true"} if include_statistics else None
+        try:
+            result = await self._get(
+                url_path=f"{self._RESOURCE_PATH}/{external_id}",
+                params=params,
+                semaphore=self._get_semaphore("read"),
+            )
+            return Stream._load(result.json())
+        except CogniteAPIError as e:
+            if e.code == 404:
+                return None
+            raise
+
+    async def delete(self, external_id: str) -> None:
+        """`Delete a stream <https://api-docs.cognite.com/20230101/tag/Streams/operation/deleteStreams>`_
+
+        Args:
+            external_id (str): External ID of stream.
+
+        Examples:
+
+            Delete a stream by external id:
+
+                >>> from cognite.client import CogniteClient, AsyncCogniteClient
+                >>> client = CogniteClient()
+                >>> # async_client = AsyncCogniteClient()  # another option
+                >>> client.data_modeling.streams.delete(external_id="my_stream")
+        """
+        self._warning.warn()
+        await self._post(
+            url_path=f"{self._RESOURCE_PATH}/delete",
+            json={"items": [{"externalId": external_id}]},
+            semaphore=self._get_semaphore("write"),
+        )
+
+    async def list(self) -> StreamList:
+        """`List streams <https://api-docs.cognite.com/20230101/tag/Streams/operation/listStreams>`_
+
+        Returns all streams available in the project.
+
+        Returns:
+            StreamList: List of all streams in the project
+
+        Examples:
+
+            List all streams:
+
+                >>> from cognite.client import CogniteClient, AsyncCogniteClient
+                >>> client = CogniteClient()
+                >>> # async_client = AsyncCogniteClient()  # another option
+                >>> stream_list = client.data_modeling.streams.list()
+
+            Iterate over the returned list:
+
+                >>> for stream in stream_list:
+                ...     stream # do something with the stream
+        """
+        self._warning.warn()
+        return await self._list(
+            list_cls=StreamList,
+            resource_cls=Stream,
+            method="GET",
+            limit=None,
+            override_semaphore=self._get_semaphore("read"),
+        )
+
+    async def create(self, stream: StreamWrite) -> Stream:
+        """`Create a stream. <https://api-docs.cognite.com/20230101/tag/Streams/operation/createStream>`_
+
+        Args:
+            stream (StreamWrite): Stream to create.
+
+        Returns:
+            Stream: Created stream
+
+        Examples:
+
+            Create a new stream:
+
+                >>> from cognite.client import CogniteClient, AsyncCogniteClient
+                >>> from cognite.client.data_classes.data_modeling import StreamWrite, StreamWriteSettings
+                >>> client = CogniteClient()
+                >>> # async_client = AsyncCogniteClient()  # another option
+                >>> stream = StreamWrite(
+                ...     external_id="my_stream",
+                ...     settings=StreamWriteSettings(template_name="ImmutableTestStream")
+                ... )
+                >>> res = client.data_modeling.streams.create(stream)
+        """
+        self._warning.warn()
+        return await self._create_multiple(
+            list_cls=StreamList,
+            resource_cls=Stream,
+            items=stream,
+            input_resource_cls=StreamWrite,
+            override_semaphore=self._get_semaphore("write"),
+        )

--- a/cognite/client/_sync_api/data_modeling/__init__.py
+++ b/cognite/client/_sync_api/data_modeling/__init__.py
@@ -1,6 +1,6 @@
 """
 ===============================================================================
-c76b2b9351d2a5eee6a710fa9893bfa4
+584030bc5e2a4b8168f54c101f7f521d
 This file is auto-generated from the Async API modules, - do not edit manually!
 ===============================================================================
 """
@@ -9,13 +9,13 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from cognite.client import AsyncCogniteClient
 from cognite.client._sync_api.data_modeling.containers import SyncContainersAPI
 from cognite.client._sync_api.data_modeling.data_models import SyncDataModelsAPI
 from cognite.client._sync_api.data_modeling.graphql import SyncDataModelingGraphQLAPI
 from cognite.client._sync_api.data_modeling.instances import SyncInstancesAPI
 from cognite.client._sync_api.data_modeling.spaces import SyncSpacesAPI
 from cognite.client._sync_api.data_modeling.statistics import SyncStatisticsAPI
+from cognite.client._sync_api.data_modeling.streams import SyncStreamsAPI
 from cognite.client._sync_api.data_modeling.views import SyncViewsAPI
 from cognite.client._sync_api_client import SyncAPIClient
 
@@ -35,3 +35,4 @@ class SyncDataModelingAPI(SyncAPIClient):
         self.instances = SyncInstancesAPI(async_client)
         self.graphql = SyncDataModelingGraphQLAPI(async_client)
         self.statistics = SyncStatisticsAPI(async_client)
+        self.streams = SyncStreamsAPI(async_client)

--- a/cognite/client/_sync_api/data_modeling/streams.py
+++ b/cognite/client/_sync_api/data_modeling/streams.py
@@ -1,6 +1,6 @@
 """
 ===============================================================================
-2e0c9681af3470230fe060510b978d92
+d5cc9b88dcf564328fbb78370c32cab7
 This file is auto-generated from the Async API modules, - do not edit manually!
 ===============================================================================
 """
@@ -46,7 +46,9 @@ class SyncStreamsAPI(SyncAPIClient):
 
             Retrieve a stream with statistics:
 
-                >>> res = client.data_modeling.streams.retrieve(external_id="my_stream", include_statistics=True)
+                >>> res = client.data_modeling.streams.retrieve(
+                ...     external_id="my_stream", include_statistics=True
+                ... )
         """
         return run_sync(
             self.__async_client.data_modeling.streams.retrieve(
@@ -93,7 +95,7 @@ class SyncStreamsAPI(SyncAPIClient):
             Iterate over the returned list:
 
                 >>> for stream in stream_list:
-                ...     stream # do something with the stream
+                ...     stream  # do something with the stream
         """
         return run_sync(self.__async_client.data_modeling.streams.list())
 
@@ -112,12 +114,15 @@ class SyncStreamsAPI(SyncAPIClient):
             Create a new stream:
 
                 >>> from cognite.client import CogniteClient, AsyncCogniteClient
-                >>> from cognite.client.data_classes.data_modeling import StreamWrite, StreamWriteSettings
+                >>> from cognite.client.data_classes.data_modeling import (
+                ...     StreamWrite,
+                ...     StreamWriteSettings,
+                ... )
                 >>> client = CogniteClient()
                 >>> # async_client = AsyncCogniteClient()  # another option
                 >>> stream = StreamWrite(
                 ...     external_id="my_stream",
-                ...     settings=StreamWriteSettings(template_name="ImmutableTestStream")
+                ...     settings=StreamWriteSettings(template_name="ImmutableTestStream"),
                 ... )
                 >>> res = client.data_modeling.streams.create(stream)
         """

--- a/cognite/client/_sync_api/data_modeling/streams.py
+++ b/cognite/client/_sync_api/data_modeling/streams.py
@@ -1,0 +1,124 @@
+"""
+===============================================================================
+2e0c9681af3470230fe060510b978d92
+This file is auto-generated from the Async API modules, - do not edit manually!
+===============================================================================
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from cognite.client import AsyncCogniteClient
+from cognite.client._sync_api_client import SyncAPIClient
+from cognite.client.data_classes.data_modeling.streams import Stream, StreamList, StreamWrite
+from cognite.client.utils._async_helpers import run_sync
+
+if TYPE_CHECKING:
+    from cognite.client import AsyncCogniteClient
+
+
+class SyncStreamsAPI(SyncAPIClient):
+    """Auto-generated, do not modify manually."""
+
+    def __init__(self, async_client: AsyncCogniteClient) -> None:
+        self.__async_client = async_client
+
+    def retrieve(self, external_id: str, include_statistics: bool = False) -> Stream | None:
+        """
+        `Retrieve a stream by external ID. <https://api-docs.cognite.com/20230101/tag/Streams/operation/getStream>`_
+
+        Args:
+            external_id (str): Stream external ID
+            include_statistics (bool): If set to True, usage statistics will be returned together with stream settings. Defaults to False.
+
+        Returns:
+            Stream | None: Requested stream or None if it does not exist.
+
+        Examples:
+
+            Retrieve a single stream by external id:
+
+                >>> from cognite.client import CogniteClient, AsyncCogniteClient
+                >>> client = CogniteClient()
+                >>> # async_client = AsyncCogniteClient()  # another option
+                >>> res = client.data_modeling.streams.retrieve(external_id="my_stream")
+
+            Retrieve a stream with statistics:
+
+                >>> res = client.data_modeling.streams.retrieve(external_id="my_stream", include_statistics=True)
+        """
+        return run_sync(
+            self.__async_client.data_modeling.streams.retrieve(
+                external_id=external_id, include_statistics=include_statistics
+            )
+        )
+
+    def delete(self, external_id: str) -> None:
+        """
+        `Delete a stream <https://api-docs.cognite.com/20230101/tag/Streams/operation/deleteStreams>`_
+
+        Args:
+            external_id (str): External ID of stream.
+
+        Examples:
+
+            Delete a stream by external id:
+
+                >>> from cognite.client import CogniteClient, AsyncCogniteClient
+                >>> client = CogniteClient()
+                >>> # async_client = AsyncCogniteClient()  # another option
+                >>> client.data_modeling.streams.delete(external_id="my_stream")
+        """
+        return run_sync(self.__async_client.data_modeling.streams.delete(external_id=external_id))
+
+    def list(self) -> StreamList:
+        """
+        `List streams <https://api-docs.cognite.com/20230101/tag/Streams/operation/listStreams>`_
+
+        Returns all streams available in the project.
+
+        Returns:
+            StreamList: List of all streams in the project
+
+        Examples:
+
+            List all streams:
+
+                >>> from cognite.client import CogniteClient, AsyncCogniteClient
+                >>> client = CogniteClient()
+                >>> # async_client = AsyncCogniteClient()  # another option
+                >>> stream_list = client.data_modeling.streams.list()
+
+            Iterate over the returned list:
+
+                >>> for stream in stream_list:
+                ...     stream # do something with the stream
+        """
+        return run_sync(self.__async_client.data_modeling.streams.list())
+
+    def create(self, stream: StreamWrite) -> Stream:
+        """
+        `Create a stream. <https://api-docs.cognite.com/20230101/tag/Streams/operation/createStream>`_
+
+        Args:
+            stream (StreamWrite): Stream to create.
+
+        Returns:
+            Stream: Created stream
+
+        Examples:
+
+            Create a new stream:
+
+                >>> from cognite.client import CogniteClient, AsyncCogniteClient
+                >>> from cognite.client.data_classes.data_modeling import StreamWrite, StreamWriteSettings
+                >>> client = CogniteClient()
+                >>> # async_client = AsyncCogniteClient()  # another option
+                >>> stream = StreamWrite(
+                ...     external_id="my_stream",
+                ...     settings=StreamWriteSettings(template_name="ImmutableTestStream")
+                ... )
+                >>> res = client.data_modeling.streams.create(stream)
+        """
+        return run_sync(self.__async_client.data_modeling.streams.create(stream=stream))

--- a/cognite/client/data_classes/data_modeling/__init__.py
+++ b/cognite/client/data_classes/data_modeling/__init__.py
@@ -114,6 +114,17 @@ from cognite.client.data_classes.data_modeling.query import (
     UnionAll,
 )
 from cognite.client.data_classes.data_modeling.spaces import Space, SpaceApply, SpaceApplyList, SpaceList
+from cognite.client.data_classes.data_modeling.streams import (
+    Stream,
+    StreamLifecycleSettings,
+    StreamLimit,
+    StreamLimitSettings,
+    StreamList,
+    StreamSettings,
+    StreamWrite,
+    StreamWriteList,
+    StreamWriteSettings,
+)
 from cognite.client.data_classes.data_modeling.sync import SubscriptionContext
 from cognite.client.data_classes.data_modeling.views import (
     ConnectionDefinition,
@@ -233,6 +244,15 @@ __all__ = [
     "SpaceApply",
     "SpaceApplyList",
     "SpaceList",
+    "Stream",
+    "StreamLifecycleSettings",
+    "StreamLimit",
+    "StreamLimitSettings",
+    "StreamList",
+    "StreamSettings",
+    "StreamWrite",
+    "StreamWriteList",
+    "StreamWriteSettings",
     "SubscriptionContext",
     "Text",
     "TimeSeriesReference",

--- a/cognite/client/data_classes/data_modeling/streams.py
+++ b/cognite/client/data_classes/data_modeling/streams.py
@@ -1,0 +1,272 @@
+from __future__ import annotations
+
+from typing import Any, Literal
+
+from typing_extensions import Self
+
+from cognite.client.data_classes._base import (
+    CogniteResource,
+    CogniteResourceList,
+    WriteableCogniteResource,
+    WriteableCogniteResourceList,
+)
+from cognite.client.utils._text import convert_all_keys_to_camel_case
+
+
+class StreamWriteSettings(CogniteResource):
+    """Settings for creating a stream.
+
+    Args:
+        template_name (str): The name of the stream template. Templates are project-specific and should be retrieved from your CDF project configuration.
+    """
+
+    def __init__(self, template_name: str) -> None:
+        self.template_name = template_name
+
+    @classmethod
+    def _load(cls, resource: dict[str, Any]) -> Self:
+        return cls(template_name=resource["template"]["name"])
+
+    def dump(self, camel_case: bool = True) -> dict[str, Any]:
+        return {"template": {"name": self.template_name}}
+
+
+class StreamLimit(CogniteResource):
+    """Limit settings for a stream resource.
+
+    Args:
+        provisioned (float): Amount of resource provisioned.
+        consumed (float | None): Amount of resource consumed. Only returned when include_statistics=True.
+    """
+
+    def __init__(self, provisioned: float, consumed: float | None = None) -> None:
+        self.provisioned = provisioned
+        self.consumed = consumed
+
+    @classmethod
+    def _load(cls, resource: dict[str, Any]) -> Self:
+        return cls(provisioned=resource["provisioned"], consumed=resource.get("consumed"))
+
+    def dump(self, camel_case: bool = True) -> dict[str, Any]:
+        dumped: dict[str, Any] = {"provisioned": self.provisioned}
+        if self.consumed is not None:
+            dumped["consumed"] = self.consumed
+        return dumped
+
+
+class StreamLifecycleSettings(CogniteResource):
+    """Lifecycle settings for a stream.
+
+    These settings are populated from the stream creation template and cannot be changed.
+
+    Args:
+        retained_after_soft_delete (str): Time until soft-deleted stream is actually deleted, in ISO-8601 format.
+        data_deleted_after (str | None): Time after which records are scheduled for deletion, in ISO-8601 format. Only for immutable streams.
+    """
+
+    def __init__(
+        self,
+        retained_after_soft_delete: str,
+        data_deleted_after: str | None = None,
+    ) -> None:
+        self.retained_after_soft_delete = retained_after_soft_delete
+        self.data_deleted_after = data_deleted_after
+
+    @classmethod
+    def _load(cls, resource: dict[str, Any]) -> Self:
+        return cls(
+            retained_after_soft_delete=resource["retainedAfterSoftDelete"],
+            data_deleted_after=resource.get("dataDeletedAfter"),
+        )
+
+    def dump(self, camel_case: bool = True) -> dict[str, Any]:
+        dumped: dict[str, Any] = {"retained_after_soft_delete": self.retained_after_soft_delete}
+        if self.data_deleted_after is not None:
+            dumped["data_deleted_after"] = self.data_deleted_after
+        if camel_case:
+            return convert_all_keys_to_camel_case(dumped)
+        return dumped
+
+
+class StreamLimitSettings(CogniteResource):
+    """Limit settings for a stream.
+
+    Args:
+        max_records_total (StreamLimit): Maximum number of records that can be stored.
+        max_giga_bytes_total (StreamLimit): Maximum amount of data in gigabytes.
+        max_filtering_interval (str | None): Maximum time range for lastUpdatedTime filter, in ISO-8601 format. Only for immutable streams.
+    """
+
+    def __init__(
+        self,
+        max_records_total: StreamLimit,
+        max_giga_bytes_total: StreamLimit,
+        max_filtering_interval: str | None = None,
+    ) -> None:
+        self.max_records_total = max_records_total
+        self.max_giga_bytes_total = max_giga_bytes_total
+        self.max_filtering_interval = max_filtering_interval
+
+    @classmethod
+    def _load(cls, resource: dict[str, Any]) -> Self:
+        return cls(
+            max_records_total=StreamLimit._load(resource["maxRecordsTotal"]),
+            max_giga_bytes_total=StreamLimit._load(resource["maxGigaBytesTotal"]),
+            max_filtering_interval=resource.get("maxFilteringInterval"),
+        )
+
+    def dump(self, camel_case: bool = True) -> dict[str, Any]:
+        dumped: dict[str, Any] = {
+            "max_records_total": self.max_records_total.dump(camel_case),
+            "max_giga_bytes_total": self.max_giga_bytes_total.dump(camel_case),
+        }
+        if self.max_filtering_interval is not None:
+            dumped["max_filtering_interval"] = self.max_filtering_interval
+        if camel_case:
+            return convert_all_keys_to_camel_case(dumped)
+        return dumped
+
+
+class StreamSettings(CogniteResource):
+    """Response settings for a stream.
+
+    These are read-only settings returned when retrieving a stream.
+
+    Args:
+        lifecycle (StreamLifecycleSettings): Lifecycle settings.
+        limits (StreamLimitSettings): Limit settings.
+    """
+
+    def __init__(self, lifecycle: StreamLifecycleSettings, limits: StreamLimitSettings) -> None:
+        self.lifecycle = lifecycle
+        self.limits = limits
+
+    @classmethod
+    def _load(cls, resource: dict[str, Any]) -> Self:
+        return cls(
+            lifecycle=StreamLifecycleSettings._load(resource["lifecycle"]),
+            limits=StreamLimitSettings._load(resource["limits"]),
+        )
+
+    def dump(self, camel_case: bool = True) -> dict[str, Any]:
+        return {
+            "lifecycle": self.lifecycle.dump(camel_case),
+            "limits": self.limits.dump(camel_case),
+        }
+
+
+class StreamWrite(WriteableCogniteResource["StreamWrite"]):
+    """A stream for data ingestion. This is the write version.
+
+    Args:
+        external_id (str): A unique identifier for the stream.
+        settings (StreamWriteSettings): The settings for the stream, including the template.
+    """
+
+    def __init__(self, external_id: str, settings: StreamWriteSettings) -> None:
+        self.external_id = external_id
+        self.settings = settings
+
+    @classmethod
+    def _load(cls, resource: dict[str, Any]) -> Self:
+        return cls(
+            external_id=resource["externalId"],
+            settings=StreamWriteSettings._load(resource["settings"]),
+        )
+
+    def dump(self, camel_case: bool = True) -> dict[str, Any]:
+        dumped: dict[str, Any] = {
+            "external_id": self.external_id,
+            "settings": self.settings.dump(camel_case=camel_case),
+        }
+        if camel_case:
+            return convert_all_keys_to_camel_case(dumped)
+        return dumped
+
+    def as_write(self) -> StreamWrite:
+        """Returns this StreamWrite instance."""
+        return self
+
+
+class Stream(WriteableCogniteResource["StreamWrite"]):
+    """A stream for data ingestion. Streams are immutable after creation and cannot be updated.
+
+    Args:
+        external_id (str): A unique identifier for the stream.
+        created_time (int): The number of milliseconds since 00:00:00 Thursday, 1 January 1970, Coordinated Universal Time (UTC), minus leap seconds.
+        type (Literal['Immutable', 'Mutable']): The type of the stream.
+        created_from_template (str): The template the stream was created from.
+        settings (StreamSettings): The stream settings including lifecycle and limits.
+    """
+
+    def __init__(
+        self,
+        external_id: str,
+        created_time: int,
+        type: Literal["Immutable", "Mutable"],
+        created_from_template: str,
+        settings: StreamSettings,
+    ) -> None:
+        self.external_id = external_id
+        self.created_time = created_time
+        self.type = type
+        self.created_from_template = created_from_template
+        self.settings = settings
+
+    @classmethod
+    def _load(cls, resource: dict[str, Any]) -> Self:
+        return cls(
+            external_id=resource["externalId"],
+            created_time=resource["createdTime"],
+            type=resource["type"],
+            created_from_template=resource["createdFromTemplate"],
+            settings=StreamSettings._load(resource["settings"]),
+        )
+
+    def dump(self, camel_case: bool = True) -> dict[str, Any]:
+        dumped: dict[str, Any] = {
+            "external_id": self.external_id,
+            "created_time": self.created_time,
+            "type": self.type,
+            "created_from_template": self.created_from_template,
+            "settings": self.settings.dump(camel_case),
+        }
+        if camel_case:
+            return convert_all_keys_to_camel_case(dumped)
+        return dumped
+
+    def as_write(self) -> StreamWrite:
+        """Returns a StreamWrite object with the same external_id and template.
+
+        Note: Since streams are immutable and cannot be updated, this method creates
+        a StreamWrite suitable for creating a NEW stream with the same template settings,
+        not for updating the existing stream. To create a new stream, you must provide
+        a different external_id.
+
+        Returns:
+            StreamWrite: A write object based on this stream's template.
+        """
+        return StreamWrite(
+            external_id=self.external_id,
+            settings=StreamWriteSettings(template_name=self.created_from_template),
+        )
+
+
+class StreamWriteList(CogniteResourceList[StreamWrite]):
+    _RESOURCE = StreamWrite
+
+
+class StreamList(WriteableCogniteResourceList[StreamWrite, Stream]):
+    _RESOURCE = Stream
+
+    def as_ids(self) -> list[str]:
+        """
+        Converts all the streams to a stream id list.
+
+        Returns:
+            list[str]: A list of stream ids.
+        """
+        return [item.external_id for item in self]
+
+    def as_write(self) -> StreamWriteList:
+        return StreamWriteList([item.as_write() for item in self])

--- a/cognite/client/data_classes/data_modeling/streams.py
+++ b/cognite/client/data_classes/data_modeling/streams.py
@@ -17,7 +17,7 @@ class StreamWriteSettings(CogniteResource):
     """Settings for creating a stream.
 
     Args:
-        template_name (str): The name of the stream template. Templates are project-specific and should be retrieved from your CDF project configuration.
+        template_name (str): The name of the stream template which should be used to define initial settings for the stream.
     """
 
     def __init__(self, template_name: str) -> None:
@@ -160,7 +160,7 @@ class StreamWrite(WriteableCogniteResource["StreamWrite"]):
 
     Args:
         external_id (str): A unique identifier for the stream.
-        settings (StreamWriteSettings): The settings for the stream, including the template.
+        settings (StreamWriteSettings): The settings for the stream.
     """
 
     def __init__(self, external_id: str, settings: StreamWriteSettings) -> None:
@@ -237,11 +237,6 @@ class Stream(WriteableCogniteResource["StreamWrite"]):
 
     def as_write(self) -> StreamWrite:
         """Returns a StreamWrite object with the same external_id and template.
-
-        Note: Since streams are immutable and cannot be updated, this method creates
-        a StreamWrite suitable for creating a NEW stream with the same template settings,
-        not for updating the existing stream. To create a new stream, you must provide
-        a different external_id.
 
         Returns:
             StreamWrite: A write object based on this stream's template.

--- a/cognite/client/testing.py
+++ b/cognite/client/testing.py
@@ -20,6 +20,7 @@ from cognite.client._api.data_modeling.instances import InstancesAPI
 from cognite.client._api.data_modeling.space_statistics import SpaceStatisticsAPI
 from cognite.client._api.data_modeling.spaces import SpacesAPI
 from cognite.client._api.data_modeling.statistics import StatisticsAPI
+from cognite.client._api.data_modeling.streams import StreamsAPI
 from cognite.client._api.data_modeling.views import ViewsAPI
 from cognite.client._api.data_sets import DataSetsAPI
 from cognite.client._api.datapoints import DatapointsAPI
@@ -103,6 +104,7 @@ from cognite.client._sync_api.data_modeling.instances import SyncInstancesAPI
 from cognite.client._sync_api.data_modeling.space_statistics import SyncSpaceStatisticsAPI
 from cognite.client._sync_api.data_modeling.spaces import SyncSpacesAPI
 from cognite.client._sync_api.data_modeling.statistics import SyncStatisticsAPI
+from cognite.client._sync_api.data_modeling.streams import SyncStreamsAPI
 from cognite.client._sync_api.data_modeling.views import SyncViewsAPI
 from cognite.client._sync_api.data_sets import SyncDataSetsAPI
 from cognite.client._sync_api.datapoints import SyncDatapointsAPI
@@ -224,6 +226,7 @@ class AsyncCogniteClientMock(MagicMock, metaclass=_SpecSetEnforcer):
         dm_views = create_autospec(ViewsAPI, instance=True, spec_set=True)
         dm_instances = create_autospec(InstancesAPI, instance=True, spec_set=True)
         dm_graphql = create_autospec(DataModelingGraphQLAPI, instance=True, spec_set=True)
+        dm_streams = create_autospec(StreamsAPI, instance=True, spec_set=True)
         self.data_modeling = create_autospec(
             DataModelingAPI,
             instance=True,
@@ -234,6 +237,7 @@ class AsyncCogniteClientMock(MagicMock, metaclass=_SpecSetEnforcer):
             instances=dm_instances,
             graphql=dm_graphql,
             statistics=dm_statistics,
+            streams=dm_streams,
         )
         flip_spec_set_on(self.data_modeling, dm_statistics)
 
@@ -423,6 +427,7 @@ class CogniteClientMock(MagicMock, metaclass=_SpecSetEnforcer):
         dm_views = create_autospec(SyncViewsAPI, instance=True, spec_set=True)
         dm_instances = create_autospec(SyncInstancesAPI, instance=True, spec_set=True)
         dm_graphql = create_autospec(SyncDataModelingGraphQLAPI, instance=True, spec_set=True)
+        dm_streams = create_autospec(SyncStreamsAPI, instance=True, spec_set=True)
         self.data_modeling = create_autospec(
             SyncDataModelingAPI,
             instance=True,
@@ -433,6 +438,7 @@ class CogniteClientMock(MagicMock, metaclass=_SpecSetEnforcer):
             instances=dm_instances,
             graphql=dm_graphql,
             statistics=dm_statistics,
+            streams=dm_streams,
         )
         flip_spec_set_on(self.data_modeling, dm_statistics)
 

--- a/cognite/client/utils/_url.py
+++ b/cognite/client/utils/_url.py
@@ -39,6 +39,7 @@ NON_RETRYABLE_CREATE_DELETE_RESOURCE_PATHS: tuple[str, ...] = (
     "simulators/models/revisions",
     "simulators/models/routines",
     "simulators/models/routines/revisions",
+    "streams",
     "timeseries",
     "transformations",
     "transformations/schedules",

--- a/docs/source/data_modeling.rst
+++ b/docs/source/data_modeling.rst
@@ -359,6 +359,30 @@ Data modeling statistics data classes
     :members:
     :show-inheritance:
 
+Streams
+-------
+Create a stream
+^^^^^^^^^^^^^^^^
+.. automethod:: cognite.client._api.data_modeling.streams.StreamsAPI.create
+
+Retrieve a stream
+^^^^^^^^^^^^^^^^^^
+.. automethod:: cognite.client._api.data_modeling.streams.StreamsAPI.retrieve
+
+List streams
+^^^^^^^^^^^^^
+.. automethod:: cognite.client._api.data_modeling.streams.StreamsAPI.list
+
+Delete a stream
+^^^^^^^^^^^^^^^^
+.. automethod:: cognite.client._api.data_modeling.streams.StreamsAPI.delete
+
+Streams data classes
+^^^^^^^^^^^^^^^^^^^^^
+.. automodule:: cognite.client.data_classes.data_modeling.streams
+    :members:
+    :show-inheritance:
+
 GraphQL
 -------
 Apply DML

--- a/tests/tests_integration/test_api/test_data_modeling/conftest.py
+++ b/tests/tests_integration/test_api/test_data_modeling/conftest.py
@@ -19,6 +19,9 @@ from cognite.client.data_classes.data_modeling import (
     SingleHopConnectionDefinition,
     Space,
     SpaceApply,
+    Stream,
+    StreamWrite,
+    StreamWriteSettings,
     View,
     ViewApply,
     ViewList,
@@ -43,6 +46,32 @@ def integration_test_space(cognite_client: CogniteClient) -> Space:
         return space
     new_space = SpaceApply(space_id, name="Integration Test Space", description="The space used for integration tests.")
     return cognite_client.data_modeling.spaces.apply(new_space)
+
+
+@pytest.fixture(scope="session")
+def immutable_test_stream(cognite_client: CogniteClient) -> Stream:
+    stream_id = "sdk_test_immutable_stream"
+    stream = cognite_client.data_modeling.streams.retrieve(stream_id)
+    if stream is not None:
+        return stream
+    new_stream = StreamWrite(
+        external_id=stream_id,
+        settings=StreamWriteSettings(template_name="ImmutableTestStream"),
+    )
+    return cognite_client.data_modeling.streams.create(new_stream)
+
+
+@pytest.fixture(scope="session")
+def mutable_test_stream(cognite_client: CogniteClient) -> Stream:
+    stream_id = "sdk_test_mutable_stream"
+    stream = cognite_client.data_modeling.streams.retrieve(stream_id)
+    if stream is not None:
+        return stream
+    new_stream = StreamWrite(
+        external_id=stream_id,
+        settings=StreamWriteSettings(template_name="BasicLiveData"),
+    )
+    return cognite_client.data_modeling.streams.create(new_stream)
 
 
 @pytest.fixture(scope="session")

--- a/tests/tests_integration/test_api/test_data_modeling/test_streams.py
+++ b/tests/tests_integration/test_api/test_data_modeling/test_streams.py
@@ -1,0 +1,54 @@
+import pytest
+
+from cognite.client import CogniteClient
+from cognite.client.data_classes.data_modeling import Stream, StreamList, StreamWrite
+
+
+class TestStreams:
+    @pytest.mark.usefixtures("immutable_test_stream", "mutable_test_stream")
+    def test_list_streams(self, cognite_client: CogniteClient) -> None:
+        streams = cognite_client.data_modeling.streams.list()
+        assert isinstance(streams, StreamList)
+        assert len(streams) > 0
+
+        stream_ids = {s.external_id for s in streams}
+        assert "sdk_test_immutable_stream" in stream_ids
+        assert "sdk_test_mutable_stream" in stream_ids
+
+    def test_retrieve_stream(self, cognite_client: CogniteClient, immutable_test_stream: Stream) -> None:
+        retrieved = cognite_client.data_modeling.streams.retrieve(immutable_test_stream.external_id)
+
+        assert retrieved is not None
+        assert isinstance(retrieved, Stream)
+        assert retrieved.external_id == immutable_test_stream.external_id
+        assert retrieved.created_time > 0
+        assert retrieved.type == "Immutable"
+        assert retrieved.settings.limits.max_records_total.provisioned >= 0
+        assert retrieved.settings.limits.max_records_total.consumed is None
+
+    def test_retrieve_stream_with_statistics(self, cognite_client: CogniteClient, mutable_test_stream: Stream) -> None:
+        retrieved = cognite_client.data_modeling.streams.retrieve(
+            mutable_test_stream.external_id, include_statistics=True
+        )
+
+        assert retrieved is not None
+        assert isinstance(retrieved, Stream)
+        assert retrieved.external_id == mutable_test_stream.external_id
+        assert retrieved.type == "Mutable"
+        assert retrieved.settings.limits.max_records_total.provisioned >= 0
+        assert retrieved.settings.limits.max_records_total.consumed is not None
+
+    def test_retrieve_non_existent_stream(self, cognite_client: CogniteClient) -> None:
+        result = cognite_client.data_modeling.streams.retrieve("non_existent_stream_id")
+
+        assert result is None
+
+    def test_delete_non_existent_stream(self, cognite_client: CogniteClient) -> None:
+        cognite_client.data_modeling.streams.delete("non_existent_stream_id")
+
+    def test_stream_as_write(self, cognite_client: CogniteClient, immutable_test_stream: Stream) -> None:
+        write = immutable_test_stream.as_write()
+
+        assert isinstance(write, StreamWrite)
+        assert write.external_id == immutable_test_stream.external_id
+        assert write.settings.template_name == immutable_test_stream.created_from_template

--- a/tests/tests_unit/test_api/test_data_modeling/test_streams.py
+++ b/tests/tests_unit/test_api/test_data_modeling/test_streams.py
@@ -1,0 +1,131 @@
+from __future__ import annotations
+
+import json
+import re
+from typing import TYPE_CHECKING
+
+import pytest
+from pytest_httpx import HTTPXMock
+
+from cognite.client import CogniteClient
+from cognite.client.data_classes.data_modeling import Stream, StreamList, StreamWrite, StreamWriteSettings
+from tests.utils import get_url
+
+if TYPE_CHECKING:
+    from cognite.client import AsyncCogniteClient
+
+STREAM_RESPONSE_BODY = {
+    "externalId": "test_stream",
+    "createdTime": 1761319720908,
+    "createdFromTemplate": "ImmutableTestStream",
+    "type": "Immutable",
+    "settings": {
+        "lifecycle": {
+            "retainedAfterSoftDelete": "PT24H",
+            "dataDeletedAfter": "PT168H",
+        },
+        "limits": {
+            "maxFilteringInterval": "PT168H",
+            "maxRecordsTotal": {"provisioned": 500000000},
+            "maxGigaBytesTotal": {"provisioned": 500},
+        },
+    },
+}
+
+
+class TestStreams:
+    @pytest.fixture
+    def mock_streams_create_response(
+        self, httpx_mock: HTTPXMock, cognite_client: CogniteClient, async_client: AsyncCogniteClient
+    ) -> HTTPXMock:
+        url_pattern = re.compile(re.escape(get_url(async_client.data_modeling.streams)) + "/streams$")
+        httpx_mock.add_response(method="POST", url=url_pattern, status_code=201, json={"items": [STREAM_RESPONSE_BODY]})
+        return httpx_mock
+
+    @pytest.fixture
+    def mock_streams_delete_response(
+        self, httpx_mock: HTTPXMock, cognite_client: CogniteClient, async_client: AsyncCogniteClient
+    ) -> HTTPXMock:
+        url_pattern = re.compile(re.escape(get_url(async_client.data_modeling.streams)) + "/streams/delete$")
+        httpx_mock.add_response(method="POST", url=url_pattern, status_code=200, json={})
+        return httpx_mock
+
+    @pytest.fixture
+    def mock_streams_retrieve_response(
+        self, httpx_mock: HTTPXMock, cognite_client: CogniteClient, async_client: AsyncCogniteClient
+    ) -> HTTPXMock:
+        url_pattern = re.compile(
+            re.escape(get_url(async_client.data_modeling.streams)) + "/streams/test_stream(\\?.*)?$"
+        )
+        httpx_mock.add_response(method="GET", url=url_pattern, status_code=200, json=STREAM_RESPONSE_BODY)
+        return httpx_mock
+
+    @pytest.fixture
+    def mock_streams_retrieve_not_found(
+        self, httpx_mock: HTTPXMock, cognite_client: CogniteClient, async_client: AsyncCogniteClient
+    ) -> HTTPXMock:
+        url_pattern = re.compile(
+            re.escape(get_url(async_client.data_modeling.streams)) + "/streams/nonexistent(\\?.*)?$"
+        )
+        httpx_mock.add_response(
+            method="GET",
+            url=url_pattern,
+            status_code=404,
+            json={"error": {"code": 404, "message": "Not Found."}},
+        )
+        return httpx_mock
+
+    @pytest.fixture
+    def mock_streams_list_response(
+        self, httpx_mock: HTTPXMock, cognite_client: CogniteClient, async_client: AsyncCogniteClient
+    ) -> HTTPXMock:
+        url_pattern = re.compile(re.escape(get_url(async_client.data_modeling.streams)) + "/streams(\\?.*)?$")
+        httpx_mock.add_response(method="GET", url=url_pattern, status_code=200, json={"items": [STREAM_RESPONSE_BODY]})
+        return httpx_mock
+
+    @pytest.mark.usefixtures("disable_gzip")
+    def test_create_stream(self, cognite_client: CogniteClient, mock_streams_create_response: HTTPXMock) -> None:
+        stream = StreamWrite(
+            external_id="test_stream",
+            settings=StreamWriteSettings(template_name="ImmutableTestStream"),
+        )
+        result = cognite_client.data_modeling.streams.create(stream)
+        assert isinstance(result, Stream)
+        assert result.external_id == "test_stream"
+        assert result.type == "Immutable"
+
+        requests = mock_streams_create_response.get_requests()
+        assert len(requests) == 1
+        sent_payload = json.loads(requests[0].content)
+        assert sent_payload["items"][0] == {
+            "externalId": "test_stream",
+            "settings": {"template": {"name": "ImmutableTestStream"}},
+        }
+
+    @pytest.mark.usefixtures("disable_gzip")
+    def test_delete_stream(self, cognite_client: CogniteClient, mock_streams_delete_response: HTTPXMock) -> None:
+        cognite_client.data_modeling.streams.delete(external_id="test_stream")
+
+        requests = mock_streams_delete_response.get_requests()
+        assert len(requests) == 1
+        sent_payload = json.loads(requests[0].content)
+        assert sent_payload == {"items": [{"externalId": "test_stream"}]}
+
+    def test_retrieve_stream(self, cognite_client: CogniteClient, mock_streams_retrieve_response: HTTPXMock) -> None:
+        result = cognite_client.data_modeling.streams.retrieve(external_id="test_stream")
+        assert isinstance(result, Stream)
+        assert result.external_id == "test_stream"
+        assert result.type == "Immutable"
+        assert result.created_from_template == "ImmutableTestStream"
+
+    def test_retrieve_stream_not_found(
+        self, cognite_client: CogniteClient, mock_streams_retrieve_not_found: HTTPXMock
+    ) -> None:
+        result = cognite_client.data_modeling.streams.retrieve(external_id="nonexistent")
+        assert result is None
+
+    def test_list_streams(self, cognite_client: CogniteClient, mock_streams_list_response: HTTPXMock) -> None:
+        result = cognite_client.data_modeling.streams.list()
+        assert isinstance(result, StreamList)
+        assert len(result) == 1
+        assert result[0].external_id == "test_stream"


### PR DESCRIPTION
## Description
Adds support for the Streams API in the Data Modeling module, enabling users to create, retrieve, list, and delete streams.

## Checklist:
- [x] Tests added/updated.
- [x] Documentation updated. Documentation is generated from docstrings - these must be updated according to your change.
  If a new method has been added it should be referenced in [cognite.rst](https://github.com/cognitedata/cognite-sdk-python/blob/master/docs/source/cognite.rst) in order to generate docs based on its docstring.
- [x] The PR title follows the [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) spec.