### PR TITLE
docs(data modelling): Add data modelling data types to the docs

### DIFF
--- a/cognite/client/_api/diagrams.py
+++ b/cognite/client/_api/diagrams.py
@@ -144,7 +144,7 @@ class DiagramsAPI(APIClient):
             file_ids (int | Sequence[int] | None): ID of the files, should already be uploaded in the same tenant.
             file_external_ids (str | SequenceNotStr[str] | None): File external ids, alternative to file_ids and file_references.
             file_instance_ids (NodeId | Sequence[NodeId] | None): Files to detect in, specified by instance id.
-            file_references (list[FileReference] | FileReference | None): File references (id, external_id or instance_id), and first_page and last_page to specify page ranges per file. Each reference can specify up to 50 pages. Providing a page range will also make the page count of the document a part of the response.
+            file_references (list[contextualization.FileReference] | contextualization.FileReference | None): File references (id, external_id or instance_id), and first_page and last_page to specify page ranges per file. Each reference can specify up to 50 pages. Providing a page range will also make the page count of the document a part of the response.
             pattern_mode (bool | None): If True, entities must be provided with a sample field. This enables detecting tags that are similar to the sample, but not necessarily identical. Defaults to None.
             configuration (DiagramDetectConfig | None): Additional configuration for the detect algorithm. See `DiagramDetectConfig` class documentation and `beta API docs <https://api-docs.cognite.com/20230101-beta/tag/Engineering-diagrams/operation/diagramDetect/#!path=configuration&t=request>`_.
             multiple_jobs (bool): Enables you to publish multiple jobs. If True the method returns a tuple of DetectJobBundle and list of potentially unposted files. If False it will return a single DiagramDetectResults. Defaults to False.
@@ -223,7 +223,7 @@ class DiagramsAPI(APIClient):
                 >>> job = client.diagrams.detect(entities=[{"name": "A1"}], file_id=123, config=config)
 
             Check the documentation for `DiagramDetectConfig` for more information on the available options.
-        """
+        """  # noqa: DOC105
         items = self._process_file_ids(file_ids, file_external_ids, file_instance_ids, file_references)
         entities_dumped = [
             entity.dump(camel_case=True) if isinstance(entity, CogniteResource) else entity for entity in entities

--- a/cognite/client/_sync_api/diagrams.py
+++ b/cognite/client/_sync_api/diagrams.py
@@ -1,6 +1,6 @@
 """
 ===============================================================================
-6f405a44b9af327b96291aa79765b1f2
+f3ee463c974a23fb18aed9753a979783
 This file is auto-generated from the Async API modules, - do not edit manually!
 ===============================================================================
 """
@@ -98,7 +98,7 @@ class SyncDiagramsAPI(SyncAPIClient):
             file_ids (int | Sequence[int] | None): ID of the files, should already be uploaded in the same tenant.
             file_external_ids (str | SequenceNotStr[str] | None): File external ids, alternative to file_ids and file_references.
             file_instance_ids (NodeId | Sequence[NodeId] | None): Files to detect in, specified by instance id.
-            file_references (list[FileReference] | FileReference | None): File references (id, external_id or instance_id), and first_page and last_page to specify page ranges per file. Each reference can specify up to 50 pages. Providing a page range will also make the page count of the document a part of the response.
+            file_references (list[contextualization.FileReference] | contextualization.FileReference | None): File references (id, external_id or instance_id), and first_page and last_page to specify page ranges per file. Each reference can specify up to 50 pages. Providing a page range will also make the page count of the document a part of the response.
             pattern_mode (bool | None): If True, entities must be provided with a sample field. This enables detecting tags that are similar to the sample, but not necessarily identical. Defaults to None.
             configuration (DiagramDetectConfig | None): Additional configuration for the detect algorithm. See `DiagramDetectConfig` class documentation and `beta API docs <https://api-docs.cognite.com/20230101-beta/tag/Engineering-diagrams/operation/diagramDetect/#!path=configuration&t=request>`_.
             multiple_jobs (bool): Enables you to publish multiple jobs. If True the method returns a tuple of DetectJobBundle and list of potentially unposted files. If False it will return a single DiagramDetectResults. Defaults to False.
@@ -177,7 +177,7 @@ class SyncDiagramsAPI(SyncAPIClient):
                 >>> job = client.diagrams.detect(entities=[{"name": "A1"}], file_id=123, config=config)
 
             Check the documentation for `DiagramDetectConfig` for more information on the available options.
-        """
+        """  # noqa: DOC105
         return run_sync(
             self.__async_client.diagrams.detect(
                 entities=entities,

--- a/docs/source/data_modeling.rst
+++ b/docs/source/data_modeling.rst
@@ -329,3 +329,9 @@ Debugging Data Classes
 .. automodule:: cognite.client.data_classes.data_modeling.debug
     :members:
     :show-inheritance:
+
+Data Types
+----------
+.. automodule:: cognite.client.data_classes.data_modeling.data_types
+    :members:
+    :show-inheritance:

--- a/scripts/custom_checks/docstrings.py
+++ b/scripts/custom_checks/docstrings.py
@@ -20,6 +20,8 @@ from pathlib import Path
 
 import numpy as np
 
+from cognite.client._api.diagrams import DiagramsAPI
+from cognite.client._sync_api.diagrams import SyncDiagramsAPI
 from cognite.client.data_classes.data_modeling.query import Query, QuerySync
 from cognite.client.data_classes.functions import FunctionHandle
 from cognite.client.utils._text import shorten
@@ -29,6 +31,8 @@ CLS_METHOD_EXCEPTIONS = {
     (Query, "__init__"),  # Reason (Generics[...]): Avoid showing (bounded) type var instead of actual class
     (QuerySync, "__init__"),  # Reason (Generics[...]): Avoid showing (bounded) type var instead of actual class
     (FunctionHandle, "__init__"),  # Reason: Protocol class doesn't have __init__ with return type
+    (DiagramsAPI, "detect"),  # Reason: References FileReference, which there are two of in the documentation
+    (SyncDiagramsAPI, "detect"),  # Reason: References FileReference, which there are two of in the documentation
 }
 
 # Helper for testing specific class + method/property:


### PR DESCRIPTION
## Description
There are many references to the data modelling data types classes in the docs, but they have not been documented. Now they are included.

## Checklist:
- [ ] Tests added/updated.
- [x] Documentation updated. Documentation is generated from docstrings - these must be updated according to your change.
  If a new method has been added it should be referenced in [cognite.rst](https://github.com/cognitedata/cognite-sdk-python/blob/master/docs/source/cognite.rst) in order to generate docs based on its docstring.
- [x] The PR title follows the [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) spec.
