### PR TITLE
chore(ci): surface pyodide test errors via .catch()

### DIFF
--- a/scripts/test-pyodide.js
+++ b/scripts/test-pyodide.js
@@ -51,5 +51,9 @@ server.listen(PORT, () => {
   test_cognite_sdk().then((result) => {
     console.log("Response from Python =", result);
     server.close();
+  }).catch((err) => {
+    console.error("Pyodide test failed:", err && err.stack ? err.stack : err);
+    server.close();
+    process.exit(1);
   });
 });


### PR DESCRIPTION
## Summary

`scripts/test-pyodide.js` wraps an async `test_cognite_sdk()` with a bare `.then(...)` and no `.catch(...)`. When the pyodide promise rejects, Node's default unhandled-rejection handler dumps the 69KB minified `pyodide.asm.js` source instead of the actual Python traceback, and GitHub Actions' log collector then truncates everything after the blob. The real error never reaches the build log.

This PR adds a `.catch()` that logs `err.stack` and exits 1, so future failures surface the actual traceback.

## Reproduction example

See PR #2577: an empty-commit branch off master fails `build_and_test_streamlit_pyodide` with no visible error. With this change applied, the failing step log prints:

```
Pyodide test failed: PythonError: Traceback (most recent call last):
  ...
  File ".../micropip/transaction.py", line 281, in find_wheel
ValueError: Can't find a pure Python 3 wheel for 'cryptography>=45.0.1'.
```

(The separate authlib pin PR addresses the actual CI failure surfaced here.)

## Test plan
- [ ] `build_and_test_streamlit_pyodide` still fails (expected — this PR only changes error surfacing, not the underlying cause), but the failing step log now contains a readable traceback instead of a minified asm.js dump.