### PR TITLE
fix(data workflow tests): cancel running workflow executions before delete

### DIFF
--- a/tests/tests_integration/test_api/test_workflows.py
+++ b/tests/tests_integration/test_api/test_workflows.py
@@ -494,7 +494,6 @@ def _delete_workflow_after_executions_finish(
     last_exc: CogniteAPIError | None = None
     while time.monotonic() < delete_deadline:
         try:
-            cognite_client.workflows.versions.delete(version_id, ignore_unknown_ids=True)
             cognite_client.workflows.delete(workflow_external_id, ignore_unknown_ids=True)
             return
         except CogniteAPIError as exc:

--- a/tests/tests_integration/test_api/test_workflows.py
+++ b/tests/tests_integration/test_api/test_workflows.py
@@ -462,6 +462,47 @@ class TestWorkflows:
         assert persisted_workflow_list._external_id_to_item.keys() <= listed._external_id_to_item.keys()
 
 
+def _delete_workflow_after_executions_finish(
+    cognite_client: CogniteClient,
+    workflow_external_id: str,
+    version_id: WorkflowVersionId,
+    *,
+    timeout: float = 120,
+) -> None:
+    """Cancel running executions and delete once the API allows it (jazz-api#2424)."""
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        running = cognite_client.workflows.executions.list(
+            workflow_version_ids=WorkflowVersionId(workflow_external_id),
+            statuses=["running"],
+            limit=None,
+        )
+        for execution in running:
+            try:
+                cognite_client.workflows.executions.cancel(id=execution.id, reason="integration test cleanup")
+            except CogniteAPIError:
+                pass
+        if not running:
+            break
+        time.sleep(0.5)
+
+    delete_deadline = time.monotonic() + 60
+    last_exc: CogniteAPIError | None = None
+    while time.monotonic() < delete_deadline:
+        try:
+            cognite_client.workflows.versions.delete(version_id, ignore_unknown_ids=True)
+            cognite_client.workflows.delete(workflow_external_id, ignore_unknown_ids=True)
+            return
+        except CogniteAPIError as exc:
+            if "running executions" not in str(exc):
+                raise
+            last_exc = exc
+            time.sleep(1)
+
+    if last_exc is not None:
+        raise last_exc
+
+
 class TestWorkflowVersions:
     @pytest.mark.allow_no_semaphore(
         "Test setup uses simulator fixtures that exercise worker-facing endpoints "
@@ -531,8 +572,11 @@ class TestWorkflowVersions:
 
         finally:
             if created_version is not None:
-                cognite_client.workflows.versions.delete(created_version.as_id())
-                cognite_client.workflows.delete(created_version.workflow_external_id)
+                _delete_workflow_after_executions_finish(
+                    cognite_client,
+                    created_version.workflow_external_id,
+                    created_version.as_id(),
+                )
 
     def test_upsert_preexisting(
         self, cognite_client: CogniteClient, new_workflow_version_test_scoped: WorkflowVersion

--- a/tests/tests_integration/test_api/test_workflows.py
+++ b/tests/tests_integration/test_api/test_workflows.py
@@ -465,7 +465,6 @@ class TestWorkflows:
 def _delete_workflow_after_executions_finish(
     cognite_client: CogniteClient,
     workflow_external_id: str,
-    version_id: WorkflowVersionId,
     *,
     timeout: float = 120,
 ) -> None:
@@ -578,7 +577,6 @@ class TestWorkflowVersions:
                 _delete_workflow_after_executions_finish(
                     cognite_client,
                     created_version.workflow_external_id,
-                    created_version.as_id(),
                 )
 
     def test_upsert_preexisting(

--- a/tests/tests_integration/test_api/test_workflows.py
+++ b/tests/tests_integration/test_api/test_workflows.py
@@ -470,6 +470,7 @@ def _delete_workflow_after_executions_finish(
     timeout: float = 120,
 ) -> None:
     """Cancel running executions and delete once the API allows it (jazz-api#2424)."""
+    cancelled_ids: set[str] = set()
     deadline = time.monotonic() + timeout
     while time.monotonic() < deadline:
         running = cognite_client.workflows.executions.list(
@@ -478,8 +479,11 @@ def _delete_workflow_after_executions_finish(
             limit=None,
         )
         for execution in running:
+            if execution.id in cancelled_ids:
+                continue
             try:
                 cognite_client.workflows.executions.cancel(id=execution.id, reason="integration test cleanup")
+                cancelled_ids.add(execution.id)
             except CogniteAPIError:
                 pass
         if not running:


### PR DESCRIPTION
Fixes flaky teardown in the workflow simulator integration test by waiting for and cancelling running executions before deleting the workflow version and workflow. The API rejects deletes while executions are still running ([jazz-api#2424](https://github.com/cognitedata/cognite-sdk-python/pull/2703)), which caused intermittent cleanup failures in `test_upsert_run_delete_with_simulation_task`.