### PR TITLE
chore: add a nice repr to CogniteHTTPResponse + tests

### DIFF
--- a/cognite/client/response.py
+++ b/cognite/client/response.py
@@ -118,6 +118,9 @@ class CogniteHTTPResponse:
             self._json_cache = self._response.json()
             return self._json_cache
 
+    def __repr__(self) -> str:
+        return f"<CogniteHTTPResponse [{self.status_code} {self.reason_phrase}]>"
+
     def raise_for_status(self) -> CogniteHTTPResponse:
         """
         Raises a CogniteHTTPStatusError if the response status code is 4xx or 5xx.

--- a/tests/tests_unit/test_http_client.py
+++ b/tests/tests_unit/test_http_client.py
@@ -14,6 +14,7 @@ from cognite.client._http_client import (
     get_global_async_httpx_client,
 )
 from cognite.client.config import global_config
+from cognite.client.response import CogniteHTTPResponse
 
 
 @pytest.fixture
@@ -171,3 +172,21 @@ class TestGetGlobalAsyncHttpxClient:
         assert pool._keepalive_expiry == 5
         assert pool._ssl_context.verify_mode == ssl.CERT_NONE  # disable_ssl should cause this
         assert pool._ssl_context.check_hostname is False
+
+
+def make_response(status_code: int) -> CogniteHTTPResponse:
+    request = httpx.Request("GET", URL)
+    return CogniteHTTPResponse(httpx.Response(status_code=status_code, request=request))
+
+
+class TestCogniteHTTPResponseRepr:
+    @pytest.mark.parametrize(
+        "status_code, expected",
+        [
+            (200, "<CogniteHTTPResponse [200 OK]>"),
+            (404, "<CogniteHTTPResponse [404 Not Found]>"),
+            (500, "<CogniteHTTPResponse [500 Internal Server Error]>"),
+        ],
+    )
+    def test_repr_format(self, status_code: int, expected: str) -> None:
+        assert repr(make_response(status_code)) == expected


### PR DESCRIPTION
Makes interactive usage of the PySDK simpler when you don't have to guess status code