### PR TITLE
feat(config): honor COGNITE_DISABLE_PYPI_VERSION_CHECK for PyPI version warning

### DIFF
--- a/cognite/client/config.py
+++ b/cognite/client/config.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import getpass
+import os
 import pprint
 import re
 import warnings
@@ -19,7 +20,8 @@ class GlobalConfig:
             by the CogniteClient constructor if no config is passed directly. Defaults to None.
         disable_gzip (bool): Whether or not to disable gzipping of json bodies. Defaults to False.
         disable_pypi_version_check (bool): Whether or not to check for newer SDK versions when instantiating a new client.
-            Defaults to False.
+            Defaults to False. You can also set the environment variable ``COGNITE_DISABLE_PYPI_VERSION_CHECK`` to a truthy
+            value (``1``, ``true``, ``yes``, ``on``, case-insensitive) to disable the check without changing this attribute.
         status_forcelist (Set[int]): HTTP status codes to retry. Defaults to {429, 502, 503, 504}
         max_retries (int): Max number of retries on a given http request. Defaults to 10.
         max_retries_connect (int): Max number of retries on connection errors. Defaults to 3.
@@ -100,6 +102,17 @@ class GlobalConfig:
 global_config = GlobalConfig()
 
 
+def _env_truthy(name: str) -> bool:
+    val = os.environ.get(name)
+    if val is None:
+        return False
+    return val.strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _pypi_version_check_disabled() -> bool:
+    return global_config.disable_pypi_version_check or _env_truthy("COGNITE_DISABLE_PYPI_VERSION_CHECK")
+
+
 class ClientConfig:
     """Configuration object for the client
 
@@ -145,7 +158,7 @@ class ClientConfig:
             self.debug = True
         self._validate_config()
 
-        if not global_config.disable_pypi_version_check:
+        if not _pypi_version_check_disabled():
             from cognite.client.utils._version_checker import check_client_is_running_latest_version
 
             check_client_is_running_latest_version()

--- a/cognite/client/utils/_version_checker.py
+++ b/cognite/client/utils/_version_checker.py
@@ -36,7 +36,8 @@ def check_client_is_running_latest_version() -> None:
             if version.parse(__version__) < newest_version:
                 warnings.warn(
                     f"You are using version={__version__!r} of the SDK, however version={newest_version.public!r} is "
-                    "available. To suppress this warning, either upgrade or do the following:\n"
+                    "available. To suppress this warning, upgrade the package, set the environment variable "
+                    "COGNITE_DISABLE_PYPI_VERSION_CHECK to a truthy value (e.g. 1 or true), or do the following:\n"
                     ">>> from cognite.client.config import global_config\n"
                     ">>> global_config.disable_pypi_version_check = True",
                     stacklevel=3,

--- a/tests/tests_unit/test_config.py
+++ b/tests/tests_unit/test_config.py
@@ -1,4 +1,5 @@
 from contextlib import nullcontext as does_not_raise
+from unittest.mock import patch
 
 import pytest
 
@@ -131,3 +132,25 @@ class TestClientConfig:
     def test_extract_invalid_url(self, client_config: ClientConfig) -> None:
         client_config.base_url = "invalid"
         assert client_config.cdf_cluster is None
+
+    @pytest.mark.parametrize("env_value", ("1", "true", "TRUE", "yes", "on"))
+    def test_pypi_version_check_skipped_when_env_set(self, monkeypatch, env_value: str) -> None:
+        monkeypatch.setattr(global_config, "disable_pypi_version_check", False)
+        monkeypatch.setenv("COGNITE_DISABLE_PYPI_VERSION_CHECK", env_value)
+        with patch("cognite.client.utils._version_checker.check_client_is_running_latest_version") as check_fn:
+            ClientConfig(client_name="t", project="p", credentials=Token("x"))
+            check_fn.assert_not_called()
+
+    def test_pypi_version_check_runs_when_env_unset(self, monkeypatch) -> None:
+        monkeypatch.setattr(global_config, "disable_pypi_version_check", False)
+        monkeypatch.delenv("COGNITE_DISABLE_PYPI_VERSION_CHECK", raising=False)
+        with patch("cognite.client.utils._version_checker.check_client_is_running_latest_version") as check_fn:
+            ClientConfig(client_name="t", project="p", credentials=Token("x"))
+            check_fn.assert_called_once()
+
+    def test_pypi_version_check_skipped_when_global_config_true_despite_env(self, monkeypatch) -> None:
+        monkeypatch.setattr(global_config, "disable_pypi_version_check", True)
+        monkeypatch.delenv("COGNITE_DISABLE_PYPI_VERSION_CHECK", raising=False)
+        with patch("cognite.client.utils._version_checker.check_client_is_running_latest_version") as check_fn:
+            ClientConfig(client_name="t", project="p", credentials=Token("x"))
+            check_fn.assert_not_called()


### PR DESCRIPTION
## Summary

Honor `COGNITE_DISABLE_PYPI_VERSION_CHECK` when instantiating `ClientConfig`, so deployments can disable the newer-version `UserWarning` without importing `global_config` first.

Truthy values: `1`, `true`, `yes`, `on` (case-insensitive).

## Motivation

Downstream projects (e.g. unstructured-search) already set this env var; the SDK previously ignored it and only respected `global_config.disable_pypi_version_check`.

## Changes

- `config.py`: `_env_truthy` / `_pypi_version_check_disabled`
- `_version_checker.py`: mention env var in warning text
- `test_config.py`: unit tests for env + global precedence

Made with [Cursor](https://cursor.com)