### PR TITLE
chore(tests): attempt to fix flaky doctests test

### DIFF
--- a/tests/tests_unit/test_meta.py
+++ b/tests/tests_unit/test_meta.py
@@ -17,7 +17,7 @@ from cognite.client.data_classes._base import (
 from cognite.client.data_classes.datapoints import DatapointsArrayList, DatapointsList
 from cognite.client.data_classes.principals import PrincipalList
 from cognite.client.utils._url import NON_IDEMPOTENT_POST_ENDPOINT_REGEX_PATTERN
-from tests.utils import all_concrete_subclasses, all_subclasses
+from tests.utils import all_concrete_subclasses, all_subclasses, dict_without
 
 
 def test_assert_no_root_init_file() -> None:
@@ -122,6 +122,18 @@ def test_POST_endpoint_idempotency_vs_retries(api: str, apis_matching_non_idempo
             "You'll need to either remove it from the whitelist or from "
             "NON_IDEMPOTENT_POST_ENDPOINT_REGEX_PATTERN."
         )
+
+
+def test_dict_without() -> None:
+    # Was previously a doctest on dict_without itself, but pytest's built-in --doctest-modules
+    # collection of it was a source of rare, very confusing CI flakes. Moved here as a plain test.
+    a = {"foo": "bar", "bar": "baz", "zip": "zap"}
+    b = dict_without(a, {"foo", "bar"})
+    assert b == {"zip": "zap"}
+
+    b["foo"] = "not bar"
+    # Should be unaffected: dict_without returns a copy
+    assert a == {"foo": "bar", "bar": "baz", "zip": "zap"}
 
 
 def test_constants_are_importable() -> None:

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -317,16 +317,7 @@ V = TypeVar("V")
 
 
 def dict_without(input_dict: Mapping[K, V], without_keys: collections.abc.Set[str]) -> dict[K, V]:
-    """Copy `input_dict`, but exclude the keys in `without_keys`.
-
-    >>> a = {"foo": "bar", "bar": "baz", "zip": "zap"}
-    >>> b = dict_without(a, {"foo", "bar"})
-    >>> b
-    {'zip': 'zap'}
-    >>> b["foo"] = "not bar"
-    >>> a
-    {'foo': 'bar', 'bar': 'baz', 'zip': 'zap'}
-    """
+    """Copy `input_dict`, but exclude the keys in `without_keys`"""
     return {k: v for k, v in input_dict.items() if k not in without_keys}
 
 


### PR DESCRIPTION
CI occasionally failed with a confusing `UNEXPECTED EXCEPTION: NameError("name 'dict_without' is not defined")`:

```
=========================== short test summary info ============================
FAILED tests/utils.py::tests.utils.dict_without - 319 Copy `input_dict`, but exclude the keys in `without_keys`.
320 
321     >>> a = {"foo": "bar", "bar": "baz", "zip": "zap"}
322     >>> b = dict_without(a, {"foo", "bar"})
UNEXPECTED EXCEPTION: NameError("name 'dict_without' is not defined")
Traceback (most recent call last):
  File "/opt/hostedtoolcache/Python/3.11.15/x64/lib/python3.11/doctest.py", line 1355, in __run
    exec(compile(example.source, filename, "single",
  File "<doctest tests.utils.dict_without[1]>", line 1, in <module>
NameError: name 'dict_without' is not defined
/home/runner/work/cognite-sdk-python/cognite-sdk-python/tests/utils.py:322: UnexpectedException
= 1 failed, 6756 passed, 50 skipped, 1 xpassed, 58 warnings, 2 rerun in 211.60s (0:03:31) =
Error: Process completed with exit code 1.
```

Example link: https://github.com/cognitedata/cognite-sdk-python/actions/runs/30624787459/job/91138993416?pr=2730

`tests/utils.py::dict_without` was the only doctest left anywhere under `tests/` still going through pytest's built-in `--doctest-modules` collection. Everything else in the SDK already tests docstring examples via the `doctest.DocTestSuite` + `TextTestRunner` pattern in `test_docstring_examples.py`, specifically to avoid this kind of fragility under our `xdist` setup (`-n8 --dist loadscope --reruns 2`).

This PR converts the doctest into a plain assert-based test (`test_dict_without` in `test_meta.py`) assuming this was the culprit.