### PR TITLE
chore(agents): update agents runtime version to 1.2.0

### DIFF
--- a/cognite/client/_api/agents/agents.py
+++ b/cognite/client/_api/agents/agents.py
@@ -106,7 +106,7 @@ class AgentsAPI(APIClient):
                 ...     external_id="my_agent",
                 ...     name="My Agent",
                 ...     labels=["published"],
-                ...     runtime_version="1.1.2-preview",
+                ...     runtime_version="1.2.0",
                 ...     tools=[query_tool],
                 ... )
                 >>> client.agents.upsert(agent)

--- a/cognite/client/_sync_api/agents/agents.py
+++ b/cognite/client/_sync_api/agents/agents.py
@@ -1,6 +1,6 @@
 """
 ===============================================================================
-178ce7222985b04d03174af7b7e0f525
+edc424110b87b8b0c7db22d65ea2a446
 This file is auto-generated from the Async API modules, - do not edit manually!
 ===============================================================================
 """
@@ -104,7 +104,7 @@ class SyncAgentsAPI(SyncAPIClient):
                 ...     external_id="my_agent",
                 ...     name="My Agent",
                 ...     labels=["published"],
-                ...     runtime_version="1.1.2-preview",
+                ...     runtime_version="1.2.0",
                 ...     tools=[query_tool],
                 ... )
                 >>> client.agents.upsert(agent)

--- a/tests/tests_unit/test_api/test_agents.py
+++ b/tests/tests_unit/test_api/test_agents.py
@@ -27,7 +27,7 @@ def agent_response_body() -> dict:
                 "description": "Description 1",
                 "instructions": "Instructions 1",
                 "model": "vendor/model_1",
-                "runtimeVersion": "1.1.1",
+                "runtimeVersion": "1.2.0",
                 "labels": ["published"],
                 "tools": [
                     {
@@ -150,7 +150,7 @@ class TestAgentsAPI:
             description="Description 1",
             instructions="Instructions 1",
             model="vendor/model_1",
-            runtime_version="1.1.1",
+            runtime_version="1.2.0",
             tools=[
                 QueryKnowledgeGraphAgentToolUpsert(
                     name="tool_1",
@@ -170,9 +170,9 @@ class TestAgentsAPI:
         created_agent = cognite_client.agents.upsert(agent_write)
         assert isinstance(created_agent, Agent)
         assert created_agent.external_id == "agent_1"
-        assert created_agent.runtime_version == "1.1.1"
+        assert created_agent.runtime_version == "1.2.0"
         request_body = jsgz_load(mock_agent_upsert_response.get_requests()[-1].content)
-        assert request_body["items"][0]["runtimeVersion"] == "1.1.1"
+        assert request_body["items"][0]["runtimeVersion"] == "1.2.0"
         url = str(mock_agent_upsert_response.get_requests()[-1].url)
         assert url.endswith(async_client.agents._RESOURCE_PATH)
 

--- a/tests/tests_unit/test_data_classes/test_agents/test_agents.py
+++ b/tests/tests_unit/test_data_classes/test_agents/test_agents.py
@@ -22,7 +22,7 @@ def agent_upsert_dump() -> dict[str, Any]:
         "description": "A test agent",
         "instructions": "Test instructions",
         "model": "gpt-4",
-        "runtimeVersion": "1.1.1",
+        "runtimeVersion": "1.2.0",
         "tools": [
             {  # Valid queryKnowledgeGraph tool
                 "name": "test_tool",
@@ -59,7 +59,7 @@ def agent_minimal_dump() -> dict[str, Any]:
     return {
         "externalId": "test_agent",
         "name": "Test Agent",
-        "runtimeVersion": "1.1.1",
+        "runtimeVersion": "1.2.0",
         "createdTime": 667008000000,
         "lastUpdatedTime": 667008000001,
         "ownerId": "owner_minimal",
@@ -75,7 +75,7 @@ class TestAgentUpsert:
         assert agent.description == "A test agent"
         assert agent.instructions == "Test instructions"
         assert agent.model == "gpt-4"
-        assert agent.runtime_version == "1.1.1"
+        assert agent.runtime_version == "1.2.0"
         assert agent.tools
         assert len(agent.tools) == 1
         assert isinstance(agent.tools[0], AgentToolUpsert)
@@ -135,7 +135,7 @@ class TestAgent:
         assert agent.description == "A test agent"
         assert agent.instructions == "Test instructions"
         assert agent.model == "gpt-4"
-        assert agent.runtime_version == "1.1.1"
+        assert agent.runtime_version == "1.2.0"
         assert agent.tools
         assert len(agent.tools) == 1
         assert isinstance(agent.tools[0], AgentTool)
@@ -164,7 +164,7 @@ class TestAgent:
         agent_data = {
             "externalId": "test_agent",
             "name": "Test Agent",
-            "runtimeVersion": "1.1.1",
+            "runtimeVersion": "1.2.0",
             "unknownProperty": "unknown_value",
             "createdTime": 123,
             "lastUpdatedTime": 123,


### PR DESCRIPTION
## Summary
- Updates the agents runtime version from `1.1.2-preview` to `1.2.0` in docstring examples
- Updates test fixtures from `1.1.1` to `1.2.0`

## Test plan
- [x] Unit tests pass: `pytest tests/tests_unit/test_api/test_agents.py tests/tests_unit/test_data_classes/test_agents/`