### PR TITLE
chore(gitignore): don't track git worktrees

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,9 @@ my_file.txt
 
 # docs
 docs/source/generated/
+
+# git worktrees
+.worktree
+.worktrees
+.claude/worktrees
+.cursor/worktrees


### PR DESCRIPTION
## Description

Git worktrees allows us to have multiple "workspaces" of the same repo. Essentially just branches of the same repo data, that we shouldn't search through or commit as part of our work.