### PR TITLE
feat(ACLs): Add missing acl: slaAcl

### DIFF
--- a/cognite/client/data_classes/capabilities.py
+++ b/cognite/client/data_classes/capabilities.py
@@ -1534,6 +1534,19 @@ class SimulatorsAcl(Capability):
 
 
 @dataclass
+class SlaAcl(Capability):
+    _capability_name = "slaAcl"
+    actions: Sequence[Action]
+    scope: AllScope = field(default_factory=AllScope)
+
+    class Action(Capability.Action):  # type: ignore [misc]
+        Read = "READ"
+
+    class Scope:
+        All = AllScope
+
+
+@dataclass
 class LegacyModelHostingAcl(LegacyCapability):
     _capability_name = "modelHostingAcl"
     actions: Sequence[Action]

--- a/tests/tests_unit/test_data_classes/test_capabilities.py
+++ b/tests/tests_unit/test_data_classes/test_capabilities.py
@@ -152,6 +152,7 @@ def all_acls() -> Iterator[dict[str, Any]]:
         {"sessionsAcl": {"actions": ["LIST", "CREATE", "DELETE"], "scope": {"all": {}}}},
         {"simulatorsAcl": {"actions": ["READ", "WRITE", "DELETE", "RUN", "MANAGE"], "scope": {"all": {}}}},
         {"simulatorsAcl": {"actions": ["READ", "WRITE"], "scope": {"datasetScope": {"ids": ["123", "456"]}}}},
+        {"slaAcl": {"actions": ["READ"], "scope": {"all": {}}}},
         {"streamsAcl": {"actions": ["READ"], "scope": {"all": {}}}},
         {"streamsAcl": {"actions": ["CREATE", "DELETE"], "scope": {"all": {}}}},
         {"streamRecordsAcl": {"actions": ["READ", "WRITE"], "scope": {"all": {}}}},


### PR DESCRIPTION
## Description

Adds the `slaAcl` capability (read-only, `AllScope`-only), mirroring the existing `cogUnitsAcl` exactly (same precedent commit: #2693).

`slaAcl` gates read access to `sla.*` meter entries in the Metering API. The schema was added to `groups.yml`/`token.yml` in [cognitedata/service-contracts#3322](https://github.com/cognitedata/service-contracts/pull/3322) (merged), and the capability itself is defined and enforced in the infrastructure monorepo (proto, limit-service, gandalf-auth) in [cognitedata/infrastructure#37081](https://github.com/cognitedata/infrastructure/pull/37081) (merged).

Until this merges and a new SDK version is released, callers can use `UnknownAcl` as a workaround:

```python
from cognite.client.data_classes.capabilities import UnknownAcl

sla_read_capability = UnknownAcl(
    capability_name="slaAcl",
    actions=None,
    scope=None,
    raw_data={"slaAcl": {"actions": ["READ"], "scope": {"all": {}}}},
    allow_unknown=True,
)
```
