### PR TITLE
chore(release-please): hide docs commits from changelog

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -7,6 +7,20 @@
       "package-name": "cognite-sdk-python",
       "extra-files": [
         "cognite/client/_version.py"
+      ],
+      "changelog-sections": [
+        { "type": "feat", "section": "Features" },
+        { "type": "fix", "section": "Bug Fixes" },
+        { "type": "perf", "section": "Performance Improvements" },
+        { "type": "deps", "section": "Dependencies" },
+        { "type": "revert", "section": "Reverts" },
+        { "type": "docs", "section": "Documentation", "hidden": true },
+        { "type": "style", "section": "Styles", "hidden": true },
+        { "type": "chore", "section": "Miscellaneous Chores", "hidden": true },
+        { "type": "refactor", "section": "Code Refactoring", "hidden": true },
+        { "type": "test", "section": "Tests", "hidden": true },
+        { "type": "build", "section": "Build System", "hidden": true },
+        { "type": "ci", "section": "Continuous Integration", "hidden": true }
       ]
     }
   }


### PR DESCRIPTION
Override `changelog-sections` to the same defaults as the "python release-type" strategy uses, but with docs hidden

The `changelog-sections` option, when given, overrides the default. There is no option to just override:
`{ "type": "docs", "section": "Documentation", "hidden": true }`

The list is most likely static for the forseeable future, so simply copying it in here should be just fine.