### PR TITLE
ci: key venv cache on exact Python version to avoid stale interp…

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -13,7 +13,8 @@ inputs:
 runs:
   using: 'composite'
   steps:
-    - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
+    - id: setup-python
+      uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
       with:
         python-version: ${{ inputs.python_version }}
 
@@ -27,7 +28,8 @@ runs:
       uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
       with:
         path: .venv
-        key: venv-${{ runner.os }}-${{ inputs.python_version }}-${{ inputs.extras }}-${{ hashFiles('**/poetry.lock') }}
+        # Use the exact resolved interpreter version
+        key: venv-${{ runner.os }}-${{ steps.setup-python.outputs.python-version }}-${{ inputs.extras }}-${{ hashFiles('**/poetry.lock') }}
 
     - name: Install dependencies
       shell: bash


### PR DESCRIPTION
## Description
Fix Windows CI failures in `test_full`: the venv cache key was keyed on the requested minor Python version (e.g. `3.13`) instead of the exact resolved version. When GitHub bumps the hosted Python patch on the Windows runner (e.g. `3.13.14` -> `3.13.15`), the old cache key still matches and restores a `.venv` whose launcher stub points at the now-removed old interpreter path, causing `poetry install` to fail with an executable-not-found error.

Now the cache key uses `steps.setup-python.outputs.python-version` (the exact resolved version), so a patch bump naturally invalidates the cache instead of restoring a broken venv.

## Checklist:
- [ ] Tests added/updated. — N/A, CI config only
- [ ] Documentation updated. — N/A, no docstring/API changes
- [x] The PR title follows the [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) spec.

<img width="1398" height="545" alt="image" src="https://github.com/user-attachments/assets/8ee789e5-697f-4f7a-95de-40beef605f4e" />
