### PR TITLE
fix: parameterize UserList with T_CogniteResource in CogniteResourceList

### DIFF
--- a/cognite/client/_api/datapoints.py
+++ b/cognite/client/_api/datapoints.py
@@ -718,7 +718,7 @@ class DatapointsAPI(APIClient):
 
             # We should never yield an empty chunk, so we filter out empty or exhausted time series from result
             # (need to rebuild to not keep references to those empty in various private "id lookups")
-            dps_lst = dps_lst_cls(list(filter(None, dps_lst)))
+            dps_lst = dps_lst_cls(list(filter(None, dps_lst)))  # type: ignore [arg-type]
             if not any(dps_lst):
                 if alive_queries:
                     continue

--- a/cognite/client/_api/geospatial.py
+++ b/cognite/client/_api/geospatial.py
@@ -296,7 +296,7 @@ class GeospatialAPI(APIClient):
         if chunk_size is not None and (chunk_size < 1 or chunk_size > self._CREATE_LIMIT):
             raise ValueError(f"The chunk_size must be strictly positive and not exceed {self._CREATE_LIMIT}")
         if isinstance(feature, (FeatureList, FeatureWriteList)):
-            feature = list(feature)
+            feature = list(feature)  # type: ignore [assignment]
 
         resource_path = self._feature_resource_path(feature_type_external_id)
         extra_body_fields = {"allowCrsTransformation": "true"} if allow_crs_transformation else {}

--- a/cognite/client/data_classes/_base.py
+++ b/cognite/client/data_classes/_base.py
@@ -240,7 +240,7 @@ class WriteableCogniteResourceWithClientRef(
         raise NotImplementedError
 
 
-class CogniteResourceList(UserList, Generic[T_CogniteResource]):
+class CogniteResourceList(UserList[T_CogniteResource], Generic[T_CogniteResource]):
     _RESOURCE: type[T_CogniteResource]
 
     def __init__(self, resources: Sequence[T_CogniteResource]) -> None:
@@ -257,19 +257,24 @@ class CogniteResourceList(UserList, Generic[T_CogniteResource]):
     @cached_property
     def _id_to_item(self) -> dict[int, T_CogniteResource]:
         if self.data and hasattr(self.data[0], "id"):
-            return {item.id: item for item in self.data if item.id is not None}
+            # T_CogniteResource is not bound to HasInternalId, but concrete subclasses that
+            # use this property always have an `id` attribute. The hasattr guard ensures safety.
+            data = cast(list[Any], self.data)
+            return {item.id: item for item in data if item.id is not None}
         return {}
 
     @cached_property
     def _external_id_to_item(self) -> dict[str, T_CogniteResource]:
         if self.data and hasattr(self.data[0], "external_id"):
-            return {item.external_id: item for item in self.data if item.external_id is not None}
+            data = cast(list[Any], self.data)
+            return {item.external_id: item for item in data if item.external_id is not None}
         return {}
 
     @cached_property
     def _instance_id_to_item(self) -> dict[InstanceId, T_CogniteResource]:
         if self.data and hasattr(self.data[0], "instance_id"):
-            return {item.instance_id: item for item in self.data if item.instance_id is not None}
+            data = cast(list[Any], self.data)
+            return {item.instance_id: item for item in data if item.instance_id is not None}
         return {}
 
     def pop(self, i: int = -1) -> T_CogniteResource:

--- a/cognite/client/data_classes/datapoints.py
+++ b/cognite/client/data_classes/datapoints.py
@@ -1715,15 +1715,15 @@ class LatestDatapointList(CogniteResourceListWithClientRef[LatestDatapoint], IdT
 
     @cached_property
     def _id_to_item(self) -> dict[int, LatestDatapoint | list[LatestDatapoint]]:  # type: ignore [override]
-        return build_id_mapping_with_duplicates(self.data, "id")
+        return build_id_mapping_with_duplicates(self.data, "id")  # type: ignore [type-var]
 
     @cached_property
     def _external_id_to_item(self) -> dict[str, LatestDatapoint | list[LatestDatapoint]]:  # type: ignore [override]
-        return build_id_mapping_with_duplicates(self.data, "external_id")
+        return build_id_mapping_with_duplicates(self.data, "external_id")  # type: ignore [type-var]
 
     @cached_property
     def _instance_id_to_item(self) -> dict[InstanceId, LatestDatapoint | list[LatestDatapoint]]:  # type: ignore [override]
-        return build_id_mapping_with_duplicates(self.data, "instance_id")
+        return build_id_mapping_with_duplicates(self.data, "instance_id")  # type: ignore [type-var]
 
     def get(  # type: ignore [override]
         self,

--- a/cognite/client/utils/_pandas_helpers.py
+++ b/cognite/client/utils/_pandas_helpers.py
@@ -103,7 +103,7 @@ def concat_dps_dataframe_list(
     dfs = [
         pd.DataFrame(
             {i: col.as_array() for i, col in zip(counter, columns)},
-            index=_create_timestamp_index(dps.timestamp, dps.timezone),
+            index=_create_timestamp_index(dps.timestamp, dps.timezone),  # type: ignore [attr-defined]
             copy=False,  # we pass arrays directly for O(1) conversion
         )
         for dps, columns in zip(dps_lst, columns_lst, strict=True)


### PR DESCRIPTION
## Summary

Parameterize the `UserList` base class in `CogniteResourceList` so that `self.data` is properly typed as `list[T_CogniteResource]` instead of `list[Any]`. This eliminates the `Unknown` element type that the unparameterized `UserList` contributed to type inference in strict type checkers.

Relates to #2682

## Change

```python
# Before
class CogniteResourceList(UserList, Generic[T_CogniteResource]): ...

# After
class CogniteResourceList(UserList[T_CogniteResource], Generic[T_CogniteResource]): ...
```

## Mypy regression fixes

The stricter `self.data` typing (`list[T_CogniteResource]` instead of `list[Any]`) surfaced 11 pre-existing type-safety gaps. Each is fixed with a targeted suppression:

| File | Error | Fix |
|------|-------|-----|
| `_base.py` (3 errors) | `T_CogniteResource` has no attribute `id`/`external_id`/`instance_id` | `cast(list[Any], self.data)` - accesses are runtime-guarded by `hasattr()` but `T_CogniteResource` is not bound to these protocols |
| `datapoints.py` (3 errors) | `_T_DPS` type variable cannot be `LatestDatapoint` | `# type: ignore [type-var]` - `LatestDatapoint` is not `Datapoints | DatapointsArray` but has the same interface |
| `_api/datapoints.py` (2 errors) | `filter(None, dps_lst)` incompatible with `Iterable[T | None]` | `# type: ignore [arg-type]` - filter correctly removes None values |
| `_api/geospatial.py` (1 error) | `list(feature)` narrows to `list[FeatureCore]`, incompatible with broader union | `# type: ignore [assignment]` - narrowing is correct within the `isinstance` guard |
| `_pandas_helpers.py` (2 errors) | `.timestamp`/`.timezone` not on `CogniteResource` base | `# type: ignore [attr-defined]` - both `Datapoints` and `DatapointsArray` have these attributes |

## Non-breaking

- All unit tests pass (2,755 passed, 1 skipped)
- mypy reports zero new errors on `cognite/`
- No runtime behavior changes - `UserList[T]` is erased at runtime; only type checkers see the difference
