### PR TITLE
fix(SyntaxWarning): Fix unnecessary SyntaxWarning in SyncApi (docstring not marked as r(aw))

### DIFF
--- a/cognite/client/_api/data_modeling/instances.py
+++ b/cognite/client/_api/data_modeling/instances.py
@@ -1864,7 +1864,7 @@ class InstancesAPI(APIClient):
                 ...     backup_on_exit=True,
                 ... )
                 >>> def do_work(nodes: NodeList) -> None:
-                ...     print(len(nodes))  # ¯\_(ツ)_/¯
+                ...     print(len(nodes))
                 >>>
                 >>> async with session:  # doctest: +SKIP
                 ...     await session.sync_until_live()

--- a/cognite/client/_sync_api/data_modeling/instances.py
+++ b/cognite/client/_sync_api/data_modeling/instances.py
@@ -1,6 +1,6 @@
 """
 ===============================================================================
-c0fa2584c449180c323f8b8b94af8789
+8119eac43b13e45670dd42119b853c41
 This file is auto-generated from the Async API modules, - do not edit manually!
 ===============================================================================
 """
@@ -1358,7 +1358,7 @@ class SyncInstancesAPI(SyncAPIClient):
                 ...     backup_on_exit=True,
                 ... )
                 >>> def do_work(nodes: NodeList) -> None:
-                ...     print(len(nodes))  # ¯\_(ツ)_/¯
+                ...     print(len(nodes))
                 >>>
                 >>> async with session:  # doctest: +SKIP
                 ...     await session.sync_until_live()


### PR DESCRIPTION
Just there for the memes (my bad ofc.. 🙄 ). Thanks to @ks93 for "noticing enough to be annoyed" 🙏 

<img width="2386" height="306" alt="image" src="https://github.com/user-attachments/assets/2a06ca9a-2caa-4a8c-aa39-09d607b1cfd9" />
