### PR TITLE
chore(tests): add test suite for semaphore usage (e.g. multithreaded env)

### DIFF
--- a/cognite/client/utils/_concurrency.py
+++ b/cognite/client/utils/_concurrency.py
@@ -563,30 +563,28 @@ class _PyodideEventLoopExecutor:
 
 
 # We need this in order to support a synchronous Cognite client.
-_INTERNAL_EVENT_LOOP_THREAD_EXECUTOR_SINGLETON: EventLoopThreadExecutor
+_INTERNAL_EVENT_LOOP_THREAD_EXECUTOR_SINGLETON: EventLoopThreadExecutor | None = None
 _EXECUTOR_INIT_LOCK = threading.Lock()
 
 
 def _get_event_loop_executor() -> EventLoopThreadExecutor:
     global _INTERNAL_EVENT_LOOP_THREAD_EXECUTOR_SINGLETON
+
     # Fast path: singleton already initialized — no lock needed.
-    try:
+    if _INTERNAL_EVENT_LOOP_THREAD_EXECUTOR_SINGLETON is not None:
         return _INTERNAL_EVENT_LOOP_THREAD_EXECUTOR_SINGLETON
-    except NameError:
-        pass
+
     # Slow path: serialize initialization. Without this, multiple threads racing on the first
     # call (e.g. a ThreadPoolExecutor of sync clients) can each construct their own executor
     # and end up using different background loops, breaking the per-loop semaphore cache key.
     with _EXECUTOR_INIT_LOCK:
-        try:
-            return _INTERNAL_EVENT_LOOP_THREAD_EXECUTOR_SINGLETON
-        except NameError:
+        if _INTERNAL_EVENT_LOOP_THREAD_EXECUTOR_SINGLETON is None:
             ex_cls = EventLoopThreadExecutor
             if _RUNNING_IN_BROWSER:
                 ex_cls = cast(type[EventLoopThreadExecutor], _PyodideEventLoopExecutor)
-            executor = _INTERNAL_EVENT_LOOP_THREAD_EXECUTOR_SINGLETON = ex_cls()
-            executor.start()
-            return executor
+            _INTERNAL_EVENT_LOOP_THREAD_EXECUTOR_SINGLETON = ex_cls()
+            _INTERNAL_EVENT_LOOP_THREAD_EXECUTOR_SINGLETON.start()
+        return _INTERNAL_EVENT_LOOP_THREAD_EXECUTOR_SINGLETON
 
 
 async def execute_async_tasks_with_fail_fast(tasks: list[AsyncSDKTask]) -> TasksSummary:

--- a/cognite/client/utils/_concurrency.py
+++ b/cognite/client/utils/_concurrency.py
@@ -262,6 +262,13 @@ class ConcurrencySettings:
             write_schema=1,
         )
 
+    @functools.cached_property
+    def _all_concurrency_configs(self) -> list[ConcurrencyConfig]:
+        """Helper method primarily used in testing to handle the 'annoying' state of concurrency settings"""
+        configs = [name for name, val in vars(type(self)).items() if isinstance(val, property)]
+        configs.remove("is_frozen")
+        return [getattr(self, name) for name in configs]
+
     def _check_frozen(self, name: str, api_name: str) -> None:
         if self.__frozen:
             raise RuntimeError(
@@ -557,21 +564,29 @@ class _PyodideEventLoopExecutor:
 
 # We need this in order to support a synchronous Cognite client.
 _INTERNAL_EVENT_LOOP_THREAD_EXECUTOR_SINGLETON: EventLoopThreadExecutor
+_EXECUTOR_INIT_LOCK = threading.Lock()
 
 
 def _get_event_loop_executor() -> EventLoopThreadExecutor:
     global _INTERNAL_EVENT_LOOP_THREAD_EXECUTOR_SINGLETON
+    # Fast path: singleton already initialized — no lock needed.
     try:
         return _INTERNAL_EVENT_LOOP_THREAD_EXECUTOR_SINGLETON
     except NameError:
-        # First time we need to initialize:
-        ex_cls = EventLoopThreadExecutor
-        if _RUNNING_IN_BROWSER:
-            ex_cls = cast(type[EventLoopThreadExecutor], _PyodideEventLoopExecutor)
-
-        executor = _INTERNAL_EVENT_LOOP_THREAD_EXECUTOR_SINGLETON = ex_cls()
-        executor.start()
-        return executor
+        pass
+    # Slow path: serialize initialization. Without this, multiple threads racing on the first
+    # call (e.g. a ThreadPoolExecutor of sync clients) can each construct their own executor
+    # and end up using different background loops, breaking the per-loop semaphore cache key.
+    with _EXECUTOR_INIT_LOCK:
+        try:
+            return _INTERNAL_EVENT_LOOP_THREAD_EXECUTOR_SINGLETON
+        except NameError:
+            ex_cls = EventLoopThreadExecutor
+            if _RUNNING_IN_BROWSER:
+                ex_cls = cast(type[EventLoopThreadExecutor], _PyodideEventLoopExecutor)
+            executor = _INTERNAL_EVENT_LOOP_THREAD_EXECUTOR_SINGLETON = ex_cls()
+            executor.start()
+            return executor
 
 
 async def execute_async_tasks_with_fail_fast(tasks: list[AsyncSDKTask]) -> TasksSummary:

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,7 +1,8 @@
 [pytest]
 markers =
-    dsl
-    coredeps
+    dsl: requires optional data-science deps (e.g. pandas/numpy) - skipped when only core deps are installed
+    coredeps: runs only with --test-deps-only-core (verifies that optional deps are NOT installed in the core-only env)
+    allow_no_semaphore: opts a test out of the strict semaphore check (see tests/conftest.py)
 
 anyio_mode = auto
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import platform
 from collections.abc import Callable, Iterator
+from typing import Any
 
 import dotenv
 import pytest
@@ -9,10 +10,47 @@ from _pytest.monkeypatch import MonkeyPatch
 
 from cognite.client import global_config
 from cognite.client._api_client import APIClient
+from cognite.client._http_client import AsyncHTTPClientWithRetry
 
 dotenv.load_dotenv()
 
 global_config.disable_pypi_version_check = True
+
+ALLOW_NO_SEMAPHORE_MARKER = "allow_no_semaphore"
+
+
+@pytest.fixture(autouse=True)
+def require_semaphore_on_every_request(request: pytest.FixtureRequest, monkeypatch: pytest.MonkeyPatch) -> None:
+    """As a main rule, all API calls in the test suite MUST route through a semaphore.
+
+    Production code falls back to ``nullcontext()`` when ``semaphore is None``; that path
+    exists for users calling top-level ``client.post(...)``/``client.get(...)`` with raw URLs,
+    but no internal API method should ever hit it. Patching here turns a missing semaphore
+    into a hard failure so a regression (forgotten ``semaphore=...`` arg) shows up loudly.
+
+    Tests that legitimately exercise the None path opt out via ``@pytest.mark.allow_no_semaphore("<reason>")``.
+    These are the top-level methods mentioned above plus any method entering the semaphore
+    at a higher level than at the HTTP request level (e.g. datapoints.insert)
+    """
+    if request.node.get_closest_marker(ALLOW_NO_SEMAPHORE_MARKER):
+        return
+
+    original = AsyncHTTPClientWithRetry._with_retry
+
+    async def strict(
+        self: AsyncHTTPClientWithRetry, coro_factory: Any, *, url: str, headers: Any, semaphore: Any
+    ) -> Any:
+        if semaphore is None:
+            pytest.fail(
+                f"Internal API call to {url!r} did not pass a semaphore. "
+                "All endpoints behind client.<api>.<method> must route through a semaphore — "
+                "the nullcontext fallback is reserved for top-level client.post/get calls only. "
+                "If this call legitimately holds the semaphore at a higher level, mark the test "
+                f"with @pytest.mark.{ALLOW_NO_SEMAPHORE_MARKER}('<reason>')."
+            )
+        return await original(self, coro_factory, url=url, headers=headers, semaphore=semaphore)
+
+    monkeypatch.setattr(AsyncHTTPClientWithRetry, "_with_retry", strict)
 
 
 @pytest.fixture(scope="session")

--- a/tests/tests_integration/test_api/test_datapoint_subscriptions.py
+++ b/tests/tests_integration/test_api/test_datapoint_subscriptions.py
@@ -302,6 +302,7 @@ class TestDatapointSubscriptions:
             assert {a.external_id for a in batch.subscription_changes.removed} == {first_ts}
             assert len(batch.updates) == 0
 
+    @pytest.mark.allow_no_semaphore("Part of the tests hits DatapointsAPI._insert_datapoints")
     def test_iterate_data_subscription_datapoints_added(
         self, cognite_client: CogniteClient, time_series_external_ids: list[str]
     ) -> None:
@@ -384,6 +385,7 @@ class TestDatapointSubscriptions:
             "you run these tests, please wait 1 minute and try again.",
         )
 
+    @pytest.mark.allow_no_semaphore("Part of the tests hits DatapointsAPI._insert_datapoints")
     def test_iterate_data__using_status_codes(
         self, cognite_client: CogniteClient, sub_for_status_codes: DatapointSubscription
     ) -> None:

--- a/tests/tests_integration/test_api/test_datapoint_subscriptions.py
+++ b/tests/tests_integration/test_api/test_datapoint_subscriptions.py
@@ -2,18 +2,16 @@ from __future__ import annotations
 
 import math
 import random
-import time
 import unittest
 from collections.abc import Iterator
 from contextlib import contextmanager
-from datetime import datetime
 
 import numpy as np
 import pandas as pd
 import pytest
 
 from cognite.client import CogniteClient
-from cognite.client.data_classes import TimeSeries, TimeSeriesWrite, filters
+from cognite.client.data_classes import TimeSeriesWrite, filters
 from cognite.client.data_classes.data_modeling import NodeId, SpaceApply
 from cognite.client.data_classes.data_modeling.cdm.v1 import CogniteTimeSeriesApply
 from cognite.client.data_classes.datapoints_subscriptions import (
@@ -431,63 +429,3 @@ class TestDatapointSubscriptions:
         assert bad_upsert_value[0] is None
         assert all(isinstance(v, float) for v in bad_upsert_value[1:])
         assert no_bad[0].upserts.status_symbol == ["Uncertain", "Good", "Good", "Good"]
-
-    @pytest.mark.skip(reason="Using a filter (as opposed to specific identifiers) is eventually consistent")
-    def test_update_filter_subscription_added_times_series(
-        self, cognite_client: CogniteClient, time_series_external_ids: list[str]
-    ) -> None:
-        f = filters
-        p = DatapointSubscriptionProperty
-        numerical_timeseries = f.And(
-            f.Equals(p.is_string, False), f.Prefix(p.external_id, "PYSDK DataPoint Subscription Test")
-        )
-        new_subscription = DataPointSubscriptionWrite(
-            external_id=f"PYSDKDataPointSubscriptionUpdateFilterTest-{random_string(10)}",
-            name="PYSDKDataPointSubscriptionUpdateFilterTest",
-            filter=numerical_timeseries,
-            partition_count=1,
-        )
-        created_timeseries: TimeSeries | None = None
-        with create_subscription_with_cleanup(cognite_client, new_subscription) as created:
-            assert created.created_time
-
-            initial_added_count = 0
-            for batch in cognite_client.time_series.subscriptions.iterate_data(
-                new_subscription.external_id,
-                poll_timeout=0,
-            ):
-                initial_added_count += len(batch.subscription_changes.added)
-                if not batch.has_next:
-                    break
-
-            assert initial_added_count > 0, "There should be at least one numerical timeseries added"
-
-            new_numerical_timeseries = TimeSeriesWrite(
-                external_id=f"PYSDK DataPoint Subscription Test 42 ({random_string(10)})",
-                name="PYSDK DataPoint Subscription Test 42",
-                is_string=False,
-            )
-            try:
-                created_timeseries = cognite_client.time_series.create(new_numerical_timeseries)
-                cognite_client.time_series.data.insert(
-                    [(datetime.now(), 42)], external_id=new_numerical_timeseries.external_id
-                )
-                # Ensure that the subscription has been updated
-                time.sleep(10)
-
-                updated_added_count = 0
-                for batch in cognite_client.time_series.subscriptions.iterate_data(
-                    new_subscription.external_id,
-                    poll_timeout=0,
-                ):
-                    updated_added_count += len(batch.subscription_changes.added)
-                    if not batch.has_next:
-                        break
-
-                assert initial_added_count + 1 == updated_added_count, (
-                    "The new timeseries should be added. This is most likely because using a filter with "
-                    "datapoint subscriptions is eventually consistent."
-                )
-            finally:
-                if created_timeseries:
-                    cognite_client.time_series.delete(created_timeseries.id)

--- a/tests/tests_integration/test_api/test_datapoints.py
+++ b/tests/tests_integration/test_api/test_datapoints.py
@@ -501,6 +501,10 @@ def ts_create_in_dms(
 
 
 class TestTimeSeriesCreatedInDMS:
+    @pytest.mark.allow_no_semaphore(
+        "Test inserts datapoints; DatapointsAPI._insert_datapoints holds the semaphore via outer "
+        "'async with' and passes None to _post to avoid double-acquiring."
+    )
     def test_insert_read_delete_dps(self, cognite_client: CogniteClient, ts_create_in_dms: NodeApplyResult) -> None:
         # Ensure the DMS time series is retrievable from normal TS API:
         inst_id = ts_create_in_dms.as_id()
@@ -2855,6 +2859,11 @@ class TestRetrieveLatestDatapointsAPI:
             cognite_client.time_series.data.retrieve_latest(instance_id=missing, ignore_unknown_ids=False)
 
 
+@pytest.mark.allow_no_semaphore(
+    "Insert paths go through DatapointsAPI._insert_datapoints, which holds the semaphore via "
+    "outer 'async with' for memory backpressure and passes None to _post. Delete paths in this "
+    "class use the regular semaphore route and are still checked against the broader suite."
+)
 class TestInsertDatapointsAPI:
     @pytest.mark.usefixtures("post_spy")
     def test_insert(

--- a/tests/tests_integration/test_api/test_event_loop_interop.py
+++ b/tests/tests_integration/test_api/test_event_loop_interop.py
@@ -6,26 +6,23 @@ Ensures connections and semaphores aren't cross-contaminated between event loops
 from __future__ import annotations
 
 import random
+from collections.abc import Iterator
 from concurrent.futures import ThreadPoolExecutor
 from typing import Any
 
 import pytest
 
-from cognite.client import AsyncCogniteClient, CogniteClient, global_config
+from cognite.client import AsyncCogniteClient, CogniteClient
 from cognite.client._http_client import _global_async_httpx_clients
+from tests.utils import fresh_concurrency_state
 
 
 @pytest.fixture(autouse=True)
-def _clear_loop_caches() -> None:
+def _clear_loop_caches() -> Iterator[None]:
     """Reset per-loop caches so each test starts with a clean slate (...and state lol)."""
     _global_async_httpx_clients.clear()
-    for config in (
-        global_config.concurrency_settings.general,
-        global_config.concurrency_settings.datapoints,
-        global_config.concurrency_settings.raw,
-        global_config.concurrency_settings.data_modeling,
-    ):
-        config._semaphore_cache.clear()
+    with fresh_concurrency_state():
+        yield
 
 
 def make_sync_api_call(client: CogniteClient) -> Any:

--- a/tests/tests_integration/test_api/test_simulators/test_models.py
+++ b/tests/tests_integration/test_api/test_simulators/test_models.py
@@ -31,6 +31,11 @@ from tests.tests_integration.test_api.test_simulators.utils import update_logs
     "seed_resource_names",
     "seed_simulator_model_revisions",
 )
+@pytest.mark.allow_no_semaphore(
+    "Simulator tests use direct _post(..., semaphore=None) calls in fixtures/seed helpers to "
+    "exercise endpoints (logs/update, callback, integrations/update) that aren't exposed via "
+    "public SDK methods — they're worker-facing endpoints used here for test setup only."
+)
 class TestSimulatorModels:
     def test_list_models(self, cognite_client: CogniteClient, seed_resource_names: ResourceNames) -> None:
         models = cognite_client.simulators.models.list(

--- a/tests/tests_integration/test_api/test_simulators/test_runs.py
+++ b/tests/tests_integration/test_api/test_simulators/test_runs.py
@@ -20,6 +20,10 @@ from cognite.client.utils._async_helpers import run_sync
 from tests.tests_integration.test_api.test_simulators.seed.data import RESOURCES, ResourceNames
 
 
+@pytest.mark.allow_no_semaphore(
+    "Simulator tests use direct _post(..., semaphore=None) calls (e.g. /simulators/run/callback) "
+    "to exercise worker-facing endpoints not exposed via public SDK methods."
+)
 @pytest.mark.usefixtures("seed_resource_names", "seed_simulator_routine_revisions")
 class TestSimulatorRuns:
     def test_list_filtering(

--- a/tests/tests_integration/test_api/test_workflows.py
+++ b/tests/tests_integration/test_api/test_workflows.py
@@ -463,6 +463,10 @@ class TestWorkflows:
 
 
 class TestWorkflowVersions:
+    @pytest.mark.allow_no_semaphore(
+        "Test setup uses simulator fixtures that exercise worker-facing endpoints "
+        "(/simulators/integrations/update) via direct _post(..., semaphore=None)."
+    )
     def test_upsert_run_delete_with_simulation_task(
         self,
         cognite_client: CogniteClient,

--- a/tests/tests_integration/test_cognite_client.py
+++ b/tests/tests_integration/test_cognite_client.py
@@ -19,6 +19,10 @@ def cognite_client_with_wrong_base_url(
     return cognite_client
 
 
+@pytest.mark.allow_no_semaphore(
+    "Tests exercise top-level client.post/get/put/token-inspect on the (Async)CogniteClient — "
+    "the documented nullcontext path. Concurrency limiting is unrelated."
+)
 class TestCogniteClient:
     def test_wrong_project(
         self, monkeypatch: MonkeyPatch, async_client: AsyncCogniteClient, cognite_client: CogniteClient

--- a/tests/tests_unit/test_api/test_datapoints.py
+++ b/tests/tests_unit/test_api/test_datapoints.py
@@ -227,6 +227,10 @@ def mock_post_datapoints_400(httpx_mock: HTTPXMock, async_client: AsyncCogniteCl
     return httpx_mock
 
 
+@pytest.mark.allow_no_semaphore(
+    "DatapointsAPI._insert_datapoints holds the semaphore via outer 'async with' for memory "
+    "backpressure, then passes None to _post to avoid double-acquiring."
+)
 class TestInsertDatapoints:
     def test_insert_tuples(self, cognite_client: CogniteClient, mock_post_datapoints: HTTPXMock) -> None:
         dps = [(i * 1e11, i) for i in range(1, 11)]
@@ -762,6 +766,7 @@ class TestPandasIntegration:
         dps_list = DatapointsList([])
         assert dps_list.to_pandas().empty
 
+    @pytest.mark.allow_no_semaphore
     def test_insert_dataframe_id_and_xid(self, cognite_client: CogniteClient, mock_post_datapoints: HTTPXMock) -> None:
         import pandas as pd
 
@@ -786,6 +791,7 @@ class TestPandasIntegration:
             ]
         } == request_body
 
+    @pytest.mark.allow_no_semaphore
     @pytest.mark.parametrize(
         "instance_ids", [(NodeId("space", "123"), NodeId("space", "456")), (("space", "123"), ("space", "456"))]
     )
@@ -816,6 +822,7 @@ class TestPandasIntegration:
         }
         assert expected_body == request_body
 
+    @pytest.mark.allow_no_semaphore
     def test_insert_dataframe_all_identifier_types(
         self, cognite_client: CogniteClient, mock_post_datapoints: HTTPXMock
     ) -> None:
@@ -868,6 +875,7 @@ class TestPandasIntegration:
         with pytest.raises(ValueError, match="contains one or more NaNs"):
             cognite_client.time_series.data.insert_dataframe(df, dropna=False)
 
+    @pytest.mark.allow_no_semaphore
     def test_insert_dataframe_with_dropna(self, cognite_client: CogniteClient, mock_post_datapoints: HTTPXMock) -> None:
         import pandas as pd
 
@@ -894,6 +902,7 @@ class TestPandasIntegration:
             ]
         } == request_body
 
+    @pytest.mark.allow_no_semaphore
     def test_insert_dataframe_single_dp(self, cognite_client: CogniteClient, mock_post_datapoints: HTTPXMock) -> None:
         import pandas as pd
 
@@ -913,6 +922,7 @@ class TestPandasIntegration:
         with pytest.raises(ValueError, match=re.escape("contains one or more (+/-) Infinity")):
             cognite_client.time_series.data.insert_dataframe(df)
 
+    @pytest.mark.allow_no_semaphore
     def test_insert_dataframe_with_strings(
         self, cognite_client: CogniteClient, mock_post_datapoints: HTTPXMock
     ) -> None:

--- a/tests/tests_unit/test_api_client.py
+++ b/tests/tests_unit/test_api_client.py
@@ -77,6 +77,10 @@ def api_client_with_token(async_client: AsyncCogniteClient) -> APIClient:
 RequestCase = namedtuple("RequestCase", ["name", "method", "kwargs"])
 
 
+@pytest.mark.allow_no_semaphore(
+    "These tests exercise the transport layer (_post/_get/_put with explicit semaphore=None) to "
+    "verify gzip, headers, retries and payload validation. Concurrency limiting is unrelated."
+)
 class TestBasicRequests:
     @pytest.fixture
     def mock_all_requests_ok(self, httpx_mock: HTTPXMock) -> Iterator[HTTPXMock]:

--- a/tests/tests_unit/test_exceptions.py
+++ b/tests/tests_unit/test_exceptions.py
@@ -25,6 +25,10 @@ def mock_get_400_error(httpx_mock: HTTPXMock, cognite_client: CogniteClient, asy
     )
 
 
+@pytest.mark.allow_no_semaphore(
+    "These tests use the top-level cognite_client.get(...) nullcontext path to verify "
+    "error parsing and cluster info; concurrency limiting is unrelated."
+)
 class TestAPIError:
     def test_api_error(self) -> None:
         e = CogniteAPIError(

--- a/tests/tests_unit/test_utils/test_concurrency.py
+++ b/tests/tests_unit/test_utils/test_concurrency.py
@@ -2,16 +2,131 @@ from __future__ import annotations
 
 import asyncio
 import random
+from collections.abc import Iterator
+from typing import ClassVar
 
 import pytest
 
+from cognite.client import global_config
 from cognite.client.exceptions import CogniteAPIError
 from cognite.client.utils._concurrency import (
     AsyncSDKTask,
+    ConcurrencySettings,
     EventLoopThreadExecutor,
     _get_event_loop_executor,
     execute_async_tasks,
 )
+from tests.utils import fresh_concurrency_state
+
+
+@pytest.fixture
+def fresh_unfrozen_global_concurrency() -> Iterator[None]:
+    with fresh_concurrency_state():
+        yield
+
+
+class TestConcurrencySettingsConfig:
+    def test_setters_work_before_freeze(self) -> None:
+        cs = ConcurrencySettings()
+        cs.general.read = 10
+        cs.general.delete = 3
+        assert cs.general.read == 10
+        assert cs.general.delete == 3
+
+    def test_data_modeling_extra_setters_work_before_freeze(self) -> None:
+        cs = ConcurrencySettings()
+        cs.data_modeling.search = 5
+        cs.data_modeling.read_schema = 6
+        cs.data_modeling.write_schema = 3
+        assert cs.data_modeling.search == 5
+        assert cs.data_modeling.read_schema == 6
+        assert cs.data_modeling.write_schema == 3
+
+    def test_is_frozen_starts_false(self) -> None:
+        cs = ConcurrencySettings()
+        assert cs.is_frozen is False
+
+    def test_freeze_sets_is_frozen(self) -> None:
+        cs = ConcurrencySettings()
+        cs._freeze()
+        assert cs.is_frozen is True
+
+    @pytest.mark.parametrize(
+        "sub_config_name, attr",
+        [
+            ("general", "delete"),
+            ("raw", "delete"),
+            ("datapoints", "write"),
+            ("data_modeling", "search"),
+        ],
+    )
+    def test_setter_raises_after_freeze(self, sub_config_name: str, attr: str) -> None:
+        cs = ConcurrencySettings()
+        cs._freeze()
+        sub = getattr(cs, sub_config_name)
+        with pytest.raises(RuntimeError, match="Cannot modify"):
+            setattr(sub, attr, 99)
+
+    def test_repr_unfrozen(self) -> None:
+        cs = ConcurrencySettings()
+        r = repr(cs)
+        assert "ConcurrencySettings(" in r
+        assert "general=" in r
+        assert "frozen" not in r
+
+    def test_repr_frozen(self) -> None:
+        cs = ConcurrencySettings()
+        cs._freeze()
+        r = repr(cs)
+        assert "(frozen)" in r
+
+    def test_error_message_names_api_and_attribute(self) -> None:
+        cs = ConcurrencySettings()
+        cs._freeze()
+        with pytest.raises(RuntimeError, match=r"general\.read"):
+            cs.general.read = 1
+        with pytest.raises(RuntimeError, match=r"data_modeling\.search"):
+            cs.data_modeling.search = 1
+
+
+@pytest.mark.usefixtures("fresh_unfrozen_global_concurrency")
+class TestSemaphoreFactory:
+    cs: ClassVar[ConcurrencySettings] = global_config.concurrency_settings
+
+    async def test_returns_bounded_semaphore_with_correct_value(self) -> None:
+        sem = self.cs.general._semaphore_factory("read", "proj-a")
+        assert isinstance(sem, asyncio.BoundedSemaphore)
+        assert sem._value == self.cs.general.read
+
+    async def test_cache_hit_returns_same_object(self) -> None:
+        sem1 = self.cs.general._semaphore_factory("read", "proj-a")
+        sem2 = self.cs.general._semaphore_factory("read", "proj-a")
+        assert sem1 is sem2
+
+    async def test_different_project_returns_different_semaphore(self) -> None:
+        sem_a = self.cs.general._semaphore_factory("read", "proj-a")
+        sem_b = self.cs.general._semaphore_factory("read", "proj-b")
+        assert sem_a is not sem_b
+
+    async def test_different_operation_returns_different_semaphore(self) -> None:
+        sem_r = self.cs.general._semaphore_factory("read", "proj-a")
+        sem_w = self.cs.general._semaphore_factory("write", "proj-a")
+        sem_d = self.cs.general._semaphore_factory("delete", "proj-a")
+        assert len({sem_r, sem_w, sem_d}) == 3
+
+    async def test_semaphore_value_reflects_configured_limit(self) -> None:
+        self.cs.general.read = 7
+        sem = self.cs.general._semaphore_factory("read", "proj-x")
+        assert sem._value == 7
+
+    async def test_factory_call_freezes_global_config(self) -> None:
+        assert not self.cs.is_frozen
+        self.cs.general._semaphore_factory("read", "proj-a")
+        assert self.cs.is_frozen
+
+    async def test_invalid_operation_hits_assert_never(self) -> None:
+        with pytest.raises(AssertionError):
+            self.cs.general._semaphore_factory("totally_invalid", "proj-a")  # type: ignore[arg-type]
 
 
 async def i_dont_like_5(i: int) -> int:
@@ -28,6 +143,14 @@ class TestExecutor:
     def test_get_event_loop_executor(self) -> None:
         executor = _get_event_loop_executor()
         assert isinstance(executor, EventLoopThreadExecutor)
+
+    def test_get_event_loop_executor_is_singleton(self) -> None:
+        assert _get_event_loop_executor() is _get_event_loop_executor()
+
+    def test_executor_thread_is_alive_and_daemon(self) -> None:
+        executor = _get_event_loop_executor()
+        assert executor.is_alive()
+        assert executor.daemon
 
     async def test_async_tasks__results_ordering_match_tasks(self) -> None:
         async def async_task(i: int) -> int:

--- a/tests/tests_unit/test_utils/test_concurrency_api_routing.py
+++ b/tests/tests_unit/test_utils/test_concurrency_api_routing.py
@@ -1,0 +1,163 @@
+"""Verifies that each top-level concurrency category routes to the correct semaphore.
+
+The strict-semaphore check in tests/conftest.py provides suite-wide coverage of "every
+internal API call passes a semaphore". This file adds the narrower contract: that each
+sub-config (general/raw/datapoints/data_modeling) and operation type (read/write/delete
+/search/read_schema/write_schema) is wired to the API methods that should use it.
+One representative test per (sub_config, operation) combination — adding more is redundant.
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Awaitable, Callable, Iterator
+from typing import Any
+
+import pytest
+from pytest_httpx import HTTPXMock
+
+from cognite.client import AsyncCogniteClient
+from cognite.client.data_classes.data_modeling.ids import NodeId
+from tests.utils import fresh_concurrency_state
+
+SemCall = tuple[str, str, str]  # (sub_config_name (eg 'general'), operation, project)
+ApiCall = Callable[[AsyncCogniteClient], Awaitable[Any]]
+
+
+@pytest.fixture
+def semaphore_spy(monkeypatch: pytest.MonkeyPatch) -> Iterator[list[SemCall]]:
+    """Records every _semaphore_factory call across all sub-configs (on a freshly-reset state)."""
+    calls: list[SemCall] = []
+    with fresh_concurrency_state() as settings:
+        for sub_config in settings._all_concurrency_configs:
+            original = sub_config._semaphore_factory
+
+            def make_spy(_orig: Any, _name: str) -> Any:
+                def spy(operation: str, project: str) -> Any:
+                    calls.append((_name, operation, project))
+                    return _orig(operation, project)
+
+                return spy
+
+            monkeypatch.setattr(sub_config, "_semaphore_factory", make_spy(original, sub_config.api_name))
+
+        yield calls
+
+
+@pytest.fixture
+def mock_any_request(httpx_mock: HTTPXMock) -> HTTPXMock:
+    """Catch-all 200 response for any HTTP method/URL — tests only care about the semaphore."""
+    any_url = re.compile(r".*")
+    for method in ("GET", "POST", "PUT", "DELETE", "PATCH"):
+        httpx_mock.add_response(method=method, url=any_url, status_code=200, json={"items": []}, is_optional=True)
+    return httpx_mock
+
+
+def assert_routed(calls: list[SemCall], sub_config: str, operation: str) -> None:
+    matches = [(s, o) for s, o, _ in calls if s == sub_config and o == operation]
+    assert matches, f"Expected a ({sub_config!r}, {operation!r}) semaphore call, got: {[(s, o) for s, o, _ in calls]}"
+
+
+def _raw_write_call(c: AsyncCogniteClient) -> Awaitable[None]:
+    import pandas as pd
+
+    df = pd.DataFrame({"col-a": [1, 2]}, index=["r1", "r2"])
+    return c.raw.rows.insert_dataframe("db1", "t1", df)
+
+
+@pytest.mark.usefixtures("mock_any_request")
+class TestSemaphoreRouting:
+    @pytest.mark.parametrize(
+        "api_call, sub_config, operation",
+        [
+            pytest.param(lambda c: c.assets.retrieve(id=1), "general", "read", id="general_read"),
+            pytest.param(lambda c: c.assets.delete(id=1), "general", "delete", id="general_delete"),
+            pytest.param(
+                _raw_write_call,
+                "raw",
+                "write",
+                id="raw_write",
+                marks=pytest.mark.dsl,
+            ),
+            pytest.param(
+                lambda c: c.raw.rows.delete("db1", "t1", key=["k1", "k2"]),
+                "raw",
+                "delete",
+                id="raw_delete",
+            ),
+            pytest.param(
+                lambda c: c.time_series.data.insert(datapoints=[(1000, 1.0)], id=1),
+                "datapoints",
+                "write",
+                id="datapoints_write",
+                marks=pytest.mark.allow_no_semaphore(
+                    "DatapointsAPI._insert_datapoints holds the semaphore via outer 'async with' "
+                    "for memory backpressure, then passes None to _post to avoid double-acquiring."
+                ),
+            ),
+            pytest.param(
+                lambda c: c.time_series.data.delete_range(start=0, end=1000, id=1),
+                "datapoints",
+                "delete",
+                id="datapoints_delete",
+            ),
+            pytest.param(
+                lambda c: c.data_modeling.instances.retrieve(nodes=NodeId("space1", "node1")),
+                "data_modeling",
+                "read",
+                id="data_modeling_read",
+            ),
+            pytest.param(
+                lambda c: c.data_modeling.spaces.retrieve(spaces="my-space"),
+                "data_modeling",
+                "read_schema",
+                id="data_modeling_read_schema",
+            ),
+            pytest.param(
+                lambda c: c.data_modeling.spaces.delete(spaces="my-space"),
+                "data_modeling",
+                "write_schema",
+                id="data_modeling_write_schema",
+            ),
+        ],
+    )
+    async def test_routing(
+        self,
+        async_client: AsyncCogniteClient,
+        semaphore_spy: list[SemCall],
+        api_call: ApiCall,
+        sub_config: str,
+        operation: str,
+    ) -> None:
+        await api_call(async_client)
+        assert_routed(semaphore_spy, sub_config, operation)
+        # Project is part of the (op, project, loop) cache key — verify it's threaded through:
+        assert async_client.config.project in {proj for _, _, proj in semaphore_spy}
+
+
+class TestSemaphoreRoutingSpecialResponses:
+    """Tests where the catch-all ``mock_any_request`` shape doesn't fit the response parser."""
+
+    async def test_raw_read(
+        self, async_client: AsyncCogniteClient, semaphore_spy: list[SemCall], httpx_mock: HTTPXMock
+    ) -> None:
+        # raw.rows.retrieve parses a single Row directly (not {items: [...]}); supply a row shape:
+        httpx_mock.add_response(
+            method="GET",
+            url=re.compile(r".*/raw/dbs/.*"),
+            status_code=200,
+            json={"key": "k1", "columns": {"col1": "v1"}, "lastUpdatedTime": 0},
+        )
+        await async_client.raw.rows.retrieve("db1", "t1", "k1")
+        assert_routed(semaphore_spy, "raw", "read")
+
+
+class TestStrictFixtureCatchesMissingSemaphore:
+    """Sanity check that the suite-wide strict fixture in tests/conftest.py still works.
+
+    Without this, a regression in the strict fixture would silently pass every test.
+    """
+
+    async def test_top_level_post_without_semaphore_raises(self, async_client: AsyncCogniteClient) -> None:
+        with pytest.raises(pytest.fail.Exception, match="did not pass a semaphore"):
+            await async_client.post("/assets/byids", json={"items": [{"id": 1}]})

--- a/tests/tests_unit/test_utils/test_concurrency_threading.py
+++ b/tests/tests_unit/test_utils/test_concurrency_threading.py
@@ -1,0 +1,226 @@
+"""Tests for concurrency primitives in multi-threaded environments.
+
+The SDK's sync client submits coroutines to a background event loop from caller threads.
+Semaphores are loop-bound, so each loop must get its own semaphore instance — we verify
+that the (operation, project, loop) cache key enforces this correctly.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import random
+import re
+import threading
+from concurrent.futures import ThreadPoolExecutor
+from typing import Any
+
+import pytest
+from httpx import Response
+from pytest_httpx import HTTPXMock
+
+from cognite.client import CogniteClient
+from cognite.client.utils._async_helpers import run_sync
+from cognite.client.utils._concurrency import (
+    EventLoopThreadExecutor,
+    _get_event_loop_executor,
+)
+from tests.utils import fresh_concurrency_state
+
+
+class TestPerLoopSemaphoreIsolation:
+    def test_cache_keyed_by_loop_and_project(self) -> None:
+        sems: set[asyncio.BoundedSemaphore] = set()
+
+        with fresh_concurrency_state() as cs:
+
+            def run_for_both_projects() -> None:
+                async def get() -> tuple[asyncio.BoundedSemaphore, asyncio.BoundedSemaphore, asyncio.BoundedSemaphore]:
+                    a = cs.general._semaphore_factory("read", "proj-1")
+                    b = cs.general._semaphore_factory("read", "proj-22")
+                    c = cs.general._semaphore_factory("read", "proj-1")
+                    return a, b, c
+
+                a, b, c = asyncio.run(get())
+                sems.update([a, b, c])
+
+            t1 = threading.Thread(target=run_for_both_projects)
+            t2 = threading.Thread(target=run_for_both_projects)
+            t1.start()
+            t2.start()
+            t1.join()
+            t2.join()
+
+        # We expect 4 (not 6), as 'c is a' should be true:
+        assert len(sems) == 4
+
+    def test_background_loop_and_asyncio_run_loop_get_distinct_semaphores(self) -> None:
+        """The sync client's background loop and a direct asyncio.run() caller must never share semaphores.
+
+        This is the concrete sync-client-plus-async-client coexistence scenario: a semaphore
+        created on the background EventLoopThreadExecutor loop and one created on a fresh loop
+        (e.g. an async test or Jupyter cell) are keyed to different loops and must be different objects.
+        """
+        with fresh_concurrency_state() as cs:
+
+            async def factory_coro() -> asyncio.BoundedSemaphore:
+                return cs.general._semaphore_factory("read", "shared-project")
+
+            # Background (sync-client) loop:
+            bg_sem = run_sync(factory_coro())
+            # Fresh loop (async-client / asyncio.run path):
+            fresh_sem = asyncio.run(factory_coro())
+
+        assert bg_sem is not fresh_sem
+
+
+class TestSyncClientMultiThreadedEnv:
+    """
+    The (sync) CogniteClient uses the helper function 'run_sync' internally to wrap the
+    AsyncCogniteClient. Thus we run tests against said helper function
+    """
+
+    def test_concurrent_run_sync_calls_all_return_correct_results(self) -> None:
+        """Verifies that multiple different threads submitting coroutines all get the right results back."""
+
+        async def identity(x: int) -> int:
+            await asyncio.sleep(random.uniform(0, 0.02))
+            return x
+
+        # This is a typical construct our users would use:
+        with ThreadPoolExecutor(max_workers=8) as pool:
+            futures = [pool.submit(run_sync, identity(i)) for i in range(50)]
+            results = [f.result() for f in futures]
+
+        assert results == list(range(50))
+
+    def test_run_sync_propagates_exceptions_to_mainthread(self) -> None:
+        async def boom() -> None:
+            raise ValueError("from async")
+
+        with pytest.raises(ValueError, match="from async"):
+            run_sync(boom())
+
+    def test_run_sync_propagates_exception_from_thread_pool(self) -> None:
+        async def boom() -> None:
+            raise RuntimeError("thread-propagated")
+
+        with ThreadPoolExecutor(max_workers=2) as pool:
+            futures = [pool.submit(run_sync, boom()) for _ in range(2)]
+            for f in futures:
+                with pytest.raises(RuntimeError, match="thread-propagated"):
+                    f.result()
+
+    def test_semaphore_limits_concurrent_operations_via_background_loop(
+        self, cognite_client: CogniteClient, httpx_mock: HTTPXMock
+    ) -> None:
+        """Backpressure (semaphores) works end-to-end: 10 concurrent sync API calls from a thread pool
+        produce at most N (e.g., 3 in this test) in-flight HTTP requests at any time."""
+        max_concurrent_requests = 3
+        active, peak = 0, 0
+
+        async def slow_response(request: Any) -> Response:
+            nonlocal active, peak
+            active += 1
+            peak = max(peak, active)
+            await asyncio.sleep(random.uniform(0, 0.05))
+            active -= 1
+            return Response(200, json={"items": []})
+
+        httpx_mock.add_callback(slow_response, method="POST", url=re.compile(r".*"), is_reusable=True)
+
+        with fresh_concurrency_state() as cs:
+            cs.general.read = max_concurrent_requests
+            with ThreadPoolExecutor(max_workers=10) as pool:
+                # All these retrieve methods use the same 'general read' semaphore:
+                futures = (
+                    [pool.submit(cognite_client.assets.retrieve, id=i) for i in range(3)]
+                    + [pool.submit(cognite_client.events.retrieve, id=i) for i in range(4)]
+                    + [pool.submit(cognite_client.files.retrieve, id=i) for i in range(3)]
+                )
+                for f in futures:
+                    f.result()
+
+        assert peak == max_concurrent_requests
+
+
+class TestEventLoopThreadExecutorLifecycle:
+    def test_fresh_executor_starts_and_runs(self) -> None:
+        ex = EventLoopThreadExecutor(daemon=True)
+        ex.start()
+        try:
+            assert ex.is_alive()
+            result = ex.run_coro(asyncio.sleep(0, result=42))
+            assert result == 42
+        finally:
+            ex.stop()
+
+    def test_run_coro_with_timeout(self) -> None:
+        ex = EventLoopThreadExecutor(daemon=True)
+        ex.start()
+
+        async def slow() -> None:
+            # Wrapping in wait_for ensures clean cancellation when the timeout fires:
+            await asyncio.wait_for(asyncio.sleep(10), timeout=0.01)
+
+        try:
+            with pytest.raises(asyncio.TimeoutError):
+                ex.run_coro(slow(), timeout=0.05)
+        finally:
+            ex.stop()
+
+    def test_singleton_init_is_thread_safe(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Bug in 8.0.0 to 8.2.0: Many threads racing on the very first _get_event_loop_executor()
+        call did not get the same instance (thread), leading to e.g. broken concurrency limits."""
+        import cognite.client.utils._concurrency as conc
+
+        # Force the lazy-init branch by removing any pre-existing singleton:
+        executor_attribute = "_INTERNAL_EVENT_LOOP_THREAD_EXECUTOR_SINGLETON"
+        monkeypatch.delattr(conc, executor_attribute, raising=False)
+
+        results: list[Any] = []
+        barrier = threading.Barrier(10)
+
+        def get_executor() -> None:
+            barrier.wait()  # maximize the race window
+            results.append(_get_event_loop_executor())
+
+        threads = [threading.Thread(target=get_executor) for _ in range(10)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert len(set(results)) == 1, "init race produced multiple executor instances"
+
+        # Make sure that if someone renames executor_attribute, we fail here,
+        # getattr will raise when not given a default. So - DO NOT rewrite this to
+        # conc._INTERNAL_EVENT_LOOP_THREAD_EXECUTOR_SINGLETON:
+        assert getattr(conc, executor_attribute) is results[0]
+
+
+class TestFreezeRaceUnderThreads:
+    def test_concurrent_factory_calls_all_succeed_and_freeze(self) -> None:
+        """Multiple threads calling _semaphore_factory concurrently must not raise or corrupt state."""
+        errors: list[BaseException] = []
+
+        with fresh_concurrency_state() as cs:
+
+            def run_factory() -> None:
+                try:
+
+                    async def call() -> None:
+                        cs.general._semaphore_factory("read", "proj-race")
+
+                    asyncio.run(call())
+                except Exception as e:
+                    errors.append(e)
+
+            threads = [threading.Thread(target=run_factory) for _ in range(6)]
+            for t in threads:
+                t.start()
+            for t in threads:
+                t.join()
+
+            assert errors == [], f"Unexpected errors: {errors}"
+            # Cache should have one entry per unique loop (one per thread):
+            assert len(cs.general._semaphore_cache) == 6

--- a/tests/tests_unit/test_utils/test_concurrency_threading.py
+++ b/tests/tests_unit/test_utils/test_concurrency_threading.py
@@ -173,9 +173,9 @@ class TestEventLoopThreadExecutorLifecycle:
         call did not get the same instance (thread), leading to e.g. broken concurrency limits."""
         import cognite.client.utils._concurrency as conc
 
-        # Force the lazy-init branch by removing any pre-existing singleton:
-        executor_attribute = "_INTERNAL_EVENT_LOOP_THREAD_EXECUTOR_SINGLETON"
-        monkeypatch.delattr(conc, executor_attribute, raising=False)
+        # Force the lazy-init branch by clearing any pre-existing singleton:
+        if conc._INTERNAL_EVENT_LOOP_THREAD_EXECUTOR_SINGLETON is not None:
+            monkeypatch.setattr(conc, "_INTERNAL_EVENT_LOOP_THREAD_EXECUTOR_SINGLETON", None)
 
         results: list[Any] = []
         barrier = threading.Barrier(10)
@@ -191,11 +191,7 @@ class TestEventLoopThreadExecutorLifecycle:
             t.join()
 
         assert len(set(results)) == 1, "init race produced multiple executor instances"
-
-        # Make sure that if someone renames executor_attribute, we fail here,
-        # getattr will raise when not given a default. So - DO NOT rewrite this to
-        # conc._INTERNAL_EVENT_LOOP_THREAD_EXECUTOR_SINGLETON:
-        assert getattr(conc, executor_attribute) is results[0]
+        assert conc._INTERNAL_EVENT_LOOP_THREAD_EXECUTOR_SINGLETON is results[0]
 
 
 class TestFreezeRaceUnderThreads:

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -240,6 +240,30 @@ def random_gamma_dist_integer(inclusive_max: int, max_tries: int = 100) -> int:
 
 
 @contextmanager
+def fresh_concurrency_state() -> typing.Iterator[Any]:
+    """Clears all per-loop/-project semaphore caches and unfreezes ``global_config.concurrency_settings``
+    for the duration of the block, then restores the original frozen state.
+
+    Use this when a test needs to mutate concurrency settings or observe semaphore creation
+    on a clean slate. Yields the (singleton) ``ConcurrencySettings`` for convenience.
+    """
+    from cognite.client import global_config
+
+    cs = global_config.concurrency_settings
+    orig_frozen = cs.is_frozen
+    cs._ConcurrencySettings__frozen = False  # type: ignore[attr-defined]
+    for sub in cs._all_concurrency_configs:
+        sub._semaphore_cache.clear()
+    try:
+        yield cs
+    finally:
+        cs._ConcurrencySettings__frozen = False  # type: ignore[attr-defined]
+        for sub in cs._all_concurrency_configs:
+            sub._semaphore_cache.clear()
+        cs._ConcurrencySettings__frozen = orig_frozen  # type: ignore[attr-defined]
+
+
+@contextmanager
 def override_semaphore(
     new: int,
     target: Literal["general", "datapoints", "raw"],


### PR DESCRIPTION
Also fixes a race condition on `_get_event_loop_executor()` which is called internally by `run_sync(...)` which is called by all methods on the sync `CogniteClient`. This no longer uses the "uninitialized" try-except logic flow, but "is not None" (suggested by Gemini)