### PR TITLE
feat(Data Modeling): add alpha `instances.sync_with_file_cache` for /sync jobs with file cache (DM-3759)

### DIFF
--- a/cognite/client/_api/data_modeling/instances.py
+++ b/cognite/client/_api/data_modeling/instances.py
@@ -5,7 +5,7 @@ import inspect
 import logging
 import random
 from collections.abc import AsyncIterator, Awaitable, Callable, Iterable, Sequence
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -68,10 +68,10 @@ from cognite.client.data_classes.data_modeling.query import (
     QuerySync,
     SourceSelector,
 )
-from cognite.client.data_classes.data_modeling.sync import SubscriptionContext
+from cognite.client.data_classes.data_modeling.sync import SubscriptionContext, SyncSessionWithCache
 from cognite.client.data_classes.data_modeling.views import View
 from cognite.client.data_classes.filters import _BASIC_FILTERS, Filter, _validate_filter
-from cognite.client.utils._auxiliary import is_unlimited, load_yaml_or_json, unpack_items
+from cognite.client.utils._auxiliary import at_least_one_is_not_none, is_unlimited, load_yaml_or_json, unpack_items
 from cognite.client.utils._experimental import FeaturePreviewWarning
 from cognite.client.utils._identifier import DataModelingIdentifierSequence
 from cognite.client.utils._retry import Backoff
@@ -175,6 +175,12 @@ class InstancesAPI(APIClient):
             sdk_maturity="alpha",
             feature_name="Data modeling debug parameters 'includeTranslatedQuery' and 'includePlan'",
             pluralize=True,
+        )
+        self._warn_on_sync_with_file_cache = FeaturePreviewWarning(
+            api_maturity="General Availability",
+            sdk_maturity="alpha",
+            feature_name="Sync sessions with file caching for the Instances API",
+            pluralize=False,
         )
 
     def _get_semaphore(self, operation: Literal["read", "write", "delete", "search"]) -> asyncio.BoundedSemaphore:
@@ -1774,6 +1780,136 @@ class InstancesAPI(APIClient):
             cursors=json_payload["nextCursor"],
             typing=json_payload.get("typing"),
             debug=json_payload.get("debug"),
+        )
+
+    async def sync_with_file_cache(
+        self,
+        query: QuerySync,
+        *,
+        file_external_id: str,
+        security_category: int,
+        backup_every: timedelta | None = timedelta(minutes=15),
+        backup_on_exit: bool = False,
+    ) -> SyncSessionWithCache:
+        r"""Create a managed sync session with persistent backup to a CDF file.
+
+        Returns a :class:`SyncSessionWithCache` that you use as an async context manager. On entry
+        the session downloads the backup file from CDF and restores the instance data and previous
+        cursor positions if the query hash matches, allowing you to immediately continue syncing
+        instances from where your last session left off (no need for a full backfill).
+
+        We **require** a security category for the file to prevent users who lack access to the
+        underlying instances from bypassing those restrictions by reading the backup file directly.
+
+        Note:
+            This session (or rather /sync) must be invoked frequently enough to keep cursors alive.
+            Cursors expire after 3 days (the soft-delete retention period). If a cursor
+            expires the session will raise an error — call ``await session.invalidate()``
+            followed by ``await session.sync_until_live()`` to start fresh from a full backfill.
+
+            If you *really* don't care about missing deleted instances, there's
+            ``allow_expired_cursors_and_accept_missed_deletes=True`` on :class:`QuerySync`
+            that will allow you to use an older cursor. **Be careful**, you can not change this
+            setting mid-session, as the hash of your query would no longer match the existing,
+            and a full backfill would be triggered.
+
+        Warning:
+            This functionality is in **alpha** and only the async context manager interface is
+            currently available. The API and behaviour may change without notice.
+
+        Args:
+            query (QuerySync): The sync query.
+            file_external_id (str): External ID of the CDF file used as the durable backup store.
+                The file is created automatically on the first backup if it does not yet exist.
+            security_category (int): The security category to apply to the backup file. The file is
+                created (and re-uploaded on each backup) with this security category set, preventing
+                users who lack access to the underlying instances from reading the backup directly.
+            backup_every (timedelta | None): How often to upload state to CDF during a
+                session (when active). ``None`` uploads only on context-manager exit.
+            backup_on_exit (bool): Whether to upload state to CDF on context-manager exit.
+
+        Raises:
+            ValueError: If ``query`` already has cursors set (cursors are managed internally).
+            ValueError: If any result-set expression referenced in ``select`` does not have an
+                explicit ``limit`` set.
+            ValueError: If the given ``security_category`` does not exist in this project.
+            ValueError: If ``backup_every`` is set to a value smaller than 1 minute.
+
+        Returns:
+            SyncSessionWithCache: The context manager for managing the sync session.
+
+        Examples:
+
+            One-off job that loads state from the Files API, syncs until it has caught up with all
+            live changes, then does some work that require huge amounts of instance data, then backs
+            up the progress on exit (from the context manager):
+
+                >>> import asyncio
+                >>> from cognite.client import AsyncCogniteClient
+                >>> from cognite.client.data_classes.data_modeling.query import (
+                ...     QuerySync,
+                ...     SelectSync,
+                ...     NodeResultSetExpressionSync,
+                ... )
+                >>> client = AsyncCogniteClient()
+                >>> query = QuerySync(
+                ...     with_={"my_nodes": NodeResultSetExpressionSync(limit=1000)},
+                ...     select={"my_nodes": SelectSync()},
+                ... )
+                >>> session = client.data_modeling.instances.sync_with_file_cache(
+                ...     query,
+                ...     file_external_id="my_backup_file",
+                ...     security_category=123,
+                ...     backup_every=None,  # Only backup on exit
+                ...     backup_on_exit=True,
+                ... )
+                >>> def do_work(nodes: NodeList) -> None:
+                ...     print(len(nodes))  # ¯\_(ツ)_/¯
+                >>>
+                >>> async with session:  # doctest: +SKIP
+                ...     await session.sync_until_live()
+                ...     do_work(session.get_nodes("my_nodes"))
+
+            Longer-running job with periodic backups, e.g. regularly computing statistics for a
+            dashboard:
+
+                >>> session = client.data_modeling.instances.sync_with_file_cache(
+                ...     query,
+                ...     file_external_id="my_backup_file",
+                ...     security_category=123,
+                ...     backup_every=timedelta(minutes=15),
+                ... )
+                >>> async with session:  # doctest: +SKIP
+                ...     while True:
+                ...         await session.sync_until_live()
+                ...         do_work(session.get_nodes("my_nodes"))
+                ...         await asyncio.sleep(60)
+        """
+        self._warn_on_sync_with_file_cache.warn()
+
+        if at_least_one_is_not_none(*query.cursors.values()):
+            raise ValueError(
+                "The 'query' must not have cursors set. The session manages cursors internally "
+                "and restores them from the CDF backup file on entry."
+            )
+        if missing := [k for k in query.select if query.with_[k].limit is None]:
+            raise ValueError(
+                f"All result-set expressions referenced in 'select' must have an explicit 'limit'. Missing: {missing}"
+            )
+        categories = await self._cognite_client.iam.security_categories.list(limit=None)
+        if security_category not in categories.as_ids():
+            raise ValueError(f"Security category {security_category!r} does not exist in this project.")
+
+        if backup_every is not None and backup_every < timedelta(minutes=1):
+            raise ValueError("'backup_every' must be at least 1 minute to prevent unnecessary file transfers.")
+
+        return SyncSessionWithCache(
+            self,
+            query,
+            file_external_id=file_external_id,
+            security_category=security_category,
+            backup_every=backup_every,
+            backup_on_exit=backup_on_exit,
         )
 
     @overload

--- a/cognite/client/_sync_api/data_modeling/instances.py
+++ b/cognite/client/_sync_api/data_modeling/instances.py
@@ -1,6 +1,6 @@
 """
 ===============================================================================
-02a87cb0afc86242caefa040616c386c
+c0af4f83cd8ffa0aaed6fa641bde9a98
 This file is auto-generated from the Async API modules, - do not edit manually!
 ===============================================================================
 """
@@ -8,6 +8,7 @@ This file is auto-generated from the Async API modules, - do not edit manually!
 from __future__ import annotations
 
 from collections.abc import Awaitable, Callable, Iterator, Sequence
+from datetime import timedelta
 from typing import TYPE_CHECKING, Any, Literal, overload
 
 from cognite.client import AsyncCogniteClient
@@ -41,7 +42,7 @@ from cognite.client.data_classes.data_modeling.instances import (
     TargetUnit,
 )
 from cognite.client.data_classes.data_modeling.query import Query, QueryResult, QuerySync
-from cognite.client.data_classes.data_modeling.sync import SubscriptionContext
+from cognite.client.data_classes.data_modeling.sync import SubscriptionContext, SyncSessionWithCache
 from cognite.client.data_classes.filters import Filter
 from cognite.client.utils._async_helpers import SyncIterator, run_sync
 from cognite.client.utils.useful_types import SequenceNotStr
@@ -142,7 +143,7 @@ class SyncInstancesAPI(SyncAPIClient):
 
         Yields:
             Edge | EdgeList | Node | NodeList: yields Instance one by one if chunk_size is not specified, else NodeList/EdgeList objects.
-        """
+        """  # noqa: DOC404
         yield from SyncIterator(
             self.__async_client.data_modeling.instances(
                 chunk_size=chunk_size,
@@ -1264,6 +1265,120 @@ class SyncInstancesAPI(SyncAPIClient):
         """
         return run_sync(
             self.__async_client.data_modeling.instances.sync(query=query, include_typing=include_typing, debug=debug)
+        )
+
+    def sync_with_file_cache(
+        self,
+        query: QuerySync,
+        *,
+        file_external_id: str,
+        security_category: int,
+        backup_every: timedelta | None = timedelta(minutes=15),
+        backup_on_exit: bool = False,
+    ) -> SyncSessionWithCache:
+        r"""
+        Create a managed sync session with persistent backup to a CDF file.
+
+        Returns a :class:`SyncSessionWithCache` that you use as an async context manager. On entry
+        the session downloads the backup file from CDF and restores the instance data and previous
+        cursor positions if the query hash matches, allowing you to immediately continue syncing
+        instances from where your last session left off (no need for a full backfill).
+
+        We **require** a security category for the file to prevent users who lack access to the
+        underlying instances from bypassing those restrictions by reading the backup file directly.
+
+        Note:
+            This session (or rather /sync) must be invoked frequently enough to keep cursors alive.
+            Cursors expire after 3 days (the soft-delete retention period). If a cursor
+            expires the session will raise an error — call ``await session.invalidate()``
+            followed by ``await session.sync_until_live()`` to start fresh from a full backfill.
+
+            If you *really* don't care about missing deleted instances, there's
+            ``allow_expired_cursors_and_accept_missed_deletes=True`` on :class:`QuerySync`
+            that will allow you to use an older cursor. **Be careful**, you can not change this
+            setting mid-session, as the hash of your query would no longer match the existing,
+            and a full backfill would be triggered.
+
+        Warning:
+            This functionality is in **alpha** and only the async context manager interface is
+            currently available. The API and behaviour may change without notice.
+
+        Args:
+            query (QuerySync): The sync query.
+            file_external_id (str): External ID of the CDF file used as the durable backup store.
+                The file is created automatically on the first backup if it does not yet exist.
+            security_category (int): The security category to apply to the backup file. The file is
+                created (and re-uploaded on each backup) with this security category set, preventing
+                users who lack access to the underlying instances from reading the backup directly.
+            backup_every (timedelta | None): How often to upload state to CDF during a
+                session (when active). ``None`` uploads only on context-manager exit.
+            backup_on_exit (bool): Whether to upload state to CDF on context-manager exit.
+
+        Raises:
+            ValueError: If ``query`` already has cursors set (cursors are managed internally).
+            ValueError: If any result-set expression referenced in ``select`` does not have an
+                explicit ``limit`` set.
+            ValueError: If the given ``security_category`` does not exist in this project.
+            ValueError: If ``backup_every`` is set to a value smaller than 1 minute.
+
+        Returns:
+            SyncSessionWithCache: The context manager for managing the sync session.
+
+        Examples:
+
+            One-off job that loads state from the Files API, syncs until it has caught up with all
+            live changes, then does some work that require huge amounts of instance data, then backs
+            up the progress on exit (from the context manager):
+
+                >>> import asyncio
+                >>> from cognite.client import AsyncCogniteClient
+                >>> from cognite.client.data_classes.data_modeling.query import (
+                ...     QuerySync,
+                ...     SelectSync,
+                ...     NodeResultSetExpressionSync,
+                ... )
+                >>> client = AsyncCogniteClient()
+                >>> query = QuerySync(
+                ...     with_={"my_nodes": NodeResultSetExpressionSync(limit=1000)},
+                ...     select={"my_nodes": SelectSync()},
+                ... )
+                >>> session = client.data_modeling.instances.sync_with_file_cache(
+                ...     query,
+                ...     file_external_id="my_backup_file",
+                ...     security_category=123,
+                ...     backup_every=None,  # Only backup on exit
+                ...     backup_on_exit=True,
+                ... )
+                >>> def do_work(nodes: NodeList) -> None:
+                ...     print(len(nodes))  # ¯\_(ツ)_/¯
+                >>>
+                >>> async with session:  # doctest: +SKIP
+                ...     await session.sync_until_live()
+                ...     do_work(session.get_nodes("my_nodes"))
+
+            Longer-running job with periodic backups, e.g. regularly computing statistics for a
+            dashboard:
+
+                >>> session = client.data_modeling.instances.sync_with_file_cache(
+                ...     query,
+                ...     file_external_id="my_backup_file",
+                ...     security_category=123,
+                ...     backup_every=timedelta(minutes=15),
+                ... )
+                >>> async with session:  # doctest: +SKIP
+                ...     while True:
+                ...         await session.sync_until_live()
+                ...         do_work(session.get_nodes("my_nodes"))
+                ...         await asyncio.sleep(60)
+        """
+        return run_sync(
+            self.__async_client.data_modeling.instances.sync_with_file_cache(
+                query=query,
+                file_external_id=file_external_id,
+                security_category=security_category,
+                backup_every=backup_every,
+                backup_on_exit=backup_on_exit,
+            )
         )
 
     @overload

--- a/cognite/client/data_classes/data_modeling/instances.py
+++ b/cognite/client/data_classes/data_modeling/instances.py
@@ -72,6 +72,7 @@ if TYPE_CHECKING:
 
     from cognite.client.data_classes.data_modeling.debug import DebugInfo
 
+
 PropertyValue: TypeAlias = (
     str | int | float | bool | dict | list[str] | list[int] | list[float] | list[bool] | list[dict]
 )

--- a/cognite/client/data_classes/data_modeling/sync.py
+++ b/cognite/client/data_classes/data_modeling/sync.py
@@ -1,11 +1,24 @@
 from __future__ import annotations
 
+import hashlib
+import logging
+from contextlib import AbstractAsyncContextManager
 from dataclasses import dataclass
-from typing import TYPE_CHECKING
+from datetime import datetime, timedelta, timezone
+from typing import TYPE_CHECKING, Any, NoReturn
+
+from cognite.client._version import __version__ as sdk_version
+from cognite.client.data_classes.data_modeling.instances import EdgeList, NodeList
+from cognite.client.data_classes.data_modeling.query import QueryResult, QuerySync
+from cognite.client.exceptions import CogniteAPIError, CogniteNotFoundError
+from cognite.client.utils import _json_extended as json
 
 if TYPE_CHECKING:
     import asyncio
-    from datetime import datetime
+
+    from cognite.client._api.data_modeling.instances import InstancesAPI
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass
@@ -25,3 +38,217 @@ class SubscriptionContext:
 
     def is_alive(self) -> bool:
         return self.is_running()
+
+
+class SyncSessionWithCache(AbstractAsyncContextManager["SyncSessionWithCache"]):
+    """Data modeling /sync session with persistent backup to a CDF Data Modeling file.
+
+    Obtain via :meth:`InstancesAPI.sync_with_file_cache`. Use as an async context manager.
+
+    On entry the session downloads the backup file from CDF and restores the instance data and
+    previous cursor positions if the query hash matches, allowing you to immediately continue
+    syncing instances from where your last session left off (no need for a full backfill).
+    """
+
+    def __init__(
+        self,
+        api: InstancesAPI,
+        query: QuerySync,
+        *,
+        file_external_id: str,
+        security_category: int,
+        backup_every: timedelta | None,
+        backup_on_exit: bool,
+    ) -> None:
+        self._api = api
+        self._query = query
+        self._file_external_id = file_external_id
+        self._security_category = security_category
+        self._backup_every = backup_every
+        self._backup_on_exit = backup_on_exit
+
+        # Populated on enter:
+        self._query_hash: str
+        self._last_backup_time: datetime
+
+        # Runtime state
+        self._cursors: dict[str, str] = {}
+        self._instances: dict[str, list[dict[str, Any]]] = {}
+        self._has_changes_since_backup: bool = False
+        self._entered: bool = False
+        # When the user is running with sync_mode="two_phase" (default), the backfill phase may be done
+        # (we don't know), so we'll fetch two consecutive batches with "less than limit" before we consider
+        # it done (just to be sure):
+        self._backfill_done: bool = False
+
+    async def __aenter__(self) -> SyncSessionWithCache:
+        self._query_hash = self._compute_query_hash(self._query)
+        await self._load_from_cdf()
+        if self._cursors:
+            self._query.cursors = self._cursors
+        self._last_backup_time = datetime.now(timezone.utc)
+        self._entered = True
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: object,
+    ) -> None:
+        if self._entered and self._has_changes_since_backup and self._backup_on_exit:
+            await self._backup_to_cdf()
+
+    def __enter__(self) -> NoReturn:
+        raise NotImplementedError(
+            f"{type(self).__name__} must be used as an async context manager (for now). Hint: `async with session:`"
+        )
+
+    def __exit__(self, *_: object) -> NoReturn:
+        raise NotImplementedError(
+            f"{type(self).__name__} must be used as an async context manager (for now). Hint: `async with session:`"
+        )
+
+    async def sync(self) -> None:
+        """Perform one incremental sync, updating the internal snapshot state."""
+        await self._sync_one()
+
+    async def sync_until_live(self) -> None:
+        """Call :meth:`sync` repeatedly until we have caught up with all live changes."""
+        n_consecutive_small_batches = 0  # small as in "less than limit"
+        required = 1 if self._backfill_done else 2
+        while True:
+            if self._batch_is_full(await self._sync_one()):
+                n_consecutive_small_batches = 0
+                continue
+
+            n_consecutive_small_batches += 1
+            if n_consecutive_small_batches >= required:
+                self._backfill_done = True
+                break
+
+    def get_nodes(self, key: str) -> NodeList:
+        """Return the current in-memory snapshot of nodes for the given result-expression key.
+
+        Args:
+            key (str): A key from ``query.select`` that maps to a node result-set expression.
+
+        Returns:
+            NodeList: The current in-memory snapshot for that key.
+
+        Raises:
+            KeyError: If *key* is not found.
+            ValueError: If the data stored under *key* contains edges, not nodes.
+        """
+        items = self._instances[key]
+        if items and items[0].get("instanceType") == "edge":
+            raise ValueError(f"Key {key!r} contains edges, not nodes. Use get_edges() instead.")
+        return NodeList._load(items)
+
+    def get_edges(self, key: str) -> EdgeList:
+        """Return the current in-memory snapshot of edges for the given result-expression key.
+
+        Args:
+            key (str): A key from ``query.select`` that maps to an edge result-set expression.
+
+        Returns:
+            EdgeList: The current in-memory snapshot for that key.
+
+        Raises:
+            KeyError: If *key* is not found.
+            ValueError: If the data stored under *key* contains nodes, not edges.
+        """
+        items = self._instances[key]
+        if items and items[0].get("instanceType") != "edge":
+            raise ValueError(f"Key {key!r} contains nodes, not edges. Use get_nodes() instead.")
+        return EdgeList._load(items)
+
+    async def invalidate(self) -> None:
+        """Clear all in-memory state and immediately overwrite the CDF backup file."""
+        self._cursors = {}
+        self._query.cursors = {}
+        self._instances = {}
+        self._has_changes_since_backup = True
+        await self._backup_to_cdf()
+
+    def _batch_is_full(self, result: QueryResult) -> bool:
+        # We have enforcement on limit being given (although mypy doesn't know that):
+        return any(len(result[k]) >= self._query.with_[k].limit for k in result)  # type: ignore[operator]
+
+    async def _sync_one(self) -> QueryResult:
+        if self._cursors:
+            self._query.cursors = self._cursors
+
+        sync_result = await self._api.sync(self._query)
+        self._merge_result(sync_result)
+        self._cursors = sync_result.cursors
+        self._has_changes_since_backup = True  # TODO: simple but could be wrong, not that big deal
+
+        if self._backup_every is not None and self._last_backup_time is not None:
+            if datetime.now(timezone.utc) - self._last_backup_time >= self._backup_every:
+                await self._backup_to_cdf()
+                self._last_backup_time = datetime.now(timezone.utc)
+                self._has_changes_since_backup = False
+
+        return sync_result
+
+    def _merge_result(self, sync_result: QueryResult) -> None:
+        for key, sync_list in sync_result.items():
+            cached_by_id: dict[tuple[str, str], dict[str, Any]] = {
+                (item["space"], item["externalId"]): item for item in self._instances.get(key, [])
+            }
+            # Deletes first: an instance may be deleted and re-created in the same batch,
+            # so we must not let a delete that appears after a re-create win.
+            for item in sync_list:
+                if item.deleted_time is not None:
+                    cached_by_id.pop((item.space, item.external_id), None)
+            for item in sync_list:
+                if item.deleted_time is None:
+                    cached_by_id[(item.space, item.external_id)] = item.dump(camel_case=True)
+            self._instances[key] = list(cached_by_id.values())
+
+    async def _load_from_cdf(self) -> None:
+        try:
+            cached_bytes = await self._api._cognite_client.files.download_bytes(external_id=self._file_external_id)
+        except CogniteNotFoundError:
+            logger.info(f"No existing cache file {self._file_external_id!r}, will create on first backup")
+            return
+
+        cached_data = json.loads(cached_bytes.decode("utf-8"))
+        if cached_data.get("hash") != self._query_hash:
+            logger.warning(f"Cache hash mismatch for {self._file_external_id!r}, starting fresh")
+            return
+
+        self._instances = cached_data["instances"]
+        self._cursors = cached_data["cursors"]
+        n_instances = sum(len(v) for v in self._instances.values())
+        logger.info(f"Restored cache state from CDF file {self._file_external_id!r} ({n_instances:,} instances)")
+
+    async def _backup_to_cdf(self) -> None:
+        try:
+            cache_data: dict[str, Any] = {
+                "hash": self._query_hash,
+                "cursors": self._cursors,
+                "instances": self._instances,
+                # We add the SDK version in case we ever need to evolve (break) the format of the cache file,
+                # then we can reason based on current- vs. cached SDK version:
+                "sdk-version": sdk_version,
+            }
+            await self._api._cognite_client.files.upload_bytes(
+                content=json.dumps(cache_data).encode("utf-8"),
+                name=self._file_external_id,
+                external_id=self._file_external_id,
+                mime_type="application/json",
+                security_categories=[self._security_category],
+                overwrite=True,
+            )
+            logger.info(f"Backed up cache to CDF file {self._file_external_id!r}")
+        except CogniteAPIError as e:
+            logger.warning(f"Failed to back up to CDF Files ({self._file_external_id!r}): {e}. In-memory state intact.")
+
+    @staticmethod
+    def _compute_query_hash(query: QuerySync) -> str:
+        query_dict = query.dump(camel_case=True)
+        query_dict.pop("cursors", None)
+        serialized = json.dumps_deterministic(query_dict)
+        return hashlib.sha256(serialized.encode()).hexdigest()[:16]

--- a/cognite/client/utils/_json_extended.py
+++ b/cognite/client/utils/_json_extended.py
@@ -93,3 +93,7 @@ def dumps_no_nan_or_inf(obj: Any) -> str:
                 e.__traceback__
             ) from None
         raise
+
+
+def dumps_deterministic(obj: Any) -> str:
+    return dumps(obj, indent=None, allow_nan=False, sort_keys=True)

--- a/scripts/sync_client_codegen/codegen_utils.py
+++ b/scripts/sync_client_codegen/codegen_utils.py
@@ -26,7 +26,7 @@ def get_api_class_by_attribute(cls_: object, parent_name: tuple[str, ...] = ()) 
     return available_apis
 
 
-def find_api_class_name(source_code: str, file: Path, raise_on_missing: bool = True) -> str | None:
+def find_api_class_name(source_code: str, file: Path) -> str | None:
     match re.findall(r"class (\w+API)\((?:Org)?APIClient\):", source_code):
         case []:
             return None

--- a/tests/tests_integration/test_api/test_data_modeling/test_instances.py
+++ b/tests/tests_integration/test_api/test_data_modeling/test_instances.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import contextlib
 import json
 import math
 import time
@@ -1653,3 +1654,214 @@ class TestInstancesSync:
                 return
         else:
             assert not context.is_alive()
+
+
+class TestSyncSessionWithCache:
+    """
+    Integration test for SyncSessionWithCache (the new sync_with_file_cache API).
+
+    One large test that exercises the full lifecycle:
+      1. Fresh session: sync_until_live loads all matching nodes into the snapshot.
+      2. Backup is written to CDF on exit.
+      3. Second session restores from backup and picks up only new changes.
+      4. Delete + re-sync removes the deleted node from the snapshot.
+      5. invalidate() clears state so the third session does a full backfill again.
+    """
+
+    @pytest.fixture(scope="class")
+    def sync_security_category(self, cognite_client: CogniteClient) -> int:
+        from cognite.client.data_classes.iam import SecurityCategoryWrite
+
+        existing = cognite_client.iam.security_categories.list(limit=1)
+        if existing:
+            return existing[0].id
+        created = cognite_client.iam.security_categories.create(SecurityCategoryWrite(name="sdk_sync_integration_test"))
+        return created.id
+
+    @staticmethod
+    def _make_movie(space: str, movie_id: ViewId, prefix: str, suffix: str, year: int = 2020) -> NodeApply:
+        return NodeApply(
+            space=space,
+            external_id=f"{prefix}_{suffix}",
+            sources=[
+                NodeOrEdgeData(source=movie_id, properties={"title": suffix, "releaseYear": year, "runTimeMinutes": 90})
+            ],
+        )
+
+    @staticmethod
+    def _make_query(movie_id: ViewId, prefix: str) -> QuerySync:
+        return QuerySync(
+            with_={
+                "movies": NodeResultSetExpressionSync(
+                    filter=filters.Prefix(["node", "externalId"], prefix), sync_mode="two_phase", limit=100
+                )
+            },
+            select={"movies": SelectSync([SourceSelector(movie_id, ["title", "releaseYear"])])},
+        )
+
+    async def test_sync_with_file_cache_full_lifecycle(
+        self,
+        async_client: AsyncCogniteClient,
+        movie_view: View,
+        sync_security_category: int,
+    ) -> None:
+        movie_id = movie_view.as_id()
+        prefix = f"sswc_{random_string(6)}"
+        file_external_id = f"{prefix}_cache_file"
+
+        movie_a = self._make_movie(movie_view.space, movie_id, prefix, "movie_a", 2020)
+        movie_b = self._make_movie(movie_view.space, movie_id, prefix, "movie_b", 2021)
+        sync_query = self._make_query(movie_id, prefix)
+
+        try:
+            # --- Phase 1: seed data and do first session ---
+            await async_client.data_modeling.instances.apply(nodes=movie_a)
+
+            async with await async_client.data_modeling.instances.sync_with_file_cache(
+                sync_query,
+                file_external_id=file_external_id,
+                security_category=sync_security_category,
+                backup_every=None,
+                backup_on_exit=True,
+            ) as sess:
+                await sess.sync_until_live()
+                nodes_after_first = sess.get_nodes("movies")
+
+            assert any(n.external_id == movie_a.external_id for n in nodes_after_first), (
+                "movie_a should be in snapshot after first session"
+            )
+
+            # --- Phase 2: add movie_b, new session should restore cursors from backup ---
+            await async_client.data_modeling.instances.apply(nodes=movie_b)
+            sync_query.cursors = {}
+
+            async with await async_client.data_modeling.instances.sync_with_file_cache(
+                sync_query,
+                file_external_id=file_external_id,
+                security_category=sync_security_category,
+                backup_every=None,
+                backup_on_exit=True,
+            ) as sess:
+                await sess.sync_until_live()
+                nodes_after_second = sess.get_nodes("movies")
+
+            ext_ids_second = {n.external_id for n in nodes_after_second}
+            assert movie_a.external_id in ext_ids_second, "movie_a should still be present in second session"
+            assert movie_b.external_id in ext_ids_second, "movie_b should appear in second session"
+
+            # --- Phase 3: delete movie_a, verify it's removed from snapshot ---
+            await async_client.data_modeling.instances.delete(nodes=[movie_a.as_id()])
+            sync_query.cursors = {}
+
+            async with await async_client.data_modeling.instances.sync_with_file_cache(
+                sync_query,
+                file_external_id=file_external_id,
+                security_category=sync_security_category,
+                backup_every=None,
+                backup_on_exit=True,
+            ) as sess:
+                await sess.sync_until_live()
+                nodes_after_delete = sess.get_nodes("movies")
+
+            ext_ids_delete = {n.external_id for n in nodes_after_delete}
+            assert movie_a.external_id not in ext_ids_delete, "deleted movie_a should be gone from snapshot"
+            assert movie_b.external_id in ext_ids_delete, "movie_b should still be present after delete phase"
+
+            # --- Phase 4: invalidate forces full backfill from scratch ---
+            sync_query.cursors = {}
+
+            async with await async_client.data_modeling.instances.sync_with_file_cache(
+                sync_query,
+                file_external_id=file_external_id,
+                security_category=sync_security_category,
+                backup_every=None,
+                backup_on_exit=False,
+            ) as sess:
+                await sess.invalidate()
+                await sess.sync_until_live()
+                nodes_after_invalidate = sess.get_nodes("movies")
+
+            ext_ids_invalidate = {n.external_id for n in nodes_after_invalidate}
+            assert movie_a.external_id not in ext_ids_invalidate, "movie_a was deleted; should not reappear"
+            assert movie_b.external_id in ext_ids_invalidate, "movie_b should be present after invalidate+backfill"
+
+        finally:
+            with contextlib.suppress(Exception):
+                await async_client.data_modeling.instances.delete(nodes=[movie_a.as_id(), movie_b.as_id()])
+            with contextlib.suppress(Exception):
+                await async_client.files.delete(external_id=file_external_id)
+
+    async def test_hash_mismatch_discards_cache(
+        self,
+        async_client: AsyncCogniteClient,
+        movie_view: View,
+        sync_security_category: int,
+    ) -> None:
+        movie_id = movie_view.as_id()
+        prefix_a = f"hma_{random_string(6)}"
+        prefix_b = f"hmb_{random_string(6)}"
+        file_external_id = f"{prefix_a}_cache"
+
+        movie_a = self._make_movie(movie_view.space, movie_id, prefix_a, "movie_a")
+        try:
+            await async_client.data_modeling.instances.apply(nodes=movie_a)
+
+            # Session 1: backfill with query for prefix_a, saves cache containing movie_a
+            async with await async_client.data_modeling.instances.sync_with_file_cache(
+                self._make_query(movie_id, prefix_a),
+                file_external_id=file_external_id,
+                security_category=sync_security_category,
+                backup_every=None,
+                backup_on_exit=True,
+            ) as sess:
+                await sess.sync_until_live()
+                assert any(n.external_id == movie_a.external_id for n in sess.get_nodes("movies"))
+
+            # Session 2: different query → hash mismatch → cache discarded, fresh backfill
+            # movie_a should NOT appear because the new query filters on prefix_b
+            async with await async_client.data_modeling.instances.sync_with_file_cache(
+                self._make_query(movie_id, prefix_b),
+                file_external_id=file_external_id,
+                security_category=sync_security_category,
+                backup_every=None,
+                backup_on_exit=False,
+            ) as sess:
+                await sess.sync_until_live()
+                nodes = sess.get_nodes("movies")
+
+            assert not any(n.external_id == movie_a.external_id for n in nodes), (
+                "Hash mismatch should discard cached instances from the previous query"
+            )
+        finally:
+            with contextlib.suppress(Exception):
+                await async_client.data_modeling.instances.delete(nodes=[movie_a.as_id()])
+            with contextlib.suppress(Exception):
+                await async_client.files.delete(external_id=file_external_id)
+
+    async def test_backup_on_exit_false_does_not_write_cache(
+        self,
+        async_client: AsyncCogniteClient,
+        movie_view: View,
+        sync_security_category: int,
+    ) -> None:
+        movie_id = movie_view.as_id()
+        prefix = f"bof_{random_string(6)}"
+        file_external_id = f"{prefix}_cache"
+
+        try:
+            async with await async_client.data_modeling.instances.sync_with_file_cache(
+                self._make_query(movie_id, prefix),
+                file_external_id=file_external_id,
+                security_category=sync_security_category,
+                backup_every=None,
+                backup_on_exit=False,
+            ) as sess:
+                await sess.sync_until_live()
+
+            from cognite.client.exceptions import CogniteNotFoundError
+
+            with pytest.raises(CogniteNotFoundError):
+                await async_client.files.download_bytes(external_id=file_external_id)
+        finally:
+            with contextlib.suppress(Exception):
+                await async_client.files.delete(external_id=file_external_id)

--- a/tests/tests_unit/test_api/test_data_modeling/test_instances.py
+++ b/tests/tests_unit/test_api/test_data_modeling/test_instances.py
@@ -4,6 +4,7 @@ import json
 import math
 import re
 from typing import Any
+from unittest.mock import MagicMock
 
 import pytest
 from pytest_httpx import HTTPXMock
@@ -11,7 +12,14 @@ from pytest_httpx import HTTPXMock
 from cognite.client import AsyncCogniteClient, CogniteClient
 from cognite.client.data_classes.aggregations import Count
 from cognite.client.data_classes.data_modeling.ids import ViewId
-from cognite.client.data_classes.data_modeling.query import SourceSelector
+from cognite.client.data_classes.data_modeling.query import (
+    NodeResultSetExpressionSync,
+    QueryResult,
+    QuerySync,
+    SelectSync,
+    SourceSelector,
+)
+from cognite.client.data_classes.data_modeling.sync import SyncSessionWithCache
 from tests.tests_unit.test_api.test_data_modeling.conftest import make_test_view
 
 SINGLE_SRC_DUMP = {"source": {"space": "a", "externalId": "b", "version": "c", "type": "view"}}
@@ -115,3 +123,71 @@ class TestSearch:
                 "dummy text",
                 operator="INVALID",  # type: ignore [call-overload]
             )
+
+
+class TestSyncSessionWithCache:
+    @pytest.fixture
+    def session(self) -> SyncSessionWithCache:
+        query = QuerySync(
+            with_={"movies": NodeResultSetExpressionSync(limit=10)},
+            select={"movies": SelectSync([])},
+        )
+        return SyncSessionWithCache(
+            api=MagicMock(),
+            query=query,
+            file_external_id="test_cache_file",
+            security_category=42,
+            backup_every=None,
+            backup_on_exit=True,
+        )
+
+    def test_enter_raises_not_implemented_error(self, session: SyncSessionWithCache) -> None:
+        with pytest.raises(NotImplementedError, match="async context manager"):
+            with session:
+                pass  # pragma: no cover
+
+    @pytest.mark.parametrize(
+        "counts, limits, expected",
+        [
+            # Single key
+            ({"k": 10}, {"k": 10}, True),  # at limit → full
+            ({"k": 11}, {"k": 10}, True),  # over limit → full (should not happen ofc...)
+            ({"k": 9}, {"k": 10}, False),  # under limit → not full
+            ({"k": 0}, {"k": 10}, False),  # empty → not full
+            # Multiple keys: ANY key at limit makes the batch full
+            ({"k1": 10, "k2": 10}, {"k1": 10, "k2": 10}, True),  # both full
+            ({"k1": 10, "k2": 9}, {"k1": 10, "k2": 10}, True),  # one full, one not
+            ({"k1": 9, "k2": 9}, {"k1": 10, "k2": 10}, False),  # ALL under limit → not full
+        ],
+    )
+    def test_batch_is_full(self, counts: dict, limits: dict, expected: bool) -> None:
+        query = QuerySync(
+            with_={k: NodeResultSetExpressionSync(limit=v) for k, v in limits.items()},
+            select={k: SelectSync([]) for k in limits},
+        )
+        sess = SyncSessionWithCache(
+            api=MagicMock(),
+            query=query,
+            file_external_id="f",
+            security_category=0,
+            backup_every=None,
+            backup_on_exit=True,
+        )
+        result = QueryResult({k: [None] * v for k, v in counts.items()})
+        assert sess._batch_is_full(result) is expected
+
+    def test_compute_query_hash_strips_cursors(self, session: SyncSessionWithCache) -> None:
+        hash_without = SyncSessionWithCache._compute_query_hash(session._query)
+        session._query.cursors = {"movies": "some_cursor_value"}
+        hash_with = SyncSessionWithCache._compute_query_hash(session._query)
+        assert hash_without == hash_with
+
+    def test_get_nodes_raises_on_edge_data(self, session: SyncSessionWithCache) -> None:
+        session._instances = {"movies": [{"instanceType": "edge", "space": "s", "externalId": "e"}]}
+        with pytest.raises(ValueError, match="edges"):
+            session.get_nodes("movies")
+
+    def test_get_edges_raises_on_node_data(self, session: SyncSessionWithCache) -> None:
+        session._instances = {"movies": [{"instanceType": "node", "space": "s", "externalId": "e"}]}
+        with pytest.raises(ValueError, match="nodes"):
+            session.get_edges("movies")


### PR DESCRIPTION
An evolution of https://github.com/cognitedata/cognite-sdk-python/pull/2586, adding or changing a few things:

- **Context manager pattern** — `SyncSessionWithCache` holds state across multiple syncs; first PR did a full load/sync/save roundtrip on every call
- **Fewer CDF file API calls** — state is kept in memory and only written on a timer (`backup_every`) or on exiting from the context manager, instead of every call
- **`sync_until_live()`** — built-in loop to catch up with all pending changes; previously up to the caller to handle
- **Typed accessors** — `get_nodes()` / `get_edges()`, lifted from `QueryResults`.
- **`invalidate()`** — explicit reset to trigger a fresh backfill
- **Stricter permissions** — only security category allowed (and enforced)

Usage examples from docstring:

```py
# One-off job that loads state from the Files API, syncs until it has caught up with all
# live changes, then does some work that require huge amounts of instance data, then backs
# up the progress on exit (from the context manager):

from cognite.client import AsyncCogniteClient
from cognite.client.data_classes.data_modeling.query import (
    QuerySync,
    SelectSync,
    NodeResultSetExpressionSync,
)
client = AsyncCogniteClient()
query = QuerySync(
    with_={"my_nodes": NodeResultSetExpressionSync(limit=1000)},
    select={"my_nodes": SelectSync()},
)
session = client.data_modeling.instances.sync_with_file_cache(
    query,
    file_external_id="my_backup_file",
    security_category=123,
    backup_every=None,  # Only backup on exit
    backup_on_exit=True,
)
def do_work(nodes: NodeList) -> None:
    print(len(nodes))  # ¯\_(ツ)_/¯

async with session:
    await session.sync_until_live()
    do_work(session.get_nodes("my_nodes"))

# Longer-running job with periodic backups, e.g. regularly computing statistics for a
# dashboard:

import asyncio
session = client.data_modeling.instances.sync_with_file_cache(
    query,
    file_external_id="my_backup_file",
    security_category=123,
    backup_every=timedelta(minutes=15),
)
async with session:
    while True:
        await session.sync_until_live()
        do_work(session.get_nodes("my_nodes"))
        await asyncio.sleep(60)
```