### PR TITLE
ci: use plain version tags so Read the Docs can version releases (DM-3216)

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
+  "include-component-in-tag": false,
   "packages": {
     ".": {
       "release-type": "python",


### PR DESCRIPTION
## Description

Set `"include-component-in-tag": false` so release tags become `v8.13.0` instead of `cognite-sdk-python-v8.13.0`.

Read the Docs cannot parse the current tag format as a version, so no release can be activated as a docs version. The project only has `latest` (built from `master`), meaning users always read docs for unreleased code. With plain tags we can activate release versions on RTD and make `stable` the default.

Notes:
- The tag`v8.12.0` has been pushed manually at the commit`d7806bd` as the lookup anchor. Without it Release Please would fall back to the leftover `v7.89.0` and generate a release PR with ~730 commits. The next release PR should contain only the six entries from #2746.
- The release PR branch name also drops the component, so #2746 will be superseded by a new PR and should be closed manually.

Follow-ups: activate versions and set default to `stable` on RTD (needs admin access), then update the README badge/links that are hardcoded to `/en/latest/`.

## Checklist:
- [ ] Tests added/updated.
- [ ] Documentation updated. Documentation is generated from docstrings - these must be updated according to your change.
  If a new method has been added it should be referenced in [cognite.rst](https://github.com/cognitedata/cognite-sdk-python/blob/master/docs/source/cognite.rst) in order to generate docs based on its docstring.
- [x] The PR title follows the [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) spec.