### PR TITLE
docs: fix poisition of some data classes pages in the docs

### DIFF
--- a/docs/source/data_ingestion.rst
+++ b/docs/source/data_ingestion.rst
@@ -72,7 +72,7 @@ Extraction pipeline configs
    AsyncCogniteClient.extraction_pipelines.config
 
 Extraction pipelines data classes
---------------------------------
+---------------------------------
 .. automodule:: cognite.client.data_classes.extractionpipelines
     :members:
     :show-inheritance:

--- a/docs/source/data_ingestion.rst
+++ b/docs/source/data_ingestion.rst
@@ -71,8 +71,8 @@ Extraction pipeline configs
 
    AsyncCogniteClient.extraction_pipelines.config
 
-Extractor Config Data classes
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Extraction pipelines data classes
+--------------------------------
 .. automodule:: cognite.client.data_classes.extractionpipelines
     :members:
     :show-inheritance:

--- a/docs/source/data_workflows.rst
+++ b/docs/source/data_workflows.rst
@@ -54,7 +54,7 @@ Workflow Triggers
 
 
 Data Workflows data classes
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+---------------------------
 .. automodule:: cognite.client.data_classes.workflows
     :members:
     :show-inheritance:

--- a/docs/source/functions.rst
+++ b/docs/source/functions.rst
@@ -30,7 +30,7 @@ Function schedules
    AsyncCogniteClient.functions.schedules
 
 Data classes
-^^^^^^^^^^^^
+------------
 .. automodule:: cognite.client.data_classes.functions
     :members:
     :show-inheritance:

--- a/docs/source/postgres_gateway.rst
+++ b/docs/source/postgres_gateway.rst
@@ -21,7 +21,7 @@ Postgres Gateway Tables API
    AsyncCogniteClient.postgres_gateway.tables
 
 Postgres Gateway classes
-^^^^^^^^^^^^^^^^^^^^^^^^^
+------------------------
 .. automodule:: cognite.client.data_classes.postgres_gateway
     :members:
     :show-inheritance:

--- a/docs/source/sequences.rst
+++ b/docs/source/sequences.rst
@@ -22,7 +22,7 @@ Rows
    AsyncCogniteClient.sequences.data
 
 Sequence Data classes
-^^^^^^^^^^^^^^^^^^^^^
+---------------------
 .. automodule:: cognite.client.data_classes.sequences
     :members:
     :show-inheritance:

--- a/docs/source/unit_catalog.rst
+++ b/docs/source/unit_catalog.rst
@@ -21,7 +21,7 @@ Unit Systems
    AsyncCogniteClient.units.systems
 
 Unit data classes
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+-----------------
 .. automodule:: cognite.client.data_classes.units
     :members:
     :show-inheritance:


### PR DESCRIPTION
## Description
Some of the data classes pages had the wrong position in the table of contents.

Before: 

<img width="493" height="597" alt="image" src="https://github.com/user-attachments/assets/bca38ab4-5f69-4a2a-b8ec-d3565e669517" />

After:

<img width="440" height="336" alt="image" src="https://github.com/user-attachments/assets/9044f233-d1f0-452c-8c2c-3528b6e200cb" />


## Checklist:
- [ ] Tests added/updated.
- [x] Documentation updated. Documentation is generated from docstrings - these must be updated according to your change.
  If a new method has been added it should be referenced in [cognite.rst](https://github.com/cognitedata/cognite-sdk-python/blob/master/docs/source/cognite.rst) in order to generate docs based on its docstring.
- [x] The PR title follows the [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) spec.
