### PR TITLE
fix: support Pyodide 314 IN_PYODIDE rename for browser detection

### DIFF
--- a/.github/workflows/verify-jupyter.yml
+++ b/.github/workflows/verify-jupyter.yml
@@ -8,6 +8,14 @@ on:
 jobs:
   build_and_test_jupyter_pyodide:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        # Test against multiple Pyodide releases so breaking changes (e.g. the
+        # pyodide 314 IN_BROWSER -> IN_PYODIDE rename / Python 3.14) are caught:
+        #   0.29.0  -> Python 3.12, used by stlite and older JupyterLite
+        #   314.0.0 -> Python 3.14, used by JupyterLite 0.8.0+
+        pyodide-version: ["0.29.0", "314.0.0"]
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
@@ -23,7 +31,7 @@ jobs:
         with:
           node-version: "24"
       - name: Install dependencies
-        run: npm install pyodide@0.29.0 # JupyterLite currently using pyodide 0.29.0
+        run: npm install pyodide@${{ matrix.pyodide-version }}
       - name: Install cognite-sdk in pyodide environment
         run: |
           whl_file=$(find dist -name "*.whl" | sed 's|^dist/||') # Find the built wheel file, remove dist/ prefix

--- a/cognite/client/_constants.py
+++ b/cognite/client/_constants.py
@@ -3,8 +3,12 @@ from __future__ import annotations
 from typing import Literal
 
 try:
-    from pyodide.ffi import IN_BROWSER  # type: ignore [import-not-found]
-except ModuleNotFoundError:
+    import pyodide.ffi  # type: ignore [import-not-found]
+
+    # Pyodide 314 renamed `pyodide.ffi.IN_BROWSER` to `IN_PYODIDE` (pyodide#5916).
+    # Support both names, and use getattr so a missing attribute raises no error.
+    IN_BROWSER = bool(getattr(pyodide.ffi, "IN_PYODIDE", getattr(pyodide.ffi, "IN_BROWSER", False)))
+except ImportError:
     IN_BROWSER = False
 
 try:

--- a/scripts/test-pyodide.js
+++ b/scripts/test-pyodide.js
@@ -38,15 +38,16 @@ server.listen(PORT, () => {
     await pyodide.loadPackage("micropip");
     const micropip = pyodide.pyimport("micropip");
 
-    // TEMPORARY WORKAROUND (added 2026-04-19, auto-disables 2026-05-03):
-    // authlib 1.7+ requires cryptography>=45.0.1, which has no pure-Python wheel;
-    // the streamlit-pinned Pyodide 0.26.2 only ships cryptography 43.x, so
-    // micropip resolution fails. Preload Pyodide's built cryptography and cap
-    // authlib below 1.7 to satisfy the transitive requirement. Revisit once
-    // stlite bumps to a Pyodide release that ships cryptography>=45.0.1
-    // (Pyodide 0.29.0 already does). After the expiry date, the workaround is
-    // skipped — if it's still needed the install will fail loudly.
-    if (new Date() < new Date("2026-07-04")) {
+    // authlib 1.7+ requires cryptography>=45.0.1, which has no pure-Python wheel.
+    // Older Pyodide releases (e.g. stlite's 0.26.2) only ship cryptography 43.x,
+    // so micropip resolution fails. On those runtimes, preload Pyodide's bundled
+    // cryptography and cap authlib below 1.7 to satisfy the transitive requirement.
+    // Pyodide >= 0.29 ships cryptography>=45.0.1, so the workaround is skipped there
+    // (and for the 314.x line / Python 3.14).
+    const [pyMajor, pyMinor] = pyodide.version.split(".").map(Number);
+    const needsCryptographyWorkaround = pyMajor === 0 && pyMinor < 29;
+    if (needsCryptographyWorkaround) {
+      console.log(`Applying cryptography workaround for Pyodide ${pyodide.version}`);
       await pyodide.loadPackage(["cryptography", "ssl"]);
       await micropip.install("authlib<1.7");
     }

--- a/tests/tests_unit/test_constants.py
+++ b/tests/tests_unit/test_constants.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+import importlib
+import sys
+import types
+
+import pytest
+
+import cognite.client._constants as constants
+
+
+@pytest.fixture
+def restore_constants():
+    # Reload after each test so the real (pyodide-absent) module state is
+    # restored and other tests are not affected by the simulated environment.
+    yield
+    importlib.reload(constants)
+
+
+def _reload_with_fake_pyodide_ffi(monkeypatch: pytest.MonkeyPatch, ffi_attrs: dict[str, bool]) -> types.ModuleType:
+    """Reload ``cognite.client._constants`` with a fake ``pyodide.ffi`` module."""
+    pyodide_mod = types.ModuleType("pyodide")
+    ffi_mod = types.ModuleType("pyodide.ffi")
+    for name, value in ffi_attrs.items():
+        setattr(ffi_mod, name, value)
+    pyodide_mod.ffi = ffi_mod  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "pyodide", pyodide_mod)
+    monkeypatch.setitem(sys.modules, "pyodide.ffi", ffi_mod)
+    return importlib.reload(constants)
+
+
+class TestBrowserDetection:
+    @pytest.mark.parametrize(
+        ("ffi_attrs", "expected"),
+        [
+            # Pyodide >= 314 renamed IN_BROWSER to IN_PYODIDE (pyodide#5916).
+            pytest.param({"IN_PYODIDE": True}, True, id="pyodide-314-in_pyodide-true"),
+            pytest.param({"IN_PYODIDE": False}, False, id="pyodide-314-in_pyodide-false"),
+            # Pyodide < 314 still exposes the old IN_BROWSER name.
+            pytest.param({"IN_BROWSER": True}, True, id="old-pyodide-in_browser-true"),
+            pytest.param({"IN_BROWSER": False}, False, id="old-pyodide-in_browser-false"),
+            # If both are present (transitional), the new name wins.
+            pytest.param({"IN_PYODIDE": True, "IN_BROWSER": False}, True, id="prefers-in_pyodide"),
+            # Defensive: pyodide.ffi present but neither flag exposed.
+            pytest.param({}, False, id="ffi-present-neither-name"),
+        ],
+    )
+    def test_detects_browser_across_pyodide_versions(
+        self, monkeypatch: pytest.MonkeyPatch, restore_constants: None, ffi_attrs: dict[str, bool], expected: bool
+    ) -> None:
+        reloaded = _reload_with_fake_pyodide_ffi(monkeypatch, ffi_attrs)
+        assert reloaded.IN_BROWSER is expected
+        assert reloaded._RUNNING_IN_BROWSER is expected
+
+    def test_not_in_browser_when_pyodide_absent(self, monkeypatch: pytest.MonkeyPatch, restore_constants: None) -> None:
+        # Setting the modules to None makes `import pyodide.ffi` raise ImportError,
+        # mirroring a non-pyodide (regular CPython) environment.
+        monkeypatch.setitem(sys.modules, "pyodide", None)
+        monkeypatch.setitem(sys.modules, "pyodide.ffi", None)
+        reloaded = importlib.reload(constants)
+        assert reloaded.IN_BROWSER is False
+        assert reloaded._RUNNING_IN_BROWSER is False

--- a/tests/tests_unit/test_constants.py
+++ b/tests/tests_unit/test_constants.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import importlib
 import sys
 import types
+from collections.abc import Iterator
 
 import pytest
 
@@ -10,23 +11,23 @@ import cognite.client._constants as constants
 
 
 @pytest.fixture
-def restore_constants():
+def restore_constants() -> Iterator[None]:
     # Reload after each test so the real (pyodide-absent) module state is
     # restored and other tests are not affected by the simulated environment.
     yield
     importlib.reload(constants)
 
 
-def _reload_with_fake_pyodide_ffi(monkeypatch: pytest.MonkeyPatch, ffi_attrs: dict[str, bool]) -> types.ModuleType:
+def _reload_with_fake_pyodide_ffi(monkeypatch: pytest.MonkeyPatch, ffi_attrs: dict[str, bool]) -> None:
     """Reload ``cognite.client._constants`` with a fake ``pyodide.ffi`` module."""
     pyodide_mod = types.ModuleType("pyodide")
     ffi_mod = types.ModuleType("pyodide.ffi")
     for name, value in ffi_attrs.items():
         setattr(ffi_mod, name, value)
-    pyodide_mod.ffi = ffi_mod  # type: ignore[attr-defined]
+    setattr(pyodide_mod, "ffi", ffi_mod)
     monkeypatch.setitem(sys.modules, "pyodide", pyodide_mod)
     monkeypatch.setitem(sys.modules, "pyodide.ffi", ffi_mod)
-    return importlib.reload(constants)
+    importlib.reload(constants)
 
 
 class TestBrowserDetection:
@@ -46,17 +47,21 @@ class TestBrowserDetection:
         ],
     )
     def test_detects_browser_across_pyodide_versions(
-        self, monkeypatch: pytest.MonkeyPatch, restore_constants: None, ffi_attrs: dict[str, bool], expected: bool
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        restore_constants: None,
+        ffi_attrs: dict[str, bool],
+        expected: bool,
     ) -> None:
-        reloaded = _reload_with_fake_pyodide_ffi(monkeypatch, ffi_attrs)
-        assert reloaded.IN_BROWSER is expected
-        assert reloaded._RUNNING_IN_BROWSER is expected
+        _reload_with_fake_pyodide_ffi(monkeypatch, ffi_attrs)
+        assert constants.IN_BROWSER is expected
+        assert constants._RUNNING_IN_BROWSER is expected
 
     def test_not_in_browser_when_pyodide_absent(self, monkeypatch: pytest.MonkeyPatch, restore_constants: None) -> None:
-        # Setting the modules to None makes `import pyodide.ffi` raise ImportError,
-        # mirroring a non-pyodide (regular CPython) environment.
-        monkeypatch.setitem(sys.modules, "pyodide", None)
-        monkeypatch.setitem(sys.modules, "pyodide.ffi", None)
-        reloaded = importlib.reload(constants)
-        assert reloaded.IN_BROWSER is False
-        assert reloaded._RUNNING_IN_BROWSER is False
+        # A plain (non-package) pyodide module makes `import pyodide.ffi` raise
+        # ModuleNotFoundError, mirroring a regular (non-pyodide) CPython runtime.
+        monkeypatch.setitem(sys.modules, "pyodide", types.ModuleType("pyodide"))
+        monkeypatch.delitem(sys.modules, "pyodide.ffi", raising=False)
+        importlib.reload(constants)
+        assert constants.IN_BROWSER is False
+        assert constants._RUNNING_IN_BROWSER is False


### PR DESCRIPTION
## Summary
Fixes browser/Pyodide detection under **Pyodide 314**, which broke `from cognite.client import CogniteClient` in JupyterLite / browser environments.

Pyodide 314 renamed `pyodide.ffi.IN_BROWSER` → `IN_PYODIDE` ([pyodide#5916](https://github.com/pyodide/pyodide/pull/5916)). `cognite/client/_constants.py` imported the old name and only guarded against `ModuleNotFoundError`:

```python
try:
    from pyodide.ffi import IN_BROWSER
except ModuleNotFoundError:
    IN_BROWSER = False
```

Because `pyodide.ffi` still exists and only the *name* is gone, Python raises `ImportError` (not `ModuleNotFoundError`), so it propagates and crashes at import time:

```
ImportError: cannot import name 'IN_BROWSER' from 'pyodide.ffi'
```

## Fix
Import the `pyodide.ffi` module and read the flag via `getattr`, preferring the new `IN_PYODIDE` name and falling back to the old `IN_BROWSER`, all under a single `ImportError` guard:

```python
try:
    import pyodide.ffi

    IN_BROWSER = bool(getattr(pyodide.ffi, "IN_PYODIDE", getattr(pyodide.ffi, "IN_BROWSER", False)))
except ImportError:
    IN_BROWSER = False
```

This works across old and new Pyodide versions and outside Pyodide entirely.

## Regression coverage
This slipped through because the real Pyodide smoke test (`verify-jupyter` / `scripts/test-pyodide.js`) was pinned to `pyodide@0.29.0`. Added two layers of coverage:

1. **Unit test** `tests/tests_unit/test_constants.py` — reloads `_constants` against simulated `pyodide.ffi` modules exposing:
   | Simulated environment | Expected `IN_BROWSER` |
   | --- | --- |
   | Pyodide 314 (`IN_PYODIDE=True` / `False`) | `True` / `False` |
   | Older Pyodide (`IN_BROWSER=True` / `False`) | `True` / `False` |
   | Both names present (transitional) | `True` (prefers `IN_PYODIDE`) |
   | `pyodide.ffi` present, neither name | `False` |
   | Pyodide not installed | `False` |

   Runs across the full Python **3.10–3.14** unit-test matrix.

2. **Pyodide-version matrix** in `verify-jupyter.yml` — the real in-browser `from cognite.client import CogniteClient` smoke test now runs against both `pyodide@0.29.0` (Python 3.12) and `pyodide@314.0.0` (Python 3.14), so future breaking renames are caught in a real runtime.

## Test plan
- [x] Verified all detection scenarios pass in isolation
- [ ] CI green (incl. new unit tests on 3.10–3.14 and both Pyodide versions)

## Context
Discovered while upgrading Cognite's JupyterLite distribution to Pyodide 314 (JupyterLite 0.8.0). A temporary shim currently restores `pyodide.ffi.IN_BROWSER` in the kernel; this SDK fix lets that shim be removed.

Made with [Cursor](https://cursor.com)