### PR TITLE
fix: avoid RuntimeWarning from run_sync on tzdata install in pyodide

### DIFF
--- a/cognite/client/utils/_pyodide_helpers.py
+++ b/cognite/client/utils/_pyodide_helpers.py
@@ -19,6 +19,8 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+_TASK_REF_TZDATA: object = None  # We need a global ref
+
 
 def patch_sdk_for_pyodide() -> None:
     # -------------------
@@ -65,10 +67,12 @@ def patch_sdk_for_pyodide() -> None:
     #   internally for e.g. datapoints and workflows.
     #   Note: This convenience will only work in chromium-based browsers (as of Sept 2025)
     try:
-        import micropip  # type: ignore [import-not-found]
-        from pyodide.ffi import run_sync  # type: ignore [import-not-found]
+        import asyncio
 
-        run_sync(micropip.install("tzdata"))
+        import micropip  # type: ignore [import-not-found]
+
+        global _TASK_REF_TZDATA  # keep the gc at bay
+        _TASK_REF_TZDATA = asyncio.ensure_future(micropip.install("tzdata"))
     except Exception:
         logger.debug(
             "Could not load 'tzdata' package automatically in pyodide. You may need to do this manually:"

--- a/cognite/client/utils/_pyodide_helpers.py
+++ b/cognite/client/utils/_pyodide_helpers.py
@@ -72,7 +72,7 @@ def patch_sdk_for_pyodide() -> None:
         import micropip  # type: ignore [import-not-found]
 
         global _TASK_REF_TZDATA  # keep the gc at bay
-        _TASK_REF_TZDATA = asyncio.ensure_future(micropip.install("tzdata"))
+        _TASK_REF_TZDATA = asyncio.create_task(micropip.install("tzdata"))
     except Exception:
         logger.debug(
             "Could not load 'tzdata' package automatically in pyodide. You may need to do this manually:"


### PR DESCRIPTION
Replace blocking run_sync with fire-and-forget asyncio.ensure_future, keeping a module-level reference to shield the task from GC.

Although we caught the error, the RuntimeWarning was quite annoying for any e.g. Firefox user:

<img width="2056" height="278" alt="image" src="https://github.com/user-attachments/assets/8832a8c9-92cb-45f1-8637-4161956cf95b" />
