### PR TITLE
fix(deps): pin authlib <1.7 to keep pyodide 0.26 (stlite) working

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ python = "^3.10"
 
 httpx = "^0"
 msal = "^1.31"
-authlib = "^1"
+authlib = ">=1,<1.7"  # 1.7 adds joserfc transitive dep requiring cryptography>=45, breaks pyodide 0.26 (stlite)
 protobuf = ">=4"
 packaging = ">=20"
 pip = ">=20.0.0"  # make optional once poetry doesn't auto-remove it on "simple install"


### PR DESCRIPTION
## Summary

`authlib 1.7.0` (released 2026-04-18) added `joserfc>=1.6.0` as a transitive dependency. `joserfc 1.6.4` requires `cryptography>=45.0.1`. pyodide 0.26.2 (used by stlite) bundles an older `cryptography` and PyPI only ships cryptography as an sdist, so micropip cannot satisfy the constraint. Every master-based PR has been failing `build_and_test_streamlit_pyodide` since 2026-04-18.

Pinning `authlib` to `>=1,<1.7` prevents micropip from selecting `authlib 1.7+` when resolving the SDK wheel's declared dependencies, keeping stlite installs working. The current lockfile already has authlib 1.6.9, so no lockfile update is required.

## Reproduction

PR #2577 (empty commit off master) fails `build_and_test_streamlit_pyodide`. The actual traceback is surfaced by the stacked PR (chore/pyodide-surface-errors):

```
ValueError: Can't find a pure Python 3 wheel for 'cryptography>=45.0.1'.
```

## Test plan
- [ ] `build_and_test_streamlit_pyodide` passes on this PR
- [ ] `build_and_test_jupyter_pyodide` still passes (pyodide 0.29 build is unaffected)
- [ ] All other jobs remain green