### PR TITLE
feat!: move publicly exposed constants to a new public constants file

### DIFF
--- a/cognite/client/_api/annotations.py
+++ b/cognite/client/_api/annotations.py
@@ -5,7 +5,7 @@ from copy import deepcopy
 from typing import TYPE_CHECKING, Any, Literal, cast, overload
 
 from cognite.client._api_client import APIClient
-from cognite.client._constants import DEFAULT_LIMIT_READ
+from cognite.client.constants import DEFAULT_LIMIT_READ
 from cognite.client.data_classes import Annotation, AnnotationFilter, AnnotationList, AnnotationUpdate
 from cognite.client.data_classes._base import CogniteResource, PropertySpec, T_CogniteResource
 from cognite.client.data_classes.annotations import AnnotationCore, AnnotationReverseLookupFilter, AnnotationWrite

--- a/cognite/client/_api/assets.py
+++ b/cognite/client/_api/assets.py
@@ -19,7 +19,7 @@ from typing import (
 
 from cognite.client._api_client import APIClient
 from cognite.client._basic_api_client import FailedRequestHandler
-from cognite.client._constants import DEFAULT_LIMIT_READ
+from cognite.client.constants import DEFAULT_LIMIT_READ
 from cognite.client.data_classes import (
     Asset,
     AssetFilter,

--- a/cognite/client/_api/data_modeling/containers.py
+++ b/cognite/client/_api/data_modeling/containers.py
@@ -5,7 +5,7 @@ from collections.abc import AsyncIterator, Sequence
 from typing import TYPE_CHECKING, Literal, cast, overload
 
 from cognite.client._api_client import APIClient
-from cognite.client._constants import DATA_MODELING_DEFAULT_LIMIT_READ
+from cognite.client.constants import DATA_MODELING_DEFAULT_LIMIT_READ
 from cognite.client.data_classes.data_modeling.containers import (
     Container,
     ContainerApply,

--- a/cognite/client/_api/data_modeling/data_models.py
+++ b/cognite/client/_api/data_modeling/data_models.py
@@ -5,7 +5,7 @@ from collections.abc import AsyncIterator, Sequence
 from typing import TYPE_CHECKING, Literal, cast, overload
 
 from cognite.client._api_client import APIClient
-from cognite.client._constants import DATA_MODELING_DEFAULT_LIMIT_READ
+from cognite.client.constants import DATA_MODELING_DEFAULT_LIMIT_READ
 from cognite.client.data_classes.data_modeling.data_models import (
     DataModel,
     DataModelApply,

--- a/cognite/client/_api/data_modeling/instances.py
+++ b/cognite/client/_api/data_modeling/instances.py
@@ -17,7 +17,7 @@ from typing import (
 )
 
 from cognite.client._api_client import APIClient
-from cognite.client._constants import DEFAULT_LIMIT_READ
+from cognite.client.constants import DEFAULT_LIMIT_READ
 from cognite.client.data_classes import filters
 from cognite.client.data_classes._base import CogniteResourceList, WriteableCogniteResource
 from cognite.client.data_classes.aggregations import (

--- a/cognite/client/_api/data_modeling/spaces.py
+++ b/cognite/client/_api/data_modeling/spaces.py
@@ -5,7 +5,7 @@ from collections.abc import AsyncIterator, Sequence
 from typing import TYPE_CHECKING, Literal, cast, overload
 
 from cognite.client._api_client import APIClient
-from cognite.client._constants import DEFAULT_LIMIT_READ
+from cognite.client.constants import DEFAULT_LIMIT_READ
 from cognite.client.data_classes.data_modeling.ids import _load_space_identifier
 from cognite.client.data_classes.data_modeling.spaces import Space, SpaceApply, SpaceList
 from cognite.client.utils.useful_types import SequenceNotStr

--- a/cognite/client/_api/data_modeling/views.py
+++ b/cognite/client/_api/data_modeling/views.py
@@ -6,7 +6,7 @@ from collections.abc import AsyncIterator, Sequence
 from typing import TYPE_CHECKING, Literal, cast, overload
 
 from cognite.client._api_client import APIClient
-from cognite.client._constants import DATA_MODELING_DEFAULT_LIMIT_READ
+from cognite.client.constants import DATA_MODELING_DEFAULT_LIMIT_READ
 from cognite.client.data_classes.data_modeling.ids import (
     ViewId,
     ViewIdentifier,

--- a/cognite/client/_api/data_sets.py
+++ b/cognite/client/_api/data_sets.py
@@ -4,7 +4,7 @@ from collections.abc import AsyncIterator, Sequence
 from typing import TYPE_CHECKING, Any, Literal, overload
 
 from cognite.client._api_client import APIClient
-from cognite.client._constants import DEFAULT_LIMIT_READ
+from cognite.client.constants import DEFAULT_LIMIT_READ
 from cognite.client.data_classes import (
     DataSet,
     DataSetFilter,

--- a/cognite/client/_api/datapoints.py
+++ b/cognite/client/_api/datapoints.py
@@ -33,8 +33,8 @@ from cognite.client._api.datapoint_tasks import (
 )
 from cognite.client._api.synthetic_time_series import SyntheticDatapointsAPI
 from cognite.client._api_client import APIClient
-from cognite.client._constants import DEFAULT_DATAPOINTS_CHUNK_SIZE
 from cognite.client._proto.data_point_list_response_pb2 import DataPointListItem, DataPointListResponse
+from cognite.client.constants import DEFAULT_DATAPOINTS_CHUNK_SIZE
 from cognite.client.data_classes import (
     Datapoints,
     DatapointsArray,

--- a/cognite/client/_api/datapoints_subscriptions.py
+++ b/cognite/client/_api/datapoints_subscriptions.py
@@ -5,7 +5,7 @@ from collections.abc import AsyncIterator
 from typing import TYPE_CHECKING, Literal, cast, overload
 
 from cognite.client._api_client import APIClient
-from cognite.client._constants import DEFAULT_LIMIT_READ
+from cognite.client.constants import DEFAULT_LIMIT_READ
 from cognite.client.data_classes.datapoints_subscriptions import (
     DatapointSubscription,
     DatapointSubscriptionBatch,

--- a/cognite/client/_api/documents.py
+++ b/cognite/client/_api/documents.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING, Any, BinaryIO, Literal, overload
 
 from cognite.client._api.document_preview import DocumentPreviewAPI
 from cognite.client._api_client import APIClient
-from cognite.client._constants import DEFAULT_LIMIT_READ
+from cognite.client.constants import DEFAULT_LIMIT_READ
 from cognite.client.data_classes import filters
 from cognite.client.data_classes.aggregations import AggregationFilter, UniqueResultList
 from cognite.client.data_classes.data_modeling.ids import NodeId

--- a/cognite/client/_api/entity_matching.py
+++ b/cognite/client/_api/entity_matching.py
@@ -4,7 +4,7 @@ from collections.abc import Sequence
 from typing import Literal, TypeVar
 
 from cognite.client._api_client import APIClient
-from cognite.client._constants import DEFAULT_LIMIT_READ
+from cognite.client.constants import DEFAULT_LIMIT_READ
 from cognite.client.data_classes._base import CogniteResource
 from cognite.client.data_classes.contextualization import (
     ContextualizationJob,

--- a/cognite/client/_api/events.py
+++ b/cognite/client/_api/events.py
@@ -4,7 +4,7 @@ from collections.abc import AsyncIterator, Sequence
 from typing import Any, Literal, TypeAlias, overload
 
 from cognite.client._api_client import APIClient
-from cognite.client._constants import DEFAULT_LIMIT_READ
+from cognite.client.constants import DEFAULT_LIMIT_READ
 from cognite.client.data_classes import (
     EndTimeFilter,
     Event,

--- a/cognite/client/_api/extractionpipelines/__init__.py
+++ b/cognite/client/_api/extractionpipelines/__init__.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING, Literal, TypeAlias, overload
 from cognite.client._api.extractionpipelines.configs import ExtractionPipelineConfigsAPI
 from cognite.client._api.extractionpipelines.runs import ExtractionPipelineRunsAPI
 from cognite.client._api_client import APIClient
-from cognite.client._constants import DEFAULT_LIMIT_READ
+from cognite.client.constants import DEFAULT_LIMIT_READ
 from cognite.client.data_classes import (
     ExtractionPipeline,
     ExtractionPipelineList,

--- a/cognite/client/_api/extractionpipelines/runs.py
+++ b/cognite/client/_api/extractionpipelines/runs.py
@@ -4,7 +4,7 @@ from collections.abc import Sequence
 from typing import Any, Literal, cast, overload
 
 from cognite.client._api_client import APIClient
-from cognite.client._constants import DEFAULT_LIMIT_READ
+from cognite.client.constants import DEFAULT_LIMIT_READ
 from cognite.client.data_classes import (
     ExtractionPipelineRun,
     ExtractionPipelineRunFilter,

--- a/cognite/client/_api/files.py
+++ b/cognite/client/_api/files.py
@@ -14,12 +14,12 @@ from typing_extensions import assert_never
 
 from cognite.client._api_client import APIClient
 from cognite.client._constants import (
-    DEFAULT_LIMIT_READ,
     FILE_DEFAULT_MULTIPART_SIZE,
     FILE_MAX_MULTIPART_COUNT,
     FILE_MAX_MULTIPART_SIZE,
     FILE_MIN_MULTIPART_SIZE,
 )
+from cognite.client.constants import DEFAULT_LIMIT_READ
 from cognite.client.data_classes import (
     FileMetadata,
     FileMetadataFilter,

--- a/cognite/client/_api/functions/__init__.py
+++ b/cognite/client/_api/functions/__init__.py
@@ -19,7 +19,8 @@ from cognite.client._api.functions.calls import FunctionCallsAPI
 from cognite.client._api.functions.schedules import FunctionSchedulesAPI
 from cognite.client._api.functions.utils import _get_function_internal_id
 from cognite.client._api_client import APIClient
-from cognite.client._constants import _RUNNING_IN_BROWSER, DEFAULT_LIMIT_READ
+from cognite.client._constants import _RUNNING_IN_BROWSER
+from cognite.client.constants import DEFAULT_LIMIT_READ
 from cognite.client.data_classes import (
     Function,
     FunctionCall,

--- a/cognite/client/_api/functions/calls.py
+++ b/cognite/client/_api/functions/calls.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from cognite.client._api.functions.utils import _get_function_identifier, _get_function_internal_id
 from cognite.client._api_client import APIClient
-from cognite.client._constants import DEFAULT_LIMIT_READ
+from cognite.client.constants import DEFAULT_LIMIT_READ
 from cognite.client.data_classes import (
     FunctionCall,
     FunctionCallList,

--- a/cognite/client/_api/functions/schedules.py
+++ b/cognite/client/_api/functions/schedules.py
@@ -10,7 +10,7 @@ from cognite.client._api.functions.utils import (
     _get_function_internal_id,
 )
 from cognite.client._api_client import APIClient
-from cognite.client._constants import DEFAULT_LIMIT_READ
+from cognite.client.constants import DEFAULT_LIMIT_READ
 from cognite.client.data_classes import (
     ClientCredentials,
     FunctionSchedule,

--- a/cognite/client/_api/geospatial.py
+++ b/cognite/client/_api/geospatial.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from typing import Any, overload
 
 from cognite.client._api_client import APIClient
-from cognite.client._constants import DEFAULT_LIMIT_READ
+from cognite.client.constants import DEFAULT_LIMIT_READ
 from cognite.client.data_classes.geospatial import (
     CoordinateReferenceSystem,
     CoordinateReferenceSystemList,

--- a/cognite/client/_api/hosted_extractors/destinations.py
+++ b/cognite/client/_api/hosted_extractors/destinations.py
@@ -4,7 +4,7 @@ from collections.abc import AsyncIterator, Sequence
 from typing import TYPE_CHECKING, Any, Literal, overload
 
 from cognite.client._api_client import APIClient
-from cognite.client._constants import DEFAULT_LIMIT_READ
+from cognite.client.constants import DEFAULT_LIMIT_READ
 from cognite.client.data_classes.hosted_extractors.destinations import (
     Destination,
     DestinationList,

--- a/cognite/client/_api/hosted_extractors/jobs.py
+++ b/cognite/client/_api/hosted_extractors/jobs.py
@@ -4,7 +4,7 @@ from collections.abc import AsyncIterator, Sequence
 from typing import TYPE_CHECKING, Any, Literal, overload
 
 from cognite.client._api_client import APIClient
-from cognite.client._constants import DEFAULT_LIMIT_READ
+from cognite.client.constants import DEFAULT_LIMIT_READ
 from cognite.client.data_classes.hosted_extractors.jobs import (
     Job,
     JobList,

--- a/cognite/client/_api/hosted_extractors/mappings.py
+++ b/cognite/client/_api/hosted_extractors/mappings.py
@@ -4,7 +4,7 @@ from collections.abc import AsyncIterator, Sequence
 from typing import TYPE_CHECKING, Any, overload
 
 from cognite.client._api_client import APIClient
-from cognite.client._constants import DEFAULT_LIMIT_READ
+from cognite.client.constants import DEFAULT_LIMIT_READ
 from cognite.client.data_classes.hosted_extractors import Mapping, MappingList, MappingUpdate, MappingWrite
 from cognite.client.utils._experimental import FeaturePreviewWarning
 from cognite.client.utils._identifier import IdentifierSequence

--- a/cognite/client/_api/hosted_extractors/sources.py
+++ b/cognite/client/_api/hosted_extractors/sources.py
@@ -4,7 +4,7 @@ from collections.abc import AsyncIterator, Mapping, Sequence
 from typing import TYPE_CHECKING, Any, Literal, overload
 
 from cognite.client._api_client import APIClient
-from cognite.client._constants import DEFAULT_LIMIT_READ
+from cognite.client.constants import DEFAULT_LIMIT_READ
 from cognite.client.data_classes._base import CogniteResource, PropertySpec, T_CogniteResource
 from cognite.client.data_classes.hosted_extractors.sources import Source, SourceList, SourceUpdate, SourceWrite
 from cognite.client.utils._experimental import FeaturePreviewWarning

--- a/cognite/client/_api/iam/security_categories.py
+++ b/cognite/client/_api/iam/security_categories.py
@@ -4,7 +4,7 @@ from collections.abc import Sequence
 from typing import Literal, overload
 
 from cognite.client._api_client import APIClient
-from cognite.client._constants import DEFAULT_LIMIT_READ
+from cognite.client.constants import DEFAULT_LIMIT_READ
 from cognite.client.data_classes import SecurityCategory, SecurityCategoryList
 from cognite.client.data_classes.iam import SecurityCategoryWrite
 from cognite.client.utils._identifier import IdentifierSequence

--- a/cognite/client/_api/iam/sessions.py
+++ b/cognite/client/_api/iam/sessions.py
@@ -4,8 +4,8 @@ from collections.abc import Sequence
 from typing import TYPE_CHECKING, Literal, cast, overload
 
 from cognite.client._api_client import APIClient
-from cognite.client._constants import DEFAULT_LIMIT_READ
 from cognite.client.config import ClientConfig
+from cognite.client.constants import DEFAULT_LIMIT_READ
 from cognite.client.credentials import OAuthClientCredentials
 from cognite.client.data_classes import (
     ClientCredentials,

--- a/cognite/client/_api/labels.py
+++ b/cognite/client/_api/labels.py
@@ -4,7 +4,7 @@ from collections.abc import AsyncIterator, Sequence
 from typing import Literal, overload
 
 from cognite.client._api_client import APIClient
-from cognite.client._constants import DEFAULT_LIMIT_READ
+from cognite.client.constants import DEFAULT_LIMIT_READ
 from cognite.client.data_classes import (
     LabelDefinition,
     LabelDefinitionFilter,

--- a/cognite/client/_api/limits.py
+++ b/cognite/client/_api/limits.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from cognite.client._api_client import APIClient
-from cognite.client._constants import DEFAULT_LIMIT_READ
+from cognite.client.constants import DEFAULT_LIMIT_READ
 from cognite.client.data_classes.limits import Limit, LimitList
 from cognite.client.utils._experimental import FeaturePreviewWarning
 from cognite.client.utils._identifier import LimitId

--- a/cognite/client/_api/org_apis/principals.py
+++ b/cognite/client/_api/org_apis/principals.py
@@ -3,8 +3,8 @@ from __future__ import annotations
 from collections.abc import Sequence
 from typing import overload
 
-from cognite.client._constants import DEFAULT_LIMIT_READ
 from cognite.client._org_client import OrgAPIClient
+from cognite.client.constants import DEFAULT_LIMIT_READ
 from cognite.client.data_classes.principals import Principal, PrincipalList
 from cognite.client.utils._auxiliary import append_url_path
 from cognite.client.utils._identifier import PrincipalIdentifierSequence

--- a/cognite/client/_api/postgres_gateway/tables.py
+++ b/cognite/client/_api/postgres_gateway/tables.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING, Literal, overload
 
 import cognite.client.data_classes.postgres_gateway.tables as pg
 from cognite.client._api_client import APIClient
-from cognite.client._constants import DEFAULT_LIMIT_READ
+from cognite.client.constants import DEFAULT_LIMIT_READ
 from cognite.client.utils._identifier import TablenameSequence
 from cognite.client.utils._url import interpolate_and_url_encode
 from cognite.client.utils.useful_types import SequenceNotStr

--- a/cognite/client/_api/postgres_gateway/users.py
+++ b/cognite/client/_api/postgres_gateway/users.py
@@ -4,7 +4,7 @@ from collections.abc import AsyncIterator, Sequence
 from typing import TYPE_CHECKING, overload
 
 from cognite.client._api_client import APIClient
-from cognite.client._constants import DEFAULT_LIMIT_READ
+from cognite.client.constants import DEFAULT_LIMIT_READ
 from cognite.client.data_classes.postgres_gateway.users import (
     User,
     UserCreated,

--- a/cognite/client/_api/raw/databases.py
+++ b/cognite/client/_api/raw/databases.py
@@ -5,7 +5,7 @@ from collections.abc import AsyncIterator, Sequence
 from typing import Any, Literal, overload
 
 from cognite.client._api_client import APIClient
-from cognite.client._constants import DEFAULT_LIMIT_READ
+from cognite.client.constants import DEFAULT_LIMIT_READ
 from cognite.client.data_classes.raw import Database, DatabaseList
 from cognite.client.utils._auxiliary import split_into_chunks, unpack_items_in_payload
 from cognite.client.utils._concurrency import AsyncSDKTask, execute_async_tasks

--- a/cognite/client/_api/raw/rows.py
+++ b/cognite/client/_api/raw/rows.py
@@ -7,7 +7,8 @@ from collections.abc import AsyncIterator, Sequence
 from typing import TYPE_CHECKING, Any, Literal, cast, overload
 
 from cognite.client._api_client import APIClient
-from cognite.client._constants import _RUNNING_IN_BROWSER, DEFAULT_LIMIT_READ
+from cognite.client._constants import _RUNNING_IN_BROWSER
+from cognite.client.constants import DEFAULT_LIMIT_READ
 from cognite.client.data_classes.raw import Row, RowCore, RowList, RowWrite
 from cognite.client.utils._auxiliary import (
     drop_none_values,

--- a/cognite/client/_api/raw/tables.py
+++ b/cognite/client/_api/raw/tables.py
@@ -5,7 +5,7 @@ from collections.abc import AsyncIterator, Sequence
 from typing import Any, Literal, overload
 
 from cognite.client._api_client import APIClient
-from cognite.client._constants import DEFAULT_LIMIT_READ
+from cognite.client.constants import DEFAULT_LIMIT_READ
 from cognite.client.data_classes import raw
 from cognite.client.utils._auxiliary import split_into_chunks, unpack_items_in_payload
 from cognite.client.utils._concurrency import AsyncSDKTask, execute_async_tasks

--- a/cognite/client/_api/relationships.py
+++ b/cognite/client/_api/relationships.py
@@ -6,7 +6,7 @@ from collections.abc import AsyncIterator, Sequence
 from typing import TYPE_CHECKING, Literal, overload
 
 from cognite.client._api_client import APIClient
-from cognite.client._constants import DEFAULT_LIMIT_READ
+from cognite.client.constants import DEFAULT_LIMIT_READ
 from cognite.client.data_classes import (
     Relationship,
     RelationshipFilter,

--- a/cognite/client/_api/sequences.py
+++ b/cognite/client/_api/sequences.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING, Any, Literal, TypeAlias, cast, overload
 
 from cognite.client._api.sequence_data import SequencesDataAPI
 from cognite.client._api_client import APIClient
-from cognite.client._constants import DEFAULT_LIMIT_READ
+from cognite.client.constants import DEFAULT_LIMIT_READ
 from cognite.client.data_classes import (
     Sequence,
     SequenceFilter,

--- a/cognite/client/_api/simulators/__init__.py
+++ b/cognite/client/_api/simulators/__init__.py
@@ -9,7 +9,7 @@ from cognite.client._api.simulators.models import SimulatorModelsAPI
 from cognite.client._api.simulators.routines import SimulatorRoutinesAPI
 from cognite.client._api.simulators.runs import SimulatorRunsAPI
 from cognite.client._api_client import APIClient
-from cognite.client._constants import DEFAULT_LIMIT_READ
+from cognite.client.constants import DEFAULT_LIMIT_READ
 from cognite.client.data_classes.simulators.simulators import Simulator, SimulatorList
 from cognite.client.utils._experimental import FeaturePreviewWarning
 

--- a/cognite/client/_api/simulators/integrations.py
+++ b/cognite/client/_api/simulators/integrations.py
@@ -4,7 +4,7 @@ from collections.abc import AsyncIterator, Sequence
 from typing import TYPE_CHECKING, overload
 
 from cognite.client._api_client import APIClient
-from cognite.client._constants import DEFAULT_LIMIT_READ
+from cognite.client.constants import DEFAULT_LIMIT_READ
 from cognite.client.data_classes.simulators.filters import SimulatorIntegrationFilter
 from cognite.client.data_classes.simulators.simulators import SimulatorIntegration, SimulatorIntegrationList
 from cognite.client.utils._experimental import FeaturePreviewWarning

--- a/cognite/client/_api/simulators/models.py
+++ b/cognite/client/_api/simulators/models.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING, overload
 
 from cognite.client._api.simulators.models_revisions import SimulatorModelRevisionsAPI
 from cognite.client._api_client import APIClient
-from cognite.client._constants import DEFAULT_LIMIT_READ
+from cognite.client.constants import DEFAULT_LIMIT_READ
 from cognite.client.data_classes.simulators.filters import PropertySort, SimulatorModelsFilter
 from cognite.client.data_classes.simulators.models import (
     SimulatorModel,

--- a/cognite/client/_api/simulators/models_revisions.py
+++ b/cognite/client/_api/simulators/models_revisions.py
@@ -4,7 +4,7 @@ from collections.abc import AsyncIterator, Sequence
 from typing import TYPE_CHECKING, overload
 
 from cognite.client._api_client import APIClient
-from cognite.client._constants import DEFAULT_LIMIT_READ
+from cognite.client.constants import DEFAULT_LIMIT_READ
 from cognite.client.data_classes.shared import TimestampRange
 from cognite.client.data_classes.simulators.filters import (
     PropertySort,

--- a/cognite/client/_api/simulators/routines.py
+++ b/cognite/client/_api/simulators/routines.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING, Literal, overload
 
 from cognite.client._api.simulators.routine_revisions import SimulatorRoutineRevisionsAPI
 from cognite.client._api_client import APIClient
-from cognite.client._constants import DEFAULT_LIMIT_READ
+from cognite.client.constants import DEFAULT_LIMIT_READ
 from cognite.client.data_classes.simulators.filters import PropertySort, SimulatorRoutinesFilter
 from cognite.client.data_classes.simulators.routines import (
     SimulatorRoutine,

--- a/cognite/client/_api/simulators/runs.py
+++ b/cognite/client/_api/simulators/runs.py
@@ -4,7 +4,7 @@ from collections.abc import AsyncIterator, Sequence
 from typing import TYPE_CHECKING, overload
 
 from cognite.client._api_client import APIClient
-from cognite.client._constants import DEFAULT_LIMIT_READ
+from cognite.client.constants import DEFAULT_LIMIT_READ
 from cognite.client.data_classes.shared import TimestampRange
 from cognite.client.data_classes.simulators.filters import SimulationRunsSort, SimulatorRunsFilter
 from cognite.client.data_classes.simulators.runs import (

--- a/cognite/client/_api/three_d/asset_mapping.py
+++ b/cognite/client/_api/three_d/asset_mapping.py
@@ -4,7 +4,7 @@ from collections.abc import Sequence
 from typing import overload
 
 from cognite.client._api_client import APIClient
-from cognite.client._constants import DEFAULT_LIMIT_READ
+from cognite.client.constants import DEFAULT_LIMIT_READ
 from cognite.client.data_classes import (
     BoundingBox3D,
     ThreeDAssetMapping,

--- a/cognite/client/_api/three_d/models.py
+++ b/cognite/client/_api/three_d/models.py
@@ -4,7 +4,7 @@ from collections.abc import AsyncIterator, Sequence
 from typing import Literal, overload
 
 from cognite.client._api_client import APIClient
-from cognite.client._constants import DEFAULT_LIMIT_READ
+from cognite.client.constants import DEFAULT_LIMIT_READ
 from cognite.client.data_classes import (
     ThreeDModel,
     ThreeDModelList,

--- a/cognite/client/_api/three_d/revisions.py
+++ b/cognite/client/_api/three_d/revisions.py
@@ -4,7 +4,7 @@ from collections.abc import AsyncIterator, Sequence
 from typing import Literal, overload
 
 from cognite.client._api_client import APIClient
-from cognite.client._constants import DEFAULT_LIMIT_READ
+from cognite.client.constants import DEFAULT_LIMIT_READ
 from cognite.client.data_classes import (
     ThreeDModelRevision,
     ThreeDModelRevisionList,

--- a/cognite/client/_api/time_series.py
+++ b/cognite/client/_api/time_series.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING, Any, Literal, TypeAlias, overload
 from cognite.client._api.datapoints import DatapointsAPI
 from cognite.client._api.datapoints_subscriptions import DatapointsSubscriptionAPI
 from cognite.client._api_client import APIClient
-from cognite.client._constants import DEFAULT_LIMIT_READ
+from cognite.client.constants import DEFAULT_LIMIT_READ
 from cognite.client.data_classes import (
     TimeSeries,
     TimeSeriesFilter,

--- a/cognite/client/_api/transformations/__init__.py
+++ b/cognite/client/_api/transformations/__init__.py
@@ -8,7 +8,7 @@ from cognite.client._api.transformations.notifications import TransformationNoti
 from cognite.client._api.transformations.schedules import TransformationSchedulesAPI
 from cognite.client._api.transformations.schema import TransformationSchemaAPI
 from cognite.client._api_client import APIClient
-from cognite.client._constants import DEFAULT_LIMIT_READ
+from cognite.client.constants import DEFAULT_LIMIT_READ
 from cognite.client.data_classes import Transformation, TransformationJob, TransformationList
 from cognite.client.data_classes.shared import TimestampRange
 from cognite.client.data_classes.transformations import (

--- a/cognite/client/_api/transformations/jobs.py
+++ b/cognite/client/_api/transformations/jobs.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from collections.abc import Sequence
 
 from cognite.client._api_client import APIClient
-from cognite.client._constants import DEFAULT_LIMIT_READ
+from cognite.client.constants import DEFAULT_LIMIT_READ
 from cognite.client.data_classes import (
     TransformationJob,
     TransformationJobFilter,

--- a/cognite/client/_api/transformations/notifications.py
+++ b/cognite/client/_api/transformations/notifications.py
@@ -4,7 +4,7 @@ from collections.abc import AsyncIterator, Sequence
 from typing import overload
 
 from cognite.client._api_client import APIClient
-from cognite.client._constants import DEFAULT_LIMIT_READ
+from cognite.client.constants import DEFAULT_LIMIT_READ
 from cognite.client.data_classes import (
     TransformationNotification,
     TransformationNotificationList,

--- a/cognite/client/_api/transformations/schedules.py
+++ b/cognite/client/_api/transformations/schedules.py
@@ -4,7 +4,7 @@ from collections.abc import AsyncIterator, Sequence
 from typing import TYPE_CHECKING, Literal, overload
 
 from cognite.client._api_client import APIClient
-from cognite.client._constants import DEFAULT_LIMIT_READ
+from cognite.client.constants import DEFAULT_LIMIT_READ
 from cognite.client.data_classes import (
     TransformationSchedule,
     TransformationScheduleList,

--- a/cognite/client/_api/user_profiles.py
+++ b/cognite/client/_api/user_profiles.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from typing import overload
 
 from cognite.client._api_client import APIClient
-from cognite.client._constants import DEFAULT_LIMIT_READ
+from cognite.client.constants import DEFAULT_LIMIT_READ
 from cognite.client.data_classes.user_profiles import UserProfile, UserProfileList, UserProfilesConfiguration
 from cognite.client.utils._identifier import UserIdentifierSequence
 from cognite.client.utils.useful_types import SequenceNotStr

--- a/cognite/client/_api/workflows/__init__.py
+++ b/cognite/client/_api/workflows/__init__.py
@@ -8,7 +8,7 @@ from cognite.client._api.workflows.tasks import WorkflowTaskAPI
 from cognite.client._api.workflows.triggers import WorkflowTriggerAPI
 from cognite.client._api.workflows.versions import WorkflowVersionAPI
 from cognite.client._api_client import APIClient
-from cognite.client._constants import DEFAULT_LIMIT_READ
+from cognite.client.constants import DEFAULT_LIMIT_READ
 from cognite.client.data_classes.workflows import (
     Workflow,
     WorkflowList,

--- a/cognite/client/_api/workflows/executions.py
+++ b/cognite/client/_api/workflows/executions.py
@@ -4,7 +4,7 @@ from collections.abc import MutableSequence
 from typing import TYPE_CHECKING, Any
 
 from cognite.client._api_client import APIClient
-from cognite.client._constants import DEFAULT_LIMIT_READ
+from cognite.client.constants import DEFAULT_LIMIT_READ
 from cognite.client.data_classes.workflows import (
     WorkflowExecution,
     WorkflowExecutionDetailed,

--- a/cognite/client/_api/workflows/triggers.py
+++ b/cognite/client/_api/workflows/triggers.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from cognite.client._api_client import APIClient
-from cognite.client._constants import DEFAULT_LIMIT_READ
+from cognite.client.constants import DEFAULT_LIMIT_READ
 from cognite.client.data_classes.workflows import (
     WorkflowTrigger,
     WorkflowTriggerList,

--- a/cognite/client/_api/workflows/versions.py
+++ b/cognite/client/_api/workflows/versions.py
@@ -4,7 +4,7 @@ from collections.abc import AsyncIterator, MutableSequence, Sequence
 from typing import TYPE_CHECKING, Any, Literal, overload
 
 from cognite.client._api_client import APIClient
-from cognite.client._constants import DEFAULT_LIMIT_READ
+from cognite.client.constants import DEFAULT_LIMIT_READ
 from cognite.client.data_classes.workflows import (
     WorkflowIds,
     WorkflowVersion,

--- a/cognite/client/_sync_api/annotations.py
+++ b/cognite/client/_sync_api/annotations.py
@@ -1,6 +1,6 @@
 """
 ===============================================================================
-dfae0e191c572120b16241f21bc24a54
+7ba51f64b502ca2d8dbc904909a38d22
 This file is auto-generated from the Async API modules, - do not edit manually!
 ===============================================================================
 """
@@ -11,8 +11,8 @@ from collections.abc import Sequence
 from typing import TYPE_CHECKING, Literal, overload
 
 from cognite.client import AsyncCogniteClient
-from cognite.client._constants import DEFAULT_LIMIT_READ
 from cognite.client._sync_api_client import SyncAPIClient
+from cognite.client.constants import DEFAULT_LIMIT_READ
 from cognite.client.data_classes import Annotation, AnnotationFilter, AnnotationList, AnnotationUpdate
 from cognite.client.data_classes.annotations import AnnotationReverseLookupFilter, AnnotationWrite
 from cognite.client.data_classes.contextualization import ResourceReferenceList

--- a/cognite/client/_sync_api/assets.py
+++ b/cognite/client/_sync_api/assets.py
@@ -1,6 +1,6 @@
 """
 ===============================================================================
-f6ec26190e7bfb4f44c836ffd243fc07
+7d2202764d40e0615680101a713a9ef1
 This file is auto-generated from the Async API modules, - do not edit manually!
 ===============================================================================
 """
@@ -12,8 +12,8 @@ from typing import Any, Literal, overload
 
 from cognite.client import AsyncCogniteClient
 from cognite.client._api.assets import AggregateAssetProperty, SortSpec
-from cognite.client._constants import DEFAULT_LIMIT_READ
 from cognite.client._sync_api_client import SyncAPIClient
+from cognite.client.constants import DEFAULT_LIMIT_READ
 from cognite.client.data_classes import (
     Asset,
     AssetFilter,

--- a/cognite/client/_sync_api/data_modeling/containers.py
+++ b/cognite/client/_sync_api/data_modeling/containers.py
@@ -1,6 +1,6 @@
 """
 ===============================================================================
-fa523a777c9b728e0712f75d938fbb0c
+eb36dfc96cafbbc90464466081359ac8
 This file is auto-generated from the Async API modules, - do not edit manually!
 ===============================================================================
 """
@@ -11,8 +11,8 @@ from collections.abc import Iterator, Sequence
 from typing import TYPE_CHECKING, overload
 
 from cognite.client import AsyncCogniteClient
-from cognite.client._constants import DATA_MODELING_DEFAULT_LIMIT_READ
 from cognite.client._sync_api_client import SyncAPIClient
+from cognite.client.constants import DATA_MODELING_DEFAULT_LIMIT_READ
 from cognite.client.data_classes.data_modeling.containers import (
     Container,
     ContainerApply,

--- a/cognite/client/_sync_api/data_modeling/data_models.py
+++ b/cognite/client/_sync_api/data_modeling/data_models.py
@@ -1,6 +1,6 @@
 """
 ===============================================================================
-a5e7baa292ef66c1c7db7a0d62f32b0b
+ad6dcebaeab6efff2db94023b050e2e9
 This file is auto-generated from the Async API modules, - do not edit manually!
 ===============================================================================
 """
@@ -11,8 +11,8 @@ from collections.abc import Iterator, Sequence
 from typing import TYPE_CHECKING, Literal, overload
 
 from cognite.client import AsyncCogniteClient
-from cognite.client._constants import DATA_MODELING_DEFAULT_LIMIT_READ
 from cognite.client._sync_api_client import SyncAPIClient
+from cognite.client.constants import DATA_MODELING_DEFAULT_LIMIT_READ
 from cognite.client.data_classes.data_modeling.data_models import (
     DataModel,
     DataModelApply,

--- a/cognite/client/_sync_api/data_modeling/instances.py
+++ b/cognite/client/_sync_api/data_modeling/instances.py
@@ -1,6 +1,6 @@
 """
 ===============================================================================
-c0af4f83cd8ffa0aaed6fa641bde9a98
+604798c61eb8ab518a1d50db5c6f2ed0
 This file is auto-generated from the Async API modules, - do not edit manually!
 ===============================================================================
 """
@@ -13,8 +13,8 @@ from typing import TYPE_CHECKING, Any, Literal, overload
 
 from cognite.client import AsyncCogniteClient
 from cognite.client._api.data_modeling.instances import Source
-from cognite.client._constants import DEFAULT_LIMIT_READ
 from cognite.client._sync_api_client import SyncAPIClient
+from cognite.client.constants import DEFAULT_LIMIT_READ
 from cognite.client.data_classes.aggregations import (
     AggregatedNumberedValue,
     Histogram,

--- a/cognite/client/_sync_api/data_modeling/spaces.py
+++ b/cognite/client/_sync_api/data_modeling/spaces.py
@@ -1,6 +1,6 @@
 """
 ===============================================================================
-999009f73cff69a3b217af0109ee31e6
+284997643640546031c8668b0d7ef640
 This file is auto-generated from the Async API modules, - do not edit manually!
 ===============================================================================
 """
@@ -11,8 +11,8 @@ from collections.abc import Iterator, Sequence
 from typing import TYPE_CHECKING, overload
 
 from cognite.client import AsyncCogniteClient
-from cognite.client._constants import DEFAULT_LIMIT_READ
 from cognite.client._sync_api_client import SyncAPIClient
+from cognite.client.constants import DEFAULT_LIMIT_READ
 from cognite.client.data_classes.data_modeling.spaces import Space, SpaceApply, SpaceList
 from cognite.client.utils._async_helpers import SyncIterator, run_sync
 from cognite.client.utils.useful_types import SequenceNotStr

--- a/cognite/client/_sync_api/data_modeling/views.py
+++ b/cognite/client/_sync_api/data_modeling/views.py
@@ -1,6 +1,6 @@
 """
 ===============================================================================
-d8f86e74e224daebaf4d984d88cf1842
+d02ade3fd495aae81b88e5ed3176a309
 This file is auto-generated from the Async API modules, - do not edit manually!
 ===============================================================================
 """
@@ -11,8 +11,8 @@ from collections.abc import Iterator, Sequence
 from typing import TYPE_CHECKING, overload
 
 from cognite.client import AsyncCogniteClient
-from cognite.client._constants import DATA_MODELING_DEFAULT_LIMIT_READ
 from cognite.client._sync_api_client import SyncAPIClient
+from cognite.client.constants import DATA_MODELING_DEFAULT_LIMIT_READ
 from cognite.client.data_classes.data_modeling.ids import ViewId, ViewIdentifier
 from cognite.client.data_classes.data_modeling.views import View, ViewApply, ViewList
 from cognite.client.utils._async_helpers import SyncIterator, run_sync

--- a/cognite/client/_sync_api/data_sets.py
+++ b/cognite/client/_sync_api/data_sets.py
@@ -1,6 +1,6 @@
 """
 ===============================================================================
-2a396ea3e9b0baf4f113cef7ed72f19b
+78ac9606d58d2e3fe3f9a34d9a98e864
 This file is auto-generated from the Async API modules, - do not edit manually!
 ===============================================================================
 """
@@ -11,8 +11,8 @@ from collections.abc import Iterator, Sequence
 from typing import TYPE_CHECKING, Any, Literal, overload
 
 from cognite.client import AsyncCogniteClient
-from cognite.client._constants import DEFAULT_LIMIT_READ
 from cognite.client._sync_api_client import SyncAPIClient
+from cognite.client.constants import DEFAULT_LIMIT_READ
 from cognite.client.data_classes import DataSet, DataSetFilter, DataSetList, DataSetUpdate, DataSetWrite, TimestampRange
 from cognite.client.utils._async_helpers import SyncIterator, run_sync
 from cognite.client.utils.useful_types import SequenceNotStr

--- a/cognite/client/_sync_api/datapoints.py
+++ b/cognite/client/_sync_api/datapoints.py
@@ -1,6 +1,6 @@
 """
 ===============================================================================
-830266fb5fd8d205e7c1163175ba904e
+6b8f21074977b8dc339f6269b87004ab
 This file is auto-generated from the Async API modules, - do not edit manually!
 ===============================================================================
 """
@@ -13,9 +13,9 @@ from typing import TYPE_CHECKING, Any, Literal, overload
 from zoneinfo import ZoneInfo
 
 from cognite.client import AsyncCogniteClient
-from cognite.client._constants import DEFAULT_DATAPOINTS_CHUNK_SIZE
 from cognite.client._sync_api.synthetic_time_series import SyncSyntheticDatapointsAPI
 from cognite.client._sync_api_client import SyncAPIClient
+from cognite.client.constants import DEFAULT_DATAPOINTS_CHUNK_SIZE
 from cognite.client.data_classes import (
     Datapoints,
     DatapointsArray,

--- a/cognite/client/_sync_api/datapoints_subscriptions.py
+++ b/cognite/client/_sync_api/datapoints_subscriptions.py
@@ -1,6 +1,6 @@
 """
 ===============================================================================
-175dd6dcb2b25e5980d8828619fc7db6
+a5d9cfe4768f15c4f6af1f10baa56872
 This file is auto-generated from the Async API modules, - do not edit manually!
 ===============================================================================
 """
@@ -11,8 +11,8 @@ from collections.abc import Iterator
 from typing import TYPE_CHECKING, Literal, overload
 
 from cognite.client import AsyncCogniteClient
-from cognite.client._constants import DEFAULT_LIMIT_READ
 from cognite.client._sync_api_client import SyncAPIClient
+from cognite.client.constants import DEFAULT_LIMIT_READ
 from cognite.client.data_classes.datapoints_subscriptions import (
     DatapointSubscription,
     DatapointSubscriptionBatch,

--- a/cognite/client/_sync_api/documents.py
+++ b/cognite/client/_sync_api/documents.py
@@ -1,6 +1,6 @@
 """
 ===============================================================================
-cd41b0877c343fa505b6b809f823dd6f
+d79c48274f3dfaac14038ce475123229
 This file is auto-generated from the Async API modules, - do not edit manually!
 ===============================================================================
 """
@@ -11,9 +11,9 @@ from collections.abc import Iterator
 from typing import TYPE_CHECKING, Any, BinaryIO, Literal, overload
 
 from cognite.client import AsyncCogniteClient
-from cognite.client._constants import DEFAULT_LIMIT_READ
 from cognite.client._sync_api.document_preview import SyncDocumentPreviewAPI
 from cognite.client._sync_api_client import SyncAPIClient
+from cognite.client.constants import DEFAULT_LIMIT_READ
 from cognite.client.data_classes.aggregations import AggregationFilter, UniqueResultList
 from cognite.client.data_classes.data_modeling.ids import NodeId
 from cognite.client.data_classes.documents import (

--- a/cognite/client/_sync_api/entity_matching.py
+++ b/cognite/client/_sync_api/entity_matching.py
@@ -1,6 +1,6 @@
 """
 ===============================================================================
-804bc9b708b2641457184ca681292d1a
+fb4549febc15c7b49490263fa68bd6b4
 This file is auto-generated from the Async API modules, - do not edit manually!
 ===============================================================================
 """
@@ -11,8 +11,8 @@ from collections.abc import Sequence
 from typing import Literal
 
 from cognite.client import AsyncCogniteClient
-from cognite.client._constants import DEFAULT_LIMIT_READ
 from cognite.client._sync_api_client import SyncAPIClient
+from cognite.client.constants import DEFAULT_LIMIT_READ
 from cognite.client.data_classes._base import CogniteResource
 from cognite.client.data_classes.contextualization import (
     ContextualizationJobList,

--- a/cognite/client/_sync_api/events.py
+++ b/cognite/client/_sync_api/events.py
@@ -1,6 +1,6 @@
 """
 ===============================================================================
-8b6c6ae83aaf32dec50a4e3acf4ff5cb
+712906e5d11bfbe20eb928d99373e78e
 This file is auto-generated from the Async API modules, - do not edit manually!
 ===============================================================================
 """
@@ -12,8 +12,8 @@ from typing import Any, Literal, overload
 
 from cognite.client import AsyncCogniteClient
 from cognite.client._api.events import SortSpec
-from cognite.client._constants import DEFAULT_LIMIT_READ
 from cognite.client._sync_api_client import SyncAPIClient
+from cognite.client.constants import DEFAULT_LIMIT_READ
 from cognite.client.data_classes import (
     EndTimeFilter,
     Event,

--- a/cognite/client/_sync_api/extractionpipelines/__init__.py
+++ b/cognite/client/_sync_api/extractionpipelines/__init__.py
@@ -1,6 +1,6 @@
 """
 ===============================================================================
-93056e9e9785e9889b8eb51e42855834
+70258a2cb98cc8a67a6d287d8b482ff5
 This file is auto-generated from the Async API modules, - do not edit manually!
 ===============================================================================
 """
@@ -11,10 +11,10 @@ from collections.abc import Iterator, Sequence
 from typing import TYPE_CHECKING, Literal, overload
 
 from cognite.client import AsyncCogniteClient
-from cognite.client._constants import DEFAULT_LIMIT_READ
 from cognite.client._sync_api.extractionpipelines.configs import SyncExtractionPipelineConfigsAPI
 from cognite.client._sync_api.extractionpipelines.runs import SyncExtractionPipelineRunsAPI
 from cognite.client._sync_api_client import SyncAPIClient
+from cognite.client.constants import DEFAULT_LIMIT_READ
 from cognite.client.data_classes import ExtractionPipeline, ExtractionPipelineList, ExtractionPipelineUpdate
 from cognite.client.data_classes.extractionpipelines import ExtractionPipelineWrite
 from cognite.client.utils._async_helpers import SyncIterator, run_sync

--- a/cognite/client/_sync_api/extractionpipelines/runs.py
+++ b/cognite/client/_sync_api/extractionpipelines/runs.py
@@ -1,6 +1,6 @@
 """
 ===============================================================================
-7819cebdbaa57d146a973df630ad8d75
+2c2553d1c57b610c4a2be3317a17515a
 This file is auto-generated from the Async API modules, - do not edit manually!
 ===============================================================================
 """
@@ -12,8 +12,8 @@ from typing import Any, overload
 
 from cognite.client import AsyncCogniteClient
 from cognite.client._api.extractionpipelines import RunStatus
-from cognite.client._constants import DEFAULT_LIMIT_READ
 from cognite.client._sync_api_client import SyncAPIClient
+from cognite.client.constants import DEFAULT_LIMIT_READ
 from cognite.client.data_classes import (
     ExtractionPipelineRun,
     ExtractionPipelineRunList,

--- a/cognite/client/_sync_api/files.py
+++ b/cognite/client/_sync_api/files.py
@@ -1,6 +1,6 @@
 """
 ===============================================================================
-1f615115f322d471c0ae15347e13f8c2
+fbb9ea33379c01aab6c13703f2d3bb52
 This file is auto-generated from the Async API modules, - do not edit manually!
 ===============================================================================
 """
@@ -12,10 +12,10 @@ from pathlib import Path
 from typing import Any, BinaryIO, Literal, overload
 
 from cognite.client import AsyncCogniteClient
-from cognite.client._constants import (
+from cognite.client._sync_api_client import SyncAPIClient
+from cognite.client.constants import (
     DEFAULT_LIMIT_READ,
 )
-from cognite.client._sync_api_client import SyncAPIClient
 from cognite.client.data_classes import (
     FileMetadata,
     FileMetadataFilter,

--- a/cognite/client/_sync_api/functions/__init__.py
+++ b/cognite/client/_sync_api/functions/__init__.py
@@ -1,6 +1,6 @@
 """
 ===============================================================================
-1862715b947706f15000fe1f49906d00
+4195b1111e4ba9fe1d59ea4100bff062
 This file is auto-generated from the Async API modules, - do not edit manually!
 ===============================================================================
 """
@@ -11,10 +11,10 @@ from collections.abc import Iterator, Sequence
 from typing import TYPE_CHECKING, Literal, overload
 
 from cognite.client import AsyncCogniteClient
-from cognite.client._constants import DEFAULT_LIMIT_READ
 from cognite.client._sync_api.functions.calls import SyncFunctionCallsAPI
 from cognite.client._sync_api.functions.schedules import SyncFunctionSchedulesAPI
 from cognite.client._sync_api_client import SyncAPIClient
+from cognite.client.constants import DEFAULT_LIMIT_READ
 from cognite.client.data_classes import (
     Function,
     FunctionCall,

--- a/cognite/client/_sync_api/functions/calls.py
+++ b/cognite/client/_sync_api/functions/calls.py
@@ -1,6 +1,6 @@
 """
 ===============================================================================
-736858007431af9fb6085e1bb5f1d8a6
+ec9057c8b81f12e232bb53a74bd88f2f
 This file is auto-generated from the Async API modules, - do not edit manually!
 ===============================================================================
 """
@@ -8,8 +8,8 @@ This file is auto-generated from the Async API modules, - do not edit manually!
 from __future__ import annotations
 
 from cognite.client import AsyncCogniteClient
-from cognite.client._constants import DEFAULT_LIMIT_READ
 from cognite.client._sync_api_client import SyncAPIClient
+from cognite.client.constants import DEFAULT_LIMIT_READ
 from cognite.client.data_classes import FunctionCall, FunctionCallList, FunctionCallLog
 from cognite.client.utils._async_helpers import run_sync
 

--- a/cognite/client/_sync_api/functions/schedules.py
+++ b/cognite/client/_sync_api/functions/schedules.py
@@ -1,6 +1,6 @@
 """
 ===============================================================================
-6235647338dc58a934eb35e2aac6f9e5
+71a118199f14ad296d2d2dba6dc1a1ed
 This file is auto-generated from the Async API modules, - do not edit manually!
 ===============================================================================
 """
@@ -11,8 +11,8 @@ from collections.abc import Iterator, Sequence
 from typing import overload
 
 from cognite.client import AsyncCogniteClient
-from cognite.client._constants import DEFAULT_LIMIT_READ
 from cognite.client._sync_api_client import SyncAPIClient
+from cognite.client.constants import DEFAULT_LIMIT_READ
 from cognite.client.data_classes import (
     ClientCredentials,
     FunctionSchedule,

--- a/cognite/client/_sync_api/geospatial.py
+++ b/cognite/client/_sync_api/geospatial.py
@@ -1,6 +1,6 @@
 """
 ===============================================================================
-8c70e772dd150e100df2bbd39737e065
+5914ba1b29e06964b0777eb2014fb3f5
 This file is auto-generated from the Async API modules, - do not edit manually!
 ===============================================================================
 """
@@ -12,8 +12,8 @@ from pathlib import Path
 from typing import Any, overload
 
 from cognite.client import AsyncCogniteClient
-from cognite.client._constants import DEFAULT_LIMIT_READ
 from cognite.client._sync_api_client import SyncAPIClient
+from cognite.client.constants import DEFAULT_LIMIT_READ
 from cognite.client.data_classes.geospatial import (
     CoordinateReferenceSystem,
     CoordinateReferenceSystemList,

--- a/cognite/client/_sync_api/hosted_extractors/destinations.py
+++ b/cognite/client/_sync_api/hosted_extractors/destinations.py
@@ -1,6 +1,6 @@
 """
 ===============================================================================
-5a976b1ed38fe4beaab1deffff4c55bf
+9c0f930e29fdbcdb4dcd92c14cd7de0f
 This file is auto-generated from the Async API modules, - do not edit manually!
 ===============================================================================
 """
@@ -11,8 +11,8 @@ from collections.abc import Iterator, Sequence
 from typing import TYPE_CHECKING, Literal, overload
 
 from cognite.client import AsyncCogniteClient
-from cognite.client._constants import DEFAULT_LIMIT_READ
 from cognite.client._sync_api_client import SyncAPIClient
+from cognite.client.constants import DEFAULT_LIMIT_READ
 from cognite.client.data_classes.hosted_extractors.destinations import (
     Destination,
     DestinationList,

--- a/cognite/client/_sync_api/hosted_extractors/jobs.py
+++ b/cognite/client/_sync_api/hosted_extractors/jobs.py
@@ -1,6 +1,6 @@
 """
 ===============================================================================
-c7e303354a7fd2a606772c2cd8a6dfc6
+9b8e2be1a411f46f12190aa893248058
 This file is auto-generated from the Async API modules, - do not edit manually!
 ===============================================================================
 """
@@ -11,8 +11,8 @@ from collections.abc import Iterator, Sequence
 from typing import TYPE_CHECKING, Literal, overload
 
 from cognite.client import AsyncCogniteClient
-from cognite.client._constants import DEFAULT_LIMIT_READ
 from cognite.client._sync_api_client import SyncAPIClient
+from cognite.client.constants import DEFAULT_LIMIT_READ
 from cognite.client.data_classes.hosted_extractors.jobs import (
     Job,
     JobList,

--- a/cognite/client/_sync_api/hosted_extractors/mappings.py
+++ b/cognite/client/_sync_api/hosted_extractors/mappings.py
@@ -1,6 +1,6 @@
 """
 ===============================================================================
-d8f52d5fa4e5f94c791a0e3d33ff2173
+747a4c5693a60f4efb235459a8bbbc68
 This file is auto-generated from the Async API modules, - do not edit manually!
 ===============================================================================
 """
@@ -11,8 +11,8 @@ from collections.abc import Iterator, Sequence
 from typing import TYPE_CHECKING, overload
 
 from cognite.client import AsyncCogniteClient
-from cognite.client._constants import DEFAULT_LIMIT_READ
 from cognite.client._sync_api_client import SyncAPIClient
+from cognite.client.constants import DEFAULT_LIMIT_READ
 from cognite.client.data_classes.hosted_extractors import Mapping, MappingList, MappingUpdate, MappingWrite
 from cognite.client.utils._async_helpers import SyncIterator, run_sync
 from cognite.client.utils.useful_types import SequenceNotStr

--- a/cognite/client/_sync_api/hosted_extractors/sources.py
+++ b/cognite/client/_sync_api/hosted_extractors/sources.py
@@ -1,6 +1,6 @@
 """
 ===============================================================================
-313f24c2cf04def20a09147c4176b735
+d079b0e7869d4e80816d74b1b913cb77
 This file is auto-generated from the Async API modules, - do not edit manually!
 ===============================================================================
 """
@@ -11,8 +11,8 @@ from collections.abc import Iterator, Sequence
 from typing import TYPE_CHECKING, Literal, overload
 
 from cognite.client import AsyncCogniteClient
-from cognite.client._constants import DEFAULT_LIMIT_READ
 from cognite.client._sync_api_client import SyncAPIClient
+from cognite.client.constants import DEFAULT_LIMIT_READ
 from cognite.client.data_classes.hosted_extractors.sources import Source, SourceList, SourceUpdate, SourceWrite
 from cognite.client.utils._async_helpers import SyncIterator, run_sync
 from cognite.client.utils.useful_types import SequenceNotStr

--- a/cognite/client/_sync_api/iam/security_categories.py
+++ b/cognite/client/_sync_api/iam/security_categories.py
@@ -1,6 +1,6 @@
 """
 ===============================================================================
-af9f1bd7ee578d981c9a89566a41603a
+27a152a62ce8ed2943ad155df728fd66
 This file is auto-generated from the Async API modules, - do not edit manually!
 ===============================================================================
 """
@@ -11,8 +11,8 @@ from collections.abc import Sequence
 from typing import Literal, overload
 
 from cognite.client import AsyncCogniteClient
-from cognite.client._constants import DEFAULT_LIMIT_READ
 from cognite.client._sync_api_client import SyncAPIClient
+from cognite.client.constants import DEFAULT_LIMIT_READ
 from cognite.client.data_classes import SecurityCategory, SecurityCategoryList
 from cognite.client.data_classes.iam import SecurityCategoryWrite
 from cognite.client.utils._async_helpers import run_sync

--- a/cognite/client/_sync_api/iam/sessions.py
+++ b/cognite/client/_sync_api/iam/sessions.py
@@ -1,6 +1,6 @@
 """
 ===============================================================================
-66ef20c6bf5b2e991efb781b993720f0
+6f65e393b73684a67c08e14f6fe5d3b1
 This file is auto-generated from the Async API modules, - do not edit manually!
 ===============================================================================
 """
@@ -11,8 +11,8 @@ from collections.abc import Sequence
 from typing import TYPE_CHECKING, Literal, overload
 
 from cognite.client import AsyncCogniteClient
-from cognite.client._constants import DEFAULT_LIMIT_READ
 from cognite.client._sync_api_client import SyncAPIClient
+from cognite.client.constants import DEFAULT_LIMIT_READ
 from cognite.client.data_classes import (
     ClientCredentials,
     CreatedSession,

--- a/cognite/client/_sync_api/labels.py
+++ b/cognite/client/_sync_api/labels.py
@@ -1,6 +1,6 @@
 """
 ===============================================================================
-a6cd43591b6d369d0813909321a08ce0
+850bede8fd4832518329cb81fbcb82e0
 This file is auto-generated from the Async API modules, - do not edit manually!
 ===============================================================================
 """
@@ -11,8 +11,8 @@ from collections.abc import Iterator, Sequence
 from typing import Literal, overload
 
 from cognite.client import AsyncCogniteClient
-from cognite.client._constants import DEFAULT_LIMIT_READ
 from cognite.client._sync_api_client import SyncAPIClient
+from cognite.client.constants import DEFAULT_LIMIT_READ
 from cognite.client.data_classes import (
     LabelDefinition,
     LabelDefinitionList,

--- a/cognite/client/_sync_api/limits.py
+++ b/cognite/client/_sync_api/limits.py
@@ -1,6 +1,6 @@
 """
 ===============================================================================
-fa9b4b13df083257c7593d43dc67181f
+0c47c820db4aebf7ec06e07468978880
 This file is auto-generated from the Async API modules, - do not edit manually!
 ===============================================================================
 """
@@ -10,8 +10,8 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from cognite.client import AsyncCogniteClient
-from cognite.client._constants import DEFAULT_LIMIT_READ
 from cognite.client._sync_api_client import SyncAPIClient
+from cognite.client.constants import DEFAULT_LIMIT_READ
 from cognite.client.data_classes.limits import Limit, LimitList
 from cognite.client.utils._async_helpers import run_sync
 

--- a/cognite/client/_sync_api/org_apis/principals.py
+++ b/cognite/client/_sync_api/org_apis/principals.py
@@ -1,6 +1,6 @@
 """
 ===============================================================================
-5cc9532c186c06eff25c52dc2c10a016
+4c7fd108957122fb6c2038278b1f0cd7
 This file is auto-generated from the Async API modules, - do not edit manually!
 ===============================================================================
 """
@@ -11,8 +11,8 @@ from collections.abc import Sequence
 from typing import overload
 
 from cognite.client import AsyncCogniteClient
-from cognite.client._constants import DEFAULT_LIMIT_READ
 from cognite.client._sync_api_client import SyncAPIClient
+from cognite.client.constants import DEFAULT_LIMIT_READ
 from cognite.client.data_classes.principals import Principal, PrincipalList
 from cognite.client.utils._async_helpers import run_sync
 from cognite.client.utils.useful_types import SequenceNotStr

--- a/cognite/client/_sync_api/postgres_gateway/tables.py
+++ b/cognite/client/_sync_api/postgres_gateway/tables.py
@@ -1,6 +1,6 @@
 """
 ===============================================================================
-76644d0a1e130c795027e8e205f1d20f
+c1010253ff0e678f04d030f60b44bd6f
 This file is auto-generated from the Async API modules, - do not edit manually!
 ===============================================================================
 """
@@ -12,8 +12,8 @@ from typing import TYPE_CHECKING, Literal, overload
 
 import cognite.client.data_classes.postgres_gateway.tables as pg
 from cognite.client import AsyncCogniteClient
-from cognite.client._constants import DEFAULT_LIMIT_READ
 from cognite.client._sync_api_client import SyncAPIClient
+from cognite.client.constants import DEFAULT_LIMIT_READ
 from cognite.client.utils._async_helpers import SyncIterator, run_sync
 from cognite.client.utils.useful_types import SequenceNotStr
 

--- a/cognite/client/_sync_api/postgres_gateway/users.py
+++ b/cognite/client/_sync_api/postgres_gateway/users.py
@@ -1,6 +1,6 @@
 """
 ===============================================================================
-9e343dcd2734f2822251a2f28026bdbe
+b4feb01a0143a7af3a6d773ff53a662e
 This file is auto-generated from the Async API modules, - do not edit manually!
 ===============================================================================
 """
@@ -11,8 +11,8 @@ from collections.abc import Iterator, Sequence
 from typing import TYPE_CHECKING, overload
 
 from cognite.client import AsyncCogniteClient
-from cognite.client._constants import DEFAULT_LIMIT_READ
 from cognite.client._sync_api_client import SyncAPIClient
+from cognite.client.constants import DEFAULT_LIMIT_READ
 from cognite.client.data_classes.postgres_gateway.users import (
     User,
     UserCreated,

--- a/cognite/client/_sync_api/raw/databases.py
+++ b/cognite/client/_sync_api/raw/databases.py
@@ -1,6 +1,6 @@
 """
 ===============================================================================
-87febdf9ebef1038e6f3889c86c39492
+eb173e046da2f85625a67c2b97ab3232
 This file is auto-generated from the Async API modules, - do not edit manually!
 ===============================================================================
 """
@@ -11,8 +11,8 @@ from collections.abc import Iterator
 from typing import overload
 
 from cognite.client import AsyncCogniteClient
-from cognite.client._constants import DEFAULT_LIMIT_READ
 from cognite.client._sync_api_client import SyncAPIClient
+from cognite.client.constants import DEFAULT_LIMIT_READ
 from cognite.client.data_classes.raw import Database, DatabaseList
 from cognite.client.utils._async_helpers import SyncIterator, run_sync
 from cognite.client.utils.useful_types import SequenceNotStr

--- a/cognite/client/_sync_api/raw/rows.py
+++ b/cognite/client/_sync_api/raw/rows.py
@@ -1,6 +1,6 @@
 """
 ===============================================================================
-a128a85c662169c336426ee222e0baec
+981bb3859595f0d872c3672ea6366b58
 This file is auto-generated from the Async API modules, - do not edit manually!
 ===============================================================================
 """
@@ -11,8 +11,8 @@ from collections.abc import Iterator, Sequence
 from typing import TYPE_CHECKING, overload
 
 from cognite.client import AsyncCogniteClient
-from cognite.client._constants import DEFAULT_LIMIT_READ
 from cognite.client._sync_api_client import SyncAPIClient
+from cognite.client.constants import DEFAULT_LIMIT_READ
 from cognite.client.data_classes.raw import Row, RowList, RowWrite
 from cognite.client.utils._async_helpers import SyncIterator, run_sync
 from cognite.client.utils.useful_types import SequenceNotStr

--- a/cognite/client/_sync_api/raw/tables.py
+++ b/cognite/client/_sync_api/raw/tables.py
@@ -1,6 +1,6 @@
 """
 ===============================================================================
-4059b7de51c4541f19cf4f0449b16a86
+77c134103a9036c8e27cca20bb0cfbd5
 This file is auto-generated from the Async API modules, - do not edit manually!
 ===============================================================================
 """
@@ -11,8 +11,8 @@ from collections.abc import Iterator
 from typing import overload
 
 from cognite.client import AsyncCogniteClient
-from cognite.client._constants import DEFAULT_LIMIT_READ
 from cognite.client._sync_api_client import SyncAPIClient
+from cognite.client.constants import DEFAULT_LIMIT_READ
 from cognite.client.data_classes import raw
 from cognite.client.utils._async_helpers import SyncIterator, run_sync
 from cognite.client.utils.useful_types import SequenceNotStr

--- a/cognite/client/_sync_api/relationships.py
+++ b/cognite/client/_sync_api/relationships.py
@@ -1,6 +1,6 @@
 """
 ===============================================================================
-e44e896e412b61c408689bdfb74669b1
+1fbf07acee711b9ce381079f1d4efd3b
 This file is auto-generated from the Async API modules, - do not edit manually!
 ===============================================================================
 """
@@ -11,8 +11,8 @@ from collections.abc import Iterator, Sequence
 from typing import TYPE_CHECKING, Literal, overload
 
 from cognite.client import AsyncCogniteClient
-from cognite.client._constants import DEFAULT_LIMIT_READ
 from cognite.client._sync_api_client import SyncAPIClient
+from cognite.client.constants import DEFAULT_LIMIT_READ
 from cognite.client.data_classes import (
     Relationship,
     RelationshipList,

--- a/cognite/client/_sync_api/sequences.py
+++ b/cognite/client/_sync_api/sequences.py
@@ -1,6 +1,6 @@
 """
 ===============================================================================
-b5f1d5448101c9e7ffbd03e82068ba1c
+1ae3c4369e12be8f0e74bb65b54804e7
 This file is auto-generated from the Async API modules, - do not edit manually!
 ===============================================================================
 """
@@ -13,9 +13,9 @@ from typing import TYPE_CHECKING, Any, Literal, overload
 
 from cognite.client import AsyncCogniteClient
 from cognite.client._api.sequences import SortSpec
-from cognite.client._constants import DEFAULT_LIMIT_READ
 from cognite.client._sync_api.sequence_data import SyncSequencesDataAPI
 from cognite.client._sync_api_client import SyncAPIClient
+from cognite.client.constants import DEFAULT_LIMIT_READ
 from cognite.client.data_classes import Sequence, SequenceFilter, SequenceList, SequenceUpdate
 from cognite.client.data_classes.aggregations import AggregationFilter, UniqueResultList
 from cognite.client.data_classes.filters import Filter

--- a/cognite/client/_sync_api/simulators/__init__.py
+++ b/cognite/client/_sync_api/simulators/__init__.py
@@ -1,6 +1,6 @@
 """
 ===============================================================================
-0eb88d958406c07c70a3a70bb4b168c9
+02fe4c77f6ddabe5d9a5994900d4e675
 This file is auto-generated from the Async API modules, - do not edit manually!
 ===============================================================================
 """
@@ -11,13 +11,13 @@ from collections.abc import Iterator
 from typing import TYPE_CHECKING, overload
 
 from cognite.client import AsyncCogniteClient
-from cognite.client._constants import DEFAULT_LIMIT_READ
 from cognite.client._sync_api.simulators.integrations import SyncSimulatorIntegrationsAPI
 from cognite.client._sync_api.simulators.logs import SyncSimulatorLogsAPI
 from cognite.client._sync_api.simulators.models import SyncSimulatorModelsAPI
 from cognite.client._sync_api.simulators.routines import SyncSimulatorRoutinesAPI
 from cognite.client._sync_api.simulators.runs import SyncSimulatorRunsAPI
 from cognite.client._sync_api_client import SyncAPIClient
+from cognite.client.constants import DEFAULT_LIMIT_READ
 from cognite.client.data_classes.simulators.simulators import Simulator, SimulatorList
 from cognite.client.utils._async_helpers import SyncIterator, run_sync
 

--- a/cognite/client/_sync_api/simulators/integrations.py
+++ b/cognite/client/_sync_api/simulators/integrations.py
@@ -1,6 +1,6 @@
 """
 ===============================================================================
-cc66cced91c72607a9a48412b697fc97
+69eca4d0d4226a67aa665345fea8b43f
 This file is auto-generated from the Async API modules, - do not edit manually!
 ===============================================================================
 """
@@ -11,8 +11,8 @@ from collections.abc import Iterator, Sequence
 from typing import TYPE_CHECKING, overload
 
 from cognite.client import AsyncCogniteClient
-from cognite.client._constants import DEFAULT_LIMIT_READ
 from cognite.client._sync_api_client import SyncAPIClient
+from cognite.client.constants import DEFAULT_LIMIT_READ
 from cognite.client.data_classes.simulators.simulators import SimulatorIntegration, SimulatorIntegrationList
 from cognite.client.utils._async_helpers import SyncIterator, run_sync
 from cognite.client.utils.useful_types import SequenceNotStr

--- a/cognite/client/_sync_api/simulators/models.py
+++ b/cognite/client/_sync_api/simulators/models.py
@@ -1,6 +1,6 @@
 """
 ===============================================================================
-4f5f358c779dd350123fd61c39bfbfb8
+53d2a764907cf1b3c35530931b56614c
 This file is auto-generated from the Async API modules, - do not edit manually!
 ===============================================================================
 """
@@ -11,9 +11,9 @@ from collections.abc import Iterator, Sequence
 from typing import TYPE_CHECKING, overload
 
 from cognite.client import AsyncCogniteClient
-from cognite.client._constants import DEFAULT_LIMIT_READ
 from cognite.client._sync_api.simulators.models_revisions import SyncSimulatorModelRevisionsAPI
 from cognite.client._sync_api_client import SyncAPIClient
+from cognite.client.constants import DEFAULT_LIMIT_READ
 from cognite.client.data_classes.simulators.filters import PropertySort
 from cognite.client.data_classes.simulators.models import (
     SimulatorModel,

--- a/cognite/client/_sync_api/simulators/models_revisions.py
+++ b/cognite/client/_sync_api/simulators/models_revisions.py
@@ -1,6 +1,6 @@
 """
 ===============================================================================
-03b4ddd2ad52415dca0fe62f12b4a3c1
+f7481f9e34dfa0b8e6a86819055bc1f5
 This file is auto-generated from the Async API modules, - do not edit manually!
 ===============================================================================
 """
@@ -11,8 +11,8 @@ from collections.abc import Iterator, Sequence
 from typing import TYPE_CHECKING, overload
 
 from cognite.client import AsyncCogniteClient
-from cognite.client._constants import DEFAULT_LIMIT_READ
 from cognite.client._sync_api_client import SyncAPIClient
+from cognite.client.constants import DEFAULT_LIMIT_READ
 from cognite.client.data_classes.shared import TimestampRange
 from cognite.client.data_classes.simulators.filters import PropertySort
 from cognite.client.data_classes.simulators.models import (

--- a/cognite/client/_sync_api/simulators/routines.py
+++ b/cognite/client/_sync_api/simulators/routines.py
@@ -1,6 +1,6 @@
 """
 ===============================================================================
-e25ff4296135886bcbe58f933f5d7da6
+4c13ec828aed44487f45aa56f0502911
 This file is auto-generated from the Async API modules, - do not edit manually!
 ===============================================================================
 """
@@ -11,9 +11,9 @@ from collections.abc import Iterator, Sequence
 from typing import TYPE_CHECKING, Literal, overload
 
 from cognite.client import AsyncCogniteClient
-from cognite.client._constants import DEFAULT_LIMIT_READ
 from cognite.client._sync_api.simulators.routine_revisions import SyncSimulatorRoutineRevisionsAPI
 from cognite.client._sync_api_client import SyncAPIClient
+from cognite.client.constants import DEFAULT_LIMIT_READ
 from cognite.client.data_classes.simulators.filters import PropertySort
 from cognite.client.data_classes.simulators.routines import (
     SimulatorRoutine,

--- a/cognite/client/_sync_api/simulators/runs.py
+++ b/cognite/client/_sync_api/simulators/runs.py
@@ -1,6 +1,6 @@
 """
 ===============================================================================
-c2ccaaf731fd07a67787a512a5a9acd2
+9f1dbefe06d6265415dd40e58a561191
 This file is auto-generated from the Async API modules, - do not edit manually!
 ===============================================================================
 """
@@ -11,8 +11,8 @@ from collections.abc import Iterator, Sequence
 from typing import TYPE_CHECKING, overload
 
 from cognite.client import AsyncCogniteClient
-from cognite.client._constants import DEFAULT_LIMIT_READ
 from cognite.client._sync_api_client import SyncAPIClient
+from cognite.client.constants import DEFAULT_LIMIT_READ
 from cognite.client.data_classes.shared import TimestampRange
 from cognite.client.data_classes.simulators.filters import SimulationRunsSort
 from cognite.client.data_classes.simulators.runs import (

--- a/cognite/client/_sync_api/three_d/asset_mapping.py
+++ b/cognite/client/_sync_api/three_d/asset_mapping.py
@@ -1,6 +1,6 @@
 """
 ===============================================================================
-5df166262e8c65029e1adcb884de5ec9
+f55c4089bd5540b0687841c2a4d4f52c
 This file is auto-generated from the Async API modules, - do not edit manually!
 ===============================================================================
 """
@@ -11,8 +11,8 @@ from collections.abc import Sequence
 from typing import overload
 
 from cognite.client import AsyncCogniteClient
-from cognite.client._constants import DEFAULT_LIMIT_READ
 from cognite.client._sync_api_client import SyncAPIClient
+from cognite.client.constants import DEFAULT_LIMIT_READ
 from cognite.client.data_classes import (
     BoundingBox3D,
     ThreeDAssetMapping,

--- a/cognite/client/_sync_api/three_d/models.py
+++ b/cognite/client/_sync_api/three_d/models.py
@@ -1,6 +1,6 @@
 """
 ===============================================================================
-867a006e45c5867d9e70d5f19bc77084
+b95612bd866f87f4f896db27dd8510ab
 This file is auto-generated from the Async API modules, - do not edit manually!
 ===============================================================================
 """
@@ -11,8 +11,8 @@ from collections.abc import Iterator, Sequence
 from typing import Literal, overload
 
 from cognite.client import AsyncCogniteClient
-from cognite.client._constants import DEFAULT_LIMIT_READ
 from cognite.client._sync_api_client import SyncAPIClient
+from cognite.client.constants import DEFAULT_LIMIT_READ
 from cognite.client.data_classes import ThreeDModel, ThreeDModelList, ThreeDModelUpdate, ThreeDModelWrite
 from cognite.client.utils._async_helpers import SyncIterator, run_sync
 from cognite.client.utils.useful_types import SequenceNotStr

--- a/cognite/client/_sync_api/three_d/revisions.py
+++ b/cognite/client/_sync_api/three_d/revisions.py
@@ -1,6 +1,6 @@
 """
 ===============================================================================
-a236c0e18fb9fb2f240d85c6acf54c8c
+1ff0d7890761d836bbac266218599813
 This file is auto-generated from the Async API modules, - do not edit manually!
 ===============================================================================
 """
@@ -11,8 +11,8 @@ from collections.abc import Iterator, Sequence
 from typing import Literal, overload
 
 from cognite.client import AsyncCogniteClient
-from cognite.client._constants import DEFAULT_LIMIT_READ
 from cognite.client._sync_api_client import SyncAPIClient
+from cognite.client.constants import DEFAULT_LIMIT_READ
 from cognite.client.data_classes import (
     ThreeDModelRevision,
     ThreeDModelRevisionList,

--- a/cognite/client/_sync_api/time_series.py
+++ b/cognite/client/_sync_api/time_series.py
@@ -1,6 +1,6 @@
 """
 ===============================================================================
-6019e3c2ccde3aafc9dd27ac6379507a
+2d40db286c31de01930f3e80f0aad9b4
 This file is auto-generated from the Async API modules, - do not edit manually!
 ===============================================================================
 """
@@ -12,10 +12,10 @@ from typing import TYPE_CHECKING, Any, Literal, overload
 
 from cognite.client import AsyncCogniteClient
 from cognite.client._api.time_series import SortSpec
-from cognite.client._constants import DEFAULT_LIMIT_READ
 from cognite.client._sync_api.datapoints import SyncDatapointsAPI
 from cognite.client._sync_api.datapoints_subscriptions import SyncDatapointsSubscriptionAPI
 from cognite.client._sync_api_client import SyncAPIClient
+from cognite.client.constants import DEFAULT_LIMIT_READ
 from cognite.client.data_classes import TimeSeries, TimeSeriesFilter, TimeSeriesList, TimeSeriesUpdate
 from cognite.client.data_classes.aggregations import AggregationFilter, UniqueResultList
 from cognite.client.data_classes.data_modeling import NodeId

--- a/cognite/client/_sync_api/transformations/__init__.py
+++ b/cognite/client/_sync_api/transformations/__init__.py
@@ -1,6 +1,6 @@
 """
 ===============================================================================
-8bca411648596701cde79f2c9e6f2a88
+d1f7f6a2cdc838c811d9137a79890c81
 This file is auto-generated from the Async API modules, - do not edit manually!
 ===============================================================================
 """
@@ -11,12 +11,12 @@ from collections.abc import Iterator, Sequence
 from typing import TYPE_CHECKING, Any, Literal, overload
 
 from cognite.client import AsyncCogniteClient
-from cognite.client._constants import DEFAULT_LIMIT_READ
 from cognite.client._sync_api.transformations.jobs import SyncTransformationJobsAPI
 from cognite.client._sync_api.transformations.notifications import SyncTransformationNotificationsAPI
 from cognite.client._sync_api.transformations.schedules import SyncTransformationSchedulesAPI
 from cognite.client._sync_api.transformations.schema import SyncTransformationSchemaAPI
 from cognite.client._sync_api_client import SyncAPIClient
+from cognite.client.constants import DEFAULT_LIMIT_READ
 from cognite.client.data_classes import Transformation, TransformationJob, TransformationList
 from cognite.client.data_classes.shared import TimestampRange
 from cognite.client.data_classes.transformations import (

--- a/cognite/client/_sync_api/transformations/jobs.py
+++ b/cognite/client/_sync_api/transformations/jobs.py
@@ -1,6 +1,6 @@
 """
 ===============================================================================
-67b9772bb8487c14b0c47ed52431e6d1
+6ad6ed63d516595adc5438983cd1a8e1
 This file is auto-generated from the Async API modules, - do not edit manually!
 ===============================================================================
 """
@@ -10,8 +10,8 @@ from __future__ import annotations
 from collections.abc import Sequence
 
 from cognite.client import AsyncCogniteClient
-from cognite.client._constants import DEFAULT_LIMIT_READ
 from cognite.client._sync_api_client import SyncAPIClient
+from cognite.client.constants import DEFAULT_LIMIT_READ
 from cognite.client.data_classes import (
     TransformationJob,
     TransformationJobList,

--- a/cognite/client/_sync_api/transformations/notifications.py
+++ b/cognite/client/_sync_api/transformations/notifications.py
@@ -1,6 +1,6 @@
 """
 ===============================================================================
-9e9a4769323f5526fcef2c63f1583579
+2f14836d407c891ef29880b8371e96a2
 This file is auto-generated from the Async API modules, - do not edit manually!
 ===============================================================================
 """
@@ -11,8 +11,8 @@ from collections.abc import Iterator, Sequence
 from typing import overload
 
 from cognite.client import AsyncCogniteClient
-from cognite.client._constants import DEFAULT_LIMIT_READ
 from cognite.client._sync_api_client import SyncAPIClient
+from cognite.client.constants import DEFAULT_LIMIT_READ
 from cognite.client.data_classes import (
     TransformationNotification,
     TransformationNotificationList,

--- a/cognite/client/_sync_api/transformations/schedules.py
+++ b/cognite/client/_sync_api/transformations/schedules.py
@@ -1,6 +1,6 @@
 """
 ===============================================================================
-2380acb3b90c1a3d2955d56571534c5a
+9704b181e9a2ced58dfa3bd73b7fa948
 This file is auto-generated from the Async API modules, - do not edit manually!
 ===============================================================================
 """
@@ -11,8 +11,8 @@ from collections.abc import Iterator, Sequence
 from typing import TYPE_CHECKING, Literal, overload
 
 from cognite.client import AsyncCogniteClient
-from cognite.client._constants import DEFAULT_LIMIT_READ
 from cognite.client._sync_api_client import SyncAPIClient
+from cognite.client.constants import DEFAULT_LIMIT_READ
 from cognite.client.data_classes import (
     TransformationSchedule,
     TransformationScheduleList,

--- a/cognite/client/_sync_api/user_profiles.py
+++ b/cognite/client/_sync_api/user_profiles.py
@@ -1,6 +1,6 @@
 """
 ===============================================================================
-c4247be566a248f374fe66bb764f5051
+eba918eea90cda1ae4d7c0d56e273aa1
 This file is auto-generated from the Async API modules, - do not edit manually!
 ===============================================================================
 """
@@ -10,8 +10,8 @@ from __future__ import annotations
 from typing import overload
 
 from cognite.client import AsyncCogniteClient
-from cognite.client._constants import DEFAULT_LIMIT_READ
 from cognite.client._sync_api_client import SyncAPIClient
+from cognite.client.constants import DEFAULT_LIMIT_READ
 from cognite.client.data_classes.user_profiles import UserProfile, UserProfileList, UserProfilesConfiguration
 from cognite.client.utils._async_helpers import run_sync
 from cognite.client.utils.useful_types import SequenceNotStr

--- a/cognite/client/_sync_api/workflows/__init__.py
+++ b/cognite/client/_sync_api/workflows/__init__.py
@@ -1,6 +1,6 @@
 """
 ===============================================================================
-7962fb2e1b2f6aedd8ac425437667a9d
+a021b58a9bf20309876d8e0cce0c2aaf
 This file is auto-generated from the Async API modules, - do not edit manually!
 ===============================================================================
 """
@@ -11,19 +11,18 @@ from collections.abc import Iterator, Sequence
 from typing import TYPE_CHECKING, Literal, overload
 
 from cognite.client import AsyncCogniteClient
-from cognite.client._constants import DEFAULT_LIMIT_READ
 from cognite.client._sync_api.workflows.executions import SyncWorkflowExecutionAPI
 from cognite.client._sync_api.workflows.tasks import SyncWorkflowTaskAPI
 from cognite.client._sync_api.workflows.triggers import SyncWorkflowTriggerAPI
 from cognite.client._sync_api.workflows.versions import SyncWorkflowVersionAPI
 from cognite.client._sync_api_client import SyncAPIClient
+from cognite.client.constants import DEFAULT_LIMIT_READ
 from cognite.client.data_classes.workflows import Workflow, WorkflowList, WorkflowUpsert
 from cognite.client.utils._async_helpers import SyncIterator, run_sync
 from cognite.client.utils.useful_types import SequenceNotStr
 
 if TYPE_CHECKING:
     from cognite.client import AsyncCogniteClient
-    from cognite.client import ClientConfig as ClientConfig
 
 
 class SyncWorkflowAPI(SyncAPIClient):

--- a/cognite/client/_sync_api/workflows/executions.py
+++ b/cognite/client/_sync_api/workflows/executions.py
@@ -1,6 +1,6 @@
 """
 ===============================================================================
-162dd73ca5991c5bbbffc4c1525093d9
+29772e0d4c678ed6a0f5890cf11e2d98
 This file is auto-generated from the Async API modules, - do not edit manually!
 ===============================================================================
 """
@@ -12,8 +12,8 @@ from typing import TYPE_CHECKING
 
 from cognite.client import AsyncCogniteClient
 from cognite.client._api.workflows import WorkflowVersionIdentifier
-from cognite.client._constants import DEFAULT_LIMIT_READ
 from cognite.client._sync_api_client import SyncAPIClient
+from cognite.client.constants import DEFAULT_LIMIT_READ
 from cognite.client.data_classes.workflows import (
     WorkflowExecution,
     WorkflowExecutionDetailed,

--- a/cognite/client/_sync_api/workflows/triggers.py
+++ b/cognite/client/_sync_api/workflows/triggers.py
@@ -1,6 +1,6 @@
 """
 ===============================================================================
-f5edbbb225707bdc150a94fc1aa31095
+add01b88b9785ef6b54fce16955d13ce
 This file is auto-generated from the Async API modules, - do not edit manually!
 ===============================================================================
 """
@@ -10,8 +10,8 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from cognite.client import AsyncCogniteClient
-from cognite.client._constants import DEFAULT_LIMIT_READ
 from cognite.client._sync_api_client import SyncAPIClient
+from cognite.client.constants import DEFAULT_LIMIT_READ
 from cognite.client.data_classes.workflows import (
     WorkflowTrigger,
     WorkflowTriggerList,

--- a/cognite/client/_sync_api/workflows/versions.py
+++ b/cognite/client/_sync_api/workflows/versions.py
@@ -1,6 +1,6 @@
 """
 ===============================================================================
-997204d5a50defcdbd6f6986d4b6a08d
+b56b4cde4d56acfe8ecb4bbee9a23ead
 This file is auto-generated from the Async API modules, - do not edit manually!
 ===============================================================================
 """
@@ -12,8 +12,8 @@ from typing import TYPE_CHECKING, Literal, overload
 
 from cognite.client import AsyncCogniteClient
 from cognite.client._api.workflows import WorkflowIdentifier, WorkflowVersionIdentifier
-from cognite.client._constants import DEFAULT_LIMIT_READ
 from cognite.client._sync_api_client import SyncAPIClient
+from cognite.client.constants import DEFAULT_LIMIT_READ
 from cognite.client.data_classes.workflows import (
     WorkflowIds,
     WorkflowVersion,

--- a/cognite/client/constants.py
+++ b/cognite/client/constants.py
@@ -1,3 +1,7 @@
+from __future__ import annotations
+
+from typing import Literal
+
 try:
     from pyodide.ffi import IN_BROWSER  # type: ignore [import-not-found]
 except ModuleNotFoundError:
@@ -12,8 +16,22 @@ except ImportError:  # pragma no cover
     NUMPY_IS_AVAILABLE = False
 
 
+class Omitted:
+    """Sentinel value for parameters that are not given or should be treated as not given."""
+
+    def __repr__(self) -> str:
+        return "<Omitted parameter>"
+
+    def __bool__(self) -> Literal[False]:
+        return False
+
+
+OMITTED = Omitted()
+DEFAULT_LIMIT_READ = 25
 # Max JavaScript-safe integer 2^53 - 1
 MAX_VALID_INTERNAL_ID = 9007199254740991
+DATA_MODELING_DEFAULT_LIMIT_READ = 10
+DEFAULT_DATAPOINTS_CHUNK_SIZE = 100_000
 _RUNNING_IN_BROWSER = IN_BROWSER
 
 # Files API constants

--- a/cognite/client/constants.py
+++ b/cognite/client/constants.py
@@ -2,19 +2,6 @@ from __future__ import annotations
 
 from typing import Literal
 
-try:
-    from pyodide.ffi import IN_BROWSER  # type: ignore [import-not-found]
-except ModuleNotFoundError:
-    IN_BROWSER = False
-
-try:
-    import numpy as np  # noqa F401
-
-    NUMPY_IS_AVAILABLE = True
-
-except ImportError:  # pragma no cover
-    NUMPY_IS_AVAILABLE = False
-
 
 class Omitted:
     """Sentinel value for parameters that are not given or should be treated as not given."""
@@ -28,14 +15,6 @@ class Omitted:
 
 OMITTED = Omitted()
 DEFAULT_LIMIT_READ = 25
-# Max JavaScript-safe integer 2^53 - 1
-MAX_VALID_INTERNAL_ID = 9007199254740991
+
 DATA_MODELING_DEFAULT_LIMIT_READ = 10
 DEFAULT_DATAPOINTS_CHUNK_SIZE = 100_000
-_RUNNING_IN_BROWSER = IN_BROWSER
-
-# Files API constants
-FILE_MIN_MULTIPART_SIZE = 5 * 1024 * 1024  # 5 MiB
-FILE_MAX_MULTIPART_SIZE = 4000 * 1024 * 1024  # 4000 MiB
-FILE_DEFAULT_MULTIPART_SIZE = 50 * 1024 * 1024  # 50 MiB
-FILE_MAX_MULTIPART_COUNT = 250

--- a/cognite/client/data_classes/data_modeling/cdm/v1.py
+++ b/cognite/client/data_classes/data_modeling/cdm/v1.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from datetime import datetime
 from typing import Literal
 
-from cognite.client._constants import OMITTED, Omitted
+from cognite.client.constants import OMITTED, Omitted
 from cognite.client.data_classes.data_modeling import DirectRelationReference
 from cognite.client.data_classes.data_modeling.ids import ViewId
 from cognite.client.data_classes.data_modeling.instances import (

--- a/cognite/client/data_classes/data_modeling/extractor_extensions/v1.py
+++ b/cognite/client/data_classes/data_modeling/extractor_extensions/v1.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from datetime import datetime
 from typing import Literal
 
-from cognite.client._constants import OMITTED, Omitted
+from cognite.client.constants import OMITTED, Omitted
 from cognite.client.data_classes.data_modeling import DirectRelationReference
 from cognite.client.data_classes.data_modeling.ids import ViewId
 from cognite.client.data_classes.data_modeling.instances import (

--- a/cognite/client/data_classes/data_modeling/instances.py
+++ b/cognite/client/data_classes/data_modeling/instances.py
@@ -32,7 +32,7 @@ from typing import (
 
 from typing_extensions import Self
 
-from cognite.client._constants import OMITTED, Omitted
+from cognite.client.constants import OMITTED, Omitted
 from cognite.client.data_classes._base import (
     CogniteResource,
     CogniteResourceList,

--- a/cognite/client/data_classes/functions.py
+++ b/cognite/client/data_classes/functions.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING, Any, Literal, NoReturn, Protocol, TypeAlias
 
 from typing_extensions import Self
 
-from cognite.client._constants import DEFAULT_LIMIT_READ
+from cognite.client.constants import DEFAULT_LIMIT_READ
 from cognite.client.data_classes._base import (
     CogniteFilter,
     CogniteResource,

--- a/tests/tests_integration/test_api/test_annotations.py
+++ b/tests/tests_integration/test_api/test_annotations.py
@@ -8,7 +8,7 @@ from typing import Any, cast
 import pytest
 
 from cognite.client import CogniteClient
-from cognite.client._constants import DEFAULT_LIMIT_READ
+from cognite.client.constants import DEFAULT_LIMIT_READ
 from cognite.client.data_classes import (
     Annotation,
     AnnotationFilter,

--- a/tests/tests_unit/test_meta.py
+++ b/tests/tests_unit/test_meta.py
@@ -127,6 +127,6 @@ def test_constants_are_importable() -> None:
     # Extractor utils using extractor_extensions/v1.py has a legit use case for needing the OMITTED singleton.
     # Thus this test is here to ensure we don't accidentally move it or break it.
     # Do not change this test without doing new major version release!!
-    from cognite.client._constants import OMITTED, Omitted
+    from cognite.client.constants import OMITTED, Omitted
 
     assert isinstance(OMITTED, Omitted)


### PR DESCRIPTION
## Description
Some constants that were part of the public interface were included in a private constatns file. These constants have been move to a new public constatns file. 

Alternatively, all constants could be moved to this new file, and private constants can have a leading underscore, or what is public can be set with \__all__.

## Checklist:
- [x] Tests added/updated.
- [x] Documentation updated. Documentation is generated from docstrings - these must be updated according to your change.
  If a new method has been added it should be referenced in [cognite.rst](https://github.com/cognitedata/cognite-sdk-python/blob/master/docs/source/cognite.rst) in order to generate docs based on its docstring.
- [x] The PR title follows the [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) spec.
