### PR TITLE
docs: add missing hosted extractor data classes. fix /list filters for Limits- & Metering APIs

### DIFF
--- a/cognite/client/_api/limits.py
+++ b/cognite/client/_api/limits.py
@@ -11,7 +11,7 @@ from cognite.client.utils._identifier import LimitId
 if TYPE_CHECKING:
     from cognite.client import AsyncCogniteClient
     from cognite.client.config import ClientConfig
-    from cognite.client.data_classes.filters import Prefix
+    from cognite.client.data_classes import filters
 
 
 class LimitsAPI(APIClient):
@@ -58,13 +58,13 @@ class LimitsAPI(APIClient):
             headers=headers,
         )
 
-    async def list(self, filter: Prefix | None = None, limit: int | None = DEFAULT_LIMIT_READ) -> LimitList:
+    async def list(self, filter: filters.Prefix | None = None, limit: int | None = DEFAULT_LIMIT_READ) -> LimitList:
         """`List all limit values <https://api-docs.cognite.com/20230101-alpha/tag/Limits/operation/listLimits/>`_.
 
         Retrieves all limit values for a specific project. Optionally filter by limit ID prefix using a `Prefix` filter.
 
         Args:
-            filter (Prefix | None): Optional `Prefix` filter to apply on the `limitId` property (only `Prefix` filters are supported).
+            filter (filters.Prefix | None): Optional `Prefix` filter to apply on the `limitId` property (only `Prefix` filters are supported).
             limit (int | None): Maximum number of limits to return. Defaults to 25. Set to None or -1 to return all limits
 
         Returns:

--- a/cognite/client/_api/metering.py
+++ b/cognite/client/_api/metering.py
@@ -14,7 +14,7 @@ from cognite.client.utils.useful_types import SequenceNotStr
 if TYPE_CHECKING:
     from cognite.client import AsyncCogniteClient
     from cognite.client.config import ClientConfig
-    from cognite.client.data_classes.filters import Prefix
+    from cognite.client.data_classes import filters
 
 
 class MeteringAPI(APIClient):
@@ -119,7 +119,7 @@ class MeteringAPI(APIClient):
 
     async def list(
         self,
-        filter: Prefix | None = None,
+        filter: filters.Prefix | None = None,
         limit: int | None = DEFAULT_LIMIT_READ,
         start: int | str | datetime.datetime | None = None,
         end: int | str | datetime.datetime | None = None,
@@ -130,7 +130,7 @@ class MeteringAPI(APIClient):
         Lists all available meters for a specific project. Optionally filter by meter ID prefix using a ``Prefix`` filter.
 
         Args:
-            filter (Prefix | None): Optional ``Prefix`` filter to apply on the ``meterId`` property (only ``Prefix`` filters are supported).
+            filter (filters.Prefix | None): Optional ``Prefix`` filter to apply on the ``meterId`` property (only ``Prefix`` filters are supported).
             limit (int | None): Maximum number of meters to return. Defaults to 25. Set to ``None`` or ``-1`` to return all meters.
             start (int | str | datetime.datetime | None): Start of the time range for historical data. Accepts milliseconds since epoch, a ``datetime`` object, or a relative time string like ``"2w-ago"``. **Must be provided together with** ``number_of_datapoints`` to get time-series data. If omitted, only meter metadata is returned without time-series data.
             end (int | str | datetime.datetime | None): End of the time range for historical data. Accepts milliseconds since epoch, a ``datetime`` object, or a relative time string like ``"now"``. Only relevant when ``start`` is provided. Defaults to the current time on the server if omitted.

--- a/cognite/client/_sync_api/limits.py
+++ b/cognite/client/_sync_api/limits.py
@@ -1,6 +1,6 @@
 """
 ===============================================================================
-1618cd136c2298204c3ef739741cd879
+112abcec4f8e03fe14e65a2a57f0f848
 This file is auto-generated from the Async API modules, - do not edit manually!
 ===============================================================================
 """
@@ -17,7 +17,7 @@ from cognite.client.utils._async_helpers import run_sync
 
 if TYPE_CHECKING:
     from cognite.client import AsyncCogniteClient
-from cognite.client.data_classes.filters import Prefix
+from cognite.client.data_classes import filters
 
 
 class SyncLimitsAPI(SyncAPIClient):
@@ -52,14 +52,14 @@ class SyncLimitsAPI(SyncAPIClient):
         """
         return run_sync(self.__async_client.limits.retrieve(id=id))
 
-    def list(self, filter: Prefix | None = None, limit: int | None = DEFAULT_LIMIT_READ) -> LimitList:
+    def list(self, filter: filters.Prefix | None = None, limit: int | None = DEFAULT_LIMIT_READ) -> LimitList:
         """
         `List all limit values <https://api-docs.cognite.com/20230101-alpha/tag/Limits/operation/listLimits/>`_.
 
         Retrieves all limit values for a specific project. Optionally filter by limit ID prefix using a `Prefix` filter.
 
         Args:
-            filter (Prefix | None): Optional `Prefix` filter to apply on the `limitId` property (only `Prefix` filters are supported).
+            filter (filters.Prefix | None): Optional `Prefix` filter to apply on the `limitId` property (only `Prefix` filters are supported).
             limit (int | None): Maximum number of limits to return. Defaults to 25. Set to None or -1 to return all limits
 
         Returns:

--- a/cognite/client/_sync_api/metering.py
+++ b/cognite/client/_sync_api/metering.py
@@ -1,6 +1,6 @@
 """
 ===============================================================================
-2c36ebd92aba4d3441e88d4f8de45f7e
+1caf230ab4e426e1c90aa06eab8a5ec4
 This file is auto-generated from the Async API modules, - do not edit manually!
 ===============================================================================
 """
@@ -19,7 +19,7 @@ from cognite.client.utils.useful_types import SequenceNotStr
 
 if TYPE_CHECKING:
     from cognite.client import AsyncCogniteClient
-from cognite.client.data_classes.filters import Prefix
+from cognite.client.data_classes import filters
 
 
 class SyncMeteringAPI(SyncAPIClient):
@@ -98,7 +98,7 @@ class SyncMeteringAPI(SyncAPIClient):
 
     def list(
         self,
-        filter: Prefix | None = None,
+        filter: filters.Prefix | None = None,
         limit: int | None = DEFAULT_LIMIT_READ,
         start: int | str | datetime.datetime | None = None,
         end: int | str | datetime.datetime | None = None,
@@ -110,7 +110,7 @@ class SyncMeteringAPI(SyncAPIClient):
         Lists all available meters for a specific project. Optionally filter by meter ID prefix using a ``Prefix`` filter.
 
         Args:
-            filter (Prefix | None): Optional ``Prefix`` filter to apply on the ``meterId`` property (only ``Prefix`` filters are supported).
+            filter (filters.Prefix | None): Optional ``Prefix`` filter to apply on the ``meterId`` property (only ``Prefix`` filters are supported).
             limit (int | None): Maximum number of meters to return. Defaults to 25. Set to ``None`` or ``-1`` to return all meters.
             start (int | str | datetime.datetime | None): Start of the time range for historical data. Accepts milliseconds since epoch, a ``datetime`` object, or a relative time string like ``"2w-ago"``. **Must be provided together with** ``number_of_datapoints`` to get time-series data. If omitted, only meter metadata is returned without time-series data.
             end (int | str | datetime.datetime | None): End of the time range for historical data. Accepts milliseconds since epoch, a ``datetime`` object, or a relative time string like ``"now"``. Only relevant when ``start`` is provided. Defaults to the current time on the server if omitted.

--- a/docs/source/hosted_extractors.rst
+++ b/docs/source/hosted_extractors.rst
@@ -39,3 +39,9 @@ Mappings
    :template: custom-automethods-template.rst
 
    AsyncCogniteClient.hosted_extractors.mappings
+
+Data classes
+------------
+.. automodule:: cognite.client.data_classes.hosted_extractors
+    :members:
+    :show-inheritance:


### PR DESCRIPTION
## Description
Add missing hosted extractors data classes to the docs

Because hosted extractors has a class called `Prefix` and there is an existing class called `Prefix` in filters, we need to help Sphinx understand which `Prefix` links should point to.

Before: 
<img width="415" height="280" alt="image" src="https://github.com/user-attachments/assets/56b9d973-b0a9-405a-8e0f-f3f87673cdf3" />

After:
<img width="400" height="302" alt="image" src="https://github.com/user-attachments/assets/2bd5fc58-dc5e-43de-8359-0403c1a7c84c" />


## Checklist:
- [ ] Tests added/updated.
- [x] Documentation updated. Documentation is generated from docstrings - these must be updated according to your change.
  If a new method has been added it should be referenced in [cognite.rst](https://github.com/cognitedata/cognite-sdk-python/blob/master/docs/source/cognite.rst) in order to generate docs based on its docstring.
- [x] The PR title follows the [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) spec.
