### PR TITLE
fix: narrow Sequence to Iterable in transformer mixins

### DIFF
--- a/cognite/client/data_classes/_base.py
+++ b/cognite/client/data_classes/_base.py
@@ -838,7 +838,7 @@ class HasExternalAndInternalId(Protocol):
     def id(self) -> int: ...
 
 
-class ExternalIDTransformerMixin(Sequence[HasExternalId], ABC):
+class ExternalIDTransformerMixin(Iterable[HasExternalId], ABC):
     def as_external_ids(self) -> list[str]:
         """
         Returns the external ids of all resources.
@@ -857,7 +857,7 @@ class ExternalIDTransformerMixin(Sequence[HasExternalId], ABC):
         return external_ids
 
 
-class NameTransformerMixin(Sequence[HasName], ABC):
+class NameTransformerMixin(Iterable[HasName], ABC):
     def as_names(self) -> list[str]:
         """
         Returns the names of all resources.
@@ -876,7 +876,7 @@ class NameTransformerMixin(Sequence[HasName], ABC):
         return names
 
 
-class InternalIdTransformerMixin(Sequence[HasInternalId], ABC):
+class InternalIdTransformerMixin(Iterable[HasInternalId], ABC):
     def as_ids(self) -> list[int]:
         """
         Returns the ids of all resources.


### PR DESCRIPTION
Copy of #2686 to allow CI to run with credentials (strict org policy rules re. forks)