### PR TITLE
chore(tests): Make debug notice tests tolerate extra notices

### DIFF
--- a/tests/tests_integration/test_api/test_data_modeling/test_instances.py
+++ b/tests/tests_integration/test_api/test_data_modeling/test_instances.py
@@ -1482,8 +1482,8 @@ class TestInstancesAPI:
             assert isinstance(res.debug.translated_query, TranslatedQuery)
             assert isinstance(res.debug.plan, ExecutionPlan)
             assert isinstance(res.debug.notices, DebugNoticeList)
-            assert len(res.debug.notices) == 1
-            assert isinstance(res.debug.notices[0], SortNotBackedByIndexNotice)
+            assert len(res.debug.notices) >= 1
+            assert any(isinstance(notice, SortNotBackedByIndexNotice) for notice in res.debug.notices)
 
             if include_typing:
                 assert res.typing is not None
@@ -1512,9 +1512,9 @@ class TestInstancesAPI:
             assert isinstance(res.debug.plan, ExecutionPlan)
             assert isinstance(res.debug.notices, DebugNoticeList)
             if res is res_query:  # Sort not allowed for /sync
-                assert len(res.debug.notices) == 1
+                assert len(res.debug.notices) >= 1
                 # Since we specify both emit_results and timeout, we should get...:
-                assert isinstance(res.debug.notices[0], SortNotBackedByIndexNotice)
+                assert any(isinstance(notice, SortNotBackedByIndexNotice) for notice in res.debug.notices)
 
             for node_lst in res.values():
                 assert isinstance(node_lst, NodeList)


### PR DESCRIPTION
Make data modeling debug notice integration tests tolerant of new/additional notices.

The backend now returns `UnfilteredContainerScanNotice` in some responses, introduced in ark commit cognitedata/ark#21018. These tests only need to verify that the expected `SortNotBackedByIndexNotice` is present and deserialized correctly, not that it is the only notice returned.

Currently this is breaking CI.