### PR TITLE
fix(data_classes): invalidate CogniteResourceList lookups on mutation

### DIFF
--- a/cognite/client/data_classes/_base.py
+++ b/cognite/client/data_classes/_base.py
@@ -304,7 +304,7 @@ class CogniteResourceList(UserList, Generic[T_CogniteResource]):
         return item
 
     def __setitem__(self, i: SupportsIndex | slice, item: T_CogniteResource | Iterable[T_CogniteResource]) -> None:
-        super().__setitem__(i, item)  # type: ignore[index, assignment]
+        super().__setitem__(i, item)  # type: ignore[index]
         self._clear_identifier_lookups()
 
     def __delitem__(self, i: SupportsIndex | slice) -> None:

--- a/cognite/client/data_classes/_base.py
+++ b/cognite/client/data_classes/_base.py
@@ -303,17 +303,20 @@ class CogniteResourceList(UserList, Generic[T_CogniteResource]):
         self._clear_identifier_lookups()
         return item
 
-    def __setitem__(self, i: Any, item: Any) -> None:
-        super().__setitem__(i, item)
+    def __setitem__(self, i: SupportsIndex | slice, item: T_CogniteResource | Iterable[T_CogniteResource]) -> None:
+        super().__setitem__(i, item)  # type: ignore[index, assignment]
         self._clear_identifier_lookups()
 
-    def __delitem__(self, i: Any) -> None:
+    def __delitem__(self, i: SupportsIndex | slice) -> None:
         super().__delitem__(i)
         self._clear_identifier_lookups()
 
-    def __iadd__(self: T_CogniteResourceList, other: Iterable[Any]) -> T_CogniteResourceList:
-        super().__iadd__(other)
-        self._clear_identifier_lookups()
+    def __iadd__(  # type: ignore[misc]
+        self: T_CogniteResourceList, other: Iterable[T_CogniteResource]
+    ) -> T_CogniteResourceList:
+        # Delegate to extend() so `+=` gets the same duplicate-id check (and
+        # cache maintenance) as extend(), rather than bypassing it via UserList.
+        self.extend(other)
         return self
 
     def __imul__(self: T_CogniteResourceList, n: int) -> T_CogniteResourceList:

--- a/cognite/client/data_classes/_base.py
+++ b/cognite/client/data_classes/_base.py
@@ -272,8 +272,54 @@ class CogniteResourceList(UserList, Generic[T_CogniteResource]):
             return {item.instance_id: item for item in self.data if item.instance_id is not None}
         return {}
 
+    def _clear_identifier_lookups(self) -> None:
+        """Invalidate the cached id/external_id/instance_id lookup maps.
+
+        They are ``cached_property`` values built lazily on the first ``get(...)``
+        call; dropping the cached values forces a rebuild so lookups reflect the
+        current items after any membership change.
+        """
+        for attr in ("_id_to_item", "_external_id_to_item", "_instance_id_to_item"):
+            self.__dict__.pop(attr, None)
+
+    def append(self, item: T_CogniteResource) -> None:
+        super().append(item)
+        self._clear_identifier_lookups()
+
+    def insert(self, i: int, item: T_CogniteResource) -> None:
+        super().insert(i, item)
+        self._clear_identifier_lookups()
+
+    def remove(self, item: T_CogniteResource) -> None:
+        super().remove(item)
+        self._clear_identifier_lookups()
+
+    def clear(self) -> None:
+        super().clear()
+        self._clear_identifier_lookups()
+
     def pop(self, i: int = -1) -> T_CogniteResource:
-        return super().pop(i)
+        item = super().pop(i)
+        self._clear_identifier_lookups()
+        return item
+
+    def __setitem__(self, i: Any, item: Any) -> None:
+        super().__setitem__(i, item)
+        self._clear_identifier_lookups()
+
+    def __delitem__(self, i: Any) -> None:
+        super().__delitem__(i)
+        self._clear_identifier_lookups()
+
+    def __iadd__(self: T_CogniteResourceList, other: Iterable[Any]) -> T_CogniteResourceList:
+        super().__iadd__(other)
+        self._clear_identifier_lookups()
+        return self
+
+    def __imul__(self: T_CogniteResourceList, n: int) -> T_CogniteResourceList:
+        super().__imul__(n)
+        self._clear_identifier_lookups()
+        return self
 
     def __iter__(self) -> Iterator[T_CogniteResource]:
         return super().__iter__()

--- a/tests/tests_unit/test_base.py
+++ b/tests/tests_unit/test_base.py
@@ -791,6 +791,10 @@ class TestCogniteResourceList:
         resource_list += MyResourceList([MyResource(id=5, external_id="5")])
         assert resource_list.get(id=5) == MyResource(id=5, external_id="5")
 
+        # `+=` delegates to extend(), so it enforces the same duplicate-id check.
+        with pytest.raises(ValueError, match="introduce duplicates"):
+            resource_list += MyResourceList([MyResource(id=5, external_id="5")])
+
         # __setitem__ replaces an item.
         resource_list[0] = MyResource(id=6, external_id="6")
         assert resource_list.get(id=4) is None

--- a/tests/tests_unit/test_base.py
+++ b/tests/tests_unit/test_base.py
@@ -764,6 +764,47 @@ class TestCogniteResourceList:
         assert MyResource(id=1, external_id="1") == resource_list.get(external_id="1")
         assert MyResource(id=2, external_id="2") == resource_list.get(external_id="2")
 
+    def test_get_is_invalidated_by_mutations(self) -> None:
+        # The id/external_id lookup maps are cached on first `.get(...)`. Every
+        # membership-mutating operation must invalidate them, otherwise `.get()`
+        # returns stale (removed) or misses newly-added items.
+        resource_list = MyResourceList([MyResource(id=1, external_id="1"), MyResource(id=2, external_id="2")])
+
+        # Prime the cached lookup maps.
+        assert resource_list.get(id=1) == MyResource(id=1, external_id="1")
+
+        # Removals: the removed item must no longer be found.
+        assert resource_list.pop() == MyResource(id=2, external_id="2")
+        assert resource_list.get(id=2) is None
+
+        resource_list.remove(MyResource(id=1, external_id="1"))
+        assert resource_list.get(id=1) is None
+
+        # Additions: newly-added items must be found (by id and external_id).
+        resource_list.append(MyResource(id=3, external_id="3"))
+        assert resource_list.get(id=3) == MyResource(id=3, external_id="3")
+        assert resource_list.get(external_id="3") == MyResource(id=3, external_id="3")
+
+        resource_list.insert(0, MyResource(id=4, external_id="4"))
+        assert resource_list.get(id=4) == MyResource(id=4, external_id="4")
+
+        resource_list += MyResourceList([MyResource(id=5, external_id="5")])
+        assert resource_list.get(id=5) == MyResource(id=5, external_id="5")
+
+        # __setitem__ replaces an item.
+        resource_list[0] = MyResource(id=6, external_id="6")
+        assert resource_list.get(id=4) is None
+        assert resource_list.get(id=6) == MyResource(id=6, external_id="6")
+
+        # __delitem__ removes by index.
+        del resource_list[0]
+        assert resource_list.get(id=6) is None
+
+        # clear() empties the list.
+        resource_list.clear()
+        assert resource_list.get(id=3) is None
+        assert resource_list.get(id=5) is None
+
     def test_constructor_bad_type(self) -> None:
         with pytest.raises(TypeError, match="must be of type 'MyResource'"):
             MyResourceList([1, 2, 3])


### PR DESCRIPTION
## Description

Fixes #1188.

`CogniteResourceList` builds three identifier→item lookup maps as `@cached_property` — `_id_to_item`, `_external_id_to_item`, `_instance_id_to_item` — which `.get(id=.../external_id=.../instance_id=...)` reads. The maps are built lazily on the first `.get(...)` call.

Only `extend()` was written to keep those cached maps in sync. **Every other membership-mutating operation** — `append`, `insert`, `remove`, `pop`, `clear`, `__setitem__`, `__delitem__`, `__iadd__` (`+=`), `__imul__` (`*=`) — is inherited straight from `UserList` and mutates `self.data` **without invalidating the caches**. So once a map is cached:

- `get(id=X)` after `pop`/`remove`/`del` returns the **removed** item (should be `None`);
- `get(id=X)` after `append`/`insert`/`+=` returns **`None`** for an item that **is** present.

This is exactly the gap the existing `# TODO: We inherit a lot from UserList that we don't actually support...` comment flags.

## Fix

Add `_clear_identifier_lookups()` — which drops the three `cached_property` entries from `self.__dict__` so they rebuild on next access — and override each mutating method to call it after delegating to `super()`. The invalidate-then-rebuild approach is simpler and less error-prone than hand-patching the dicts.

## Test

`test_get_is_invalidated_by_mutations` primes the lookup cache with a `get()`, then runs each mutator (`pop`/`remove`/`append`/`insert`/`+=`/`__setitem__`/`del`/`clear`) and asserts `get()` reflects the new membership (removed → `None`, added → found). It fails on the current code (`get(id=2)` returns the popped item) and passes with the fix.

I ran the `TestCogniteResourceList` suite: 22 passed. The one remaining failure (`test_to_pandas`) is a pre-existing pandas-version dtype mismatch unrelated to this change (tracked separately). `ruff` check/format clean; `mypy` clean on the changed file.