### PR TITLE
chore: bump version to 8.4.0 and fix ruff config for sync API __init__ files

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "cognite-sdk"
-version = "8.4.0"
+version = "8.3.0"
 
 description = "Cognite Python SDK"
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "cognite-sdk"
-version = "8.3.0"
+version = "8.4.0"
 
 description = "Cognite Python SDK"
 readme = "README.md"
@@ -30,6 +30,9 @@ external = ["DOC"]
 [tool.ruff.lint.per-file-ignores]
 # let scripts use print statements
 "scripts/*" = ["T201"]
+# auto-generated sync __init__.py files aggregate sub-APIs; the codegen template adds imports that
+# ruff 0.9+ won't auto-remove from __init__.py files (treats them as potential re-exports)
+"cognite/client/_sync_api/**/__init__.py" = ["F401"]
 
 [tool.ruff.format]
 # format code examples in docstrings to avoid users scrolling horizontally
@@ -99,7 +102,7 @@ ipykernel = "^7.2.0"
 [tool.poetry.group.docs.dependencies]
 sphinx = ">=8.1"
 sphinx-rtd-theme = ">=1"
-sphinx-copybutton = "^0.5.2"    
+sphinx-copybutton = "^0.5.2"
 sphinx-autosummary-accessors = "^2025.3.1"
 
 [build-system]


### PR DESCRIPTION
## Summary

- Bump version from `8.3.0` to `8.4.0`
- Add ruff `F401` ignore for `cognite/client/_sync_api/**/__init__.py` — auto-generated sync `__init__` files aggregate sub-APIs via imports that ruff 0.9+ won't auto-remove (it treats them as potential re-exports)
- Remove trailing whitespace on `sphinx-copybutton` line

## Test plan

- [ ] Verify ruff passes with the new ignore rule

🤖 Generated with [Claude Code](https://claude.com/claude-code)