### PR TITLE
feat(SimInt): Add `delete_oldest` option to model revision creation

### DIFF
--- a/cognite/client/_api/simulators/models_revisions.py
+++ b/cognite/client/_api/simulators/models_revisions.py
@@ -220,18 +220,25 @@ class SimulatorModelRevisionsAPI(APIClient):
             yield item
 
     @overload
-    async def create(self, items: SimulatorModelRevisionWrite) -> SimulatorModelRevision: ...
+    async def create(
+        self, items: SimulatorModelRevisionWrite, delete_oldest: bool = False
+    ) -> SimulatorModelRevision: ...
 
     @overload
-    async def create(self, items: Sequence[SimulatorModelRevisionWrite]) -> SimulatorModelRevisionList: ...
+    async def create(
+        self, items: Sequence[SimulatorModelRevisionWrite], delete_oldest: bool = False
+    ) -> SimulatorModelRevisionList: ...
 
     async def create(
-        self, items: SimulatorModelRevisionWrite | Sequence[SimulatorModelRevisionWrite]
+        self,
+        items: SimulatorModelRevisionWrite | Sequence[SimulatorModelRevisionWrite],
+        delete_oldest: bool = False,
     ) -> SimulatorModelRevision | SimulatorModelRevisionList:
         """`Create simulator model revisions <https://api-docs.cognite.com/20230101-beta/tag/Simulator-Models/operation/create_simulator_model_revision_simulators_models_revisions_post>`_
 
         Args:
             items (SimulatorModelRevisionWrite | Sequence[SimulatorModelRevisionWrite]): The model revision(s) to create.
+            delete_oldest (bool): When true, deletes the oldest revisions for the model, keeping only the newest revisions up to the per model limit.
 
         Returns:
             SimulatorModelRevision | SimulatorModelRevisionList: Created simulator model revision(s)
@@ -268,6 +275,9 @@ class SimulatorModelRevisionsAPI(APIClient):
                 ...     ),
                 ... ]
                 >>> res = client.simulators.models.revisions.create(revisions)
+
+            Create a new simulator model revision, deleting the oldest revision if the per-model limit is reached:
+                >>> res = client.simulators.models.revisions.create(revisions, delete_oldest=True)
         """
         assert_type(items, "simulator_model_revision", [SimulatorModelRevisionWrite, Sequence])
 
@@ -276,6 +286,7 @@ class SimulatorModelRevisionsAPI(APIClient):
             resource_cls=SimulatorModelRevision,
             items=items,
             input_resource_cls=SimulatorModelRevisionWrite,
+            extra_body_fields={"deleteOldest": delete_oldest},
         )
 
     async def retrieve_data(self, model_revision_external_id: str) -> SimulatorModelRevisionDataList:

--- a/cognite/client/_sync_api/simulators/models_revisions.py
+++ b/cognite/client/_sync_api/simulators/models_revisions.py
@@ -136,7 +136,11 @@ class SyncSimulatorModelRevisionsAPI(SyncAPIClient):
                 ...     external_ids=["revision1", "revision2"]
                 ... )
         """
-        return run_sync(self.__async_client.simulators.models.revisions.retrieve(ids=ids, external_ids=external_ids))
+        return run_sync(
+            self.__async_client.simulators.models.revisions.retrieve(  # type: ignore [call-overload]
+                ids=ids, external_ids=external_ids
+            )
+        )
 
     @overload
     def __call__(

--- a/cognite/client/_sync_api/simulators/models_revisions.py
+++ b/cognite/client/_sync_api/simulators/models_revisions.py
@@ -1,6 +1,6 @@
 """
 ===============================================================================
-47e322bfcfd2d8e68861dbb683a9a381
+4a274f2368e47ba6916476d30269cace
 This file is auto-generated from the Async API modules, - do not edit manually!
 ===============================================================================
 """
@@ -136,11 +136,7 @@ class SyncSimulatorModelRevisionsAPI(SyncAPIClient):
                 ...     external_ids=["revision1", "revision2"]
                 ... )
         """
-        return run_sync(
-            self.__async_client.simulators.models.revisions.retrieve(  # type: ignore [call-overload]
-                ids=ids, external_ids=external_ids
-            )
-        )
+        return run_sync(self.__async_client.simulators.models.revisions.retrieve(ids=ids, external_ids=external_ids))
 
     @overload
     def __call__(
@@ -206,19 +202,22 @@ class SyncSimulatorModelRevisionsAPI(SyncAPIClient):
         )  # type: ignore [misc]
 
     @overload
-    def create(self, items: SimulatorModelRevisionWrite) -> SimulatorModelRevision: ...
+    def create(self, items: SimulatorModelRevisionWrite, delete_oldest: bool = False) -> SimulatorModelRevision: ...
 
     @overload
-    def create(self, items: Sequence[SimulatorModelRevisionWrite]) -> SimulatorModelRevisionList: ...
+    def create(
+        self, items: Sequence[SimulatorModelRevisionWrite], delete_oldest: bool = False
+    ) -> SimulatorModelRevisionList: ...
 
     def create(
-        self, items: SimulatorModelRevisionWrite | Sequence[SimulatorModelRevisionWrite]
+        self, items: SimulatorModelRevisionWrite | Sequence[SimulatorModelRevisionWrite], delete_oldest: bool = False
     ) -> SimulatorModelRevision | SimulatorModelRevisionList:
         """
         `Create simulator model revisions <https://api-docs.cognite.com/20230101-beta/tag/Simulator-Models/operation/create_simulator_model_revision_simulators_models_revisions_post>`_
 
         Args:
             items (SimulatorModelRevisionWrite | Sequence[SimulatorModelRevisionWrite]): The model revision(s) to create.
+            delete_oldest (bool): When true, deletes the oldest revisions for the model, keeping only the newest revisions up to the per model limit.
 
         Returns:
             SimulatorModelRevision | SimulatorModelRevisionList: Created simulator model revision(s)
@@ -255,8 +254,13 @@ class SyncSimulatorModelRevisionsAPI(SyncAPIClient):
                 ...     ),
                 ... ]
                 >>> res = client.simulators.models.revisions.create(revisions)
+
+            Create a new simulator model revision, deleting the oldest revision if the per-model limit is reached:
+                >>> res = client.simulators.models.revisions.create(revisions, delete_oldest=True)
         """
-        return run_sync(self.__async_client.simulators.models.revisions.create(items=items))
+        return run_sync(
+            self.__async_client.simulators.models.revisions.create(items=items, delete_oldest=delete_oldest)
+        )
 
     def retrieve_data(self, model_revision_external_id: str) -> SimulatorModelRevisionDataList:
         """

--- a/tests/tests_unit/test_api/test_simulators/test_model_revisions.py
+++ b/tests/tests_unit/test_api/test_simulators/test_model_revisions.py
@@ -20,65 +20,11 @@ TEST_MODEL_REVISION_ITEM_RESPONSE_FIELDS = {
 
 class TestModelRevisions:
     @pytest.mark.parametrize(
-        "write_input,delete_oldest,expected_request_body",
+        "delete_kw",
         [
-            pytest.param(
-                SimulatorModelRevisionWrite(
-                    external_id="sdk-test-revision",
-                    model_external_id="sdk-test-model",
-                    file_id=1,
-                ),
-                False,
-                {
-                    "deleteOldest": False,
-                    "items": [
-                        {
-                            "externalId": "sdk-test-revision",
-                            "modelExternalId": "sdk-test-model",
-                            "fileId": 1,
-                        }
-                    ],
-                },
-                id="create_model_revision_default_delete_oldest",
-            ),
-            pytest.param(
-                SimulatorModelRevisionWrite(
-                    external_id="sdk-test-revision",
-                    model_external_id="sdk-test-model",
-                    file_id=1,
-                ),
-                True,
-                {
-                    "deleteOldest": True,
-                    "items": [
-                        {
-                            "externalId": "sdk-test-revision",
-                            "modelExternalId": "sdk-test-model",
-                            "fileId": 1,
-                        }
-                    ],
-                },
-                id="create_model_revision_with_delete_oldest",
-            ),
-            pytest.param(
-                SimulatorModelRevisionWrite(
-                    external_id="sdk-test-revision",
-                    model_external_id="sdk-test-model",
-                    file_id=1,
-                ),
-                None,
-                {
-                    "deleteOldest": False,
-                    "items": [
-                        {
-                            "externalId": "sdk-test-revision",
-                            "modelExternalId": "sdk-test-model",
-                            "fileId": 1,
-                        }
-                    ],
-                },
-                id="create_model_revision_omits_delete_oldest",
-            ),
+            pytest.param({"delete_oldest": True}, id="create_model_revision_with_delete_oldest"),
+            pytest.param({"delete_oldest": False}, id="create_model_revision_without_delete_oldest"),
+            pytest.param({}, id="create_model_revision_omits_delete_oldest"),
         ],
     )
     def test_create_model_revision(
@@ -86,10 +32,13 @@ class TestModelRevisions:
         cognite_client: CogniteClient,
         async_client: AsyncCogniteClient,
         httpx_mock: HTTPXMock,
-        write_input: SimulatorModelRevisionWrite,
-        delete_oldest: bool | None,
-        expected_request_body: dict,
+        delete_kw: dict,
     ) -> None:
+        write_input = SimulatorModelRevisionWrite(
+            external_id="sdk-test-revision",
+            model_external_id="sdk-test-model",
+            file_id=1,
+        )
         httpx_mock.add_response(
             method="POST",
             url=get_url(async_client.simulators.models.revisions, "/simulators/models/revisions"),
@@ -104,12 +53,11 @@ class TestModelRevisions:
             status_code=201,
         )
 
-        if delete_oldest is None:
-            created_revision = cognite_client.simulators.models.revisions.create(write_input)
-        else:
-            created_revision = cognite_client.simulators.models.revisions.create(
-                write_input, delete_oldest=delete_oldest
-            )
+        created_revision = cognite_client.simulators.models.revisions.create(write_input, **delete_kw)
 
         assert isinstance(created_revision, SimulatorModelRevision)
+        expected_request_body = {
+            "deleteOldest": delete_kw.get("delete_oldest", False),
+            "items": [write_input.dump()],
+        }
         assert expected_request_body == jsgz_load(httpx_mock.get_requests()[0].content)

--- a/tests/tests_unit/test_api/test_simulators/test_model_revisions.py
+++ b/tests/tests_unit/test_api/test_simulators/test_model_revisions.py
@@ -1,0 +1,115 @@
+import pytest
+from pytest_httpx import HTTPXMock
+
+from cognite.client import AsyncCogniteClient, CogniteClient
+from cognite.client.data_classes.simulators import SimulatorModelRevision, SimulatorModelRevisionWrite
+from tests.utils import get_url, jsgz_load
+
+TEST_MODEL_REVISION_ITEM_RESPONSE_FIELDS = {
+    "id": 1,
+    "dataSetId": 1,
+    "simulatorExternalId": "TestSim",
+    "createdByUserId": "test-user",
+    "status": "unknown",
+    "versionNumber": 1,
+    "logId": 1,
+    "createdTime": 1,
+    "lastUpdatedTime": 1,
+}
+
+
+class TestModelRevisions:
+    @pytest.mark.parametrize(
+        "write_input,delete_oldest,expected_request_body",
+        [
+            pytest.param(
+                SimulatorModelRevisionWrite(
+                    external_id="sdk-test-revision",
+                    model_external_id="sdk-test-model",
+                    file_id=1,
+                ),
+                False,
+                {
+                    "deleteOldest": False,
+                    "items": [
+                        {
+                            "externalId": "sdk-test-revision",
+                            "modelExternalId": "sdk-test-model",
+                            "fileId": 1,
+                        }
+                    ],
+                },
+                id="create_model_revision_default_delete_oldest",
+            ),
+            pytest.param(
+                SimulatorModelRevisionWrite(
+                    external_id="sdk-test-revision",
+                    model_external_id="sdk-test-model",
+                    file_id=1,
+                ),
+                True,
+                {
+                    "deleteOldest": True,
+                    "items": [
+                        {
+                            "externalId": "sdk-test-revision",
+                            "modelExternalId": "sdk-test-model",
+                            "fileId": 1,
+                        }
+                    ],
+                },
+                id="create_model_revision_with_delete_oldest",
+            ),
+            pytest.param(
+                SimulatorModelRevisionWrite(
+                    external_id="sdk-test-revision",
+                    model_external_id="sdk-test-model",
+                    file_id=1,
+                ),
+                None,
+                {
+                    "deleteOldest": False,
+                    "items": [
+                        {
+                            "externalId": "sdk-test-revision",
+                            "modelExternalId": "sdk-test-model",
+                            "fileId": 1,
+                        }
+                    ],
+                },
+                id="create_model_revision_omits_delete_oldest",
+            ),
+        ],
+    )
+    def test_create_model_revision(
+        self,
+        cognite_client: CogniteClient,
+        async_client: AsyncCogniteClient,
+        httpx_mock: HTTPXMock,
+        write_input: SimulatorModelRevisionWrite,
+        delete_oldest: bool | None,
+        expected_request_body: dict,
+    ) -> None:
+        httpx_mock.add_response(
+            method="POST",
+            url=get_url(async_client.simulators.models.revisions, "/simulators/models/revisions"),
+            json={
+                "items": [
+                    {
+                        **TEST_MODEL_REVISION_ITEM_RESPONSE_FIELDS,
+                        **write_input.dump(),
+                    }
+                ]
+            },
+            status_code=201,
+        )
+
+        if delete_oldest is None:
+            created_revision = cognite_client.simulators.models.revisions.create(write_input)
+        else:
+            created_revision = cognite_client.simulators.models.revisions.create(
+                write_input, delete_oldest=delete_oldest
+            )
+
+        assert isinstance(created_revision, SimulatorModelRevision)
+        assert expected_request_body == jsgz_load(httpx_mock.get_requests()[0].content)


### PR DESCRIPTION
## Description
Adds a `delete_oldest` parameter to `client.simulators.models.revisions.create()`, matching the `deleteOldest` flag added on the create model revision API. When `True`, the API deletes the oldest revision(s) for a model if the per-model revision limit has been reached, enabling rolling revision cleanup instead of failing the create call.

## Checklist:
- [ ] Tests added/updated.
- [ ] Documentation updated. Documentation is generated from docstrings - these must be updated according to your change.
  If a new method has been added it should be referenced in [cognite.rst](https://github.com/cognitedata/cognite-sdk-python/blob/master/docs/source/cognite.rst) in order to generate docs based on its docstring.
- [ ] The PR title follows the [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) spec.
