### PR TITLE
fix(Functions): skip pip validation on browser use

### DIFF
--- a/cognite/client/_api/functions/__init__.py
+++ b/cognite/client/_api/functions/__init__.py
@@ -873,7 +873,15 @@ def _validate_and_parse_requirements(requirements: list[str]) -> list[str]:
     Returns:
         list[str]: The parsed requirements
     """
-    constructors = local_import("pip._internal.req.constructors")
+    from cognite.client.exceptions import CogniteImportError
+
+    try:
+        constructors = local_import("pip._internal.req.constructors")
+    except CogniteImportError:
+        # pip internals unavailable (e.g. WebAssembly/CDF notebook environments);
+        # skip client-side validation and let the server validate instead.
+        return [r for r in requirements if r.strip()]
+
     install_req_from_line = constructors.install_req_from_line
     parsed_reqs: list[str] = []
     for req in requirements:

--- a/cognite/client/_api/functions/__init__.py
+++ b/cognite/client/_api/functions/__init__.py
@@ -7,6 +7,7 @@ import os
 import re
 import sys
 import textwrap
+import warnings
 from collections.abc import AsyncIterator, Callable, Sequence
 from inspect import getdoc, getsource, signature
 from multiprocessing import Process, Queue
@@ -873,14 +874,15 @@ def _validate_and_parse_requirements(requirements: list[str]) -> list[str]:
     Returns:
         list[str]: The parsed requirements
     """
-    from cognite.client.exceptions import CogniteImportError
-
-    try:
-        constructors = local_import("pip._internal.req.constructors")
-    except CogniteImportError:
-        # pip internals unavailable (e.g. WebAssembly/CDF notebook environments);
-        # skip client-side validation and let the server validate instead.
+    if _RUNNING_IN_BROWSER:
+        warnings.warn(
+            "Running in a browser environment, skipping client-side validation of requirements.",
+            UserWarning,
+            stacklevel=2,
+        )
         return [r for r in requirements if r.strip()]
+    else:
+        constructors = local_import("pip._internal.req.constructors")
 
     install_req_from_line = constructors.install_req_from_line
     parsed_reqs: list[str] = []

--- a/cognite/client/_sync_api/functions/__init__.py
+++ b/cognite/client/_sync_api/functions/__init__.py
@@ -7,33 +7,17 @@ This file is auto-generated from the Async API modules, - do not edit manually!
 
 from __future__ import annotations
 
-import ast
-import asyncio
-import importlib
-import os
-import re
-import sys
-import textwrap
-import warnings
-from collections.abc import AsyncIterator, Callable, Coroutine, Iterator, Sequence
-from inspect import getdoc, getsource, signature
-from multiprocessing import Process, Queue
-from pathlib import Path
-from tempfile import TemporaryDirectory
-from typing import TYPE_CHECKING, Any, Literal, cast, overload
-from zipfile import ZipFile
+from collections.abc import Iterator, Sequence
+from typing import TYPE_CHECKING, Literal, overload
 
 from cognite.client import AsyncCogniteClient
-from cognite.client._api.functions.utils import _get_function_internal_id
-from cognite.client._api_client import APIClient
-from cognite.client._constants import _RUNNING_IN_BROWSER, DEFAULT_LIMIT_READ
+from cognite.client._constants import DEFAULT_LIMIT_READ
 from cognite.client._sync_api.functions.calls import SyncFunctionCallsAPI
 from cognite.client._sync_api.functions.schedules import SyncFunctionSchedulesAPI
 from cognite.client._sync_api_client import SyncAPIClient
 from cognite.client.data_classes import (
     Function,
     FunctionCall,
-    FunctionFilter,
     FunctionList,
     FunctionsLimits,
     TimestampRange,
@@ -47,19 +31,10 @@ from cognite.client.data_classes.functions import (
     RunTime,
 )
 from cognite.client.utils._async_helpers import SyncIterator, run_sync
-from cognite.client.utils._auxiliary import is_unlimited, split_into_chunks
-from cognite.client.utils._concurrency import _get_event_loop_executor
-from cognite.client.utils._identifier import IdentifierSequence
-from cognite.client.utils._importing import local_import
-from cognite.client.utils._session import create_session_and_return_nonce
-from cognite.client.utils._validation import assert_type
 from cognite.client.utils.useful_types import SequenceNotStr
 
 if TYPE_CHECKING:
-    import pandas as pd
-
     from cognite.client import AsyncCogniteClient
-from cognite.client.config import ClientConfig
 
 
 class SyncFunctionsAPI(SyncAPIClient):

--- a/cognite/client/_sync_api/functions/__init__.py
+++ b/cognite/client/_sync_api/functions/__init__.py
@@ -1,23 +1,39 @@
 """
 ===============================================================================
-1862715b947706f15000fe1f49906d00
+9a58504453f212b9189304aa9ac90385
 This file is auto-generated from the Async API modules, - do not edit manually!
 ===============================================================================
 """
 
 from __future__ import annotations
 
-from collections.abc import Iterator, Sequence
-from typing import TYPE_CHECKING, Literal, overload
+import ast
+import asyncio
+import importlib
+import os
+import re
+import sys
+import textwrap
+import warnings
+from collections.abc import AsyncIterator, Callable, Coroutine, Iterator, Sequence
+from inspect import getdoc, getsource, signature
+from multiprocessing import Process, Queue
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from typing import TYPE_CHECKING, Any, Literal, cast, overload
+from zipfile import ZipFile
 
 from cognite.client import AsyncCogniteClient
-from cognite.client._constants import DEFAULT_LIMIT_READ
+from cognite.client._api.functions.utils import _get_function_internal_id
+from cognite.client._api_client import APIClient
+from cognite.client._constants import _RUNNING_IN_BROWSER, DEFAULT_LIMIT_READ
 from cognite.client._sync_api.functions.calls import SyncFunctionCallsAPI
 from cognite.client._sync_api.functions.schedules import SyncFunctionSchedulesAPI
 from cognite.client._sync_api_client import SyncAPIClient
 from cognite.client.data_classes import (
     Function,
     FunctionCall,
+    FunctionFilter,
     FunctionList,
     FunctionsLimits,
     TimestampRange,
@@ -31,10 +47,19 @@ from cognite.client.data_classes.functions import (
     RunTime,
 )
 from cognite.client.utils._async_helpers import SyncIterator, run_sync
+from cognite.client.utils._auxiliary import is_unlimited, split_into_chunks
+from cognite.client.utils._concurrency import _get_event_loop_executor
+from cognite.client.utils._identifier import IdentifierSequence
+from cognite.client.utils._importing import local_import
+from cognite.client.utils._session import create_session_and_return_nonce
+from cognite.client.utils._validation import assert_type
 from cognite.client.utils.useful_types import SequenceNotStr
 
 if TYPE_CHECKING:
+    import pandas as pd
+
     from cognite.client import AsyncCogniteClient
+from cognite.client.config import ClientConfig
 
 
 class SyncFunctionsAPI(SyncAPIClient):

--- a/tests/tests_unit/test_api/test_functions.py
+++ b/tests/tests_unit/test_api/test_functions.py
@@ -729,6 +729,13 @@ class TestRequirementsParser:
         parsed = _validate_and_parse_requirements(["asyncio==3.4.3", "numpy==1.23.0", "pandas==1.4.3"])
         assert parsed == ["asyncio==3.4.3", "numpy==1.23.0", "pandas==1.4.3"]
 
+    def test_validate_requirements_browser_skips_validation_and_warns(self) -> None:
+        invalid_reqs = ["num py==1.23.0"]
+        with patch("cognite.client._api.functions._RUNNING_IN_BROWSER", True):
+            with pytest.warns(UserWarning, match="browser environment"):
+                parsed = _validate_and_parse_requirements(invalid_reqs)
+        assert parsed == invalid_reqs
+
     def test_validate_requirements_error(self) -> None:
         reqs = [["asyncio=3.4.3"], ["num py==1.23.0"], ["pandas==1.4.3 python_version=='3.8'"]]
         for req in reqs:


### PR DESCRIPTION
## Description
 When deploying a function from a browser environment (e.g. a CDF notebook), pip internals are unavailable for client-side requirements validation. We now detect this via _RUNNING_IN_BROWSER, emit a warning to inform the user, and skip client-side validation. Server-side validation still applies.

## Checklist:
- [x] Tests added/updated.
- [x] Documentation updated. Documentation is generated from docstrings - these must be updated according to your change.
  If a new method has been added it should be referenced in [cognite.rst](https://github.com/cognitedata/cognite-sdk-python/blob/master/docs/source/cognite.rst) in order to generate docs based on its docstring.
- [x] The PR title follows the [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) spec.
