### PR TITLE
docs(simulators): improve type hints and default values for some arguments in the simulator module

### DIFF
--- a/cognite/client/_api/simulators/models_revisions.py
+++ b/cognite/client/_api/simulators/models_revisions.py
@@ -41,7 +41,7 @@ class SimulatorModelRevisionsAPI(APIClient):
         limit: int = DEFAULT_LIMIT_READ,
         sort: PropertySort | None = None,
         model_external_ids: str | SequenceNotStr[str] | None = None,
-        all_versions: bool | None = None,
+        all_versions: bool = False,
         created_time: TimestampRange | None = None,
         last_updated_time: TimestampRange | None = None,
     ) -> SimulatorModelRevisionList:
@@ -53,7 +53,7 @@ class SimulatorModelRevisionsAPI(APIClient):
             limit (int): Maximum number of results to return. Defaults to 25. Set to -1, float(“inf”) or None to return all items.
             sort (PropertySort | None): The criteria to sort by.
             model_external_ids (str | SequenceNotStr[str] | None): The external ids of the simulator models to filter by.
-            all_versions (bool | None): If True, all versions of the simulator model revisions are returned. If False, only the latest version is returned.
+            all_versions (bool): If True, all versions of the simulator model revisions are returned. If False, only the latest version is returned.
             created_time (TimestampRange | None): Filter by created time.
             last_updated_time (TimestampRange | None): Filter by last updated time.
 
@@ -158,7 +158,7 @@ class SimulatorModelRevisionsAPI(APIClient):
         chunk_size: int,
         sort: PropertySort | None = None,
         model_external_ids: str | SequenceNotStr[str] | None = None,
-        all_versions: bool | None = None,
+        all_versions: bool = False,
         created_time: TimestampRange | None = None,
         last_updated_time: TimestampRange | None = None,
         limit: int | None = None,
@@ -170,7 +170,7 @@ class SimulatorModelRevisionsAPI(APIClient):
         chunk_size: None = None,
         sort: PropertySort | None = None,
         model_external_ids: str | SequenceNotStr[str] | None = None,
-        all_versions: bool | None = None,
+        all_versions: bool = False,
         created_time: TimestampRange | None = None,
         last_updated_time: TimestampRange | None = None,
         limit: int | None = None,
@@ -181,7 +181,7 @@ class SimulatorModelRevisionsAPI(APIClient):
         chunk_size: int | None = None,
         sort: PropertySort | None = None,
         model_external_ids: str | SequenceNotStr[str] | None = None,
-        all_versions: bool | None = None,
+        all_versions: bool = False,
         created_time: TimestampRange | None = None,
         last_updated_time: TimestampRange | None = None,
         limit: int | None = None,
@@ -194,7 +194,7 @@ class SimulatorModelRevisionsAPI(APIClient):
             chunk_size (int | None): Number of simulator model revisions to return in each chunk. Defaults to yielding one simulator model revision a time.
             sort (PropertySort | None): The criteria to sort by.
             model_external_ids (str | SequenceNotStr[str] | None): The external ids of the simulator models to filter by.
-            all_versions (bool | None): If True, all versions of the simulator model revisions are returned. If False, only the latest version is returned.
+            all_versions (bool): If True, all versions of the simulator model revisions are returned. If False, only the latest version is returned.
             created_time (TimestampRange | None): Filter by created time.
             last_updated_time (TimestampRange | None): Filter by last updated time.
             limit (int | None): Maximum number of results to return. Defaults to 25. Set to -1, float(“inf”) or None to return all items.

--- a/cognite/client/_api/simulators/routines.py
+++ b/cognite/client/_api/simulators/routines.py
@@ -240,7 +240,7 @@ class SimulatorRoutinesAPI(APIClient):
         routine_external_id: str,
         inputs: Sequence[SimulationInputOverride] | None = None,
         run_time: int | None = None,
-        queue: bool | None = None,
+        queue: bool = False,
         log_severity: Literal["Debug", "Information", "Warning", "Error"] | None = None,
         wait: bool = True,
         timeout: float = 60,
@@ -254,7 +254,7 @@ class SimulatorRoutinesAPI(APIClient):
         model_revision_external_id: str,
         inputs: Sequence[SimulationInputOverride] | None = None,
         run_time: int | None = None,
-        queue: bool | None = None,
+        queue: bool = False,
         log_severity: Literal["Debug", "Information", "Warning", "Error"] | None = None,
         wait: bool = True,
         timeout: float = 60,
@@ -268,7 +268,7 @@ class SimulatorRoutinesAPI(APIClient):
         model_revision_external_id: str | None = None,
         inputs: Sequence[SimulationInputOverride] | None = None,
         run_time: int | None = None,
-        queue: bool | None = None,
+        queue: bool = False,
         log_severity: Literal["Debug", "Information", "Warning", "Error"] | None = None,
         wait: bool = True,
         timeout: float = 60,
@@ -292,7 +292,7 @@ class SimulatorRoutinesAPI(APIClient):
                 Must be specified together with routine_revision_external_id.
             inputs (Sequence[SimulationInputOverride] | None): List of input overrides
             run_time (int | None): Run time in milliseconds. Reference timestamp used for data pre-processing and data sampling.
-            queue (bool | None): Queue the simulation run when connector is down.
+            queue (bool): Queue the simulation run when connector is down.
             log_severity (Literal['Debug', 'Information', 'Warning', 'Error'] | None): Override the minimum severity level for the simulation run logs. If not provided, the minimum severity is read from the connector logger configuration.
             wait (bool): Wait until the simulation run is finished. Defaults to True.
             timeout (float): Timeout in seconds for waiting for the simulation run to finish. Defaults to 60 seconds.

--- a/cognite/client/_api/simulators/runs.py
+++ b/cognite/client/_api/simulators/runs.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import AsyncIterator, Sequence
-from typing import TYPE_CHECKING, overload
+from typing import TYPE_CHECKING, Literal, overload
 
 from cognite.client._api_client import APIClient
 from cognite.client._constants import DEFAULT_LIMIT_READ
@@ -47,8 +47,8 @@ class SimulatorRunsAPI(APIClient):
         self,
         chunk_size: int,
         limit: int | None = None,
-        status: str | None = None,
-        run_type: str | None = None,
+        status: Literal["queued", "ready", "running", "success", "failure"] | None = None,
+        run_type: Literal["external", "manual", "scheduled"] | None = None,
         model_external_ids: SequenceNotStr[str] | None = None,
         simulator_integration_external_ids: SequenceNotStr[str] | None = None,
         simulator_external_ids: SequenceNotStr[str] | None = None,
@@ -65,8 +65,8 @@ class SimulatorRunsAPI(APIClient):
         self,
         chunk_size: None = None,
         limit: int | None = None,
-        status: str | None = None,
-        run_type: str | None = None,
+        status: Literal["queued", "ready", "running", "success", "failure"] | None = None,
+        run_type: Literal["external", "manual", "scheduled"] | None = None,
         model_external_ids: SequenceNotStr[str] | None = None,
         simulator_integration_external_ids: SequenceNotStr[str] | None = None,
         simulator_external_ids: SequenceNotStr[str] | None = None,
@@ -82,8 +82,8 @@ class SimulatorRunsAPI(APIClient):
         self,
         chunk_size: int | None = None,
         limit: int | None = None,
-        status: str | None = None,
-        run_type: str | None = None,
+        status: Literal["queued", "ready", "running", "success", "failure"] | None = None,
+        run_type: Literal["external", "manual", "scheduled"] | None = None,
         model_external_ids: SequenceNotStr[str] | None = None,
         simulator_integration_external_ids: SequenceNotStr[str] | None = None,
         simulator_external_ids: SequenceNotStr[str] | None = None,
@@ -101,8 +101,8 @@ class SimulatorRunsAPI(APIClient):
         Args:
             chunk_size (int | None): Number of simulation runs to return in each chunk. Defaults to yielding one simulation run a time.
             limit (int | None): The maximum number of simulation runs to return, pass None to return all.
-            status (str | None): Filter by simulation run status
-            run_type (str | None): Filter by simulation run type
+            status (Literal['queued', 'ready', 'running', 'success', 'failure'] | None): Filter by simulation run status
+            run_type (Literal['external', 'manual', 'scheduled'] | None): Filter by simulation run type
             model_external_ids (SequenceNotStr[str] | None): Filter by simulator model external ids
             simulator_integration_external_ids (SequenceNotStr[str] | None): Filter by simulator integration external ids
             simulator_external_ids (SequenceNotStr[str] | None): Filter by simulator external ids
@@ -143,8 +143,8 @@ class SimulatorRunsAPI(APIClient):
     async def list(
         self,
         limit: int | None = DEFAULT_LIMIT_READ,
-        status: str | None = None,
-        run_type: str | None = None,
+        status: Literal["queued", "ready", "running", "success", "failure"] | None = None,
+        run_type: Literal["external", "manual", "scheduled"] | None = None,
         model_external_ids: SequenceNotStr[str] | None = None,
         simulator_integration_external_ids: SequenceNotStr[str] | None = None,
         simulator_external_ids: SequenceNotStr[str] | None = None,
@@ -161,8 +161,8 @@ class SimulatorRunsAPI(APIClient):
 
         Args:
             limit (int | None): The maximum number of simulation runs to return, pass None to return all.
-            status (str | None): Filter by simulation run status
-            run_type (str | None): Filter by simulation run type
+            status (Literal['queued', 'ready', 'running', 'success', 'failure'] | None): Filter by simulation run status
+            run_type (Literal['external', 'manual', 'scheduled'] | None): Filter by simulation run type
             model_external_ids (SequenceNotStr[str] | None): Filter by simulator model external ids
             simulator_integration_external_ids (SequenceNotStr[str] | None): Filter by simulator integration external ids
             simulator_external_ids (SequenceNotStr[str] | None): Filter by simulator external ids

--- a/cognite/client/_api/simulators/runs.py
+++ b/cognite/client/_api/simulators/runs.py
@@ -12,6 +12,7 @@ from cognite.client.data_classes.simulators.runs import (
     SimulationRunDataList,
     SimulationRunList,
     SimulationRunWrite,
+    SimulatorRunStatus,
 )
 from cognite.client.utils._experimental import FeaturePreviewWarning
 from cognite.client.utils._identifier import IdentifierSequence
@@ -47,7 +48,7 @@ class SimulatorRunsAPI(APIClient):
         self,
         chunk_size: int,
         limit: int | None = None,
-        status: Literal["queued", "ready", "running", "success", "failure"] | None = None,
+        status: SimulatorRunStatus | None = None,
         run_type: Literal["external", "manual", "scheduled"] | None = None,
         model_external_ids: SequenceNotStr[str] | None = None,
         simulator_integration_external_ids: SequenceNotStr[str] | None = None,
@@ -65,7 +66,7 @@ class SimulatorRunsAPI(APIClient):
         self,
         chunk_size: None = None,
         limit: int | None = None,
-        status: Literal["queued", "ready", "running", "success", "failure"] | None = None,
+        status: SimulatorRunStatus | None = None,
         run_type: Literal["external", "manual", "scheduled"] | None = None,
         model_external_ids: SequenceNotStr[str] | None = None,
         simulator_integration_external_ids: SequenceNotStr[str] | None = None,
@@ -82,7 +83,7 @@ class SimulatorRunsAPI(APIClient):
         self,
         chunk_size: int | None = None,
         limit: int | None = None,
-        status: Literal["queued", "ready", "running", "success", "failure"] | None = None,
+        status: SimulatorRunStatus | None = None,
         run_type: Literal["external", "manual", "scheduled"] | None = None,
         model_external_ids: SequenceNotStr[str] | None = None,
         simulator_integration_external_ids: SequenceNotStr[str] | None = None,
@@ -101,7 +102,7 @@ class SimulatorRunsAPI(APIClient):
         Args:
             chunk_size (int | None): Number of simulation runs to return in each chunk. Defaults to yielding one simulation run a time.
             limit (int | None): The maximum number of simulation runs to return, pass None to return all.
-            status (Literal['queued', 'ready', 'running', 'success', 'failure'] | None): Filter by simulation run status
+            status (SimulatorRunStatus | None): Filter by simulation run status
             run_type (Literal['external', 'manual', 'scheduled'] | None): Filter by simulation run type
             model_external_ids (SequenceNotStr[str] | None): Filter by simulator model external ids
             simulator_integration_external_ids (SequenceNotStr[str] | None): Filter by simulator integration external ids
@@ -143,7 +144,7 @@ class SimulatorRunsAPI(APIClient):
     async def list(
         self,
         limit: int | None = DEFAULT_LIMIT_READ,
-        status: Literal["queued", "ready", "running", "success", "failure"] | None = None,
+        status: SimulatorRunStatus | None = None,
         run_type: Literal["external", "manual", "scheduled"] | None = None,
         model_external_ids: SequenceNotStr[str] | None = None,
         simulator_integration_external_ids: SequenceNotStr[str] | None = None,
@@ -161,7 +162,7 @@ class SimulatorRunsAPI(APIClient):
 
         Args:
             limit (int | None): The maximum number of simulation runs to return, pass None to return all.
-            status (Literal['queued', 'ready', 'running', 'success', 'failure'] | None): Filter by simulation run status
+            status (SimulatorRunStatus | None): Filter by simulation run status
             run_type (Literal['external', 'manual', 'scheduled'] | None): Filter by simulation run type
             model_external_ids (SequenceNotStr[str] | None): Filter by simulator model external ids
             simulator_integration_external_ids (SequenceNotStr[str] | None): Filter by simulator integration external ids

--- a/cognite/client/_api/simulators/runs.py
+++ b/cognite/client/_api/simulators/runs.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import AsyncIterator, Sequence
-from typing import TYPE_CHECKING, Literal, overload
+from typing import TYPE_CHECKING, overload
 
 from cognite.client._api_client import APIClient
 from cognite.client._constants import DEFAULT_LIMIT_READ
@@ -13,6 +13,7 @@ from cognite.client.data_classes.simulators.runs import (
     SimulationRunList,
     SimulationRunWrite,
     SimulatorRunStatus,
+    SimulatorRunType,
 )
 from cognite.client.utils._experimental import FeaturePreviewWarning
 from cognite.client.utils._identifier import IdentifierSequence
@@ -49,7 +50,7 @@ class SimulatorRunsAPI(APIClient):
         chunk_size: int,
         limit: int | None = None,
         status: SimulatorRunStatus | None = None,
-        run_type: Literal["external", "manual", "scheduled"] | None = None,
+        run_type: SimulatorRunType | None = None,
         model_external_ids: SequenceNotStr[str] | None = None,
         simulator_integration_external_ids: SequenceNotStr[str] | None = None,
         simulator_external_ids: SequenceNotStr[str] | None = None,
@@ -67,7 +68,7 @@ class SimulatorRunsAPI(APIClient):
         chunk_size: None = None,
         limit: int | None = None,
         status: SimulatorRunStatus | None = None,
-        run_type: Literal["external", "manual", "scheduled"] | None = None,
+        run_type: SimulatorRunType | None = None,
         model_external_ids: SequenceNotStr[str] | None = None,
         simulator_integration_external_ids: SequenceNotStr[str] | None = None,
         simulator_external_ids: SequenceNotStr[str] | None = None,
@@ -84,7 +85,7 @@ class SimulatorRunsAPI(APIClient):
         chunk_size: int | None = None,
         limit: int | None = None,
         status: SimulatorRunStatus | None = None,
-        run_type: Literal["external", "manual", "scheduled"] | None = None,
+        run_type: SimulatorRunType | None = None,
         model_external_ids: SequenceNotStr[str] | None = None,
         simulator_integration_external_ids: SequenceNotStr[str] | None = None,
         simulator_external_ids: SequenceNotStr[str] | None = None,
@@ -103,7 +104,7 @@ class SimulatorRunsAPI(APIClient):
             chunk_size (int | None): Number of simulation runs to return in each chunk. Defaults to yielding one simulation run a time.
             limit (int | None): The maximum number of simulation runs to return, pass None to return all.
             status (SimulatorRunStatus | None): Filter by simulation run status
-            run_type (Literal['external', 'manual', 'scheduled'] | None): Filter by simulation run type
+            run_type (SimulatorRunType | None): Filter by simulation run type
             model_external_ids (SequenceNotStr[str] | None): Filter by simulator model external ids
             simulator_integration_external_ids (SequenceNotStr[str] | None): Filter by simulator integration external ids
             simulator_external_ids (SequenceNotStr[str] | None): Filter by simulator external ids
@@ -145,7 +146,7 @@ class SimulatorRunsAPI(APIClient):
         self,
         limit: int | None = DEFAULT_LIMIT_READ,
         status: SimulatorRunStatus | None = None,
-        run_type: Literal["external", "manual", "scheduled"] | None = None,
+        run_type: SimulatorRunType | None = None,
         model_external_ids: SequenceNotStr[str] | None = None,
         simulator_integration_external_ids: SequenceNotStr[str] | None = None,
         simulator_external_ids: SequenceNotStr[str] | None = None,
@@ -163,7 +164,7 @@ class SimulatorRunsAPI(APIClient):
         Args:
             limit (int | None): The maximum number of simulation runs to return, pass None to return all.
             status (SimulatorRunStatus | None): Filter by simulation run status
-            run_type (Literal['external', 'manual', 'scheduled'] | None): Filter by simulation run type
+            run_type (SimulatorRunType | None): Filter by simulation run type
             model_external_ids (SequenceNotStr[str] | None): Filter by simulator model external ids
             simulator_integration_external_ids (SequenceNotStr[str] | None): Filter by simulator integration external ids
             simulator_external_ids (SequenceNotStr[str] | None): Filter by simulator external ids

--- a/cognite/client/_sync_api/simulators/models_revisions.py
+++ b/cognite/client/_sync_api/simulators/models_revisions.py
@@ -1,6 +1,6 @@
 """
 ===============================================================================
-fb7d457799eb07aa51d4dd24a2224b5e
+143e2ea035bde172593740ba9733e0e2
 This file is auto-generated from the Async API modules, - do not edit manually!
 ===============================================================================
 """
@@ -39,7 +39,7 @@ class SyncSimulatorModelRevisionsAPI(SyncAPIClient):
         limit: int = DEFAULT_LIMIT_READ,
         sort: PropertySort | None = None,
         model_external_ids: str | SequenceNotStr[str] | None = None,
-        all_versions: bool | None = None,
+        all_versions: bool = False,
         created_time: TimestampRange | None = None,
         last_updated_time: TimestampRange | None = None,
     ) -> SimulatorModelRevisionList:
@@ -52,7 +52,7 @@ class SyncSimulatorModelRevisionsAPI(SyncAPIClient):
             limit (int): Maximum number of results to return. Defaults to 25. Set to -1, float(“inf”) or None to return all items.
             sort (PropertySort | None): The criteria to sort by.
             model_external_ids (str | SequenceNotStr[str] | None): The external ids of the simulator models to filter by.
-            all_versions (bool | None): If True, all versions of the simulator model revisions are returned. If False, only the latest version is returned.
+            all_versions (bool): If True, all versions of the simulator model revisions are returned. If False, only the latest version is returned.
             created_time (TimestampRange | None): Filter by created time.
             last_updated_time (TimestampRange | None): Filter by last updated time.
 
@@ -148,7 +148,7 @@ class SyncSimulatorModelRevisionsAPI(SyncAPIClient):
         chunk_size: int,
         sort: PropertySort | None = None,
         model_external_ids: str | SequenceNotStr[str] | None = None,
-        all_versions: bool | None = None,
+        all_versions: bool = False,
         created_time: TimestampRange | None = None,
         last_updated_time: TimestampRange | None = None,
         limit: int | None = None,
@@ -160,7 +160,7 @@ class SyncSimulatorModelRevisionsAPI(SyncAPIClient):
         chunk_size: None = None,
         sort: PropertySort | None = None,
         model_external_ids: str | SequenceNotStr[str] | None = None,
-        all_versions: bool | None = None,
+        all_versions: bool = False,
         created_time: TimestampRange | None = None,
         last_updated_time: TimestampRange | None = None,
         limit: int | None = None,
@@ -171,7 +171,7 @@ class SyncSimulatorModelRevisionsAPI(SyncAPIClient):
         chunk_size: int | None = None,
         sort: PropertySort | None = None,
         model_external_ids: str | SequenceNotStr[str] | None = None,
-        all_versions: bool | None = None,
+        all_versions: bool = False,
         created_time: TimestampRange | None = None,
         last_updated_time: TimestampRange | None = None,
         limit: int | None = None,
@@ -185,7 +185,7 @@ class SyncSimulatorModelRevisionsAPI(SyncAPIClient):
             chunk_size (int | None): Number of simulator model revisions to return in each chunk. Defaults to yielding one simulator model revision a time.
             sort (PropertySort | None): The criteria to sort by.
             model_external_ids (str | SequenceNotStr[str] | None): The external ids of the simulator models to filter by.
-            all_versions (bool | None): If True, all versions of the simulator model revisions are returned. If False, only the latest version is returned.
+            all_versions (bool): If True, all versions of the simulator model revisions are returned. If False, only the latest version is returned.
             created_time (TimestampRange | None): Filter by created time.
             last_updated_time (TimestampRange | None): Filter by last updated time.
             limit (int | None): Maximum number of results to return. Defaults to 25. Set to -1, float(“inf”) or None to return all items.

--- a/cognite/client/_sync_api/simulators/routines.py
+++ b/cognite/client/_sync_api/simulators/routines.py
@@ -1,6 +1,6 @@
 """
 ===============================================================================
-ed6d6d90b4df699fd5db015a0177cdcd
+e25ff4296135886bcbe58f933f5d7da6
 This file is auto-generated from the Async API modules, - do not edit manually!
 ===============================================================================
 """
@@ -213,7 +213,7 @@ class SyncSimulatorRoutinesAPI(SyncAPIClient):
         routine_external_id: str,
         inputs: Sequence[SimulationInputOverride] | None = None,
         run_time: int | None = None,
-        queue: bool | None = None,
+        queue: bool = False,
         log_severity: Literal["Debug", "Information", "Warning", "Error"] | None = None,
         wait: bool = True,
         timeout: float = 60,
@@ -227,7 +227,7 @@ class SyncSimulatorRoutinesAPI(SyncAPIClient):
         model_revision_external_id: str,
         inputs: Sequence[SimulationInputOverride] | None = None,
         run_time: int | None = None,
-        queue: bool | None = None,
+        queue: bool = False,
         log_severity: Literal["Debug", "Information", "Warning", "Error"] | None = None,
         wait: bool = True,
         timeout: float = 60,
@@ -240,7 +240,7 @@ class SyncSimulatorRoutinesAPI(SyncAPIClient):
         model_revision_external_id: str | None = None,
         inputs: Sequence[SimulationInputOverride] | None = None,
         run_time: int | None = None,
-        queue: bool | None = None,
+        queue: bool = False,
         log_severity: Literal["Debug", "Information", "Warning", "Error"] | None = None,
         wait: bool = True,
         timeout: float = 60,
@@ -265,7 +265,7 @@ class SyncSimulatorRoutinesAPI(SyncAPIClient):
                 Must be specified together with routine_revision_external_id.
             inputs (Sequence[SimulationInputOverride] | None): List of input overrides
             run_time (int | None): Run time in milliseconds. Reference timestamp used for data pre-processing and data sampling.
-            queue (bool | None): Queue the simulation run when connector is down.
+            queue (bool): Queue the simulation run when connector is down.
             log_severity (Literal['Debug', 'Information', 'Warning', 'Error'] | None): Override the minimum severity level for the simulation run logs. If not provided, the minimum severity is read from the connector logger configuration.
             wait (bool): Wait until the simulation run is finished. Defaults to True.
             timeout (float): Timeout in seconds for waiting for the simulation run to finish. Defaults to 60 seconds.

--- a/cognite/client/_sync_api/simulators/runs.py
+++ b/cognite/client/_sync_api/simulators/runs.py
@@ -1,6 +1,6 @@
 """
 ===============================================================================
-49bafacf5fe639ebcf5da0fc6ca1f9f0
+183a4d1e3ee0ff2c01d10dadfbdda9a0
 This file is auto-generated from the Async API modules, - do not edit manually!
 ===============================================================================
 """
@@ -8,7 +8,7 @@ This file is auto-generated from the Async API modules, - do not edit manually!
 from __future__ import annotations
 
 from collections.abc import Iterator, Sequence
-from typing import TYPE_CHECKING, Literal, overload
+from typing import TYPE_CHECKING, overload
 
 from cognite.client import AsyncCogniteClient
 from cognite.client._constants import DEFAULT_LIMIT_READ
@@ -21,6 +21,7 @@ from cognite.client.data_classes.simulators.runs import (
     SimulationRunList,
     SimulationRunWrite,
     SimulatorRunStatus,
+    SimulatorRunType,
 )
 from cognite.client.utils._async_helpers import SyncIterator, run_sync
 from cognite.client.utils.useful_types import SequenceNotStr
@@ -41,7 +42,7 @@ class SyncSimulatorRunsAPI(SyncAPIClient):
         chunk_size: int,
         limit: int | None = None,
         status: SimulatorRunStatus | None = None,
-        run_type: Literal["external", "manual", "scheduled"] | None = None,
+        run_type: SimulatorRunType | None = None,
         model_external_ids: SequenceNotStr[str] | None = None,
         simulator_integration_external_ids: SequenceNotStr[str] | None = None,
         simulator_external_ids: SequenceNotStr[str] | None = None,
@@ -59,7 +60,7 @@ class SyncSimulatorRunsAPI(SyncAPIClient):
         chunk_size: None = None,
         limit: int | None = None,
         status: SimulatorRunStatus | None = None,
-        run_type: Literal["external", "manual", "scheduled"] | None = None,
+        run_type: SimulatorRunType | None = None,
         model_external_ids: SequenceNotStr[str] | None = None,
         simulator_integration_external_ids: SequenceNotStr[str] | None = None,
         simulator_external_ids: SequenceNotStr[str] | None = None,
@@ -76,7 +77,7 @@ class SyncSimulatorRunsAPI(SyncAPIClient):
         chunk_size: int | None = None,
         limit: int | None = None,
         status: SimulatorRunStatus | None = None,
-        run_type: Literal["external", "manual", "scheduled"] | None = None,
+        run_type: SimulatorRunType | None = None,
         model_external_ids: SequenceNotStr[str] | None = None,
         simulator_integration_external_ids: SequenceNotStr[str] | None = None,
         simulator_external_ids: SequenceNotStr[str] | None = None,
@@ -96,7 +97,7 @@ class SyncSimulatorRunsAPI(SyncAPIClient):
             chunk_size (int | None): Number of simulation runs to return in each chunk. Defaults to yielding one simulation run a time.
             limit (int | None): The maximum number of simulation runs to return, pass None to return all.
             status (SimulatorRunStatus | None): Filter by simulation run status
-            run_type (Literal['external', 'manual', 'scheduled'] | None): Filter by simulation run type
+            run_type (SimulatorRunType | None): Filter by simulation run type
             model_external_ids (SequenceNotStr[str] | None): Filter by simulator model external ids
             simulator_integration_external_ids (SequenceNotStr[str] | None): Filter by simulator integration external ids
             simulator_external_ids (SequenceNotStr[str] | None): Filter by simulator external ids
@@ -132,7 +133,7 @@ class SyncSimulatorRunsAPI(SyncAPIClient):
         self,
         limit: int | None = DEFAULT_LIMIT_READ,
         status: SimulatorRunStatus | None = None,
-        run_type: Literal["external", "manual", "scheduled"] | None = None,
+        run_type: SimulatorRunType | None = None,
         model_external_ids: SequenceNotStr[str] | None = None,
         simulator_integration_external_ids: SequenceNotStr[str] | None = None,
         simulator_external_ids: SequenceNotStr[str] | None = None,
@@ -151,7 +152,7 @@ class SyncSimulatorRunsAPI(SyncAPIClient):
         Args:
             limit (int | None): The maximum number of simulation runs to return, pass None to return all.
             status (SimulatorRunStatus | None): Filter by simulation run status
-            run_type (Literal['external', 'manual', 'scheduled'] | None): Filter by simulation run type
+            run_type (SimulatorRunType | None): Filter by simulation run type
             model_external_ids (SequenceNotStr[str] | None): Filter by simulator model external ids
             simulator_integration_external_ids (SequenceNotStr[str] | None): Filter by simulator integration external ids
             simulator_external_ids (SequenceNotStr[str] | None): Filter by simulator external ids

--- a/cognite/client/_sync_api/simulators/runs.py
+++ b/cognite/client/_sync_api/simulators/runs.py
@@ -1,6 +1,6 @@
 """
 ===============================================================================
-0d094e36b260cdd4aee8930d6122e636
+49bafacf5fe639ebcf5da0fc6ca1f9f0
 This file is auto-generated from the Async API modules, - do not edit manually!
 ===============================================================================
 """
@@ -20,6 +20,7 @@ from cognite.client.data_classes.simulators.runs import (
     SimulationRunDataList,
     SimulationRunList,
     SimulationRunWrite,
+    SimulatorRunStatus,
 )
 from cognite.client.utils._async_helpers import SyncIterator, run_sync
 from cognite.client.utils.useful_types import SequenceNotStr
@@ -39,7 +40,7 @@ class SyncSimulatorRunsAPI(SyncAPIClient):
         self,
         chunk_size: int,
         limit: int | None = None,
-        status: Literal["queued", "ready", "running", "success", "failure"] | None = None,
+        status: SimulatorRunStatus | None = None,
         run_type: Literal["external", "manual", "scheduled"] | None = None,
         model_external_ids: SequenceNotStr[str] | None = None,
         simulator_integration_external_ids: SequenceNotStr[str] | None = None,
@@ -57,7 +58,7 @@ class SyncSimulatorRunsAPI(SyncAPIClient):
         self,
         chunk_size: None = None,
         limit: int | None = None,
-        status: Literal["queued", "ready", "running", "success", "failure"] | None = None,
+        status: SimulatorRunStatus | None = None,
         run_type: Literal["external", "manual", "scheduled"] | None = None,
         model_external_ids: SequenceNotStr[str] | None = None,
         simulator_integration_external_ids: SequenceNotStr[str] | None = None,
@@ -74,7 +75,7 @@ class SyncSimulatorRunsAPI(SyncAPIClient):
         self,
         chunk_size: int | None = None,
         limit: int | None = None,
-        status: Literal["queued", "ready", "running", "success", "failure"] | None = None,
+        status: SimulatorRunStatus | None = None,
         run_type: Literal["external", "manual", "scheduled"] | None = None,
         model_external_ids: SequenceNotStr[str] | None = None,
         simulator_integration_external_ids: SequenceNotStr[str] | None = None,
@@ -94,7 +95,7 @@ class SyncSimulatorRunsAPI(SyncAPIClient):
         Args:
             chunk_size (int | None): Number of simulation runs to return in each chunk. Defaults to yielding one simulation run a time.
             limit (int | None): The maximum number of simulation runs to return, pass None to return all.
-            status (Literal['queued', 'ready', 'running', 'success', 'failure'] | None): Filter by simulation run status
+            status (SimulatorRunStatus | None): Filter by simulation run status
             run_type (Literal['external', 'manual', 'scheduled'] | None): Filter by simulation run type
             model_external_ids (SequenceNotStr[str] | None): Filter by simulator model external ids
             simulator_integration_external_ids (SequenceNotStr[str] | None): Filter by simulator integration external ids
@@ -130,7 +131,7 @@ class SyncSimulatorRunsAPI(SyncAPIClient):
     def list(
         self,
         limit: int | None = DEFAULT_LIMIT_READ,
-        status: Literal["queued", "ready", "running", "success", "failure"] | None = None,
+        status: SimulatorRunStatus | None = None,
         run_type: Literal["external", "manual", "scheduled"] | None = None,
         model_external_ids: SequenceNotStr[str] | None = None,
         simulator_integration_external_ids: SequenceNotStr[str] | None = None,
@@ -149,7 +150,7 @@ class SyncSimulatorRunsAPI(SyncAPIClient):
 
         Args:
             limit (int | None): The maximum number of simulation runs to return, pass None to return all.
-            status (Literal['queued', 'ready', 'running', 'success', 'failure'] | None): Filter by simulation run status
+            status (SimulatorRunStatus | None): Filter by simulation run status
             run_type (Literal['external', 'manual', 'scheduled'] | None): Filter by simulation run type
             model_external_ids (SequenceNotStr[str] | None): Filter by simulator model external ids
             simulator_integration_external_ids (SequenceNotStr[str] | None): Filter by simulator integration external ids

--- a/cognite/client/_sync_api/simulators/runs.py
+++ b/cognite/client/_sync_api/simulators/runs.py
@@ -1,6 +1,6 @@
 """
 ===============================================================================
-3fb2bb1e260073e2d54317794dab4d4d
+0d094e36b260cdd4aee8930d6122e636
 This file is auto-generated from the Async API modules, - do not edit manually!
 ===============================================================================
 """
@@ -8,7 +8,7 @@ This file is auto-generated from the Async API modules, - do not edit manually!
 from __future__ import annotations
 
 from collections.abc import Iterator, Sequence
-from typing import TYPE_CHECKING, overload
+from typing import TYPE_CHECKING, Literal, overload
 
 from cognite.client import AsyncCogniteClient
 from cognite.client._constants import DEFAULT_LIMIT_READ
@@ -39,8 +39,8 @@ class SyncSimulatorRunsAPI(SyncAPIClient):
         self,
         chunk_size: int,
         limit: int | None = None,
-        status: str | None = None,
-        run_type: str | None = None,
+        status: Literal["queued", "ready", "running", "success", "failure"] | None = None,
+        run_type: Literal["external", "manual", "scheduled"] | None = None,
         model_external_ids: SequenceNotStr[str] | None = None,
         simulator_integration_external_ids: SequenceNotStr[str] | None = None,
         simulator_external_ids: SequenceNotStr[str] | None = None,
@@ -57,8 +57,8 @@ class SyncSimulatorRunsAPI(SyncAPIClient):
         self,
         chunk_size: None = None,
         limit: int | None = None,
-        status: str | None = None,
-        run_type: str | None = None,
+        status: Literal["queued", "ready", "running", "success", "failure"] | None = None,
+        run_type: Literal["external", "manual", "scheduled"] | None = None,
         model_external_ids: SequenceNotStr[str] | None = None,
         simulator_integration_external_ids: SequenceNotStr[str] | None = None,
         simulator_external_ids: SequenceNotStr[str] | None = None,
@@ -74,8 +74,8 @@ class SyncSimulatorRunsAPI(SyncAPIClient):
         self,
         chunk_size: int | None = None,
         limit: int | None = None,
-        status: str | None = None,
-        run_type: str | None = None,
+        status: Literal["queued", "ready", "running", "success", "failure"] | None = None,
+        run_type: Literal["external", "manual", "scheduled"] | None = None,
         model_external_ids: SequenceNotStr[str] | None = None,
         simulator_integration_external_ids: SequenceNotStr[str] | None = None,
         simulator_external_ids: SequenceNotStr[str] | None = None,
@@ -94,8 +94,8 @@ class SyncSimulatorRunsAPI(SyncAPIClient):
         Args:
             chunk_size (int | None): Number of simulation runs to return in each chunk. Defaults to yielding one simulation run a time.
             limit (int | None): The maximum number of simulation runs to return, pass None to return all.
-            status (str | None): Filter by simulation run status
-            run_type (str | None): Filter by simulation run type
+            status (Literal['queued', 'ready', 'running', 'success', 'failure'] | None): Filter by simulation run status
+            run_type (Literal['external', 'manual', 'scheduled'] | None): Filter by simulation run type
             model_external_ids (SequenceNotStr[str] | None): Filter by simulator model external ids
             simulator_integration_external_ids (SequenceNotStr[str] | None): Filter by simulator integration external ids
             simulator_external_ids (SequenceNotStr[str] | None): Filter by simulator external ids
@@ -130,8 +130,8 @@ class SyncSimulatorRunsAPI(SyncAPIClient):
     def list(
         self,
         limit: int | None = DEFAULT_LIMIT_READ,
-        status: str | None = None,
-        run_type: str | None = None,
+        status: Literal["queued", "ready", "running", "success", "failure"] | None = None,
+        run_type: Literal["external", "manual", "scheduled"] | None = None,
         model_external_ids: SequenceNotStr[str] | None = None,
         simulator_integration_external_ids: SequenceNotStr[str] | None = None,
         simulator_external_ids: SequenceNotStr[str] | None = None,
@@ -149,8 +149,8 @@ class SyncSimulatorRunsAPI(SyncAPIClient):
 
         Args:
             limit (int | None): The maximum number of simulation runs to return, pass None to return all.
-            status (str | None): Filter by simulation run status
-            run_type (str | None): Filter by simulation run type
+            status (Literal['queued', 'ready', 'running', 'success', 'failure'] | None): Filter by simulation run status
+            run_type (Literal['external', 'manual', 'scheduled'] | None): Filter by simulation run type
             model_external_ids (SequenceNotStr[str] | None): Filter by simulator model external ids
             simulator_integration_external_ids (SequenceNotStr[str] | None): Filter by simulator integration external ids
             simulator_external_ids (SequenceNotStr[str] | None): Filter by simulator external ids

--- a/cognite/client/data_classes/simulators/filters.py
+++ b/cognite/client/data_classes/simulators/filters.py
@@ -5,6 +5,7 @@ from typing import Any, Literal, cast
 
 from cognite.client.data_classes._base import CogniteFilter, CogniteSort
 from cognite.client.data_classes.shared import TimestampRange
+from cognite.client.data_classes.simulators.runs import SimulatorRunStatus
 from cognite.client.utils._text import to_camel_case
 from cognite.client.utils.useful_types import SequenceNotStr
 
@@ -56,7 +57,7 @@ class SimulatorModelRevisionsFilter(CogniteFilter):
 class SimulatorRunsFilter(CogniteFilter):
     def __init__(
         self,
-        status: str | None = None,
+        status: SimulatorRunStatus | None = None,
         run_type: Literal["external", "manual", "scheduled"] | None = None,
         model_external_ids: str | SequenceNotStr[str] | None = None,
         simulator_integration_external_ids: str | SequenceNotStr[str] | None = None,

--- a/cognite/client/data_classes/simulators/filters.py
+++ b/cognite/client/data_classes/simulators/filters.py
@@ -57,7 +57,7 @@ class SimulatorRunsFilter(CogniteFilter):
     def __init__(
         self,
         status: str | None = None,
-        run_type: str | None = None,
+        run_type: Literal["external", "manual", "scheduled"] | None = None,
         model_external_ids: str | SequenceNotStr[str] | None = None,
         simulator_integration_external_ids: str | SequenceNotStr[str] | None = None,
         simulator_external_ids: str | SequenceNotStr[str] | None = None,

--- a/cognite/client/data_classes/simulators/filters.py
+++ b/cognite/client/data_classes/simulators/filters.py
@@ -5,7 +5,7 @@ from typing import Any, Literal, cast
 
 from cognite.client.data_classes._base import CogniteFilter, CogniteSort
 from cognite.client.data_classes.shared import TimestampRange
-from cognite.client.data_classes.simulators.runs import SimulatorRunStatus
+from cognite.client.data_classes.simulators.runs import SimulatorRunStatus, SimulatorRunType
 from cognite.client.utils._text import to_camel_case
 from cognite.client.utils.useful_types import SequenceNotStr
 
@@ -58,7 +58,7 @@ class SimulatorRunsFilter(CogniteFilter):
     def __init__(
         self,
         status: SimulatorRunStatus | None = None,
-        run_type: Literal["external", "manual", "scheduled"] | None = None,
+        run_type: SimulatorRunType | None = None,
         model_external_ids: str | SequenceNotStr[str] | None = None,
         simulator_integration_external_ids: str | SequenceNotStr[str] | None = None,
         simulator_external_ids: str | SequenceNotStr[str] | None = None,

--- a/cognite/client/data_classes/simulators/runs.py
+++ b/cognite/client/data_classes/simulators/runs.py
@@ -29,6 +29,8 @@ if TYPE_CHECKING:
 
 _WARNING = FeaturePreviewWarning(api_maturity="General Availability", sdk_maturity="alpha", feature_name="Simulators")
 
+SimulatorRunStatus = Literal["queued", "ready", "running", "success", "failure"]
+
 
 @dataclass
 class SimulationValueUnitName(CogniteResource):
@@ -197,7 +199,7 @@ class SimulationRun(WriteableCogniteResourceWithClientRef["SimulationRunWrite"])
         routine_revision_external_id (str): External id of the associated simulator routine revision
         routine_external_id (str): External id of the associated simulator routine
         run_type (Literal['external', 'manual', 'scheduled']): The type of the simulation run
-        status (Literal['queued', 'ready', 'running', 'success', 'failure']): The status of the simulation run. When simulation run load balancing is enabled, runs initiate with ``queued`` status before an integration is assigned to them.
+        status (SimulatorRunStatus): The status of the simulation run. When simulation run load balancing is enabled, runs initiate with ``queued`` status before an integration is assigned to them.
         data_set_id (int): The id of the dataset associated with the simulation run
         user_id (str): The id of the user who executed the simulation run
         log_id (int): The id of the log associated with the simulation run
@@ -219,7 +221,7 @@ class SimulationRun(WriteableCogniteResourceWithClientRef["SimulationRunWrite"])
         routine_revision_external_id: str,
         routine_external_id: str,
         run_type: Literal["external", "manual", "scheduled"],
-        status: Literal["queued", "ready", "running", "success", "failure"],
+        status: SimulatorRunStatus,
         data_set_id: int,
         user_id: str,
         log_id: int,

--- a/cognite/client/data_classes/simulators/runs.py
+++ b/cognite/client/data_classes/simulators/runs.py
@@ -92,16 +92,13 @@ class SimulationRunWrite(WriteableCogniteResource["SimulationRunWrite"]):
     and is tied to the integration specified on the routine.
 
     Args:
-        routine_external_id (str | None): External id of the associated simulator routine.
-            Cannot be specified together with routine_revision_external_id and model_revision_external_id.
-        routine_revision_external_id (str | None): External id of the associated simulator routine revision.
-            Must be specified together with model_revision_external_id.
-        model_revision_external_id (str | None): External id of the associated simulator model revision.
-            Must be specified together with routine_revision_external_id.
-        run_type (str | None): The type of the simulation run
+        routine_external_id (str | None): External id of the associated simulator routine. Cannot be specified together with routine_revision_external_id and model_revision_external_id.
+        routine_revision_external_id (str | None): External id of the associated simulator routine revision. Must be specified together with model_revision_external_id.
+        model_revision_external_id (str | None): External id of the associated simulator model revision. Must be specified together with routine_revision_external_id.
+        run_type (Literal['external', 'manual', 'scheduled'] | None): The type of the simulation run
         run_time (int | None): Run time in milliseconds. Reference timestamp used for data pre-processing and data sampling.
-        queue (bool | None): Queue the simulation run when connector is down.
-        log_severity (str | None): Override the minimum severity level for the simulation run logs. If not provided, the minimum severity is read from the connector logger configuration.
+        queue (bool): Queue the simulation run when connector is down. Defaults to False.
+        log_severity (Literal['Debug', 'Information', 'Warning', 'Error'] | None): Override the minimum severity level for the simulation run logs. If not provided, the minimum severity is read from the connector logger configuration.
         inputs (list[SimulationInputOverride] | None): List of input overrides
     """
 
@@ -110,10 +107,10 @@ class SimulationRunWrite(WriteableCogniteResource["SimulationRunWrite"]):
         routine_external_id: str | None = None,
         routine_revision_external_id: str | None = None,
         model_revision_external_id: str | None = None,
-        run_type: str | None = None,
+        run_type: Literal["external", "manual", "scheduled"] | None = None,
         run_time: int | None = None,
-        queue: bool | None = None,
-        log_severity: str | None = None,
+        queue: bool = False,
+        log_severity: Literal["Debug", "Information", "Warning", "Error"] | None = None,
         inputs: list[SimulationInputOverride] | None = None,
     ) -> None:
         is_routine_mode = routine_external_id and not routine_revision_external_id and not model_revision_external_id
@@ -149,7 +146,7 @@ class SimulationRunWrite(WriteableCogniteResource["SimulationRunWrite"]):
         return cls(
             run_type=resource.get("runType"),
             run_time=resource.get("runTime"),
-            queue=resource.get("queue"),
+            queue=resource.get("queue", False),
             log_severity=resource.get("logSeverity"),
             inputs=[SimulationInputOverride._load(_input) for _input in inputs] if inputs else None,
             routine_external_id=routine_external_id,

--- a/cognite/client/data_classes/simulators/runs.py
+++ b/cognite/client/data_classes/simulators/runs.py
@@ -30,6 +30,7 @@ if TYPE_CHECKING:
 _WARNING = FeaturePreviewWarning(api_maturity="General Availability", sdk_maturity="alpha", feature_name="Simulators")
 
 SimulatorRunStatus = Literal["queued", "ready", "running", "success", "failure"]
+SimulatorRunType = Literal["external", "manual", "scheduled"]
 
 
 @dataclass
@@ -97,7 +98,7 @@ class SimulationRunWrite(WriteableCogniteResource["SimulationRunWrite"]):
         routine_external_id (str | None): External id of the associated simulator routine. Cannot be specified together with routine_revision_external_id and model_revision_external_id.
         routine_revision_external_id (str | None): External id of the associated simulator routine revision. Must be specified together with model_revision_external_id.
         model_revision_external_id (str | None): External id of the associated simulator model revision. Must be specified together with routine_revision_external_id.
-        run_type (Literal['external', 'manual', 'scheduled'] | None): The type of the simulation run
+        run_type (SimulatorRunType | None): The type of the simulation run
         run_time (int | None): Run time in milliseconds. Reference timestamp used for data pre-processing and data sampling.
         queue (bool): Queue the simulation run when connector is down. Defaults to False.
         log_severity (Literal['Debug', 'Information', 'Warning', 'Error'] | None): Override the minimum severity level for the simulation run logs. If not provided, the minimum severity is read from the connector logger configuration.
@@ -109,7 +110,7 @@ class SimulationRunWrite(WriteableCogniteResource["SimulationRunWrite"]):
         routine_external_id: str | None = None,
         routine_revision_external_id: str | None = None,
         model_revision_external_id: str | None = None,
-        run_type: Literal["external", "manual", "scheduled"] | None = None,
+        run_type: SimulatorRunType | None = None,
         run_time: int | None = None,
         queue: bool = False,
         log_severity: Literal["Debug", "Information", "Warning", "Error"] | None = None,
@@ -198,7 +199,7 @@ class SimulationRun(WriteableCogniteResourceWithClientRef["SimulationRunWrite"])
         model_revision_external_id (str): External id of the associated simulator model revision
         routine_revision_external_id (str): External id of the associated simulator routine revision
         routine_external_id (str): External id of the associated simulator routine
-        run_type (Literal['external', 'manual', 'scheduled']): The type of the simulation run
+        run_type (SimulatorRunType): The type of the simulation run
         status (SimulatorRunStatus): The status of the simulation run. When simulation run load balancing is enabled, runs initiate with ``queued`` status before an integration is assigned to them.
         data_set_id (int): The id of the dataset associated with the simulation run
         user_id (str): The id of the user who executed the simulation run
@@ -220,7 +221,7 @@ class SimulationRun(WriteableCogniteResourceWithClientRef["SimulationRunWrite"])
         model_revision_external_id: str,
         routine_revision_external_id: str,
         routine_external_id: str,
-        run_type: Literal["external", "manual", "scheduled"],
+        run_type: SimulatorRunType,
         status: SimulatorRunStatus,
         data_set_id: int,
         user_id: str,

--- a/tests/tests_integration/test_api/test_simulators/test_runs.py
+++ b/tests/tests_integration/test_api/test_simulators/test_runs.py
@@ -31,7 +31,7 @@ class TestSimulatorRuns:
     ) -> None:
         routine_external_id = seed_resource_names.simulator_routine_external_id
         runs_filtered_by_status = []
-        for current_status in ["running", "success", "failure"]:
+        for current_status in ("running", "success", "failure"):
             created_runs = cognite_client.simulators.runs.create([SimulationRunWrite(routine_external_id)])
 
             run_sync(


### PR DESCRIPTION
## Description
Improve some type hints and default values in the simulators module. Some None type hints have been removed, but this should be ok since simulators is in alpha.

## Checklist:
- [x] Tests added/updated.
- [x] Documentation updated. Documentation is generated from docstrings - these must be updated according to your change.
  If a new method has been added it should be referenced in [cognite.rst](https://github.com/cognitedata/cognite-sdk-python/blob/master/docs/source/cognite.rst) in order to generate docs based on its docstring.
- [x] The PR title follows the [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) spec.
