### PR TITLE
test(simint): clean up stale test models to prevent hitting limit

### DIFF
--- a/tests/tests_integration/test_api/test_simulators/conftest.py
+++ b/tests/tests_integration/test_api/test_simulators/conftest.py
@@ -8,7 +8,6 @@ from pathlib import Path
 import pytest
 
 from cognite.client import AsyncCogniteClient, CogniteClient
-from cognite.client.exceptions import CogniteAPIError
 from cognite.client.data_classes.data_sets import DataSetWrite
 from cognite.client.data_classes.files import FileMetadata
 from cognite.client.data_classes.simulators import (
@@ -21,6 +20,7 @@ from cognite.client.data_classes.simulators import (
     SimulatorRoutineRevisionWrite,
     SimulatorRoutineWrite,
 )
+from cognite.client.exceptions import CogniteAPIError
 from cognite.client.utils._async_helpers import run_sync
 from cognite.client.utils._text import to_snake_case
 from tests.tests_integration.test_api.test_simulators.seed.data import (

--- a/tests/tests_integration/test_api/test_simulators/conftest.py
+++ b/tests/tests_integration/test_api/test_simulators/conftest.py
@@ -168,6 +168,7 @@ def seed_simulator_models(
         if m.external_id
         and m.external_id.startswith("py_sdk_integration_tests_model_")
         and m.external_id != model_unique_external_id
+        and m.created_time is not None
         and m.created_time < two_hours_ago_ms
     ]
     if stale_ids:

--- a/tests/tests_integration/test_api/test_simulators/conftest.py
+++ b/tests/tests_integration/test_api/test_simulators/conftest.py
@@ -8,6 +8,7 @@ from pathlib import Path
 import pytest
 
 from cognite.client import AsyncCogniteClient, CogniteClient
+from cognite.client.exceptions import CogniteAPIError
 from cognite.client.data_classes.data_sets import DataSetWrite
 from cognite.client.data_classes.files import FileMetadata
 from cognite.client.data_classes.simulators import (
@@ -160,15 +161,20 @@ def seed_simulator_models(
     models = cognite_client.simulators.models.list(limit=None)
     model = models.get(external_id=model_unique_external_id)
 
+    two_hours_ago_ms = int(time.time() * 1000) - 2 * 60 * 60 * 1000
     stale_ids = [
         m.external_id
         for m in models
         if m.external_id
         and m.external_id.startswith("py_sdk_integration_tests_model_")
         and m.external_id != model_unique_external_id
+        and m.created_time < two_hours_ago_ms
     ]
     if stale_ids:
-        cognite_client.simulators.models.delete(external_ids=stale_ids)
+        try:
+            cognite_client.simulators.models.delete(external_ids=stale_ids)
+        except CogniteAPIError:
+            pass
 
     if not model:
         new_model = SimulatorModelWrite._load(

--- a/tests/tests_integration/test_api/test_simulators/conftest.py
+++ b/tests/tests_integration/test_api/test_simulators/conftest.py
@@ -160,6 +160,16 @@ def seed_simulator_models(
     models = cognite_client.simulators.models.list(limit=None)
     model = models.get(external_id=model_unique_external_id)
 
+    stale_ids = [
+        m.external_id
+        for m in models
+        if m.external_id
+        and m.external_id.startswith("py_sdk_integration_tests_model_")
+        and m.external_id != model_unique_external_id
+    ]
+    if stale_ids:
+        cognite_client.simulators.models.delete(external_ids=stale_ids)
+
     if not model:
         new_model = SimulatorModelWrite._load(
             {


### PR DESCRIPTION
## Description
Adds a cleanup step in the seed_simulator_models fixture to delete leftover models from prior CI runs before creating a new one. It is to prevent it from hitting limit.

## Checklist:
- [ ] Tests added/updated.
- [ ] Documentation updated. Documentation is generated from docstrings - these must be updated according to your change.
  If a new method has been added it should be referenced in [cognite.rst](https://github.com/cognitedata/cognite-sdk-python/blob/master/docs/source/cognite.rst) in order to generate docs based on its docstring.
- [ ] The PR title follows the [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) spec.
