### PR TITLE
fix(records): reject two lower or two upper bounds in TimeRange

### DIFF
--- a/cognite/client/data_classes/data_modeling/records.py
+++ b/cognite/client/data_classes/data_modeling/records.py
@@ -256,6 +256,10 @@ class TimeRange(CogniteResource):
         lte: int | str | None = None,
         lt: int | str | None = None,
     ) -> None:
+        if gte is not None and gt is not None:
+            raise ValueError("Provide at most one lower bound: 'gte' or 'gt', not both.")
+        if lte is not None and lt is not None:
+            raise ValueError("Provide at most one upper bound: 'lte' or 'lt', not both.")
         self.gte = gte
         self.gt = gt
         self.lte = lte

--- a/tests/tests_unit/test_api/test_data_modeling/test_records.py
+++ b/tests/tests_unit/test_api/test_data_modeling/test_records.py
@@ -947,3 +947,15 @@ class TestRecordDTOs:
         assert record.status == "deleted"
         assert record.properties is None
         assert "properties" not in record.dump()
+
+
+class TestTimeRangeBounds:
+    @pytest.mark.parametrize(
+        "kwargs", [{"gte": 1, "gt": 2}, {"lte": 1, "lt": 2}, {"gte": 1, "gt": 2, "lt": 3, "lte": 4}]
+    )
+    def test_time_range_rejects_two_bounds_on_the_same_side(self, kwargs: dict) -> None:
+        with pytest.raises(ValueError, match=r"lower|upper"):
+            TimeRange(**kwargs)
+
+    def test_time_range_allows_one_bound_on_each_side(self) -> None:
+        assert TimeRange(gt=1, lte=2).dump() == {"gt": 1, "lte": 2}

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -49,6 +49,7 @@ from cognite.client.data_classes.data_modeling.query import (
     Select,
     SelectSync,
 )
+from cognite.client.data_classes.data_modeling.records import TimeRange
 from cognite.client.data_classes.data_modeling.views import View
 from cognite.client.data_classes.datapoint_aggregates import (
     ALL_SORTED_DP_AGGS,
@@ -401,6 +402,10 @@ class FakeCogniteResourceGenerator:
             key = self._random_string(15)
             keyword_arguments["with_"] = {key: self.create_instance(NodeResultSetExpressionSync)}
             keyword_arguments["select"] = {key: self.create_instance(SelectSync)}
+        elif resource_cls is TimeRange:
+            # A TimeRange takes at most one lower ('gte' or 'gt') and one upper ('lte' or 'lt') bound
+            keyword_arguments.pop("gt", None)
+            keyword_arguments.pop("lt", None)
         elif resource_cls is Relationship and not skip_defaulted_args:
             # Relationship must set the source and target type consistently with the source and target
             keyword_arguments["source_type"] = type(keyword_arguments["source"]).__name__


### PR DESCRIPTION
The API rejects a range carrying both `gte` and `gt` (or both `lte` and `lt`), and the `TimeRange` docstring already says so, but the constructor builds it anyway and the request only fails server-side:

```python
TimeRange(gte=1, gt=2).dump()   # {'gte': 1, 'gt': 2}
```

Now a ValueError at construction, where the mistake is.

The fake resource generator behind the generic round-trip tests fills every field, so it gets a special case — the same way `DataPointSubscriptionWrite` already has one for its mutually exclusive arguments. That change ships here, otherwise `test_base.py` breaks the moment this merges.

First commit is the failing tests, second is the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
