### PR TITLE
chore: enable ruff rule for mutable default arguments

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -98,7 +98,7 @@ exclude = ["cognite/client/_proto"]
 [tool.ruff.lint]
 # See https://beta.ruff.rs/docs/rules for an overview of ruff rules
 ignore = ["E731", "E501", "W605", "RUF059"]
-select = ["E", "W", "F", "I", "T", "RUF", "TID", "UP", "TC005"]
+select = ["E", "W", "F", "I", "T", "RUF", "TID", "UP", "TC005", "B006"]
 fixable = ["E", "W", "F", "I", "T", "RUF", "TID", "UP", "TC005"]
 # These are used by pydoclint and we don't want 100 warnings:
 external = ["DOC"]


### PR DESCRIPTION
## Description
Enable ruff rule to dissallow mutrable default arguments. Based on discussion in #2695

## Checklist:
- [ ] Tests added/updated.
- [ ] Documentation updated. Documentation is generated from docstrings - these must be updated according to your change.
  If a new method has been added it should be referenced in [cognite.rst](https://github.com/cognitedata/cognite-sdk-python/blob/master/docs/source/cognite.rst) in order to generate docs based on its docstring.
- [x] The PR title follows the [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) spec.
