### PR TITLE
fix(tests): use real function id in workflow version list fixture

### DIFF
--- a/tests/tests_integration/test_api/test_workflows.py
+++ b/tests/tests_integration/test_api/test_workflows.py
@@ -234,7 +234,9 @@ def async_workflow_version(
     yield from _new_async_workflow_version(cognite_client, new_workflow, a_function)
 
 
-def _new_workflow_version_list(cognite_client: CogniteClient, new_workflow: Workflow) -> Iterator[WorkflowVersionList]:
+def _new_workflow_version_list(
+    cognite_client: CogniteClient, new_workflow: Workflow, a_function: Function
+) -> Iterator[WorkflowVersionList]:
     version_1 = WorkflowVersionUpsert(
         workflow_external_id=new_workflow.external_id,
         version="1",
@@ -262,7 +264,7 @@ def _new_workflow_version_list(cognite_client: CogniteClient, new_workflow: Work
                             WorkflowTask(
                                 external_id="s1-task1",
                                 parameters=FunctionTaskParameters(
-                                    external_id="non-existing-function",
+                                    external_id=get_or_raise(a_function.external_id),
                                     data={"a": 3, "b": 4},
                                     is_async_complete=True,
                                 ),
@@ -299,15 +301,17 @@ def _new_workflow_version_list(cognite_client: CogniteClient, new_workflow: Work
 
 
 @pytest.fixture(scope="session")
-def workflow_version_list(cognite_client: CogniteClient, new_workflow: Workflow) -> Iterator[WorkflowVersionList]:
-    yield from _new_workflow_version_list(cognite_client, new_workflow)
+def workflow_version_list(
+    cognite_client: CogniteClient, new_workflow: Workflow, a_function: Function
+) -> Iterator[WorkflowVersionList]:
+    yield from _new_workflow_version_list(cognite_client, new_workflow, a_function)
 
 
 @pytest.fixture
 def workflow_version_list_test_scoped(
-    cognite_client: CogniteClient, new_workflow_test_scoped: Workflow
+    cognite_client: CogniteClient, new_workflow_test_scoped: Workflow, a_function: Function
 ) -> Iterator[WorkflowVersionList]:
-    yield from _new_workflow_version_list(cognite_client, new_workflow_test_scoped)
+    yield from _new_workflow_version_list(cognite_client, new_workflow_test_scoped, a_function)
 
 
 def _new_workflow_execution_list(


### PR DESCRIPTION
## Description
The backend now validates that a FunctionTaskParameters external_id references an existing function on workflow version upsert, so the dummy "non-existing-function" id caused test_list_workflow_versions to fail. Use the session-scoped `a_function` fixture instead, matching the pattern already used by _new_async_workflow_version.

## Checklist:
- [X] Tests added/updated.
- [] Documentation updated. Documentation is generated from docstrings - these must be updated according to your change.
  If a new method has been added it should be referenced in [cognite.rst](https://github.com/cognitedata/cognite-sdk-python/blob/master/docs/source/cognite.rst) in order to generate docs based on its docstring.
- [X] The PR title follows the [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) spec.
