### PR TITLE
chore(Views for Records): change API maturity warning from alpha to GA, drop alpha header

### DIFF
--- a/cognite/client/_api/data_modeling/views.py
+++ b/cognite/client/_api/data_modeling/views.py
@@ -45,12 +45,11 @@ class ViewsAPI(APIClient):
         self._RETRIEVE_LIMIT = 100
         self._CREATE_LIMIT = 100
         self._warn_on_record_views = FeaturePreviewWarning(
-            api_maturity="alpha", sdk_maturity="alpha", feature_name="Views for Records"
+            api_maturity="General Availability", sdk_maturity="alpha", feature_name="Views for Records"
         )
 
-    def _record_views_alpha_headers(self) -> dict[str, str]:
+    def _record_views_alpha_warn(self) -> None:
         self._warn_on_record_views.warn()
-        return self._alpha_version_header()
 
     def _get_semaphore(self, operation: Literal["read_schema", "write_schema"]) -> asyncio.BoundedSemaphore:
         from cognite.client import global_config
@@ -105,15 +104,14 @@ class ViewsAPI(APIClient):
             include_inherited_properties (bool): Whether to include properties inherited from views this view implements.
             all_versions (bool): Whether to return all versions. If false, only the newest version is returned, which is determined based on the 'createdTime' field.
             include_global (bool): Whether to include global views.
-            used_for (ViewUsedFor | Sequence[ViewUsedFor] | None): Only return views used for the given
-                type(s). Passing "record" is an alpha feature, subject to breaking
-                changes without prior notice.
+            used_for (ViewUsedFor | Sequence[ViewUsedFor] | None): Only return views used for the given type(s).
 
         Yields:
             View | ViewList: yields View one by one if chunk_size is not specified, else ViewList objects.
         """  # noqa: DOC404
         filter_ = ViewFilter(space, include_inherited_properties, all_versions, include_global, used_for)
-        headers = self._record_views_alpha_headers() if filter_.used_for and "record" in filter_.used_for else None
+        if filter_.used_for and "record" in filter_.used_for:
+            self._record_views_alpha_warn()
         async for item in self._list_generator(
             list_cls=ViewList,
             resource_cls=View,
@@ -121,7 +119,6 @@ class ViewsAPI(APIClient):
             chunk_size=chunk_size,
             limit=limit,
             filter=filter_.dump(camel_case=True),
-            headers=headers,
             semaphore=self._get_semaphore("read_schema"),
         ):
             yield item
@@ -216,9 +213,7 @@ class ViewsAPI(APIClient):
             include_inherited_properties (bool): Whether to include properties inherited from views this view implements.
             all_versions (bool): Whether to return all versions. If false, only the newest version is returned, which is determined based on the 'createdTime' field.
             include_global (bool): Whether to include global views.
-            used_for (ViewUsedFor | Sequence[ViewUsedFor] | None): Only return views used for the given
-                type(s). Passing "record" is an alpha feature, subject to breaking
-                changes without prior notice.
+            used_for (ViewUsedFor | Sequence[ViewUsedFor] | None): Only return views used for the given type(s).
 
         Returns:
             ViewList: List of requested views
@@ -243,7 +238,8 @@ class ViewsAPI(APIClient):
                 ...     view_list  # do something with the views
         """
         filter_ = ViewFilter(space, include_inherited_properties, all_versions, include_global, used_for)
-        headers = self._record_views_alpha_headers() if filter_.used_for and "record" in filter_.used_for else None
+        if filter_.used_for and "record" in filter_.used_for:
+            self._record_views_alpha_warn()
 
         return await self._list(
             list_cls=ViewList,
@@ -251,7 +247,6 @@ class ViewsAPI(APIClient):
             method="GET",
             limit=limit,
             filter=filter_.dump(camel_case=True),
-            headers=headers,
             override_semaphore=self._get_semaphore("read_schema"),
         )
 
@@ -350,7 +345,7 @@ class ViewsAPI(APIClient):
                 ... )
                 >>> res = client.data_modeling.views.apply([work_order_view, asset_view])
 
-            Create a record-backed view (the stream must already exist). This is an `alpha feature <https://api-docs.cognite.com/20230101-alpha/tag/Views/operation/ApplyViews>`_, subject to breaking changes without prior notice:
+            Create a record-backed view (the stream must already exist).
 
                 >>> from cognite.client.data_classes.data_modeling import (
                 ...     ContainerId,
@@ -372,12 +367,12 @@ class ViewsAPI(APIClient):
                 >>> res = client.data_modeling.views.apply(record_view)
         """
         views = [view] if isinstance(view, (ViewApply, RecordViewApply)) else list(view)
-        headers = self._record_views_alpha_headers() if any(isinstance(v, RecordViewApply) for v in views) else None
+        if any(isinstance(v, RecordViewApply) for v in views):
+            self._record_views_alpha_warn()
         return await self._create_multiple(
             list_cls=ViewList,
             resource_cls=View,
             items=view,
             input_resource_cls=_ViewOrRecordViewApplyAdapter,
-            headers=headers,
             override_semaphore=self._get_semaphore("write_schema"),
         )

--- a/cognite/client/_sync_api/data_modeling/views.py
+++ b/cognite/client/_sync_api/data_modeling/views.py
@@ -1,6 +1,6 @@
 """
 ===============================================================================
-3bc9158207c9de76263d0b73ec5bb228
+6a3fe01c75f9eafcbf25fba6fd681817
 This file is auto-generated from the Async API modules, - do not edit manually!
 ===============================================================================
 """
@@ -79,9 +79,7 @@ class SyncViewsAPI(SyncAPIClient):
             include_inherited_properties (bool): Whether to include properties inherited from views this view implements.
             all_versions (bool): Whether to return all versions. If false, only the newest version is returned, which is determined based on the 'createdTime' field.
             include_global (bool): Whether to include global views.
-            used_for (ViewUsedFor | Sequence[ViewUsedFor] | None): Only return views used for the given
-                type(s). Passing "record" is an alpha feature, subject to breaking
-                changes without prior notice.
+            used_for (ViewUsedFor | Sequence[ViewUsedFor] | None): Only return views used for the given type(s).
 
         Yields:
             View | ViewList: yields View one by one if chunk_size is not specified, else ViewList objects.
@@ -168,9 +166,7 @@ class SyncViewsAPI(SyncAPIClient):
             include_inherited_properties (bool): Whether to include properties inherited from views this view implements.
             all_versions (bool): Whether to return all versions. If false, only the newest version is returned, which is determined based on the 'createdTime' field.
             include_global (bool): Whether to include global views.
-            used_for (ViewUsedFor | Sequence[ViewUsedFor] | None): Only return views used for the given
-                type(s). Passing "record" is an alpha feature, subject to breaking
-                changes without prior notice.
+            used_for (ViewUsedFor | Sequence[ViewUsedFor] | None): Only return views used for the given type(s).
 
         Returns:
             ViewList: List of requested views
@@ -301,7 +297,7 @@ class SyncViewsAPI(SyncAPIClient):
                 ... )
                 >>> res = client.data_modeling.views.apply([work_order_view, asset_view])
 
-            Create a record-backed view (the stream must already exist). This is an `alpha feature <https://api-docs.cognite.com/20230101-alpha/tag/Views/operation/ApplyViews>`_, subject to breaking changes without prior notice:
+            Create a record-backed view (the stream must already exist).
 
                 >>> from cognite.client.data_classes.data_modeling import (
                 ...     ContainerId,

--- a/tests/tests_unit/test_api/test_data_modeling/test_views.py
+++ b/tests/tests_unit/test_api/test_data_modeling/test_views.py
@@ -132,10 +132,9 @@ class TestViewsApiForRecordViews:
         assert error.value.failed == [record_view]
         assert error.value.code == 400
 
-    def test_apply_mixed_batch_warns_and_sends_alpha_header(
+    def test_apply_mixed_batch_warns(
         self,
         cognite_client: CogniteClient,
-        async_client: AsyncCogniteClient,
         httpx_mock: HTTPXMock,
         views_url_pattern: re.Pattern,
     ) -> None:
@@ -152,14 +151,12 @@ class TestViewsApiForRecordViews:
             cognite_client.data_modeling.views.apply([plain_view, record_view])
 
         request = httpx_mock.get_requests()[0]
-        assert request.headers["cdf-version"] == f"{async_client.config.api_subversion}-alpha"
         body = jsgz_load(request.content)
         assert body["items"][1]["streamId"] == ["my-stream"]
 
-    def test_apply_plain_views_does_not_warn_or_send_alpha_header(
+    def test_apply_plain_views_does_not_warn(
         self,
         cognite_client: CogniteClient,
-        async_client: AsyncCogniteClient,
         httpx_mock: HTTPXMock,
         views_url_pattern: re.Pattern,
         recwarn: pytest.WarningsRecorder,
@@ -170,13 +167,10 @@ class TestViewsApiForRecordViews:
         cognite_client.data_modeling.views.apply(plain_view)
 
         assert not any("Views for Records" in str(w.message) for w in recwarn.list)
-        request = httpx_mock.get_requests()[0]
-        assert request.headers["cdf-version"] == async_client.config.api_subversion
 
-    def test_list_used_for_mixed_warns_and_sends_alpha_header(
+    def test_list_used_for_mixed_warns(
         self,
         cognite_client: CogniteClient,
-        async_client: AsyncCogniteClient,
         httpx_mock: HTTPXMock,
         views_url_pattern: re.Pattern,
     ) -> None:
@@ -186,14 +180,12 @@ class TestViewsApiForRecordViews:
             cognite_client.data_modeling.views.list(used_for=["node", "record"])
 
         request = httpx_mock.get_requests()[0]
-        assert request.headers["cdf-version"] == f"{async_client.config.api_subversion}-alpha"
         qs = parse_qs(urlparse(str(request.url)).query)
         assert qs.get("usedFor") == ["node", "record"]
 
-    def test_list_default_does_not_warn_or_send_alpha_header(
+    def test_list_default_does_not_warn(
         self,
         cognite_client: CogniteClient,
-        async_client: AsyncCogniteClient,
         httpx_mock: HTTPXMock,
         views_url_pattern: re.Pattern,
         recwarn: pytest.WarningsRecorder,
@@ -204,6 +196,5 @@ class TestViewsApiForRecordViews:
 
         assert not any("Views for Records" in str(w.message) for w in recwarn.list)
         request = httpx_mock.get_requests()[0]
-        assert request.headers["cdf-version"] == async_client.config.api_subversion
         qs = parse_qs(urlparse(str(request.url)).query)
         assert "usedFor" not in qs


### PR DESCRIPTION
## Description
1. Remove alpha header from the record views calls
2. keep the warning (SDK doesn't have to be more mature than the API)

## Checklist:
- [x] Tests added/updated.
- [x] Documentation updated. Documentation is generated from docstrings - these must be updated according to your change.
  If a new method has been added it should be referenced in [cognite.rst](https://github.com/cognitedata/cognite-sdk-python/blob/master/docs/source/cognite.rst) in order to generate docs based on its docstring.
- [x] The PR title follows the [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) spec.
