### PR TITLE
feat(simulators): make clear what is the default value of the sort argument in simulation runs list

### DIFF
--- a/cognite/client/_api/simulators/runs.py
+++ b/cognite/client/_api/simulators/runs.py
@@ -155,7 +155,7 @@ class SimulatorRunsAPI(APIClient):
         model_revision_external_ids: SequenceNotStr[str] | None = None,
         created_time: TimestampRange | None = None,
         simulation_time: TimestampRange | None = None,
-        sort: SimulationRunsSort | None = None,
+        sort: SimulationRunsSort = SimulationRunsSort(),
     ) -> SimulationRunList:
         """`Filter simulation runs <https://api-docs.cognite.com/20230101/tag/Simulation-Runs/operation/filter_simulation_runs_simulators_runs_list_post>`_
 
@@ -173,7 +173,7 @@ class SimulatorRunsAPI(APIClient):
             model_revision_external_ids (SequenceNotStr[str] | None): Filter by model revision external ids
             created_time (TimestampRange | None): Filter by created time
             simulation_time (TimestampRange | None): Filter by simulation time
-            sort (SimulationRunsSort | None): The criteria to sort by.
+            sort (SimulationRunsSort): The criteria to sort by. Defaults to sorting by created time ascending.
 
         Returns:
             SimulationRunList: List of simulation runs
@@ -221,7 +221,7 @@ class SimulatorRunsAPI(APIClient):
             resource_cls=SimulationRun,
             list_cls=SimulationRunList,
             filter=filter_runs.dump(),
-            sort=[SimulationRunsSort.load(sort).dump()] if sort else None,
+            sort=[SimulationRunsSort.load(sort).dump()],
         )
 
     @overload

--- a/cognite/client/_sync_api/simulators/runs.py
+++ b/cognite/client/_sync_api/simulators/runs.py
@@ -1,6 +1,6 @@
 """
 ===============================================================================
-5f32300ea692afe9a855bd627447b49c
+75af8c68eb2fc49e584b9cdd54fc18ea
 This file is auto-generated from the Async API modules, - do not edit manually!
 ===============================================================================
 """
@@ -142,7 +142,7 @@ class SyncSimulatorRunsAPI(SyncAPIClient):
         model_revision_external_ids: SequenceNotStr[str] | None = None,
         created_time: TimestampRange | None = None,
         simulation_time: TimestampRange | None = None,
-        sort: SimulationRunsSort | None = None,
+        sort: SimulationRunsSort = SimulationRunsSort(),
     ) -> SimulationRunList:
         """
         `Filter simulation runs <https://api-docs.cognite.com/20230101/tag/Simulation-Runs/operation/filter_simulation_runs_simulators_runs_list_post>`_
@@ -161,7 +161,7 @@ class SyncSimulatorRunsAPI(SyncAPIClient):
             model_revision_external_ids (SequenceNotStr[str] | None): Filter by model revision external ids
             created_time (TimestampRange | None): Filter by created time
             simulation_time (TimestampRange | None): Filter by simulation time
-            sort (SimulationRunsSort | None): The criteria to sort by.
+            sort (SimulationRunsSort): The criteria to sort by. Defaults to sorting by created time ascending.
 
         Returns:
             SimulationRunList: List of simulation runs


### PR DESCRIPTION
## Description
Make clear what is the default sort order for simulations runs list.

## Checklist:
- [ ] Tests added/updated.
- [x] Documentation updated. Documentation is generated from docstrings - these must be updated according to your change.
  If a new method has been added it should be referenced in [cognite.rst](https://github.com/cognitedata/cognite-sdk-python/blob/master/docs/source/cognite.rst) in order to generate docs based on its docstring.
- [x] The PR title follows the [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) spec.
