### PR TITLE
ci: only publish docs for released versions (DM-3216)

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -8,6 +8,9 @@ build:
   tools:
     python: "3.10"
   jobs:
+    post_checkout:
+      # Publish docs for the latest release, not for unreleased commits on master
+      - bash ./scripts/rtd_checkout_released_version.sh
     post_create_environment:
       - pip install poetry
     post_install:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -177,7 +177,13 @@ make html
 Open `build/html/index.html` to look at the result.
 
 Documentation will be automatically generated from the google-style docstrings in the source code.
-It is then built and released when changes are merged into master.
+
+The [published documentation](https://cognite-sdk-python.readthedocs-hosted.com) always describes the most
+recent release, never unreleased changes on master: Read the Docs runs
+`scripts/rtd_checkout_released_version.sh` before building, which checks out the release tag matching
+`.release-please-manifest.json`. Your merged docstring changes therefore go live when the release-please
+PR that includes them is merged. Read the Docs also builds a preview for every pull request, and that
+preview does build your branch as-is.
 
 ### Release version conventions
 

--- a/scripts/rtd_checkout_released_version.sh
+++ b/scripts/rtd_checkout_released_version.sh
@@ -1,0 +1,46 @@
+# Read the Docs builds the 'latest' version from the tip of master, which holds commits
+# that are merged but not yet released. Check out the most recent release tag instead so
+# that the published documentation never describes an unreleased version of the SDK.
+#
+# Meant to run as a post_checkout job in .readthedocs.yaml. Tag builds and pull request
+# previews are left alone: they should document the ref they were triggered for.
+set -e
+
+if [ -z "$READTHEDOCS_VERSION" ] || [ -z "$READTHEDOCS_VERSION_TYPE" ]; then
+    echo "READTHEDOCS_VERSION and READTHEDOCS_VERSION_TYPE must be set, are we on Read the Docs?" >&2
+    exit 1
+fi
+
+if [ "$READTHEDOCS_VERSION_TYPE" != "branch" ] || [ "$READTHEDOCS_VERSION" != "latest" ]; then
+    echo "Nothing to do for $READTHEDOCS_VERSION_TYPE version '$READTHEDOCS_VERSION'."
+    exit 0
+fi
+
+released_version=$(sed -n 's/^[[:space:]]*"\.":[[:space:]]*"\(.*\)".*/\1/p' .release-please-manifest.json)
+if [ -z "$released_version" ]; then
+    echo "Could not read the released version from .release-please-manifest.json." >&2
+    exit 1
+fi
+
+# release-please tags releases as '<package-name>-v<version>'; match on the version alone so
+# a change to the tag template does not silently leave us building unreleased code.
+set +e
+matching_refs=$(git ls-remote --tags origin "*v$released_version")
+ls_remote_status=$?
+set -e
+if [ $ls_remote_status -ne 0 ]; then
+    echo "Failed to list remote tags (git ls-remote exited with $ls_remote_status)." >&2
+    exit $ls_remote_status
+fi
+
+tag=$(echo "$matching_refs" | sed -n 's|^[0-9a-f]*[[:space:]]*refs/tags/\([^^]*\)$|\1|p' | sed -n 1p)
+if [ -z "$tag" ]; then
+    # release-please creates the tag shortly after merging its release PR, so a missing tag
+    # means we are building that release commit already. The next build picks up the tag.
+    echo "No tag for version $released_version yet, building the current commit."
+    exit 0
+fi
+
+echo "Building documentation for released version $released_version (tag $tag)."
+git fetch --depth 1 origin "refs/tags/$tag:refs/tags/$tag"
+git checkout --force "$tag"


### PR DESCRIPTION
## Description

Read the Docs builds the `latest` version from the tip of `master` on every push. Since we moved to automatic releases with release-please, `master` accumulates merged-but-unreleased commits, so https://cognite-sdk-python.readthedocs-hosted.com/en/latest/ has been documenting APIs that are not on PyPI yet. There is also no released-docs version to fall back on today: our tags are named `cognite-sdk-python-v8.10.0`, which Read the Docs cannot parse as semver, so it never created a `stable` version.

This adds a `post_checkout` job that points the `latest` build at the most recent release instead:

- The released version is read from `.release-please-manifest.json` and the matching remote tag is checked out. Using the manifest rather than "newest tag wins" is what avoids docs lagging a release behind: the manifest bump *is* the release commit, so when release-please's PR merges and the tag has not been created yet, the current commit already is the released code and the script leaves it alone. Any later push to master rewinds to the release tag.
- Pull request previews and tag builds are untouched, so reviewers still get a preview of the branch as-is.
- Both failure modes (unreadable manifest, unreachable remote) fail the build rather than quietly falling back to publishing `master`.

No Read the Docs dashboard changes are needed, and all existing `/en/latest/` links keep working. We may optionally want to disable RTD's "you are reading the latest/development version" addon notification, since `latest` now means released.

Verified locally against a throwaway shallow clone that mimics RTD's checkout: the `latest` build moves from `master` (10 unreleased commits) to the 8.10.0 release commit; PR preview and tag builds skip; a not-yet-created tag keeps the current commit; missing RTD env vars exit 1; an unreachable remote exits 128.

Note that the RTD preview build on this PR takes the `external` path and therefore does not exercise the override. After merging, trigger a `latest` build and check the log for `Building documentation for released version 8.10.0 (tag cognite-sdk-python-v8.10.0)`.

## Checklist:
- [ ] Tests added/updated.
- [x] Documentation updated. Documentation is generated from docstrings - these must be updated according to your change.
- [x] The PR title follows the [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) spec.

Made with [Cursor](https://cursor.com)