### PR TITLE
fix: don't inject null cursor in _list_generator_raw_responses

### DIFF
--- a/cognite/client/_api_client.py
+++ b/cognite/client/_api_client.py
@@ -253,9 +253,7 @@ class APIClient(BasicAsyncAPIClient):
             if limit and (n_remaining := limit - total_retrieved) < current_limit:
                 current_limit = n_remaining
 
-            params["limit"] = current_limit
-            if next_cursor is not None:
-                params["cursor"] = next_cursor
+
 
             if method == "GET":
                 res = await self._get(url_path=url_path, params=params, headers=headers, semaphore=semaphore)

--- a/cognite/client/_api_client.py
+++ b/cognite/client/_api_client.py
@@ -313,7 +313,9 @@ class APIClient(BasicAsyncAPIClient):
             if limit and (n_remaining := limit - total_retrieved) < current_limit:
                 current_limit = n_remaining
 
-            params.update(limit=current_limit, cursor=next_cursor)
+            params["limit"] = current_limit
+            if next_cursor is not None:
+                params["cursor"] = next_cursor
             if method == "GET":
                 res = await self._get(url_path=url_path, params=params, headers=headers, semaphore=semaphore)
             else:

--- a/cognite/client/_api_client.py
+++ b/cognite/client/_api_client.py
@@ -253,7 +253,9 @@ class APIClient(BasicAsyncAPIClient):
             if limit and (n_remaining := limit - total_retrieved) < current_limit:
                 current_limit = n_remaining
 
-
+            params["limit"] = current_limit
+            if next_cursor is not None:
+                params["cursor"] = next_cursor
 
             if method == "GET":
                 res = await self._get(url_path=url_path, params=params, headers=headers, semaphore=semaphore)

--- a/tests/tests_unit/test_api_client.py
+++ b/tests/tests_unit/test_api_client.py
@@ -999,6 +999,25 @@ class TestStandardList:
         with pytest.raises(AttributeError):
             res2._cognite_client  # type: ignore[attr-defined]
 
+    async def test_list_generator_does_not_send_null_cursor(
+        self, api_client_with_token: APIClient, httpx_mock: HTTPXMock
+    ) -> None:
+        httpx_mock.add_response(
+            method="POST",
+            url=BASE_URL + URL_PATH + "/list",
+            status_code=200,
+            json={"items": [{"x": 1, "y": 2}]},
+        )
+        async for _ in api_client_with_token._list_generator(
+            method="POST",
+            list_cls=SomeResourceListWithClient,
+            resource_cls=SomeResourceWithClient,
+            resource_path=URL_PATH,
+        ):
+            pass
+        body = jsgz_load(httpx_mock.get_requests()[0].content)
+        assert "cursor" not in body
+
     async def test_list_generator_raw_responses_does_not_send_null_cursor(
         self, api_client_with_token: APIClient, httpx_mock: HTTPXMock
     ) -> None:

--- a/tests/tests_unit/test_api_client.py
+++ b/tests/tests_unit/test_api_client.py
@@ -999,6 +999,28 @@ class TestStandardList:
         with pytest.raises(AttributeError):
             res2._cognite_client  # type: ignore[attr-defined]
 
+    async def test_list_generator_raw_responses_does_not_send_null_cursor(
+        self, api_client_with_token: APIClient, httpx_mock: HTTPXMock
+    ) -> None:
+        httpx_mock.add_response(
+            method="POST",
+            url=BASE_URL + URL_PATH + "/list",
+            status_code=200,
+            json={"items": [{"x": 1, "y": 2}]},
+        )
+        responses = [
+            r
+            async for r in api_client_with_token._list_generator_raw_responses(
+                method="POST",
+                settings_forcing_raw_response_loading=["include_typing"],
+                resource_path=URL_PATH,
+                chunk_size=api_client_with_token._LIST_LIMIT,
+            )
+        ]
+        assert len(responses) == 1
+        body = jsgz_load(httpx_mock.get_requests()[0].content)
+        assert "cursor" not in body
+
 
 class TestStandardAggregate:
     async def test_standard_aggregate_OK(self, api_client_with_token: APIClient, httpx_mock: HTTPXMock) -> None:


### PR DESCRIPTION
Mirrors the conditional guard already present in `_list_generator` (lines 257–258 of `_api_client.py`):

```python
# _list_generator — correct
params["limit"] = current_limit
if next_cursor is not None:
    params["cursor"] = next_cursor

# _list_generator_raw_responses — before this fix
params.update(limit=current_limit, cursor=next_cursor)  # always injects "cursor": null
```

Sending `"cursor": null` on the first request breaks cursorless POST endpoints that reject unknown body fields.

🤖 Generated with [Claude Code](https://claude.com/claude-code)