### PR TITLE
fix(records): point at as_id() when delete receives records

### DIFF
--- a/cognite/client/data_classes/data_modeling/records.py
+++ b/cognite/client/data_classes/data_modeling/records.py
@@ -20,12 +20,26 @@ from cognite.client.data_classes.data_modeling.instances import TypeInformation
 from cognite.client.utils._identifier import IdentifierSequenceCore
 from cognite.client.utils._identifier import RecordId as RecordId  # explicit re-export
 
+_RECORD_ID_HINT = (
+    "Records are identified by RecordId(space=..., external_id=...); call record.as_id() or "
+    "record_list.as_ids() to convert records you have already fetched."
+)
+
 
 class RecordIdSequence(IdentifierSequenceCore[RecordId]):
     @classmethod
     def load(cls, items: RecordId | Sequence[RecordId]) -> RecordIdSequence:
         if isinstance(items, RecordId):
             return cls([items], is_singleton=True)
+        if isinstance(items, str) or not isinstance(items, Sequence):
+            raise TypeError(
+                f"'items' must be RecordId or a sequence of RecordId, not {type(items).__name__}. {_RECORD_ID_HINT}"
+            )
+        if invalid := [item for item in items if not isinstance(item, RecordId)]:
+            raise TypeError(
+                f"'items' must be RecordId or a sequence of RecordId, but got an entry of type "
+                f"{type(invalid[0]).__name__}. {_RECORD_ID_HINT}"
+            )
         return cls(list(items), is_singleton=False)
 
 

--- a/tests/tests_unit/test_api/test_data_modeling/test_records.py
+++ b/tests/tests_unit/test_api/test_data_modeling/test_records.py
@@ -947,3 +947,24 @@ class TestRecordDTOs:
         assert record.status == "deleted"
         assert record.properties is None
         assert "properties" not in record.dump()
+
+
+class TestRecordsAPIDeleteIdentifiers:
+    """Records fetched from the API are a plausible thing to hand straight back to delete()."""
+
+    def test_delete_rejects_records(self, cognite_client: CogniteClient, stream_id: str) -> None:
+        record = Record(space="sp", external_id="rec-1", created_time=1, last_updated_time=2)
+        with pytest.raises(TypeError, match="as_id"):
+            cognite_client.data_modeling.records.delete([record], stream_id=stream_id)  # type: ignore[list-item]
+
+    def test_delete_rejects_record_list(self, cognite_client: CogniteClient, stream_id: str) -> None:
+        records = RecordList([Record(space="sp", external_id="rec-1", created_time=1, last_updated_time=2)])
+        with pytest.raises(TypeError, match="as_ids"):
+            cognite_client.data_modeling.records.delete(records, stream_id=stream_id)
+
+    @pytest.mark.parametrize("bad_items", ["rec-1", [{"space": "sp", "externalId": "rec-1"}]])
+    def test_delete_rejects_non_record_ids(
+        self, cognite_client: CogniteClient, stream_id: str, bad_items: object
+    ) -> None:
+        with pytest.raises(TypeError, match="'items' must be RecordId"):
+            cognite_client.data_modeling.records.delete(bad_items, stream_id=stream_id)  # type: ignore[arg-type]


### PR DESCRIPTION
Handing `delete()` the records you just fetched is a plausible mistake, and the error points at SDK internals instead of at the conversion you need:

```python
records = client.data_modeling.records.filter(stream_id=STREAM_ID)
client.data_modeling.records.delete(records, stream_id=STREAM_ID)
# AttributeError: 'Record' object has no attribute 'as_dict'
```

`RecordIdSequence.load` now checks what it was given and raises TypeError naming `RecordId` and the `as_id()` / `as_ids()` conversions. Same for a list of dicts or a bare external-id string.

First commit is the failing tests, second is the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
