### PR TITLE
chore(metering): move metering to Specialized section in index.rst

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -167,7 +167,6 @@ Contents
 
    hosted_extractors
    postgres_gateway
-   metering
 
 .. toctree::
    :maxdepth: 1
@@ -183,6 +182,7 @@ Contents
    unit_catalog
    geospatial
    limits
+   metering
 
 .. toctree::
    :maxdepth: 1


### PR DESCRIPTION
## Summary
- Moves `metering` from the `:caption: Integrations` section to `:caption: Specialized` in `docs/source/index.rst`

Per haakonvt's review comment on #2663.