### PR TITLE
chore: `generate_code_snippets.py` script to work with v8 async client

### DIFF
--- a/scripts/generate_code_snippets.py
+++ b/scripts/generate_code_snippets.py
@@ -1,24 +1,40 @@
-import inspect
 import json
 import re
 from collections import defaultdict
 from doctest import DocTestParser, Example
+from functools import cached_property
 
-from cognite.client import ClientConfig, CogniteClient
-from cognite.client._api_client import APIClient
+from cognite.client import ClientConfig
+from cognite.client._basic_api_client import BasicAsyncAPIClient
+from cognite.client._cognite_client import AsyncCogniteClient
 from cognite.client.credentials import Token
+
+_SKIP_DESCRIPTOR_TYPES = (property, cached_property, staticmethod, classmethod)
 
 
 def collect_apis(obj, done):
     if done.get(obj.__class__):
         return []
     done[obj.__class__] = True
-    apis = inspect.getmembers(obj, lambda m: isinstance(m, APIClient) and not done.get(m.__class__))
+    apis = [(n, v) for n, v in vars(obj).items() if isinstance(v, BasicAsyncAPIClient) and not done.get(v.__class__)]
     sub = [(n + "." + sn, sa) for n, c in apis for sn, sa in collect_apis(c, done)]
     return apis + sub
 
 
-client = CogniteClient(ClientConfig(project="_", client_name="_", cluster="_", credentials=Token("_")))
+def iter_methods(api):
+    """Iterate bound methods without triggering class-level properties."""
+    seen = set()
+    for cls in type(api).__mro__:
+        for name, val in cls.__dict__.items():
+            if name in seen:
+                continue
+            seen.add(name)
+            if isinstance(val, _SKIP_DESCRIPTOR_TYPES) or not callable(val):
+                continue
+            yield name, getattr(api, name)
+
+
+client = AsyncCogniteClient(ClientConfig(project="_", client_name="_", cluster="_", credentials=Token("_")))
 parser = DocTestParser()
 
 apis = collect_apis(client, {})
@@ -35,7 +51,7 @@ duplicate_operations = {
 }
 
 for api_name, api in apis:
-    for fun_name, fun in inspect.getmembers(api, predicate=inspect.ismethod):
+    for fun_name, fun in iter_methods(api):
         docstring = fun.__doc__ or ""
         match_link_openapi = re.match(r"`.* <.*?/operation/(.*)>`_", docstring.strip().split("\n")[0])
         if api_name[0] != "_" and fun_name[0] != "_" and match_link_openapi:

--- a/scripts/generate_code_snippets.py
+++ b/scripts/generate_code_snippets.py
@@ -1,3 +1,4 @@
+import inspect
 import json
 import re
 from collections import defaultdict
@@ -23,15 +24,11 @@ def collect_apis(obj, done):
 
 def iter_methods(api):
     """Iterate bound methods without triggering class-level properties."""
-    seen = set()
-    for cls in type(api).__mro__:
-        for name, val in cls.__dict__.items():
-            if name in seen:
-                continue
-            seen.add(name)
-            if isinstance(val, _SKIP_DESCRIPTOR_TYPES) or not callable(val):
-                continue
-            yield name, getattr(api, name)
+    for name in dir(api):
+        val = inspect.getattr_static(api, name)
+        if isinstance(val, _SKIP_DESCRIPTOR_TYPES) or not callable(val):
+            continue
+        yield name, getattr(api, name)
 
 
 client = AsyncCogniteClient(ClientConfig(project="_", client_name="_", cluster="_", credentials=Token("_")))


### PR DESCRIPTION
The official documentation lags very far behind the SDK on Python examples. The script to create the links between "links" and "examples" does not even work after v8 so fix that first 😄 

Added `iter_methods` + `_SKIP_DESCRIPTOR_TYPES` to avoid the nasty surprise that the `OrgAPI` has - cached_property making API calls....