### PR TITLE
chore: Support `content` parameter in `BasicAPIClient._post` method

### DIFF
--- a/cognite/client/_basic_api_client.py
+++ b/cognite/client/_basic_api_client.py
@@ -364,6 +364,8 @@ class BasicAsyncAPIClient:
         semaphore: asyncio.BoundedSemaphore | None,
         content: str | bytes | AsyncIterator[bytes] | None = None,
     ) -> CogniteHTTPResponse:
+        if content is not None and json is not None:
+            raise ValueError("Only one of 'content' and 'json' can be passed to '_post'")
         is_retryable, full_url = resolve_url(self, "POST", url_path)
         full_headers = self._configure_headers(additional_headers=headers, api_subversion=api_subversion)
         if content is None:
@@ -401,6 +403,8 @@ class BasicAsyncAPIClient:
         *,
         semaphore: asyncio.BoundedSemaphore | None,
     ) -> CogniteHTTPResponse:
+        if content is not None and json is not None:
+            raise ValueError("Only one of 'content' and 'json' can be passed to '_put'")
         _, full_url = resolve_url(self, "PUT", url_path)
 
         full_headers = self._configure_headers(additional_headers=headers, api_subversion=api_subversion)

--- a/cognite/client/_basic_api_client.py
+++ b/cognite/client/_basic_api_client.py
@@ -362,11 +362,13 @@ class BasicAsyncAPIClient:
         api_subversion: str | None = None,
         *,
         semaphore: asyncio.BoundedSemaphore | None,
+        content: str | bytes | AsyncIterator[bytes] | None = None,
     ) -> CogniteHTTPResponse:
         is_retryable, full_url = resolve_url(self, "POST", url_path)
         full_headers = self._configure_headers(additional_headers=headers, api_subversion=api_subversion)
-        # We want to control json dumping, so we pass it along to httpx.Client.post as 'content'
-        content = self._handle_json_dump(json, full_headers)
+        if content is None:
+            # We want to control json dumping, so we pass it along to httpx.Client.post as 'content'
+            content = self._handle_json_dump(json, full_headers)
 
         http_client = self._select_async_http_client(is_retryable)
         try:
@@ -389,8 +391,8 @@ class BasicAsyncAPIClient:
     async def _put(
         self,
         url_path: str,
-        content: str | bytes | AsyncIterator[bytes] | None = None,
         json: dict[str, Any] | None = None,
+        content: str | bytes | AsyncIterator[bytes] | None = None,
         params: dict[str, Any] | None = None,
         headers: dict[str, Any] | None = None,
         follow_redirects: bool = False,

--- a/tests/tests_unit/test_api_client.py
+++ b/tests/tests_unit/test_api_client.py
@@ -239,6 +239,16 @@ class TestBasicRequests:
         exc_msg = exc_info.value.args[0]
         assert "contain NaN(s) or +/- Inf!" not in exc_msg
 
+    @pytest.mark.parametrize("method_name", ["_post", "_put"])
+    async def test_request_raises_if_both_content_and_json_passed(
+        self, api_client_with_token: APIClient, method_name: str
+    ) -> None:
+        method = getattr(api_client_with_token, method_name)
+
+        exp_err_msg = f"Only one of 'content' and 'json' can be passed to '{method_name}'"
+        with pytest.raises(ValueError, match=exp_err_msg):
+            await method(URL_PATH, content=b"raw", json={"any": "OK"}, semaphore=None)
+
     def test_client_with_base_url_including_path_segments(self, cognite_client: AsyncCogniteClient) -> None:
         client = APIClient(
             ClientConfig(


### PR DESCRIPTION
In order to support using protobuf to push state time series datapoints (and normal datapoints in the future if anyone wants to do a refactoring job...), we need to support the `content` parameter for our internal basic `_post` method.