### PR TITLE
fix(deps): pin authlib <1.7 to keep pyodide 0.26 (stlite) working

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ python = "^3.10"
 
 httpx = "^0"
 msal = "^1.31"
-authlib = "^1"
+authlib = ">=1,<1.7"  # 1.7 adds joserfc transitive dep requiring cryptography>=45, breaks pyodide 0.26 (stlite)
 protobuf = ">=4"
 packaging = ">=20"
 pip = ">=20.0.0"  # make optional once poetry doesn't auto-remove it on "simple install"

--- a/scripts/test-pyodide.js
+++ b/scripts/test-pyodide.js
@@ -51,5 +51,9 @@ server.listen(PORT, () => {
   test_cognite_sdk().then((result) => {
     console.log("Response from Python =", result);
     server.close();
+  }).catch((err) => {
+    console.error("Pyodide test failed:", err && err.stack ? err.stack : err);
+    server.close();
+    process.exit(1);
   });
 });


### PR DESCRIPTION
## Summary

`authlib 1.7.0` (released 2026-04-18) added `joserfc>=1.6.0` as a transitive dependency. `joserfc>=1.6.4` requires `cryptography>=45.0.1`. pyodide 0.26.2 (used by stlite) bundles an older `cryptography` and PyPI only ships cryptography as an sdist — no pure-Python wheel — so micropip cannot satisfy the constraint. This breaks `build_and_test_streamlit_pyodide` on every master-based PR.

Pinning `authlib` to `>=1,<1.7` prevents micropip from selecting `authlib 1.7+` when resolving the SDK wheel's declared dependencies, keeping stlite installs working. The current lockfile already has authlib 1.6.9 so no lockfile update is required.

## Reproduction

See PR #2577 (empty commit off master → streamlit_pyodide fails).

The actual traceback is visible once PR #2578 lands (adds `.catch()` to `scripts/test-pyodide.js`):

```
ValueError: Can't find a pure Python 3 wheel for 'cryptography>=45.0.1'.
```

This PR is stacked on PR #2578 so its CI benefits from that error surfacing.

## Test plan
- [ ] `build_and_test_streamlit_pyodide` passes on this PR
- [ ] `build_and_test_jupyter_pyodide` still passes (pyodide 0.29 build is unaffected by the pin)
- [ ] Other test jobs remain green