### PR TITLE
docs: add version and date to homepage

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -5,6 +5,9 @@
 
 Cognite Python SDK Documentation
 ================================
++------------------------+-------------------+
+| **Version**: |version| | **Date**: |today| |
++------------------------+-------------------+
 
 This is the Cognite Python SDK for developers and data scientists working with Cognite Data Fusion (CDF).
 The package is tightly integrated with pandas, and helps you work easily and efficiently with data in


### PR DESCRIPTION
## Description
It is not obvious which version you are viewing when you go the the documentation homepage. And it is not clear when this version is from.

Before:
<img width="1369" height="449" alt="image" src="https://github.com/user-attachments/assets/c085e814-a6eb-41cf-872a-4471cd789fba" />

After:
<img width="1389" height="548" alt="image" src="https://github.com/user-attachments/assets/e0fb8360-ca3a-4fa4-bbc6-88b813d2b445" />


## Checklist:
- [ ] Tests added/updated.
- [x] Documentation updated. Documentation is generated from docstrings - these must be updated according to your change.
  If a new method has been added it should be referenced in [cognite.rst](https://github.com/cognitedata/cognite-sdk-python/blob/master/docs/source/cognite.rst) in order to generate docs based on its docstring.
- [x] The PR title follows the [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) spec.
