### PR TITLE
feat: allow float timeouts in the clientconfig

### DIFF
--- a/cognite/client/config.py
+++ b/cognite/client/config.py
@@ -190,7 +190,7 @@ class ClientConfig:
         cluster (str | None): The cluster where the CDF project is located. When passed, it is assumed that the base
             URL can be constructed as: ``https://<cluster>.cognitedata.com``. Either base_url or cluster must be provided.
         headers (dict[str, str] | None): Additional headers to add to all requests.
-        timeout (int | None): Timeout on requests sent to the api. Defaults to 60 seconds.
+        timeout (float | None): Timeout on requests sent to the api. Defaults to 60 seconds.
         file_transfer_timeout (int | None): Timeout on file upload/download requests. Defaults to 600 seconds.
         debug (bool): Enables debug logging to stderr. This includes full request/response details and logs regarding retry
             attempts (e.g., on 429 throttling or 5xx errors).
@@ -205,7 +205,7 @@ class ClientConfig:
         base_url: str | None = None,
         cluster: str | None = None,
         headers: dict[str, str] | None = None,
-        timeout: int | None = None,
+        timeout: float | None = None,
         file_transfer_timeout: int | None = None,
         debug: bool = False,
     ) -> None:

--- a/tests/tests_integration/conftest.py
+++ b/tests/tests_integration/conftest.py
@@ -89,6 +89,7 @@ def make_cognite_client() -> CogniteClient:
             project=os.environ["COGNITE_PROJECT"],
             base_url=os.environ["COGNITE_BASE_URL"],
             credentials=credentials,
+            timeout=59.9,  # Test that a non-int timeout works
         )
     )
 


### PR DESCRIPTION
## Description
Change the timeout type hint in the `ClientConfig` to show that non-int, float timouts works.

## Checklist:
- [x] Tests added/updated.
- [x] Documentation updated. Documentation is generated from docstrings - these must be updated according to your change.
  If a new method has been added it should be referenced in [cognite.rst](https://github.com/cognitedata/cognite-sdk-python/blob/master/docs/source/cognite.rst) in order to generate docs based on its docstring.
- [x] The PR title follows the [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) spec.
