### PR TITLE
chore(records): reduce concurrency limits

### DIFF
--- a/cognite/client/utils/_concurrency.py
+++ b/cognite/client/utils/_concurrency.py
@@ -426,7 +426,7 @@ class ConcurrencySettings:
             write_schema=1,
         )
         self._files = FileConcurrencyConfig(self, read=4, write=2, upload=5, download=5, delete=2, open_files=15)
-        self._records = RecordsGlobalConcurrencyConfig(self, read=2, write=10)
+        self._records = RecordsGlobalConcurrencyConfig(self, read=1, write=2)
 
     @functools.cached_property
     def _all_concurrency_configs(self) -> list[ConcurrencyConfig]:

--- a/cognite/client/utils/_concurrency.py
+++ b/cognite/client/utils/_concurrency.py
@@ -426,7 +426,7 @@ class ConcurrencySettings:
             write_schema=1,
         )
         self._files = FileConcurrencyConfig(self, read=4, write=2, upload=5, download=5, delete=2, open_files=15)
-        self._records = RecordsGlobalConcurrencyConfig(self, read=4, write=20)
+        self._records = RecordsGlobalConcurrencyConfig(self, read=2, write=10)
 
     @functools.cached_property
     def _all_concurrency_configs(self) -> list[ConcurrencyConfig]:


### PR DESCRIPTION
# Description

Start from a more conservative stand and instead increase the concurrency limits over time as we get more traffic.