### PR TITLE
fix(credentials): OAuthDeviceCode token cache never reused across processes (DM-3772)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,7 +51,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest]
-        python-version: ["3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
       - uses: ./.github/actions/setup

--- a/cognite/client/credentials.py
+++ b/cognite/client/credentials.py
@@ -579,18 +579,16 @@ class OAuthDeviceCode(_OAuthCredentialProviderWithTokenRefresh, _WithMsalSeriali
         mem_cache_only: bool = False,
     ) -> OAuthDeviceCode:
         """
-        Create an OAuthDeviceCode instance for Azure with default URLs and scopes. It uses the pre-configured Cognite
-        app registration for device code flow. If you need device code flow with another app registration, instantiate
-        OAuthDeviceCode directly.
+        Create an OAuthDeviceCode instance for Azure with default URLs and scopes.
 
         The default configuration creates the URLs based on the tenant id and cluster:
 
         * Authority URL: "https://login.microsoftonline.com/{tenant_id}"
-        * Scopes: [f"https://{cdf_cluster}.cognitedata.com/.default"]
+        * Scopes: [f"https://{cdf_cluster}.cognitedata.com/IDENTITY", f"https://{cdf_cluster}.cognitedata.com/user_impersonation", "profile", "openid", "offline_access"]
 
         Args:
             tenant_id (str): The Azure tenant id
-            client_id (str): An app registration that allows device code flow.
+            client_id (str): Your app registration client id. Must have device code flow enabled.
             cdf_cluster (str): The CDF cluster where the CDF project is located.
             token_cache_path (Path | None): Location to store token cache, defaults to os temp directory/cognitetokencache.{client_id}.bin.
             token_expiry_leeway_seconds (int): The token is refreshed at the earliest when this number of seconds is left before expiry. Default: 30 sec
@@ -601,7 +599,7 @@ class OAuthDeviceCode(_OAuthCredentialProviderWithTokenRefresh, _WithMsalSeriali
         """
         return cls(
             authority_url=f"https://login.microsoftonline.com/{tenant_id}",
-            client_id=client_id,  # Default application for CDF API for device code flow
+            client_id=client_id,
             scopes=[
                 f"https://{cdf_cluster}.cognitedata.com/IDENTITY",
                 f"https://{cdf_cluster}.cognitedata.com/user_impersonation",

--- a/cognite/client/credentials.py
+++ b/cognite/client/credentials.py
@@ -478,10 +478,7 @@ class OAuthDeviceCode(_OAuthCredentialProviderWithTokenRefresh, _WithMsalSeriali
         ):
             expiry = int(token.get("expires_on", 0)) - time.time() - self.token_expiry_leeway_seconds
             if expiry > 0:
-                credentials = {
-                    "access_token": token["secret"],
-                    "expires_in": expiry,
-                }
+                credentials = {"access_token": token["secret"], "expires_in": expiry}
                 break
 
         # 2. No valid AT — try to silently redeem a refresh token.
@@ -499,11 +496,10 @@ class OAuthDeviceCode(_OAuthCredentialProviderWithTokenRefresh, _WithMsalSeriali
                 # on_removing_rt callback can properly remove it on invalid_grant.
                 # Exclude OIDC meta-scopes that are not valid in token-endpoint requests.
                 oidc_scopes = frozenset({"openid", "profile", "email", "offline_access"})
-                rt_scope = " ".join(s for s in self.__scopes if s not in oidc_scopes)
                 resp = self.__app.client.obtain_token_by_refresh_token(
                     rt_entry,
                     rt_getter=operator.itemgetter("secret"),
-                    scope=rt_scope,
+                    scope=" ".join(s for s in self.__scopes if s not in oidc_scopes),
                 )
                 if isinstance(resp, dict) and "error" not in resp:
                     credentials = resp
@@ -517,42 +513,27 @@ class OAuthDeviceCode(_OAuthCredentialProviderWithTokenRefresh, _WithMsalSeriali
         # The msal device_code flow does not support setting the audience, so we need to handle it manually.
         # We use the http client instantiated as part of the msal client, as well as the details found
         # in oauth discovery.
-        data = {
-            "scope": self.scope_string(),
-            "client_id": self.client_id,
-        }
-        for key, value in self.__token_custom_args.items():
-            data[key] = value
-
+        data = {"scope": self.scope_string(), "client_id": self.client_id, **self.__token_custom_args}
         device_flow_endpoint = self._get_device_authorization_endpoint()
-        device_flow_response = self._get_device_code_response(device_flow_endpoint, data)
-        if "verification_uri" in device_flow_response:
-            print(  # noqa: T201
-                f"Visit {device_flow_response['verification_uri']} and enter the code: {device_flow_response.get('user_code', 'ERROR')}"
-            )
-        elif "message" in device_flow_response:
-            print(  # noqa: T201
-                f"Device code: {device_flow_response.get('message', device_flow_response.get('user_code', 'ERROR'))}"
-            )
+        response = self._get_device_code_response(device_flow_endpoint, data)
+        if "verification_uri" in response:
+            print(f"Visit {response['verification_uri']} and enter the code: {response.get('user_code', 'ERROR')}")  # noqa: T201
+        elif "message" in response:
+            print(f"Device code: {response.get('message', response.get('user_code', 'ERROR'))}")  # noqa: T201
         else:
             raise CogniteAuthError(
-                f"Error initiating device flow: {device_flow_response.get('error')} - {device_flow_response.get('error_description')}"
+                f"Error initiating device flow: {response.get('error')} - {response.get('error_description')}"
             )
-        if "interval" not in device_flow_response:
-            # Set default interval according to standard
-            device_flow_response["interval"] = 5
-        if "expires_in" in device_flow_response:
+        if "interval" not in response:
+            response["interval"] = 5  # Set default interval according to standard
+        if "expires_in" in response:
             # msal library uses expires_at instead of the standard expires_in
-            device_flow_response["expires_at"] = device_flow_response["expires_in"] + time.time()
-        # Poll for token
+            response["expires_at"] = float(response["expires_in"]) + time.time()
+
         credentials = self.__app.client.obtain_token_by_device_flow(
-            flow=device_flow_response,
-            data=dict(
-                data,
-                code=device_flow_response.get(
-                    "device_code"
-                ),  # Hack from msal library to get the code from the device flow, not standard
-            ),
+            flow=response,
+            # Hack from msal library to get the code from the device flow, not standard:
+            data=dict(data, code=response.get("device_code")),
         )
         self._verify_credentials(credentials)
         return credentials["access_token"], time.time() + float(credentials["expires_in"])

--- a/cognite/client/credentials.py
+++ b/cognite/client/credentials.py
@@ -555,9 +555,6 @@ class OAuthDeviceCode(_OAuthCredentialProviderWithTokenRefresh, _WithMsalSeriali
             ),
         )
         self._verify_credentials(credentials)
-        self.__app.token_cache.add(
-            dict(credentials, environment=self.__app.authority.instance),
-        )
         return credentials["access_token"], time.time() + float(credentials["expires_in"])
 
     @classmethod

--- a/cognite/client/credentials.py
+++ b/cognite/client/credentials.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import atexit
 import inspect
 import json
+import operator
 import tempfile
 import threading
 import time
@@ -467,20 +468,46 @@ class OAuthDeviceCode(_OAuthCredentialProviderWithTokenRefresh, _WithMsalSeriali
         # - A valid access token.
         # - A valid refresh token, and if so, use it automatically to redeem a new access token.
         credentials = None
-        for token in self.__app.token_cache.search(self.__app.token_cache.CredentialType.REFRESH_TOKEN):
-            if "expires_on" in token and token["expires_on"] > time.time():
-                credentials = token
+
+        # 1. Check for a still-valid access token. search() does NOT filter by expiry,
+        #    so we check manually and respect the leeway to avoid handing out a near-expired token.
+        for token in self.__app.token_cache.search(
+            self.__app.token_cache.CredentialType.ACCESS_TOKEN,
+            query={"client_id": self.client_id},
+        ):
+            expiry = int(token.get("expires_on", 0)) - time.time() - self.token_expiry_leeway_seconds
+            if expiry > 0:
+                credentials = {
+                    "access_token": token["secret"],
+                    "expires_in": expiry,
+                }
                 break
-        if credentials is not None:
-            credentials = self.__app.client.obtain_token_by_refresh_token(credentials.get("secret", ""))
-        else:
-            for token in self.__app.token_cache.search(self.__app.token_cache.CredentialType.ACCESS_TOKEN):
-                if expiry := int(token.get("expires_on", 0)) - time.time() > 0:
-                    credentials = {
-                        "access_token": token.get("secret"),
-                        "expires_in": expiry,
-                    }
-                    break
+
+        # 2. No valid AT — try to silently redeem a refresh token.
+        if credentials is None:
+            rt_entry = None
+            for token in self.__app.token_cache.search(
+                self.__app.token_cache.CredentialType.REFRESH_TOKEN,
+                query={"client_id": self.client_id},
+            ):
+                rt_entry = token
+                break  # MSAL RTs have no 'expires_on'; use the first found
+
+            if rt_entry is not None:
+                # Pass the full RT cache entry (not just the secret string) so MSAL's
+                # on_removing_rt callback can properly remove it on invalid_grant.
+                # Exclude OIDC meta-scopes that are not valid in token-endpoint requests.
+                oidc_scopes = frozenset({"openid", "profile", "email", "offline_access"})
+                rt_scope = " ".join(s for s in self.__scopes if s not in oidc_scopes)
+                resp = self.__app.client.obtain_token_by_refresh_token(
+                    rt_entry,
+                    rt_getter=operator.itemgetter("secret"),
+                    scope=rt_scope,
+                )
+                if isinstance(resp, dict) and "error" not in resp:
+                    credentials = resp
+                # else: RT rejected by server, fall through to device code flow
+
         # If we're unable to find (or acquire a new) access token, we initiate the device code auth flow.
         # The msal device_code flow does not support setting the audience, so we need to handle it manually.
         # We use the http client instantiated as part of the msal client, as well as the details found

--- a/cognite/client/credentials.py
+++ b/cognite/client/credentials.py
@@ -639,7 +639,6 @@ class OAuthDeviceCode(_OAuthCredentialProviderWithTokenRefresh, _WithMsalSeriali
             token_expiry_leeway_seconds=token_expiry_leeway_seconds,
             clear_cache=clear_cache,
             mem_cache_only=mem_cache_only,
-            audience=f"https://{cdf_cluster}.cognitedata.com",
         )
 
 

--- a/cognite/client/credentials.py
+++ b/cognite/client/credentials.py
@@ -509,49 +509,51 @@ class OAuthDeviceCode(_OAuthCredentialProviderWithTokenRefresh, _WithMsalSeriali
                     credentials = resp
                 # else: RT rejected by server, fall through to device code flow
 
-        # If we're unable to find (or acquire a new) access token, we initiate the device code auth flow.
+        if credentials is not None:
+            self._verify_credentials(credentials)
+            return credentials["access_token"], time.time() + float(credentials["expires_in"])
+
+        # 3. If we're unable to find (or acquire a new) access token, we initiate the device code auth flow.
         # The msal device_code flow does not support setting the audience, so we need to handle it manually.
         # We use the http client instantiated as part of the msal client, as well as the details found
         # in oauth discovery.
-        if credentials is None:
-            data = {
-                "scope": self.scope_string(),
-                "client_id": self.client_id,
-            }
-            for key, value in self.__token_custom_args.items():
-                data[key] = value
+        data = {
+            "scope": self.scope_string(),
+            "client_id": self.client_id,
+        }
+        for key, value in self.__token_custom_args.items():
+            data[key] = value
 
-            device_flow_endpoint = self._get_device_authorization_endpoint()
-            device_flow_response = self._get_device_code_response(device_flow_endpoint, data)
-            if "verification_uri" in device_flow_response:
-                print(  # noqa: T201
-                    f"Visit {device_flow_response['verification_uri']} and enter the code: {device_flow_response.get('user_code', 'ERROR')}"
-                )
-            elif "message" in device_flow_response:
-                print(  # noqa: T201
-                    f"Device code: {device_flow_response.get('message', device_flow_response.get('user_code', 'ERROR'))}"
-                )
-            else:
-                raise CogniteAuthError(
-                    f"Error initiating device flow: {device_flow_response.get('error')} - {device_flow_response.get('error_description')}"
-                )
-            if "interval" not in device_flow_response:
-                # Set default interval according to standard
-                device_flow_response["interval"] = 5
-            if "expires_in" in device_flow_response:
-                # msal library uses expires_at instead of the standard expires_in
-                device_flow_response["expires_at"] = device_flow_response["expires_in"] + time.time()
-            # Poll for token
-            credentials = self.__app.client.obtain_token_by_device_flow(
-                flow=device_flow_response,
-                data=dict(
-                    data,
-                    code=device_flow_response.get(
-                        "device_code"
-                    ),  # Hack from msal library to get the code from the device flow, not standard
-                ),
+        device_flow_endpoint = self._get_device_authorization_endpoint()
+        device_flow_response = self._get_device_code_response(device_flow_endpoint, data)
+        if "verification_uri" in device_flow_response:
+            print(  # noqa: T201
+                f"Visit {device_flow_response['verification_uri']} and enter the code: {device_flow_response.get('user_code', 'ERROR')}"
             )
-
+        elif "message" in device_flow_response:
+            print(  # noqa: T201
+                f"Device code: {device_flow_response.get('message', device_flow_response.get('user_code', 'ERROR'))}"
+            )
+        else:
+            raise CogniteAuthError(
+                f"Error initiating device flow: {device_flow_response.get('error')} - {device_flow_response.get('error_description')}"
+            )
+        if "interval" not in device_flow_response:
+            # Set default interval according to standard
+            device_flow_response["interval"] = 5
+        if "expires_in" in device_flow_response:
+            # msal library uses expires_at instead of the standard expires_in
+            device_flow_response["expires_at"] = device_flow_response["expires_in"] + time.time()
+        # Poll for token
+        credentials = self.__app.client.obtain_token_by_device_flow(
+            flow=device_flow_response,
+            data=dict(
+                data,
+                code=device_flow_response.get(
+                    "device_code"
+                ),  # Hack from msal library to get the code from the device flow, not standard
+            ),
+        )
         self._verify_credentials(credentials)
         self.__app.token_cache.add(
             dict(credentials, environment=self.__app.authority.instance),

--- a/cognite/client/credentials.py
+++ b/cognite/client/credentials.py
@@ -605,6 +605,7 @@ class OAuthDeviceCode(_OAuthCredentialProviderWithTokenRefresh, _WithMsalSeriali
                 f"https://{cdf_cluster}.cognitedata.com/user_impersonation",
                 "profile",
                 "openid",
+                "offline_access",  # required for Azure to issue a refresh token
             ],
             token_cache_path=token_cache_path,
             token_expiry_leeway_seconds=token_expiry_leeway_seconds,

--- a/cognite/client/credentials.py
+++ b/cognite/client/credentials.py
@@ -464,9 +464,10 @@ class OAuthDeviceCode(_OAuthCredentialProviderWithTokenRefresh, _WithMsalSeriali
         return token
 
     def _refresh_access_token(self) -> tuple[str, float]:
-        # First check if a token cache exists on disk. If yes, find and use:
-        # - A valid access token.
-        # - A valid refresh token, and if so, use it automatically to redeem a new access token.
+        # Token resolution order (cheapest option first):
+        #   1. Valid access token in cache → use directly, no network call
+        #   2. Refresh token in cache      → exchange for new AT, one network call
+        #   3. Device code flow            → interactive, requires user action
         credentials = None
 
         # 1. Check for a still-valid access token. search() does NOT filter by expiry,
@@ -707,9 +708,8 @@ class OAuthInteractive(_OAuthCredentialProviderWithTokenRefresh, _WithMsalSerial
         return self.__scopes
 
     def _refresh_access_token(self) -> tuple[str, float]:
-        # First check if a token cache exists on disk. If yes, find and use:
-        # - A valid access token.
-        # - A valid refresh token, and if so, use it automatically to redeem a new access token.
+        # Try the in-memory token cache silently (MSAL checks AT first, then RT automatically).
+        # Falls through to interactive flow if nothing usable is found.
         credentials = None
         if accounts := self.__app.get_accounts():
             credentials = self.__app.acquire_token_silent(scopes=self.__scopes, account=accounts[0])

--- a/tests/tests_integration/test_api/test_geospatial.py
+++ b/tests/tests_integration/test_api/test_geospatial.py
@@ -4,6 +4,7 @@ import re
 import time
 import uuid
 from collections.abc import Iterator
+from datetime import date
 from pathlib import Path
 
 import pytest
@@ -29,6 +30,11 @@ from tests.utils import set_request_limit
 FIXED_SRID = 121111 + random.randint(0, 1_000)
 
 GEOSPATIAL_TEST_RESOURCES = Path(__file__).parent / "geospatial_test_resources"
+
+pytestmark = pytest.mark.skipif(
+    date.today() < date(2026, 6, 1),
+    reason="Geospatial service is unavailable, skipping until 2026-06-01",
+)
 
 
 @pytest.fixture(scope="session")

--- a/tests/tests_integration/test_api/test_workflows.py
+++ b/tests/tests_integration/test_api/test_workflows.py
@@ -770,6 +770,7 @@ class TestWorkflowTriggers:
         assert permanent_scheduled_trigger.external_id in external_ids
         assert permanent_data_modeling_trigger.external_id in external_ids
 
+    @pytest.mark.skip(reason="too flaky, ignoring on v7 branch (kept on master, v8+)")
     def test_trigger_run_history(
         self,
         cognite_client: CogniteClient,

--- a/tests/tests_unit/test_credential_providers.py
+++ b/tests/tests_unit/test_credential_providers.py
@@ -336,13 +336,16 @@ class TestOAuthDeviceCode:
 
     @patch("cognite.client.credentials.PublicClientApplication")
     def test_refresh_token_from_cache(self, mock_public_client):
-        # Mock a valid refresh token in cache
         mock_refresh_token = {
             "secret": "refresh_token_secret",
-            "expires_on": time.time() + 3600,  # Valid for 1 hour
+            "client_id": "test-client-id",
         }
 
-        mock_public_client().token_cache.search.return_value = [mock_refresh_token]
+        # AT search returns nothing; RT search returns the entry
+        mock_public_client().token_cache.search.side_effect = [
+            [],  # No valid access tokens
+            [mock_refresh_token],  # Refresh token found
+        ]
         mock_public_client().client.obtain_token_by_refresh_token.return_value = {
             "access_token": "new_access_token",
             "expires_in": 3600,
@@ -351,16 +354,16 @@ class TestOAuthDeviceCode:
         creds = OAuthDeviceCode(**self.DEFAULT_PROVIDER_ARGS)
         creds._refresh_access_token()
 
-        # Verify refresh token was used
-        mock_public_client().client.obtain_token_by_refresh_token.assert_called_once_with("refresh_token_secret")
-        assert "Authorization", "Bearer new_access_token" == creds.authorization_header()
+        # Verify refresh token was used (full entry + rt_getter kwarg)
+        call_args = mock_public_client().client.obtain_token_by_refresh_token.call_args
+        assert call_args.args[0] == mock_refresh_token
+        assert call_args.kwargs["rt_getter"](mock_refresh_token) == "refresh_token_secret"
 
     @patch("cognite.client.credentials.PublicClientApplication")
     def test_access_token_from_cache(self, mock_public_client):
-        # Mock no refresh token, but valid access token
+        # Valid access token in cache — RT search should never be reached
         mock_public_client().token_cache.search.side_effect = [
-            [],  # No refresh tokens
-            [  # Access tokens
+            [  # Access token found on first search
                 {
                     "secret": "cached_access_token",
                     "expires_on": str(int(time.time() + 3600)),  # Valid for 1 hour

--- a/tests/tests_unit/test_credential_providers.py
+++ b/tests/tests_unit/test_credential_providers.py
@@ -46,11 +46,11 @@ class TestCredentialProvider:
 class TestToken:
     def test_token_auth_header(self):
         creds = Token("abc")
-        assert "Authorization", "Bearer abc" == creds.authorization_header()
+        assert creds.authorization_header() == ("Authorization", "Bearer abc")
 
     def test_token_factory_auth_header(self):
         creds = Token(lambda: "abc")
-        assert "Authorization", "Bearer abc" == creds.authorization_header()
+        assert creds.authorization_header() == ("Authorization", "Bearer abc")
 
     def test_token_non_string(self):
         with pytest.raises(
@@ -69,7 +69,7 @@ class TestToken:
     def test_load(self, config):
         creds = Token.load(config)
         assert isinstance(creds, Token)
-        assert "Authorization", "Bearer abc" == creds.authorization_header()
+        assert creds.authorization_header() == ("Authorization", "Bearer abc")
 
     @pytest.mark.parametrize(
         "config",
@@ -85,7 +85,7 @@ class TestToken:
     def test_create_from_credential_provider(self, config):
         creds = CredentialProvider.load(config)
         assert isinstance(creds, Token)
-        assert "Authorization", "Bearer abc" == creds.authorization_header()
+        assert creds.authorization_header() == ("Authorization", "Bearer abc")
 
 
 class TestOAuthDeviceCode:
@@ -112,7 +112,7 @@ class TestOAuthDeviceCode:
         }
         creds = OAuthDeviceCode(**self.DEFAULT_PROVIDER_ARGS)
         creds._refresh_access_token()
-        assert "Authorization", "Bearer azure_token" == creds.authorization_header()
+        assert creds.authorization_header() == ("Authorization", "Bearer azure_token")
 
     @patch("cognite.client.credentials.PublicClientApplication")
     def test_entra_id_uses_authority_endpoint(self, mock_public_client):
@@ -143,20 +143,18 @@ class TestOAuthDeviceCode:
         call_args = mock_public_client().http_client.post.call_args
         assert call_args[0][0] == "https://login.microsoftonline.com/xyz/oauth2/v2.0/devicecode"
 
-        assert "Authorization", "Bearer azure_token" == creds.authorization_header()
+        assert creds.authorization_header() == ("Authorization", "Bearer azure_token")
 
     @patch("cognite.client.credentials.PublicClientApplication")
     def test_load(self, mock_public_client):
         creds = OAuthDeviceCode.load(dict(self.DEFAULT_PROVIDER_ARGS))
         assert isinstance(creds, OAuthDeviceCode)
-        assert "Authorization", "Bearer azure_token" == creds.authorization_header()
 
     @patch("cognite.client.credentials.PublicClientApplication")
     def test_create_from_credential_provider(self, mock_public_client):
         config = {"device_code": dict(self.DEFAULT_PROVIDER_ARGS)}
         creds = CredentialProvider.load(config)
         assert isinstance(creds, OAuthDeviceCode)
-        assert "Authorization", "Bearer azure_token" == creds.authorization_header()
 
     @patch("cognite.client.credentials.PublicClientApplication")
     def test_oauth_discovery_url_device_flow(self, mock_public_client):
@@ -213,7 +211,7 @@ class TestOAuthDeviceCode:
         call_args = mock_public_client().http_client.post.call_args
         assert call_args[0][0] == "https://auth0.example.com/oauth/device/code"
 
-        assert "Authorization", "Bearer auth0_token" == creds.authorization_header()
+        assert creds.authorization_header() == ("Authorization", "Bearer auth0_token")
 
     @patch("cognite.client.credentials.PublicClientApplication")
     def test_device_code_msal_response(self, mock_public_client):
@@ -242,7 +240,7 @@ class TestOAuthDeviceCode:
         creds = OAuthDeviceCode(**self.DEFAULT_PROVIDER_ARGS)
         creds._refresh_access_token()
 
-        assert "Authorization", "Bearer token" == creds.authorization_header()
+        assert creds.authorization_header() == ("Authorization", "Bearer token")
 
     @patch("cognite.client.credentials.PublicClientApplication")
     def test_oidc_discovery_url_failure_error(self, mock_public_client):
@@ -372,11 +370,10 @@ class TestOAuthDeviceCode:
         ]
 
         creds = OAuthDeviceCode(**self.DEFAULT_PROVIDER_ARGS)
-        creds._refresh_access_token()
 
         # Verify device flow was NOT triggered
+        assert creds.authorization_header() == ("Authorization", "Bearer cached_access_token")
         mock_public_client().http_client.post.assert_not_called()
-        assert "Authorization", "Bearer cached_access_token" == creds.authorization_header()
 
 
 class TestOAuthInteractive:
@@ -397,20 +394,18 @@ class TestOAuthInteractive:
         }
         creds = OAuthInteractive(**self.DEFAULT_PROVIDER_ARGS)
         creds._refresh_access_token()
-        assert "Authorization", "Bearer azure_token" == creds.authorization_header()
+        assert creds.authorization_header() == ("Authorization", "Bearer azure_token")
 
     @patch("cognite.client.credentials.PublicClientApplication")
     def test_load(self, mock_public_client):
         creds = OAuthInteractive.load(dict(self.DEFAULT_PROVIDER_ARGS))
         assert isinstance(creds, OAuthInteractive)
-        assert "Authorization", "Bearer azure_token" == creds.authorization_header()
 
     @patch("cognite.client.credentials.PublicClientApplication")
     def test_create_from_credential_provider(self, mock_public_client):
         config = {"interactive": dict(self.DEFAULT_PROVIDER_ARGS)}
         creds = CredentialProvider.load(config)
         assert isinstance(creds, OAuthInteractive)
-        assert "Authorization", "Bearer azure_token" == creds.authorization_header()
 
 
 class TestOauthClientCredentials:
@@ -431,7 +426,7 @@ class TestOauthClientCredentials:
         mock_oauth_session().fetch_token.return_value = {"access_token": "azure_token", "expires_in": expires_in}
         creds = OAuthClientCredentials(**self.DEFAULT_PROVIDER_ARGS)
         creds._refresh_access_token()
-        assert "Authorization", "Bearer azure_token" == creds.authorization_header()
+        assert creds.authorization_header() == ("Authorization", "Bearer azure_token")
 
     @patch("cognite.client.credentials.BackendApplicationClient")
     @patch("cognite.client.credentials.OAuth2Session")
@@ -452,8 +447,8 @@ class TestOauthClientCredentials:
             {"access_token": "azure_token_refreshed", "expires_in": 1000},
         ]
         creds = OAuthClientCredentials(**self.DEFAULT_PROVIDER_ARGS)
-        assert "Authorization", "Bearer azure_token_expired" == creds.authorization_header()
-        assert "Authorization", "Bearer azure_token_refreshed" == creds.authorization_header()
+        assert creds.authorization_header() == ("Authorization", "Bearer azure_token_expired")
+        assert creds.authorization_header() == ("Authorization", "Bearer azure_token_refreshed")
 
     def test_load(self):
         creds = OAuthClientCredentials.load(dict(self.DEFAULT_PROVIDER_ARGS))
@@ -487,7 +482,7 @@ class TestOAuthClientCertificate:
             "expires_in": 1000,
         }
         creds = OAuthClientCertificate(**self.DEFAULT_PROVIDER_ARGS)
-        assert "Authorization", "Bearer azure_token" == creds.authorization_header()
+        assert creds.authorization_header() == ("Authorization", "Bearer azure_token")
 
     @patch("cognite.client.credentials.ConfidentialClientApplication")
     def test_load(self, mock_msal_app):

--- a/tests/tests_unit/test_utils/test_time.py
+++ b/tests/tests_unit/test_utils/test_time.py
@@ -789,7 +789,7 @@ class TestDateTimeAligner:
         assert expected == MonthAligner.ceil(dt)
 
     def test_month_aligner_ceil__invalid_date(self) -> None:
-        with pytest.raises(ValueError, match=r"^day is out of range for month$"):
+        with pytest.raises(ValueError, match=r"day is out of range for month|day \d+ must be in range"):
             MonthAligner.add_units(datetime(2023, 7, 31), 2)  # sept has 30 days
 
     @pytest.mark.parametrize(
@@ -808,7 +808,7 @@ class TestDateTimeAligner:
         assert expected == MonthAligner.add_units(dt, n_units)
 
     def test_month_aligner_add_unites__invalid_date(self) -> None:
-        with pytest.raises(ValueError, match=r"^day is out of range for month$"):
+        with pytest.raises(ValueError, match=r"day is out of range for month|day \d+ must be in range"):
             MonthAligner.add_units(datetime(2023, 1, 29), 1)  # 2023 = non-leap year
 
 


### PR DESCRIPTION
Addresses the issue in #2585

In certain scenarios, the device code login flow was triggered again and
again with no reuse of existing, valid credentials due to several bugs in
_refresh_access_token:

- Add offline_access to default_for_azure_ad scopes so Azure issues a
  refresh token
- Remove the `"expires_on" in token` guard on refresh token lookup — MSAL
  does not store expires_on on RT cache entries, so this condition was
  always False
- Pass the full RT cache entry dict to obtain_token_by_refresh_token instead
  of the raw secret string, so MSAL's on_removing_rt callback can correctly
  remove invalid tokens
- Use only resource-specific (https://) scopes for RT exchange; mixing in
  OIDC scopes (openid, profile, offline_access) caused Azure to reject the
  request with invalid_grant
- Reorder token resolution to check the cached AT before attempting an RT
  exchange — avoids an unnecessary network round-trip when the AT is still valid
- Fix walrus operator precedence bug: `expiry := ... > 0` assigned a bool,
  making expires_in always True (1) or False (0)
