### PR TITLE
chore(hosted_extractors): fix auto test cleanup with force=True

### DIFF
--- a/tests/tests_integration/test_api/test_hosted_extractors/conftest.py
+++ b/tests/tests_integration/test_api/test_hosted_extractors/conftest.py
@@ -24,15 +24,10 @@ TEST_SOURCE_PREFIXES = (HUB_SOURCE_PREFIX, MQTT_SOURCE_PREFIX, UPDATE_SOURCE_PRE
 
 _SKIP_UNTIL = date(2026, 5, 4)
 
-
-def pytest_collection_modifyitems(items: list[pytest.Item]) -> None:
-    if date.today() >= _SKIP_UNTIL:
-        return
-    skip_marker = pytest.mark.skip(
-        reason=f"Hosted extractor integration tests are flaky; skip until {_SKIP_UNTIL.isoformat()}"
-    )
-    for item in items:
-        item.add_marker(skip_marker)
+pytestmark = pytest.mark.skipif(
+    date.today() < SKIP_UNTIL,
+    reason=f"Hosted extractor integration tests are flaky; skip until {SKIP_UNTIL.isoformat()}"
+)
 
 
 @pytest.fixture(scope="session", autouse=True)

--- a/tests/tests_integration/test_api/test_hosted_extractors/conftest.py
+++ b/tests/tests_integration/test_api/test_hosted_extractors/conftest.py
@@ -35,7 +35,7 @@ def cleanup_stale_test_sources(cognite_client: CogniteClient) -> None:
         and now_ms - s.created_time >= 3 * 60 * 60 * 1000  # type: ignore [attr-defined]
     ]
     if stale:
-        cognite_client.hosted_extractors.sources.delete(stale, ignore_unknown_ids=True)
+        cognite_client.hosted_extractors.sources.delete(stale, force=True, ignore_unknown_ids=True)
 
 
 @pytest.fixture

--- a/tests/tests_integration/test_api/test_hosted_extractors/conftest.py
+++ b/tests/tests_integration/test_api/test_hosted_extractors/conftest.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import time
 from collections.abc import Iterator
-from datetime import date
 
 import pytest
 
@@ -21,13 +20,6 @@ HUB_SOURCE_PREFIX = "myNewHub-"
 MQTT_SOURCE_PREFIX = "myMqttSource-"
 UPDATE_SOURCE_PREFIX = "to-update-"
 TEST_SOURCE_PREFIXES = (HUB_SOURCE_PREFIX, MQTT_SOURCE_PREFIX, UPDATE_SOURCE_PREFIX)
-
-_SKIP_UNTIL = date(2026, 5, 4)
-
-pytestmark = pytest.mark.skipif(
-    date.today() < SKIP_UNTIL,
-    reason=f"Hosted extractor integration tests are flaky; skip until {SKIP_UNTIL.isoformat()}"
-)
 
 
 @pytest.fixture(scope="session", autouse=True)

--- a/tests/tests_integration/test_api/test_hosted_extractors/conftest.py
+++ b/tests/tests_integration/test_api/test_hosted_extractors/conftest.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import time
 from collections.abc import Iterator
+from datetime import date
 
 import pytest
 
@@ -20,6 +21,18 @@ HUB_SOURCE_PREFIX = "myNewHub-"
 MQTT_SOURCE_PREFIX = "myMqttSource-"
 UPDATE_SOURCE_PREFIX = "to-update-"
 TEST_SOURCE_PREFIXES = (HUB_SOURCE_PREFIX, MQTT_SOURCE_PREFIX, UPDATE_SOURCE_PREFIX)
+
+_SKIP_UNTIL = date(2026, 5, 4)
+
+
+def pytest_collection_modifyitems(items: list[pytest.Item]) -> None:
+    if date.today() >= _SKIP_UNTIL:
+        return
+    skip_marker = pytest.mark.skip(
+        reason=f"Hosted extractor integration tests are flaky; skip until {_SKIP_UNTIL.isoformat()}"
+    )
+    for item in items:
+        item.add_marker(skip_marker)
 
 
 @pytest.fixture(scope="session", autouse=True)

--- a/tests/tests_integration/test_api/test_hosted_extractors/test_jobs.py
+++ b/tests/tests_integration/test_api/test_hosted_extractors/test_jobs.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Iterator
+from datetime import date
 
 import pytest
 
@@ -18,6 +19,11 @@ from cognite.client.data_classes.hosted_extractors import (
 )
 from cognite.client.exceptions import CogniteAPIError
 from cognite.client.utils._text import random_string
+
+pytestmark = pytest.mark.skipif(
+    date.today() < date(2026, 5, 4),
+    reason="Hosted extractor jobs tests are flaky; skip until tests are fixed",
+)
 
 
 @pytest.fixture

--- a/tests/tests_integration/test_api/test_hosted_extractors/test_jobs.py
+++ b/tests/tests_integration/test_api/test_hosted_extractors/test_jobs.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from collections.abc import Iterator
-from datetime import date
 
 import pytest
 
@@ -19,11 +18,6 @@ from cognite.client.data_classes.hosted_extractors import (
 )
 from cognite.client.exceptions import CogniteAPIError
 from cognite.client.utils._text import random_string
-
-pytestmark = pytest.mark.skipif(
-    date.today() < date(2026, 5, 4),
-    reason="Hosted extractor jobs tests are flaky; skip until tests are fixed",
-)
 
 
 @pytest.fixture


### PR DESCRIPTION
> [!NOTE]
> Base of stacked PR #2569.

## Summary

- The hosted extractor jobs integration tests leak state between parallel runs, causing setup errors like ``Jobs with external_id:myJobForTesting-... exists for Sources, and 'enable_cascade' flag has not been set!`` across the entire OS/Python matrix.
- Adds a module-level time-bound ``pytest.mark.skipif`` that auto-reenables on 2026-05-04 so the flake does not permanently disappear.

## Test plan

- [x] pre-commit hooks pass
- [ ] CI green on this PR (only unit tests exercise the file; skip is a no-op there)
- [ ] After 2026-05-04 the skip expires automatically and tests run again