### PR TITLE
fix: Retrieving routine revision with zero valued input or empty timeseries external ID in the configuration (#2470)

### DIFF
--- a/cognite/client/data_classes/simulators/routine_revisions.py
+++ b/cognite/client/data_classes/simulators/routine_revisions.py
@@ -81,11 +81,17 @@ class SimulatorRoutineInput(CogniteObject, ABC):
         if isinstance(resource, SimulatorRoutineInput):
             return cast(Self, resource)
 
-        is_constant = resource.get("value")
-        is_timeseries = resource.get("sourceExternalId")
-        type_ = "constant" if is_constant else "timeseries" if is_timeseries else None
-        if type_ is None:
+        is_constant = resource.get("value") is not None
+        is_timeseries = resource.get("sourceExternalId") is not None
+        if is_constant and is_timeseries:
+            raise ValueError("Invalid routine input, cannot contain both 'value' and 'sourceExternalId'")
+        elif is_constant:
+            type_ = "constant"
+        elif is_timeseries:
+            type_ = "timeseries"
+        else:
             return UnknownCogniteObject(resource)  # type: ignore[return-value]
+
         input_class = _INPUT_CLASS_BY_TYPE.get(type_)
         if input_class is None:
             return UnknownCogniteObject(resource)  # type: ignore[return-value]

--- a/tests/tests_integration/test_api/test_datapoints.py
+++ b/tests/tests_integration/test_api/test_datapoints.py
@@ -1810,7 +1810,7 @@ class TestRetrieveAggregateDatapointsAPI:
                         ignore_unknown_ids=random.choice((True, False)),
                     )
                 assert exc.value.code == 400
-                assert exc.value.message == "Aggregates are not supported for string time series"
+                assert exc.value.message == "Aggregates are not supported for string time series on this endpoint"
 
     @pytest.mark.parametrize("granularity, lower_lim, upper_lim", (("h", 30, 1000), ("d", 1, 200)))
     def test_granularity_invariants(

--- a/tests/tests_unit/test_data_classes/test_simulators.py
+++ b/tests/tests_unit/test_data_classes/test_simulators.py
@@ -494,7 +494,7 @@ class TestSimulationRunWrite:
 
 class TestSimulatorRoutineInput:
     def test_load_zero_value(self) -> None:
-        # Bug prior to SDK version 8.10.1 would load a value of 0 as UnknownCogniteObject/UnknownCogniteResource
+        # Bug prior to SDK version 7.94.2 and between 8.0 and 8.10 would load a value of 0 as UnknownCogniteObject/UnknownCogniteResource
         routine_input = SimulatorRoutineInput._load(
             {"name": "input", "referenceId": "input", "value": 0, "valueType": "DOUBLE"}
         )
@@ -502,7 +502,7 @@ class TestSimulatorRoutineInput:
         assert routine_input.value == 0
 
     def test_load_empty_string_source_external_id(self) -> None:
-        # Bug prior to SDK version 8.10.1 would load an empty string sourceExternalId as UnknownCogniteObject/UnknownCogniteResource
+        # Bug prior to SDK version 7.94.2 and between 8.0 and 8.10 would load an empty string sourceExternalId as UnknownCogniteObject/UnknownCogniteResource
         routine_input = SimulatorRoutineInput._load({"name": "input", "referenceId": "input", "sourceExternalId": ""})
         assert isinstance(routine_input, SimulatorRoutineInputTimeseries)
         assert routine_input.source_external_id == ""

--- a/tests/tests_unit/test_data_classes/test_simulators.py
+++ b/tests/tests_unit/test_data_classes/test_simulators.py
@@ -11,6 +11,7 @@ from cognite.client.data_classes.simulators.models import (
 from cognite.client.data_classes.simulators.routine_revisions import (
     SimulationValueUnitInput,
     SimulatorRoutineConfiguration,
+    SimulatorRoutineInput,
     SimulatorRoutineInputConstant,
     SimulatorRoutineInputTimeseries,
     SimulatorRoutineOutput,
@@ -489,3 +490,26 @@ class TestSimulationRunWrite:
             SimulationRunWrite(
                 routine_revision_external_id="routine_revision_external_id_1",
             )
+
+
+class TestSimulatorRoutineInput:
+    def test_load_zero_value(self) -> None:
+        # Bug prior to SDK version 8.10.1 would load a value of 0 as UnknownCogniteObject/UnknownCogniteResource
+        routine_input = SimulatorRoutineInput._load(
+            {"name": "input", "referenceId": "input", "value": 0, "valueType": "DOUBLE"}
+        )
+        assert isinstance(routine_input, SimulatorRoutineInputConstant)
+        assert routine_input.value == 0
+
+    def test_load_empty_string_source_external_id(self) -> None:
+        # Bug prior to SDK version 8.10.1 would load an empty string sourceExternalId as UnknownCogniteObject/UnknownCogniteResource
+        routine_input = SimulatorRoutineInput._load({"name": "input", "referenceId": "input", "sourceExternalId": ""})
+        assert isinstance(routine_input, SimulatorRoutineInputTimeseries)
+        assert routine_input.source_external_id == ""
+
+    def test_load_both_value_and_time_series(self) -> None:
+        with pytest.raises(
+            ValueError,
+            match="Invalid routine input, cannot contain both 'value' and 'sourceExternalId'",
+        ):
+            SimulatorRoutineInput._load({"name": "input", "referenceId": "input", "sourceExternalId": "", "value": 0})


### PR DESCRIPTION
## Description
Same as #2470 

## Checklist:
- [x] Tests added/updated.
- [ ] Documentation updated. Documentation is generated from docstrings - these must be updated according to your change.
  If a new method has been added it should be referenced in [cognite.rst](https://github.com/cognitedata/cognite-sdk-python/blob/master/docs/source/cognite.rst) in order to generate docs based on its docstring.
- [x] The PR title follows the [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) spec.
