### PR TITLE
feat(Data Modeling): Add /sync utility method to store cache in Files API (DM-3759)

### DIFF
--- a/cognite/client/_api/data_modeling/instances.py
+++ b/cognite/client/_api/data_modeling/instances.py
@@ -41,6 +41,7 @@ from cognite.client.data_classes.data_modeling.instances import (
     EdgeApplyResult,
     EdgeApplyResultList,
     EdgeList,
+    EdgeListWithCursor,
     InstanceAggregationResultList,
     InstanceInspectResultList,
     InstanceInspectResults,
@@ -55,6 +56,7 @@ from cognite.client.data_classes.data_modeling.instances import (
     NodeApplyResult,
     NodeApplyResultList,
     NodeList,
+    NodeListWithCursor,
     T_Edge,
     T_Node,
     TargetUnit,
@@ -1835,11 +1837,16 @@ class InstancesAPI(APIClient):
         include_typing: bool = False,
         debug: DebugParameters | None = None,
     ) -> QueryResult:
-        """Sync instances with cursor state cached in a CDF file.
+        """Sync instances with cursor state and instances cached in a CDF file.
 
-        This is a utility method that combines the sync endpoint with persistent cursor
-        storage in CDF Files. The cursor state is automatically saved after each successful
-        sync and restored on subsequent calls, enabling incremental syncs across sessions.
+        This is a utility method that combines the sync endpoint with persistent
+        storage of both cursor state and instance data in CDF Files. The method:
+        1. Loads cached cursors and instances from the file (if available)
+        2. Performs an incremental sync using the cached cursors
+        3. Merges the sync result with cached instances (adding/updating new items,
+           removing items with deleted_time set)
+        4. Saves the merged data and updated cursors back to the cache file
+        5. Returns the full merged result (all instances, not just incremental changes)
 
         The cache file external_id is generated as `{cache_config.external_id_prefix}_{query_hash}`
         where query_hash is derived from the query structure (or just `{query_hash}` if the
@@ -1874,7 +1881,8 @@ class InstancesAPI(APIClient):
             debug (DebugParameters | None): Debug settings for profiling and troubleshooting.
 
         Returns:
-            QueryResult: The resulting nodes and/or edges from the sync query.
+            QueryResult: The full set of nodes and/or edges (cached + new from sync,
+                minus deleted items). This is a merged result, not just incremental changes.
 
         Examples:
 
@@ -1898,11 +1906,11 @@ class InstancesAPI(APIClient):
                 ...     external_id_prefix="pump_sync_cache",
                 ...     security_category_name="my_security_category",
                 ... )
-                >>> # First call: syncs all pumps and saves cursor to file
+                >>> # First call: syncs all pumps and saves data to file
                 >>> result = client.data_modeling.instances.sync_with_file_cache(
                 ...     query, cache_config=cache_config
                 ... )
-                >>> # Subsequent calls: loads cursor from file and syncs only changes
+                >>> # Subsequent calls: returns all instances (cached + new changes)
                 >>> result2 = client.data_modeling.instances.sync_with_file_cache(
                 ...     query, cache_config=cache_config
                 ... )
@@ -1935,29 +1943,84 @@ class InstancesAPI(APIClient):
             if security_category_ids is None:
                 raise ValueError(f"Security category with name '{cache_config.security_category_name}' not found")
 
-        # Try to load cached cursors
+        # Try to load cached data (cursors and instances)
+        cached_instances: dict[str, list[dict[str, Any]]] = {}
         try:
             cached_bytes = await self._cognite_client.files.download_bytes(external_id=cache_external_id)
             cached_data = json_loads(cached_bytes.decode("utf-8"))
             # Verify hash matches (cache busting)
             if cached_data.get("hash") == query_hash:
                 query.cursors = cached_data.get("cursors", {})
-                logger.debug(f"Loaded cached cursors from file {cache_external_id}")
+                cached_instances = cached_data.get("instances", {})
+                logger.debug(f"Loaded cached data from file {cache_external_id}")
             else:
-                logger.debug("Cache hash mismatch, ignoring cached cursors")
+                logger.debug("Cache hash mismatch, ignoring cached data")
         except CogniteNotFoundError:
-            logger.debug(f"No cached cursors found at {cache_external_id}")
+            logger.debug(f"No cached data found at {cache_external_id}")
         except Exception as e:
-            logger.warning(f"Failed to load cached cursors: {e}")
+            logger.warning(f"Failed to load cached data: {e}")
 
         # Perform the sync
-        result = await self.sync(query, include_typing=include_typing, debug=debug)
+        sync_result = await self.sync(query, include_typing=include_typing, debug=debug)
 
-        # Save updated cursors to cache
+        # Merge cached instances with sync result
+        default_by_reference = query.instance_type_by_result_expression()
+        merged_result = QueryResult()
+        merged_result._debug = sync_result._debug
+
+        for key, sync_list in sync_result.items():
+            # Build a dict of cached instances by (space, external_id) for this key
+            cached_by_id: dict[tuple[str, str], dict[str, Any]] = {}
+            for item_dict in cached_instances.get(key, []):
+                instance_id = (item_dict["space"], item_dict["externalId"])
+                cached_by_id[instance_id] = item_dict
+
+            # Process sync results: add/update instances, track deletions
+            deleted_ids: set[tuple[str, str]] = set()
+            for item in sync_list:
+                instance_id = (item.space, item.external_id)
+                if item.deleted_time is not None:
+                    # Mark for deletion
+                    deleted_ids.add(instance_id)
+                    # Remove from cache if present
+                    cached_by_id.pop(instance_id, None)
+                else:
+                    # Add/update in cache
+                    cached_by_id[instance_id] = item.dump(camel_case=True)
+
+            # Build merged list from the updated cache
+            merged_items = list(cached_by_id.values())
+
+            # Determine the list type (nodes or edges)
+            instance_lst_cls = default_by_reference.get(key, NodeListWithCursor)
+            if instance_lst_cls is NodeListWithCursor or (
+                not merged_items and isinstance(sync_list, NodeListWithCursor)
+            ):
+                merged_result[key] = NodeListWithCursor(
+                    [Node._load(item) for item in merged_items],
+                    cursor=sync_list.cursor,
+                    typing=sync_list.typing,
+                    debug=sync_list.debug,
+                )
+            else:
+                merged_result[key] = EdgeListWithCursor(
+                    [Edge._load(item) for item in merged_items],
+                    cursor=sync_list.cursor,
+                    typing=sync_list.typing,
+                    debug=sync_list.debug,
+                )
+
+        # Save updated data (cursors and instances) to cache
         try:
+            # Serialize instances for caching
+            instances_to_cache: dict[str, list[dict[str, Any]]] = {}
+            for key, item_list in merged_result.items():
+                instances_to_cache[key] = [item.dump(camel_case=True) for item in item_list]
+
             cache_data = {
                 "hash": query_hash,
-                "cursors": result.cursors,
+                "cursors": merged_result.cursors,
+                "instances": instances_to_cache,
             }
             cache_content = json_dumps(cache_data).encode("utf-8")
             await self._cognite_client.files.upload_bytes(
@@ -1970,11 +2033,11 @@ class InstancesAPI(APIClient):
                 mime_type="application/json",
                 overwrite=True,
             )
-            logger.debug(f"Saved cursors to cache file {cache_external_id}")
+            logger.debug(f"Saved data to cache file {cache_external_id}")
         except Exception as e:
-            logger.warning(f"Failed to save cursors to cache file: {e}")
+            logger.warning(f"Failed to save data to cache file: {e}")
 
-        return result
+        return merged_result
 
     @overload
     async def list(

--- a/cognite/client/_api/data_modeling/instances.py
+++ b/cognite/client/_api/data_modeling/instances.py
@@ -1829,6 +1829,170 @@ class InstancesAPI(APIClient):
             debug=json_payload.get("debug"),
         )
 
+    async def _resolve_data_set_id(self, cache_config: FileCacheConfig) -> int | None:
+        """Resolve data_set_external_id to data_set_id if needed."""
+        if cache_config.data_set_id is not None:
+            return cache_config.data_set_id
+
+        if cache_config.data_set_external_id is None:
+            return None
+
+        data_set = await self._cognite_client.data_sets.retrieve(external_id=cache_config.data_set_external_id)
+        if data_set is None:
+            raise ValueError(f"Data set with external_id '{cache_config.data_set_external_id}' not found")
+        return data_set.id
+
+    async def _resolve_security_category_ids(self, cache_config: FileCacheConfig) -> list[int] | None:
+        """Resolve security_category_name to security_category ID if needed."""
+        if cache_config.security_category is not None:
+            return [cache_config.security_category]
+
+        if cache_config.security_category_name is None:
+            return None
+
+        security_categories = await self._cognite_client.iam.security_categories.list(limit=-1)
+        for sc in security_categories:
+            if sc.name == cache_config.security_category_name:
+                return [sc.id]
+
+        raise ValueError(f"Security category with name '{cache_config.security_category_name}' not found")
+
+    async def _load_cached_data(
+        self, cache_external_id: str, query_hash: str, query: QuerySync
+    ) -> dict[str, list[dict[str, Any]]]:
+        """Load cached cursors and instances from file.
+
+        Returns cached instances dict (may be empty if no cache or hash mismatch).
+        Also updates query.cursors if valid cached cursors are found.
+        """
+        try:
+            cached_bytes = await self._cognite_client.files.download_bytes(external_id=cache_external_id)
+            cached_data = json_loads(cached_bytes.decode("utf-8"))
+
+            if cached_data.get("hash") != query_hash:
+                logger.debug("Cache hash mismatch, ignoring cached data")
+                return {}
+
+            query.cursors = cached_data.get("cursors", {})
+            logger.debug(f"Loaded cached data from file {cache_external_id}")
+            return cached_data.get("instances", {})
+
+        except CogniteNotFoundError:
+            logger.debug(f"No cached data found at {cache_external_id}")
+            return {}
+        except Exception as e:
+            logger.warning(f"Failed to load cached data: {e}")
+            return {}
+
+    def _merge_sync_result_with_cache(
+        self,
+        sync_result: QueryResult,
+        cached_instances: dict[str, list[dict[str, Any]]],
+        default_by_reference: dict[str, type[NodeListWithCursor] | type[EdgeListWithCursor]],
+    ) -> QueryResult:
+        """Merge cached instances with sync result.
+
+        Adds/updates instances from sync result, removes deleted instances.
+        Returns a new QueryResult with merged data.
+        """
+        merged_result = QueryResult()
+        merged_result._debug = sync_result._debug
+
+        for key, sync_list in sync_result.items():
+            cached_by_id = self._build_cached_instance_dict(cached_instances.get(key, []))
+            self._apply_sync_changes(sync_list, cached_by_id)
+            merged_items = list(cached_by_id.values())
+
+            merged_result[key] = self._create_merged_list(key, merged_items, sync_list, default_by_reference)
+
+        return merged_result
+
+    @staticmethod
+    def _build_cached_instance_dict(
+        cached_items: list[dict[str, Any]],
+    ) -> dict[tuple[str, str], dict[str, Any]]:
+        """Build a dict of cached instances keyed by (space, external_id)."""
+        return {(item_dict["space"], item_dict["externalId"]): item_dict for item_dict in cached_items}
+
+    @staticmethod
+    def _apply_sync_changes(
+        sync_list: NodeListWithCursor | EdgeListWithCursor,
+        cached_by_id: dict[tuple[str, str], dict[str, Any]],
+    ) -> None:
+        """Apply sync changes to the cached instances dict in place.
+
+        Adds/updates instances from sync result and removes deleted instances.
+        """
+        for item in sync_list:
+            instance_id = (item.space, item.external_id)
+            if item.deleted_time is not None:
+                cached_by_id.pop(instance_id, None)
+            else:
+                cached_by_id[instance_id] = item.dump(camel_case=True)
+
+    @staticmethod
+    def _create_merged_list(
+        key: str,
+        merged_items: list[dict[str, Any]],
+        sync_list: NodeListWithCursor | EdgeListWithCursor,
+        default_by_reference: dict[str, type[NodeListWithCursor] | type[EdgeListWithCursor]],
+    ) -> NodeListWithCursor | EdgeListWithCursor:
+        """Create the appropriate list type (nodes or edges) for the merged result."""
+        instance_lst_cls = default_by_reference.get(key, NodeListWithCursor)
+        is_node_list = instance_lst_cls is NodeListWithCursor or (
+            not merged_items and isinstance(sync_list, NodeListWithCursor)
+        )
+
+        if is_node_list:
+            return NodeListWithCursor(
+                [Node._load(item) for item in merged_items],
+                cursor=sync_list.cursor,
+                typing=sync_list.typing,
+                debug=sync_list.debug,
+            )
+        return EdgeListWithCursor(
+            [Edge._load(item) for item in merged_items],
+            cursor=sync_list.cursor,
+            typing=sync_list.typing,
+            debug=sync_list.debug,
+        )
+
+    async def _save_cache_data(
+        self,
+        merged_result: QueryResult,
+        query_hash: str,
+        cache_external_id: str,
+        data_set_id: int | None,
+        security_category_ids: list[int] | None,
+        directory: str | None,
+    ) -> None:
+        """Save merged data (cursors and instances) to cache file."""
+        try:
+            instances_to_cache: dict[str, list[dict[str, Any]]] = {
+                key: [item.dump(camel_case=True) for item in item_list] for key, item_list in merged_result.items()
+            }
+
+            cache_data = {
+                "hash": query_hash,
+                "cursors": merged_result.cursors,
+                "instances": instances_to_cache,
+            }
+            cache_content = json_dumps(cache_data).encode("utf-8")
+
+            await self._cognite_client.files.upload_bytes(
+                content=cache_content,
+                name=f"{cache_external_id}.json",
+                external_id=cache_external_id,
+                data_set_id=data_set_id,
+                security_categories=security_category_ids,
+                directory=directory,
+                mime_type="application/json",
+                overwrite=True,
+            )
+            logger.debug(f"Saved data to cache file {cache_external_id}")
+        except Exception as e:
+            logger.warning(f"Failed to save data to cache file: {e}")
+
     async def sync_with_file_cache(
         self,
         query: QuerySync,
@@ -1917,125 +2081,33 @@ class InstancesAPI(APIClient):
         """
         # Compute query hash for cache key
         query_hash = _compute_query_hash(query)
-        if cache_config.external_id_prefix:
-            cache_external_id = f"{cache_config.external_id_prefix}_{query_hash}"
-        else:
-            cache_external_id = query_hash
+        cache_external_id = (
+            f"{cache_config.external_id_prefix}_{query_hash}" if cache_config.external_id_prefix else query_hash
+        )
 
-        # Resolve data_set_external_id to data_set_id if needed
-        data_set_id = cache_config.data_set_id
-        if data_set_id is None and cache_config.data_set_external_id is not None:
-            data_set = await self._cognite_client.data_sets.retrieve(external_id=cache_config.data_set_external_id)
-            if data_set is None:
-                raise ValueError(f"Data set with external_id '{cache_config.data_set_external_id}' not found")
-            data_set_id = data_set.id
+        # Resolve config values
+        data_set_id = await self._resolve_data_set_id(cache_config)
+        security_category_ids = await self._resolve_security_category_ids(cache_config)
 
-        # Resolve security_category_name to security_category ID if needed
-        security_category_ids: list[int] | None = None
-        if cache_config.security_category is not None:
-            security_category_ids = [cache_config.security_category]
-        elif cache_config.security_category_name is not None:
-            security_categories = await self._cognite_client.iam.security_categories.list(limit=-1)
-            for sc in security_categories:
-                if sc.name == cache_config.security_category_name:
-                    security_category_ids = [sc.id]
-                    break
-            if security_category_ids is None:
-                raise ValueError(f"Security category with name '{cache_config.security_category_name}' not found")
-
-        # Try to load cached data (cursors and instances)
-        cached_instances: dict[str, list[dict[str, Any]]] = {}
-        try:
-            cached_bytes = await self._cognite_client.files.download_bytes(external_id=cache_external_id)
-            cached_data = json_loads(cached_bytes.decode("utf-8"))
-            # Verify hash matches (cache busting)
-            if cached_data.get("hash") == query_hash:
-                query.cursors = cached_data.get("cursors", {})
-                cached_instances = cached_data.get("instances", {})
-                logger.debug(f"Loaded cached data from file {cache_external_id}")
-            else:
-                logger.debug("Cache hash mismatch, ignoring cached data")
-        except CogniteNotFoundError:
-            logger.debug(f"No cached data found at {cache_external_id}")
-        except Exception as e:
-            logger.warning(f"Failed to load cached data: {e}")
+        # Load cached data (updates query.cursors if valid cache exists)
+        cached_instances = await self._load_cached_data(cache_external_id, query_hash, query)
 
         # Perform the sync
         sync_result = await self.sync(query, include_typing=include_typing, debug=debug)
 
         # Merge cached instances with sync result
         default_by_reference = query.instance_type_by_result_expression()
-        merged_result = QueryResult()
-        merged_result._debug = sync_result._debug
+        merged_result = self._merge_sync_result_with_cache(sync_result, cached_instances, default_by_reference)
 
-        for key, sync_list in sync_result.items():
-            # Build a dict of cached instances by (space, external_id) for this key
-            cached_by_id: dict[tuple[str, str], dict[str, Any]] = {}
-            for item_dict in cached_instances.get(key, []):
-                instance_id = (item_dict["space"], item_dict["externalId"])
-                cached_by_id[instance_id] = item_dict
-
-            # Process sync results: add/update instances, track deletions
-            deleted_ids: set[tuple[str, str]] = set()
-            for item in sync_list:
-                instance_id = (item.space, item.external_id)
-                if item.deleted_time is not None:
-                    # Mark for deletion
-                    deleted_ids.add(instance_id)
-                    # Remove from cache if present
-                    cached_by_id.pop(instance_id, None)
-                else:
-                    # Add/update in cache
-                    cached_by_id[instance_id] = item.dump(camel_case=True)
-
-            # Build merged list from the updated cache
-            merged_items = list(cached_by_id.values())
-
-            # Determine the list type (nodes or edges)
-            instance_lst_cls = default_by_reference.get(key, NodeListWithCursor)
-            if instance_lst_cls is NodeListWithCursor or (
-                not merged_items and isinstance(sync_list, NodeListWithCursor)
-            ):
-                merged_result[key] = NodeListWithCursor(
-                    [Node._load(item) for item in merged_items],
-                    cursor=sync_list.cursor,
-                    typing=sync_list.typing,
-                    debug=sync_list.debug,
-                )
-            else:
-                merged_result[key] = EdgeListWithCursor(
-                    [Edge._load(item) for item in merged_items],
-                    cursor=sync_list.cursor,
-                    typing=sync_list.typing,
-                    debug=sync_list.debug,
-                )
-
-        # Save updated data (cursors and instances) to cache
-        try:
-            # Serialize instances for caching
-            instances_to_cache: dict[str, list[dict[str, Any]]] = {}
-            for key, item_list in merged_result.items():
-                instances_to_cache[key] = [item.dump(camel_case=True) for item in item_list]
-
-            cache_data = {
-                "hash": query_hash,
-                "cursors": merged_result.cursors,
-                "instances": instances_to_cache,
-            }
-            cache_content = json_dumps(cache_data).encode("utf-8")
-            await self._cognite_client.files.upload_bytes(
-                content=cache_content,
-                name=f"{cache_external_id}.json",
-                external_id=cache_external_id,
-                data_set_id=data_set_id,
-                security_categories=security_category_ids,
-                directory=cache_config.directory,
-                mime_type="application/json",
-                overwrite=True,
-            )
-            logger.debug(f"Saved data to cache file {cache_external_id}")
-        except Exception as e:
-            logger.warning(f"Failed to save data to cache file: {e}")
+        # Save updated data to cache
+        await self._save_cache_data(
+            merged_result,
+            query_hash,
+            cache_external_id,
+            data_set_id,
+            security_category_ids,
+            cache_config.directory,
+        )
 
         return merged_result
 

--- a/cognite/client/_api/data_modeling/instances.py
+++ b/cognite/client/_api/data_modeling/instances.py
@@ -104,18 +104,12 @@ class FileCacheConfig:
     will just be the query_hash.
 
     Args:
-        external_id_prefix: Prefix for the cache file external_id. The final external_id
-            will be `{external_id_prefix}_{query_hash}` (or just `{query_hash}` if empty).
-            Defaults to empty string.
-        data_set_id: The data set ID for the cache file. Mutually exclusive with
-            data_set_external_id.
-        data_set_external_id: The data set external ID for the cache file. Will be resolved
-            to data_set_id. Mutually exclusive with data_set_id.
-        security_category: Security category ID to attach to the cache file. Mutually
-            exclusive with security_category_name.
-        security_category_name: Security category name to attach to the cache file. Will be
-            resolved to security_category ID. Mutually exclusive with security_category.
-        directory: Directory associated with the cache file. Must be an absolute, unix-style path.
+        external_id_prefix (str): Prefix for the cache file external_id. The final external_id will be `{external_id_prefix}_{query_hash}` (or just `{query_hash}` if empty). Defaults to empty string.
+        data_set_id (int | None): The data set ID for the cache file. Mutually exclusive with data_set_external_id.
+        data_set_external_id (str | None): The data set external ID for the cache file. Will be resolved to data_set_id. Mutually exclusive with data_set_id.
+        security_category (int | None): Security category ID to attach to the cache file. Mutually exclusive with security_category_name.
+        security_category_name (str | None): Security category name to attach to the cache file. Will be resolved to security_category ID. Mutually exclusive with security_category.
+        directory (str | None): Directory associated with the cache file. Must be an absolute, unix-style path.
 
     Raises:
         ValueError: If both data_set_id and data_set_external_id are set.
@@ -127,14 +121,14 @@ class FileCacheConfig:
         with access to the cache file. This includes the cursor state which can be used
         to retrieve incremental changes.
 
-        **Security considerations:**
+        Security considerations:
 
-        - **Security category** is the safest way to restrict access. Only users who have
-          been granted access to the specified security category can read or write the
-          cache file.
-        - **Data set** alone does NOT limit access for users who have ``files:read`` or
-          ``files:write`` with ``scope: all`` (AllScope). Data sets are primarily for
-          organizing data, not for access control.
+        - Security category is the safest way to restrict access. Only users who have
+            been granted access to the specified security category can read or write the
+            cache file.
+        - Data set alone does NOT limit access for users who have files:read or
+            files:write with scope: all (AllScope). Data sets are primarily for
+            organizing data, not for access control.
 
         For sensitive data, always use a security category to ensure proper access control.
     """
@@ -1860,13 +1854,13 @@ class InstancesAPI(APIClient):
             with access to the cache file. This includes the cursor state which can be used
             to retrieve incremental changes.
 
-            **Security considerations:**
+            Security considerations:
 
-            - **Security category** is the safest way to restrict access. Only users who have
-              been granted access to the specified security category can read or write the
-              cache file.
-            - **Data set** alone does NOT limit access for users who have ``files:read`` or
-              ``files:write`` with ``scope: all`` (AllScope).
+            - Security category is the safest way to restrict access. Only users who have
+                been granted access to the specified security category can read or write the
+                cache file.
+            - Data set alone does NOT limit access for users who have files:read or
+                files:write with scope: all (AllScope).
 
             For sensitive data, always use a security category to ensure proper access control.
 
@@ -1924,8 +1918,9 @@ class InstancesAPI(APIClient):
         data_set_id = cache_config.data_set_id
         if data_set_id is None and cache_config.data_set_external_id is not None:
             data_set = await self._cognite_client.data_sets.retrieve(external_id=cache_config.data_set_external_id)
-            if data_set is not None:
-                data_set_id = data_set.id
+            if data_set is None:
+                raise ValueError(f"Data set with external_id '{cache_config.data_set_external_id}' not found")
+            data_set_id = data_set.id
 
         # Resolve security_category_name to security_category ID if needed
         security_category_ids: list[int] | None = None
@@ -1938,10 +1933,7 @@ class InstancesAPI(APIClient):
                     security_category_ids = [sc.id]
                     break
             if security_category_ids is None:
-                logger.warning(
-                    f"Security category with name '{cache_config.security_category_name}' not found, "
-                    "file will be created without security category"
-                )
+                raise ValueError(f"Security category with name '{cache_config.security_category_name}' not found")
 
         # Try to load cached cursors
         try:

--- a/cognite/client/_api/data_modeling/instances.py
+++ b/cognite/client/_api/data_modeling/instances.py
@@ -1864,12 +1864,12 @@ class InstancesAPI(APIClient):
         raise ValueError(f"Security category with name '{cache_config.security_category_name}' not found")
 
     async def _load_cached_data(
-        self, cache_external_id: str, query_hash: str, query: QuerySync
-    ) -> dict[str, list[dict[str, Any]]]:
+        self, cache_external_id: str, query_hash: str
+    ) -> tuple[dict[str, list[dict[str, Any]]], dict[str, str | None]]:
         """Load cached cursors and instances from file.
 
-        Returns cached instances dict (may be empty if no cache or hash mismatch).
-        Also updates query.cursors if valid cached cursors are found.
+        Returns a tuple of (cached_instances, cached_cursors).
+        Both may be empty dicts if no cache exists or hash mismatch.
         """
         try:
             cached_bytes = await self._cognite_client.files.download_bytes(external_id=cache_external_id)
@@ -1877,18 +1877,17 @@ class InstancesAPI(APIClient):
 
             if cached_data.get("hash") != query_hash:
                 logger.debug("Cache hash mismatch, ignoring cached data")
-                return {}
+                return {}, {}
 
-            query.cursors = cached_data.get("cursors", {})
             logger.debug(f"Loaded cached data from file {cache_external_id}")
-            return cached_data.get("instances", {})
+            return cached_data.get("instances", {}), cached_data.get("cursors", {})
 
         except CogniteNotFoundError:
             logger.debug(f"No cached data found at {cache_external_id}")
-            return {}
+            return {}, {}
         except Exception as e:
             logger.warning(f"Failed to load cached data: {e}")
-            return {}
+            return {}, {}
 
     def _merge_sync_result_with_cache(
         self,
@@ -2088,8 +2087,12 @@ class InstancesAPI(APIClient):
         data_set_id = await self._resolve_data_set_id(cache_config)
         security_category_ids = await self._resolve_security_category_ids(cache_config)
 
-        # Load cached data (updates query.cursors if valid cache exists)
-        cached_instances = await self._load_cached_data(cache_external_id, query_hash, query)
+        # Load cached data
+        cached_instances, cached_cursors = await self._load_cached_data(cache_external_id, query_hash)
+
+        # Apply cached cursors to query for incremental sync
+        if cached_cursors:
+            query.cursors = cached_cursors
 
         # Perform the sync
         sync_result = await self.sync(query, include_typing=include_typing, debug=debug)

--- a/cognite/client/_api/data_modeling/instances.py
+++ b/cognite/client/_api/data_modeling/instances.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
 import asyncio
+import hashlib
 import inspect
 import logging
 import random
 from collections.abc import AsyncIterator, Awaitable, Callable, Iterable, Sequence
+from dataclasses import dataclass
 from datetime import datetime, timezone
 from typing import (
     TYPE_CHECKING,
@@ -71,9 +73,12 @@ from cognite.client.data_classes.data_modeling.query import (
 from cognite.client.data_classes.data_modeling.sync import SubscriptionContext
 from cognite.client.data_classes.data_modeling.views import View
 from cognite.client.data_classes.filters import _BASIC_FILTERS, Filter, _validate_filter
+from cognite.client.exceptions import CogniteNotFoundError
 from cognite.client.utils._auxiliary import is_unlimited, load_yaml_or_json, unpack_items
 from cognite.client.utils._experimental import FeaturePreviewWarning
 from cognite.client.utils._identifier import DataModelingIdentifierSequence
+from cognite.client.utils._json_extended import dumps as json_dumps
+from cognite.client.utils._json_extended import loads as json_loads
 from cognite.client.utils._retry import Backoff
 from cognite.client.utils._text import random_string
 from cognite.client.utils.useful_types import SequenceNotStr
@@ -87,6 +92,45 @@ _FILTERS_SUPPORTED: frozenset[type[Filter]] = _BASIC_FILTERS.union(
 )
 
 logger = logging.getLogger(__name__)
+
+
+@dataclass
+class FileCacheConfig:
+    """Configuration for caching sync cursors in a CDF file.
+
+    The file external_id will be generated as: `{external_id_prefix}_{query_hash}` where
+    query_hash is a hash of the query structure (excluding cursors). This ensures cache
+    invalidation when the query changes.
+
+    Args:
+        external_id_prefix: Prefix for the cache file external_id. The final external_id
+            will be `{external_id_prefix}_{query_hash}`.
+        data_set_id: The data set ID for the cache file. Either this or data_set_external_id
+            should be provided for access control.
+        data_set_external_id: The data set external ID for the cache file. Will be resolved
+            to data_set_id. Either this or data_set_id should be provided for access control.
+        security_categories: Security categories to attach to the cache file.
+        directory: Directory associated with the cache file. Must be an absolute, unix-style path.
+    """
+
+    external_id_prefix: str
+    data_set_id: int | None = None
+    data_set_external_id: str | None = None
+    security_categories: Sequence[int] | None = None
+    directory: str | None = None
+
+
+def _compute_query_hash(query: QuerySync) -> str:
+    """Compute a hash of the query structure, excluding cursors.
+
+    This is used to generate a cache key that invalidates when the query changes.
+    """
+    query_dict = query.dump(camel_case=True)
+    # Remove cursors as they change between sync calls
+    query_dict.pop("cursors", None)
+    # Use sort_keys for deterministic hashing
+    serialized = json_dumps(query_dict, sort_keys=True)
+    return hashlib.sha256(serialized.encode()).hexdigest()[:16]
 
 
 Source: TypeAlias = SourceSelector | View | ViewId | tuple[str, str] | tuple[str, str, str]
@@ -1745,6 +1789,125 @@ class InstancesAPI(APIClient):
             typing=json_payload.get("typing"),
             debug=json_payload.get("debug"),
         )
+
+    async def sync_with_file_cache(
+        self,
+        query: QuerySync,
+        *,
+        cache_config: FileCacheConfig,
+        include_typing: bool = False,
+        debug: DebugParameters | None = None,
+    ) -> QueryResult:
+        """Sync instances with cursor state cached in a CDF file.
+
+        This is a utility method that combines the sync endpoint with persistent cursor
+        storage in CDF Files. The cursor state is automatically saved after each successful
+        sync and restored on subsequent calls, enabling incremental syncs across sessions.
+
+        The cache file external_id is generated as `{cache_config.external_id_prefix}_{query_hash}`
+        where query_hash is derived from the query structure. This ensures cache invalidation
+        when the query changes.
+
+        Note:
+            This method relies on the `allow_expired_cursors_and_accept_missed_deletes` flag
+            on QuerySync for handling cursor expiration (cursors expire after 3 days).
+
+        Args:
+            query (QuerySync): The sync query. Cursors will be loaded from cache if available.
+            cache_config (FileCacheConfig): Configuration for the cache file including
+                external_id_prefix, data_set_id/data_set_external_id, security_categories,
+                and directory.
+            include_typing (bool): Whether to return property type information as part of
+                the result.
+            debug (DebugParameters | None): Debug settings for profiling and troubleshooting.
+
+        Returns:
+            QueryResult: The resulting nodes and/or edges from the sync query.
+
+        Examples:
+
+            Sync pumps with cursor state cached in a file:
+
+                >>> from cognite.client import CogniteClient
+                >>> from cognite.client.data_classes.data_modeling.query import (
+                ...     QuerySync,
+                ...     SelectSync,
+                ...     NodeResultSetExpressionSync,
+                ... )
+                >>> from cognite.client._api.data_modeling.instances import FileCacheConfig
+                >>> from cognite.client.data_classes.data_modeling.ids import ViewId
+                >>> client = CogniteClient()
+                >>> pump_view = ViewId("mySpace", "Pump", "v1")
+                >>> query = QuerySync(
+                ...     with_={"pumps": NodeResultSetExpressionSync()},
+                ...     select={"pumps": SelectSync()},
+                ... )
+                >>> cache_config = FileCacheConfig(
+                ...     external_id_prefix="pump_sync_cache",
+                ...     data_set_external_id="my_data_set",
+                ... )
+                >>> # First call: syncs all pumps and saves cursor to file
+                >>> result = client.data_modeling.instances.sync_with_file_cache(
+                ...     query, cache_config=cache_config
+                ... )
+                >>> # Subsequent calls: loads cursor from file and syncs only changes
+                >>> result2 = client.data_modeling.instances.sync_with_file_cache(
+                ...     query, cache_config=cache_config
+                ... )
+        """
+        # Compute query hash for cache key
+        query_hash = _compute_query_hash(query)
+        cache_external_id = f"{cache_config.external_id_prefix}_{query_hash}"
+
+        # Resolve data_set_external_id to data_set_id if needed
+        data_set_id = cache_config.data_set_id
+        if data_set_id is None and cache_config.data_set_external_id is not None:
+            data_set = await self._cognite_client.data_sets.retrieve(external_id=cache_config.data_set_external_id)
+            if data_set is not None:
+                data_set_id = data_set.id
+
+        # Try to load cached cursors
+        try:
+            cached_bytes = await self._cognite_client.files.download_bytes(external_id=cache_external_id)
+            cached_data = json_loads(cached_bytes.decode("utf-8"))
+            # Verify hash matches (cache busting)
+            if cached_data.get("hash") == query_hash:
+                query.cursors = cached_data.get("cursors", {})
+                logger.debug(f"Loaded cached cursors from file {cache_external_id}")
+            else:
+                logger.debug("Cache hash mismatch, ignoring cached cursors")
+        except CogniteNotFoundError:
+            logger.debug(f"No cached cursors found at {cache_external_id}")
+        except Exception as e:
+            logger.warning(f"Failed to load cached cursors: {e}")
+
+        # Perform the sync
+        result = await self.sync(query, include_typing=include_typing, debug=debug)
+
+        # Save updated cursors to cache
+        try:
+            cache_data = {
+                "hash": query_hash,
+                "cursors": result.cursors,
+            }
+            cache_content = json_dumps(cache_data).encode("utf-8")
+            await self._cognite_client.files.upload_bytes(
+                content=cache_content,
+                name=f"{cache_external_id}.json",
+                external_id=cache_external_id,
+                data_set_id=data_set_id,
+                security_categories=list(cache_config.security_categories)
+                if cache_config.security_categories
+                else None,
+                directory=cache_config.directory,
+                mime_type="application/json",
+                overwrite=True,
+            )
+            logger.debug(f"Saved cursors to cache file {cache_external_id}")
+        except Exception as e:
+            logger.warning(f"Failed to save cursors to cache file: {e}")
+
+        return result
 
     @overload
     async def list(

--- a/cognite/client/_api/data_modeling/instances.py
+++ b/cognite/client/_api/data_modeling/instances.py
@@ -2014,7 +2014,7 @@ class InstancesAPI(APIClient):
         1. Loads cached cursors and instances from the file (if available)
         2. Performs an incremental sync using the cached cursors
         3. Merges the sync result with cached instances (adding/updating new items,
-            removing items with deleted_time set)
+        removing items with deleted_time set)
         4. Saves the merged data and updated cursors back to the cache file
         5. Returns the full merged result (all instances, not just incremental changes)
 

--- a/cognite/client/_api/data_modeling/instances.py
+++ b/cognite/client/_api/data_modeling/instances.py
@@ -259,6 +259,12 @@ class InstancesAPI(APIClient):
             feature_name="Data modeling debug parameters 'includeTranslatedQuery' and 'includePlan'",
             pluralize=True,
         )
+        self._warn_on_sync_with_file_cache = FeaturePreviewWarning(
+            api_maturity="General Availability",
+            sdk_maturity="alpha",
+            feature_name="Using file caching for sync queries in the Instances API",
+            pluralize=False,
+        )
 
     def _get_semaphore(self, operation: Literal["read", "write", "delete", "search"]) -> asyncio.BoundedSemaphore:
         from cognite.client import global_config
@@ -2079,6 +2085,7 @@ class InstancesAPI(APIClient):
                 ...     query, cache_config=cache_config
                 ... )
         """
+        self._warn_on_sync_with_file_cache.warn()
         # Compute query hash for cache key
         query_hash = _compute_query_hash(query)
         cache_external_id = (

--- a/cognite/client/_api/data_modeling/instances.py
+++ b/cognite/client/_api/data_modeling/instances.py
@@ -1894,7 +1894,6 @@ class InstancesAPI(APIClient):
         self,
         sync_result: QueryResult,
         cached_instances: dict[str, list[dict[str, Any]]],
-        default_by_reference: dict[str, type[NodeListWithCursor] | type[EdgeListWithCursor]],
     ) -> QueryResult:
         """Merge cached instances with sync result.
 
@@ -1909,7 +1908,7 @@ class InstancesAPI(APIClient):
             self._apply_sync_changes(sync_list, cached_by_id)
             merged_items = list(cached_by_id.values())
 
-            merged_result[key] = self._create_merged_list(key, merged_items, sync_list, default_by_reference)
+            merged_result[key] = self._create_merged_list(merged_items, sync_list)
 
         return merged_result
 
@@ -1938,18 +1937,11 @@ class InstancesAPI(APIClient):
 
     @staticmethod
     def _create_merged_list(
-        key: str,
         merged_items: list[dict[str, Any]],
         sync_list: NodeListWithCursor | EdgeListWithCursor,
-        default_by_reference: dict[str, type[NodeListWithCursor] | type[EdgeListWithCursor]],
     ) -> NodeListWithCursor | EdgeListWithCursor:
         """Create the appropriate list type (nodes or edges) for the merged result."""
-        instance_lst_cls = default_by_reference.get(key, NodeListWithCursor)
-        is_node_list = instance_lst_cls is NodeListWithCursor or (
-            not merged_items and isinstance(sync_list, NodeListWithCursor)
-        )
-
-        if is_node_list:
+        if isinstance(sync_list, NodeListWithCursor):
             return NodeListWithCursor(
                 [Node._load(item) for item in merged_items],
                 cursor=sync_list.cursor,
@@ -2103,8 +2095,7 @@ class InstancesAPI(APIClient):
         sync_result = await self.sync(query, include_typing=include_typing, debug=debug)
 
         # Merge cached instances with sync result
-        default_by_reference = query.instance_type_by_result_expression()
-        merged_result = self._merge_sync_result_with_cache(sync_result, cached_instances, default_by_reference)
+        merged_result = self._merge_sync_result_with_cache(sync_result, cached_instances)
 
         # Save updated data to cache
         await self._save_cache_data(

--- a/cognite/client/_api/data_modeling/instances.py
+++ b/cognite/client/_api/data_modeling/instances.py
@@ -2014,7 +2014,7 @@ class InstancesAPI(APIClient):
         1. Loads cached cursors and instances from the file (if available)
         2. Performs an incremental sync using the cached cursors
         3. Merges the sync result with cached instances (adding/updating new items,
-           removing items with deleted_time set)
+            removing items with deleted_time set)
         4. Saves the merged data and updated cursors back to the cache file
         5. Returns the full merged result (all instances, not just incremental changes)
 

--- a/cognite/client/_api/data_modeling/instances.py
+++ b/cognite/client/_api/data_modeling/instances.py
@@ -100,24 +100,67 @@ class FileCacheConfig:
 
     The file external_id will be generated as: `{external_id_prefix}_{query_hash}` where
     query_hash is a hash of the query structure (excluding cursors). This ensures cache
-    invalidation when the query changes.
+    invalidation when the query changes. If external_id_prefix is empty, the external_id
+    will just be the query_hash.
 
     Args:
         external_id_prefix: Prefix for the cache file external_id. The final external_id
-            will be `{external_id_prefix}_{query_hash}`.
-        data_set_id: The data set ID for the cache file. Either this or data_set_external_id
-            should be provided for access control.
+            will be `{external_id_prefix}_{query_hash}` (or just `{query_hash}` if empty).
+            Defaults to empty string.
+        data_set_id: The data set ID for the cache file. Mutually exclusive with
+            data_set_external_id.
         data_set_external_id: The data set external ID for the cache file. Will be resolved
-            to data_set_id. Either this or data_set_id should be provided for access control.
-        security_categories: Security categories to attach to the cache file.
+            to data_set_id. Mutually exclusive with data_set_id.
+        security_category: Security category ID to attach to the cache file. Mutually
+            exclusive with security_category_name.
+        security_category_name: Security category name to attach to the cache file. Will be
+            resolved to security_category ID. Mutually exclusive with security_category.
         directory: Directory associated with the cache file. Must be an absolute, unix-style path.
+
+    Raises:
+        ValueError: If both data_set_id and data_set_external_id are set.
+        ValueError: If both security_category and security_category_name are set.
+        ValueError: If neither data set nor security category is specified.
+
+    Caveat:
+        By using this function, you make the data from data modeling available to anyone
+        with access to the cache file. This includes the cursor state which can be used
+        to retrieve incremental changes.
+
+        **Security considerations:**
+
+        - **Security category** is the safest way to restrict access. Only users who have
+          been granted access to the specified security category can read or write the
+          cache file.
+        - **Data set** alone does NOT limit access for users who have ``files:read`` or
+          ``files:write`` with ``scope: all`` (AllScope). Data sets are primarily for
+          organizing data, not for access control.
+
+        For sensitive data, always use a security category to ensure proper access control.
     """
 
-    external_id_prefix: str
+    external_id_prefix: str = ""
     data_set_id: int | None = None
     data_set_external_id: str | None = None
-    security_categories: Sequence[int] | None = None
+    security_category: int | None = None
+    security_category_name: str | None = None
     directory: str | None = None
+
+    def __post_init__(self) -> None:
+        if self.data_set_id is not None and self.data_set_external_id is not None:
+            raise ValueError("Cannot specify both data_set_id and data_set_external_id")
+        if self.security_category is not None and self.security_category_name is not None:
+            raise ValueError("Cannot specify both security_category and security_category_name")
+        if (
+            self.data_set_id is None
+            and self.data_set_external_id is None
+            and self.security_category is None
+            and self.security_category_name is None
+        ):
+            raise ValueError(
+                "At least one of data_set_id, data_set_external_id, security_category, "
+                "or security_category_name must be specified for access control"
+            )
 
 
 def _compute_query_hash(query: QuerySync) -> str:
@@ -1805,18 +1848,33 @@ class InstancesAPI(APIClient):
         sync and restored on subsequent calls, enabling incremental syncs across sessions.
 
         The cache file external_id is generated as `{cache_config.external_id_prefix}_{query_hash}`
-        where query_hash is derived from the query structure. This ensures cache invalidation
-        when the query changes.
+        where query_hash is derived from the query structure (or just `{query_hash}` if the
+        prefix is empty). This ensures cache invalidation when the query changes.
 
         Note:
             This method relies on the `allow_expired_cursors_and_accept_missed_deletes` flag
             on QuerySync for handling cursor expiration (cursors expire after 3 days).
 
+        Caveat:
+            By using this function, you make the data from data modeling available to anyone
+            with access to the cache file. This includes the cursor state which can be used
+            to retrieve incremental changes.
+
+            **Security considerations:**
+
+            - **Security category** is the safest way to restrict access. Only users who have
+              been granted access to the specified security category can read or write the
+              cache file.
+            - **Data set** alone does NOT limit access for users who have ``files:read`` or
+              ``files:write`` with ``scope: all`` (AllScope).
+
+            For sensitive data, always use a security category to ensure proper access control.
+
         Args:
             query (QuerySync): The sync query. Cursors will be loaded from cache if available.
             cache_config (FileCacheConfig): Configuration for the cache file including
-                external_id_prefix, data_set_id/data_set_external_id, security_categories,
-                and directory.
+                external_id_prefix, data_set_id/data_set_external_id,
+                security_category/security_category_name, and directory.
             include_typing (bool): Whether to return property type information as part of
                 the result.
             debug (DebugParameters | None): Debug settings for profiling and troubleshooting.
@@ -1826,7 +1884,7 @@ class InstancesAPI(APIClient):
 
         Examples:
 
-            Sync pumps with cursor state cached in a file:
+            Sync pumps with cursor state cached in a file (using security category for access control):
 
                 >>> from cognite.client import CogniteClient
                 >>> from cognite.client.data_classes.data_modeling.query import (
@@ -1844,7 +1902,7 @@ class InstancesAPI(APIClient):
                 ... )
                 >>> cache_config = FileCacheConfig(
                 ...     external_id_prefix="pump_sync_cache",
-                ...     data_set_external_id="my_data_set",
+                ...     security_category_name="my_security_category",
                 ... )
                 >>> # First call: syncs all pumps and saves cursor to file
                 >>> result = client.data_modeling.instances.sync_with_file_cache(
@@ -1857,7 +1915,10 @@ class InstancesAPI(APIClient):
         """
         # Compute query hash for cache key
         query_hash = _compute_query_hash(query)
-        cache_external_id = f"{cache_config.external_id_prefix}_{query_hash}"
+        if cache_config.external_id_prefix:
+            cache_external_id = f"{cache_config.external_id_prefix}_{query_hash}"
+        else:
+            cache_external_id = query_hash
 
         # Resolve data_set_external_id to data_set_id if needed
         data_set_id = cache_config.data_set_id
@@ -1865,6 +1926,22 @@ class InstancesAPI(APIClient):
             data_set = await self._cognite_client.data_sets.retrieve(external_id=cache_config.data_set_external_id)
             if data_set is not None:
                 data_set_id = data_set.id
+
+        # Resolve security_category_name to security_category ID if needed
+        security_category_ids: list[int] | None = None
+        if cache_config.security_category is not None:
+            security_category_ids = [cache_config.security_category]
+        elif cache_config.security_category_name is not None:
+            security_categories = await self._cognite_client.iam.security_categories.list(limit=-1)
+            for sc in security_categories:
+                if sc.name == cache_config.security_category_name:
+                    security_category_ids = [sc.id]
+                    break
+            if security_category_ids is None:
+                logger.warning(
+                    f"Security category with name '{cache_config.security_category_name}' not found, "
+                    "file will be created without security category"
+                )
 
         # Try to load cached cursors
         try:
@@ -1896,9 +1973,7 @@ class InstancesAPI(APIClient):
                 name=f"{cache_external_id}.json",
                 external_id=cache_external_id,
                 data_set_id=data_set_id,
-                security_categories=list(cache_config.security_categories)
-                if cache_config.security_categories
-                else None,
+                security_categories=security_category_ids,
                 directory=cache_config.directory,
                 mime_type="application/json",
                 overwrite=True,

--- a/cognite/client/_sync_api/data_modeling/instances.py
+++ b/cognite/client/_sync_api/data_modeling/instances.py
@@ -1,6 +1,6 @@
 """
 ===============================================================================
-8d082dcee502b46e55dd65c99fcce5f4
+e52dde9d2ecdefa5e55a5d04c29f4906
 This file is auto-generated from the Async API modules, - do not edit manually!
 ===============================================================================
 """

--- a/cognite/client/_sync_api/data_modeling/instances.py
+++ b/cognite/client/_sync_api/data_modeling/instances.py
@@ -11,7 +11,7 @@ from collections.abc import Awaitable, Callable, Iterator, Sequence
 from typing import TYPE_CHECKING, Any, Literal, overload
 
 from cognite.client import AsyncCogniteClient
-from cognite.client._api.data_modeling.instances import Source
+from cognite.client._api.data_modeling.instances import FileCacheConfig, Source
 from cognite.client._constants import DEFAULT_LIMIT_READ
 from cognite.client._sync_api_client import SyncAPIClient
 from cognite.client.data_classes.aggregations import (
@@ -1234,6 +1234,92 @@ class SyncInstancesAPI(SyncAPIClient):
         """
         return run_sync(
             self.__async_client.data_modeling.instances.sync(query=query, include_typing=include_typing, debug=debug)
+        )
+
+    def sync_with_file_cache(
+        self,
+        query: QuerySync,
+        *,
+        cache_config: FileCacheConfig,
+        include_typing: bool = False,
+        debug: DebugParameters | None = None,
+    ) -> QueryResult:
+        """Sync instances with cursor state cached in a CDF file.
+
+        This is a utility method that combines the sync endpoint with persistent cursor
+        storage in CDF Files. The cursor state is automatically saved after each successful
+        sync and restored on subsequent calls, enabling incremental syncs across sessions.
+
+        The cache file external_id is generated as `{cache_config.external_id_prefix}_{query_hash}`
+        where query_hash is derived from the query structure (or just `{query_hash}` if the
+        prefix is empty). This ensures cache invalidation when the query changes.
+
+        Note:
+            This method relies on the `allow_expired_cursors_and_accept_missed_deletes` flag
+            on QuerySync for handling cursor expiration (cursors expire after 3 days).
+
+        Caveat:
+            By using this function, you make the data from data modeling available to anyone
+            with access to the cache file. This includes the cursor state which can be used
+            to retrieve incremental changes.
+
+            Security considerations:
+
+            - Security category is the safest way to restrict access. Only users who have
+                been granted access to the specified security category can read or write the
+                cache file.
+            - Data set alone does NOT limit access for users who have files:read or
+                files:write with scope: all (AllScope).
+
+            For sensitive data, always use a security category to ensure proper access control.
+
+        Args:
+            query (QuerySync): The sync query. Cursors will be loaded from cache if available.
+            cache_config (FileCacheConfig): Configuration for the cache file including
+                external_id_prefix, data_set_id/data_set_external_id,
+                security_category/security_category_name, and directory.
+            include_typing (bool): Whether to return property type information as part of
+                the result.
+            debug (DebugParameters | None): Debug settings for profiling and troubleshooting.
+
+        Returns:
+            QueryResult: The resulting nodes and/or edges from the sync query.
+
+        Examples:
+
+            Sync pumps with cursor state cached in a file (using security category for access control):
+
+                >>> from cognite.client import CogniteClient
+                >>> from cognite.client.data_classes.data_modeling.query import (
+                ...     QuerySync,
+                ...     SelectSync,
+                ...     NodeResultSetExpressionSync,
+                ... )
+                >>> from cognite.client._api.data_modeling.instances import FileCacheConfig
+                >>> from cognite.client.data_classes.data_modeling.ids import ViewId
+                >>> client = CogniteClient()
+                >>> pump_view = ViewId("mySpace", "Pump", "v1")
+                >>> query = QuerySync(
+                ...     with_={"pumps": NodeResultSetExpressionSync()},
+                ...     select={"pumps": SelectSync()},
+                ... )
+                >>> cache_config = FileCacheConfig(
+                ...     external_id_prefix="pump_sync_cache",
+                ...     security_category_name="my_security_category",
+                ... )
+                >>> # First call: syncs all pumps and saves cursor to file
+                >>> result = client.data_modeling.instances.sync_with_file_cache(
+                ...     query, cache_config=cache_config
+                ... )
+                >>> # Subsequent calls: loads cursor from file and syncs only changes
+                >>> result2 = client.data_modeling.instances.sync_with_file_cache(
+                ...     query, cache_config=cache_config
+                ... )
+        """
+        return run_sync(
+            self.__async_client.data_modeling.instances.sync_with_file_cache(
+                query=query, cache_config=cache_config, include_typing=include_typing, debug=debug
+            )
         )
 
     @overload

--- a/cognite/client/_sync_api/data_modeling/instances.py
+++ b/cognite/client/_sync_api/data_modeling/instances.py
@@ -1251,7 +1251,7 @@ class SyncInstancesAPI(SyncAPIClient):
         1. Loads cached cursors and instances from the file (if available)
         2. Performs an incremental sync using the cached cursors
         3. Merges the sync result with cached instances (adding/updating new items,
-           removing items with deleted_time set)
+            removing items with deleted_time set)
         4. Saves the merged data and updated cursors back to the cache file
         5. Returns the full merged result (all instances, not just incremental changes)
 

--- a/cognite/client/_sync_api/data_modeling/instances.py
+++ b/cognite/client/_sync_api/data_modeling/instances.py
@@ -186,7 +186,7 @@ class SyncInstancesAPI(SyncAPIClient):
     def retrieve_edges(
         self,
         edges: EdgeId | Sequence[EdgeId] | tuple[str, str] | Sequence[tuple[str, str]],
-        edge_cls: type[T_Edge] = Edge,
+        edge_cls: type[T_Edge] = Edge,  # type: ignore [assignment]
         sources: Source | Sequence[Source] | None = None,
         include_typing: bool = False,
     ) -> EdgeList[T_Edge] | T_Edge | Edge | None:
@@ -264,7 +264,7 @@ class SyncInstancesAPI(SyncAPIClient):
         return run_sync(
             self.__async_client.data_modeling.instances.retrieve_edges(
                 edges=edges, edge_cls=edge_cls, sources=sources, include_typing=include_typing
-            )
+            )  # type: ignore [call-overload]
         )
 
     @overload
@@ -291,12 +291,12 @@ class SyncInstancesAPI(SyncAPIClient):
         *,
         sources: Source | Sequence[Source] | None = None,
         include_typing: bool = False,
-    ) -> NodeList[Node]: ...  # type: ignore[assignment]
+    ) -> NodeList[Node]: ...
 
     def retrieve_nodes(
         self,
         nodes: NodeId | Sequence[NodeId] | tuple[str, str] | Sequence[tuple[str, str]],
-        node_cls: type[T_Node] = Node,
+        node_cls: type[T_Node] = Node,  # type: ignore [assignment]
         sources: Source | Sequence[Source] | None = None,
         include_typing: bool = False,
     ) -> NodeList[T_Node] | T_Node | Node | None:
@@ -371,7 +371,7 @@ class SyncInstancesAPI(SyncAPIClient):
         return run_sync(
             self.__async_client.data_modeling.instances.retrieve_nodes(
                 nodes=nodes, node_cls=node_cls, sources=sources, include_typing=include_typing
-            )
+            )  # type: ignore [call-overload]
         )
 
     def retrieve(
@@ -1470,7 +1470,7 @@ class SyncInstancesAPI(SyncAPIClient):
         """
         return run_sync(
             self.__async_client.data_modeling.instances.list(
-                instance_type=instance_type,
+                instance_type=instance_type,  # type: ignore [arg-type]
                 include_typing=include_typing,
                 sources=sources,
                 space=space,
@@ -1478,5 +1478,5 @@ class SyncInstancesAPI(SyncAPIClient):
                 sort=sort,
                 filter=filter,
                 debug=debug,
-            )
+            )  # type: ignore [misc]
         )

--- a/cognite/client/_sync_api/data_modeling/instances.py
+++ b/cognite/client/_sync_api/data_modeling/instances.py
@@ -1244,11 +1244,16 @@ class SyncInstancesAPI(SyncAPIClient):
         include_typing: bool = False,
         debug: DebugParameters | None = None,
     ) -> QueryResult:
-        """Sync instances with cursor state cached in a CDF file.
+        """Sync instances with cursor state and instances cached in a CDF file.
 
-        This is a utility method that combines the sync endpoint with persistent cursor
-        storage in CDF Files. The cursor state is automatically saved after each successful
-        sync and restored on subsequent calls, enabling incremental syncs across sessions.
+        This is a utility method that combines the sync endpoint with persistent
+        storage of both cursor state and instance data in CDF Files. The method:
+        1. Loads cached cursors and instances from the file (if available)
+        2. Performs an incremental sync using the cached cursors
+        3. Merges the sync result with cached instances (adding/updating new items,
+           removing items with deleted_time set)
+        4. Saves the merged data and updated cursors back to the cache file
+        5. Returns the full merged result (all instances, not just incremental changes)
 
         The cache file external_id is generated as `{cache_config.external_id_prefix}_{query_hash}`
         where query_hash is derived from the query structure (or just `{query_hash}` if the
@@ -1283,7 +1288,8 @@ class SyncInstancesAPI(SyncAPIClient):
             debug (DebugParameters | None): Debug settings for profiling and troubleshooting.
 
         Returns:
-            QueryResult: The resulting nodes and/or edges from the sync query.
+            QueryResult: The full set of nodes and/or edges (cached + new from sync,
+                minus deleted items). This is a merged result, not just incremental changes.
 
         Examples:
 
@@ -1307,11 +1313,11 @@ class SyncInstancesAPI(SyncAPIClient):
                 ...     external_id_prefix="pump_sync_cache",
                 ...     security_category_name="my_security_category",
                 ... )
-                >>> # First call: syncs all pumps and saves cursor to file
+                >>> # First call: syncs all pumps and saves data to file
                 >>> result = client.data_modeling.instances.sync_with_file_cache(
                 ...     query, cache_config=cache_config
                 ... )
-                >>> # Subsequent calls: loads cursor from file and syncs only changes
+                >>> # Subsequent calls: returns all instances (cached + new changes)
                 >>> result2 = client.data_modeling.instances.sync_with_file_cache(
                 ...     query, cache_config=cache_config
                 ... )

--- a/cognite/client/_sync_api/data_modeling/instances.py
+++ b/cognite/client/_sync_api/data_modeling/instances.py
@@ -1,6 +1,6 @@
 """
 ===============================================================================
-75e6b2be19cef62f568f6c9938b3126a
+8d082dcee502b46e55dd65c99fcce5f4
 This file is auto-generated from the Async API modules, - do not edit manually!
 ===============================================================================
 """
@@ -142,7 +142,7 @@ class SyncInstancesAPI(SyncAPIClient):
 
         Yields:
             Edge | EdgeList | Node | NodeList: yields Instance one by one if chunk_size is not specified, else NodeList/EdgeList objects.
-        """
+        """  # noqa: DOC404
         yield from SyncIterator(
             self.__async_client.data_modeling.instances(
                 chunk_size=chunk_size,
@@ -186,7 +186,7 @@ class SyncInstancesAPI(SyncAPIClient):
     def retrieve_edges(
         self,
         edges: EdgeId | Sequence[EdgeId] | tuple[str, str] | Sequence[tuple[str, str]],
-        edge_cls: type[T_Edge] = Edge,  # type: ignore [assignment]
+        edge_cls: type[T_Edge] = Edge,
         sources: Source | Sequence[Source] | None = None,
         include_typing: bool = False,
     ) -> EdgeList[T_Edge] | T_Edge | Edge | None:
@@ -264,7 +264,7 @@ class SyncInstancesAPI(SyncAPIClient):
         return run_sync(
             self.__async_client.data_modeling.instances.retrieve_edges(
                 edges=edges, edge_cls=edge_cls, sources=sources, include_typing=include_typing
-            )  # type: ignore [call-overload]
+            )
         )
 
     @overload
@@ -291,12 +291,12 @@ class SyncInstancesAPI(SyncAPIClient):
         *,
         sources: Source | Sequence[Source] | None = None,
         include_typing: bool = False,
-    ) -> NodeList[Node]: ...
+    ) -> NodeList[Node]: ...  # type: ignore[assignment]
 
     def retrieve_nodes(
         self,
         nodes: NodeId | Sequence[NodeId] | tuple[str, str] | Sequence[tuple[str, str]],
-        node_cls: type[T_Node] = Node,  # type: ignore [assignment]
+        node_cls: type[T_Node] = Node,
         sources: Source | Sequence[Source] | None = None,
         include_typing: bool = False,
     ) -> NodeList[T_Node] | T_Node | Node | None:
@@ -371,7 +371,7 @@ class SyncInstancesAPI(SyncAPIClient):
         return run_sync(
             self.__async_client.data_modeling.instances.retrieve_nodes(
                 nodes=nodes, node_cls=node_cls, sources=sources, include_typing=include_typing
-            )  # type: ignore [call-overload]
+            )
         )
 
     def retrieve(
@@ -1244,14 +1244,15 @@ class SyncInstancesAPI(SyncAPIClient):
         include_typing: bool = False,
         debug: DebugParameters | None = None,
     ) -> QueryResult:
-        """Sync instances with cursor state and instances cached in a CDF file.
+        """
+        Sync instances with cursor state and instances cached in a CDF file.
 
         This is a utility method that combines the sync endpoint with persistent
         storage of both cursor state and instance data in CDF Files. The method:
         1. Loads cached cursors and instances from the file (if available)
         2. Performs an incremental sync using the cached cursors
         3. Merges the sync result with cached instances (adding/updating new items,
-            removing items with deleted_time set)
+        removing items with deleted_time set)
         4. Saves the merged data and updated cursors back to the cache file
         5. Returns the full merged result (all instances, not just incremental changes)
 
@@ -1469,7 +1470,7 @@ class SyncInstancesAPI(SyncAPIClient):
         """
         return run_sync(
             self.__async_client.data_modeling.instances.list(
-                instance_type=instance_type,  # type: ignore [arg-type]
+                instance_type=instance_type,
                 include_typing=include_typing,
                 sources=sources,
                 space=space,
@@ -1477,5 +1478,5 @@ class SyncInstancesAPI(SyncAPIClient):
                 sort=sort,
                 filter=filter,
                 debug=debug,
-            )  # type: ignore [misc]
+            )
         )

--- a/scripts/sync_client_codegen/constants.py
+++ b/scripts/sync_client_codegen/constants.py
@@ -15,6 +15,7 @@ MAYBE_IMPORTS = (
     "WorkflowIdentifier: TypeAlias",
     "WorkflowVersionIdentifier: TypeAlias",
     "ComparableCapability: TypeAlias",
+    "FileCacheConfig",
 )
 ASYNC_API_DIR = Path("cognite/client/_api")
 SYNC_API_DIR = Path("cognite/client/_sync_api")

--- a/tests/tests_integration/test_api/test_data_modeling/test_instances.py
+++ b/tests/tests_integration/test_api/test_data_modeling/test_instances.py
@@ -9,6 +9,8 @@ from typing import Any, ClassVar, Literal, cast
 import pytest
 
 from cognite.client import AsyncCogniteClient, CogniteClient
+from cognite.client._api.data_modeling.instances import FileCacheConfig
+from cognite.client.data_classes import DataSet
 from cognite.client.data_classes.aggregations import HistogramValue
 from cognite.client.data_classes.data_modeling import (
     Container,
@@ -1653,3 +1655,87 @@ class TestInstancesSync:
                 return
         else:
             assert not context.is_alive()
+
+    def test_sync_with_file_cache(
+        self, cognite_client: CogniteClient, movie_view: View, ts_test_dataset: DataSet
+    ) -> None:
+        """Test that sync_with_file_cache correctly caches cursors and returns incremental changes."""
+        movie_id = movie_view.as_id()
+        test_prefix = f"sync_cache_test_{random_string(6)}"
+
+        # Create first movie with the test prefix
+        first_movie = NodeApply(
+            space=movie_view.space,
+            external_id=f"{test_prefix}_movie_1",
+            sources=[
+                NodeOrEdgeData(
+                    source=movie_id,
+                    properties={
+                        "title": "First Test Movie",
+                        "releaseYear": 2020,
+                        "runTimeMinutes": 120,
+                    },
+                )
+            ],
+        )
+
+        # Create sync query that filters on the test prefix
+        movies_with_prefix = NodeResultSetExpressionSync(
+            filter=Prefix(["node", "externalId"], test_prefix),
+        )
+        sync_query = QuerySync(
+            with_={"movies": movies_with_prefix},
+            select={"movies": SelectSync([SourceSelector(movie_id, ["title", "releaseYear"])])},
+        )
+
+        cache_config = FileCacheConfig(
+            external_id_prefix=f"test_sync_cache_{test_prefix}",
+            data_set_id=ts_test_dataset.id,
+        )
+
+        try:
+            # Apply first movie
+            cognite_client.data_modeling.instances.apply(nodes=first_movie)
+
+            # First sync - should return the first movie
+            result1 = cognite_client.data_modeling.instances.sync_with_file_cache(sync_query, cache_config=cache_config)
+
+            movie_external_ids_1 = [node.external_id for node in result1["movies"]]
+            assert first_movie.external_id in movie_external_ids_1
+
+            # Create second movie with the same prefix
+            second_movie = NodeApply(
+                space=movie_view.space,
+                external_id=f"{test_prefix}_movie_2",
+                sources=[
+                    NodeOrEdgeData(
+                        source=movie_id,
+                        properties={
+                            "title": "Second Test Movie",
+                            "releaseYear": 2021,
+                            "runTimeMinutes": 90,
+                        },
+                    )
+                ],
+            )
+            cognite_client.data_modeling.instances.apply(nodes=second_movie)
+
+            # Second sync - should return both movies
+            result2 = cognite_client.data_modeling.instances.sync_with_file_cache(sync_query, cache_config=cache_config)
+
+            movie_external_ids_2 = [node.external_id for node in result2["movies"]]
+            assert first_movie.external_id in movie_external_ids_2
+            assert second_movie.external_id in movie_external_ids_2
+
+        finally:
+            # Cleanup: delete test movies and cache file
+            cognite_client.data_modeling.instances.delete(
+                nodes=[first_movie.as_id(), NodeId(movie_view.space, f"{test_prefix}_movie_2")]
+            )
+            # Delete the cache file(s) - find files with matching prefix
+            try:
+                cache_files = cognite_client.files.list(external_id_prefix=f"test_sync_cache_{test_prefix}", limit=10)
+                if cache_files:
+                    cognite_client.files.delete(external_id=[f.external_id for f in cache_files])
+            except Exception:
+                pass  # Cache file cleanup failed, ignore


### PR DESCRIPTION
## Description

Adds the utility function `sync_with_file_cache`. 

From docstring:

```python
>>> from cognite.client import CogniteClient
>>> from cognite.client.data_classes.data_modeling.query import (
...     QuerySync,
...     SelectSync,
...     NodeResultSetExpressionSync,
... )
>>> from cognite.client._api.data_modeling.instances import FileCacheConfig
>>> from cognite.client.data_classes.data_modeling.ids import ViewId
>>> client = CogniteClient()
>>> pump_view = ViewId("mySpace", "Pump", "v1")
>>> query = QuerySync(
...     with_={"pumps": NodeResultSetExpressionSync()},
...     select={"pumps": SelectSync()},
... )
>>> cache_config = FileCacheConfig(
...     external_id_prefix="pump_sync_cache",
...     security_category_name="my_security_category",
... )
>>> # First call: syncs all pumps and saves data to file
>>> result = client.data_modeling.instances.sync_with_file_cache(
...     query, cache_config=cache_config
... )
>>> # Subsequent calls: returns all instances (cached + new changes)
>>> result2 = client.data_modeling.instances.sync_with_file_cache(
...     query, cache_config=cache_config
... )
```



## Checklist:
- [x] Tests added/updated.
- [x] Documentation updated. Documentation is generated from docstrings - these must be updated according to your change.
  If a new method has been added it should be referenced in [cognite.rst](https://github.com/cognitedata/cognite-sdk-python/blob/master/docs/source/cognite.rst) in order to generate docs based on its docstring.
- [x] The PR title follows the [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) spec.
