### PR TITLE
docs: add docstrings or explicit overrides to dump and as_write methods

### DIFF
--- a/cognite/client/data_classes/_base.py
+++ b/cognite/client/data_classes/_base.py
@@ -24,7 +24,7 @@ from typing import (
     runtime_checkable,
 )
 
-from typing_extensions import Self
+from typing_extensions import Self, override
 
 from cognite.client.exceptions import CogniteMissingClientError
 from cognite.client.utils import _json_extended as _json
@@ -209,6 +209,7 @@ class UnknownCogniteResource(CogniteResource):
     def _load(cls, resource: dict[str, Any]) -> Self:
         return cls(resource)
 
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         # TODO: Recursive key conversion can modify user data if present:
         return convert_all_keys_recursive(self.__data, camel_case=camel_case)
@@ -220,6 +221,7 @@ T_WriteClass = TypeVar("T_WriteClass", bound=CogniteResource)
 class WriteableCogniteResource(CogniteResource, Generic[T_WriteClass]):
     @abstractmethod
     def as_write(self) -> T_WriteClass:
+        """Return a write version of this resource."""
         raise NotImplementedError
 
 
@@ -246,6 +248,7 @@ class CogniteResourceWithClientRef(CogniteResource, _WithClientMixin):
 class WriteableCogniteResourceWithClientRef(
     WriteableCogniteResource[T_WriteClass], CogniteResourceWithClientRef, Generic[T_WriteClass]
 ):
+    @override
     @abstractmethod
     def as_write(self) -> T_WriteClass:
         raise NotImplementedError
@@ -484,6 +487,7 @@ class WriteableCogniteResourceList(
 ):
     @abstractmethod
     def as_write(self) -> CogniteResourceList[T_WriteClass]:
+        """Return a write version of this resource list."""
         raise NotImplementedError
 
 
@@ -535,6 +539,7 @@ class WriteableCogniteResourceListWithClientRef(
 ):
     @abstractmethod
     def as_write(self) -> CogniteResourceList[T_WriteClass]:
+        """Return a write version of this resource list."""
         raise NotImplementedError
 
 
@@ -813,6 +818,7 @@ class CogniteSort:
             raise ValueError(f"Unable to load {cls.__name__} from {data}")
 
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
+        """Dump the sort object to a dictionary."""
         prop = self.property
         if isinstance(prop, EnumProperty):
             prop = prop.as_reference()

--- a/cognite/client/data_classes/agents/agent_tools.py
+++ b/cognite/client/data_classes/agents/agent_tools.py
@@ -5,6 +5,8 @@ from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import Any, ClassVar, Literal
 
+from typing_extensions import override
+
 from cognite.client.data_classes._base import (
     CogniteResourceList,
     WriteableCogniteResource,
@@ -25,6 +27,7 @@ class AgentToolCore(WriteableCogniteResource["AgentToolUpsert"], ABC):
     name: str
     description: str
 
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         """Dump the instance into a json serializable Python data type."""
         result = super().dump(camel_case=camel_case)
@@ -50,6 +53,7 @@ class AgentToolUpsert(AgentToolCore, ABC):
         result["type"] = getattr(self.__class__, "_type", getattr(self, "type", ""))
         return result
 
+    @override
     def as_write(self) -> AgentToolUpsert:
         return self
 
@@ -125,10 +129,12 @@ class DataModelInfo(WriteableCogniteResource):
             view_external_ids=resource.get("viewExternalIds"),
         )
 
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         result = super().dump(camel_case=camel_case)
         return result
 
+    @override
     def as_write(self) -> DataModelInfo:
         return self
 
@@ -152,6 +158,7 @@ class InstanceSpaces(WriteableCogniteResource):
             spaces=resource.get("spaces"),
         )
 
+    @override
     def as_write(self) -> InstanceSpaces:
         return self
 
@@ -170,6 +177,7 @@ class Subagent(WriteableCogniteResource):
     def _load(cls, resource: dict[str, Any]) -> Subagent:
         return cls(agent_external_id=resource["agentExternalId"])
 
+    @override
     def as_write(self) -> Subagent:
         return self
 
@@ -201,6 +209,7 @@ class QueryKnowledgeGraphAgentToolConfiguration(WriteableCogniteResource):
             version=resource.get("version"),
         )
 
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         result: dict[str, Any] = {}
         key = "dataModels" if camel_case else "data_models"
@@ -212,6 +221,7 @@ class QueryKnowledgeGraphAgentToolConfiguration(WriteableCogniteResource):
             result["version"] = self.version
         return result
 
+    @override
     def as_write(self) -> QueryKnowledgeGraphAgentToolConfiguration:
         return self
 
@@ -237,6 +247,7 @@ class QueryAgentToolConfiguration(WriteableCogniteResource):
             instance_spaces=InstanceSpaces._load_if(resource.get("instanceSpaces")),
         )
 
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         result: dict[str, Any] = {}
         key = "dataModels" if camel_case else "data_models"
@@ -251,6 +262,7 @@ class QueryAgentToolConfiguration(WriteableCogniteResource):
             result[key] = self.instance_spaces.dump(camel_case=camel_case)
         return result
 
+    @override
     def as_write(self) -> QueryAgentToolConfiguration:
         return self
 
@@ -266,6 +278,7 @@ class SummarizeDocumentAgentTool(AgentTool):
 
     _type: ClassVar[str] = "summarizeDocument"
 
+    @override
     def as_write(self) -> SummarizeDocumentAgentToolUpsert:
         return SummarizeDocumentAgentToolUpsert(
             name=self.name,
@@ -310,6 +323,7 @@ class AskDocumentAgentTool(AgentTool):
 
     _type: ClassVar[str] = "askDocument"
 
+    @override
     def as_write(self) -> AskDocumentAgentToolUpsert:
         return AskDocumentAgentToolUpsert(
             name=self.name,
@@ -364,6 +378,7 @@ class QueryKnowledgeGraphAgentTool(AgentTool):
             configuration=QueryKnowledgeGraphAgentToolConfiguration._load_if(resource.get("configuration")),
         )
 
+    @override
     def as_write(self) -> QueryKnowledgeGraphAgentToolUpsert:
         return QueryKnowledgeGraphAgentToolUpsert(
             name=self.name,
@@ -371,6 +386,7 @@ class QueryKnowledgeGraphAgentTool(AgentTool):
             configuration=self.configuration,
         )
 
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         result = super().dump(camel_case=camel_case)
         if self.configuration:
@@ -391,6 +407,7 @@ class QueryKnowledgeGraphAgentToolUpsert(AgentToolUpsert):
     _type: ClassVar[str] = "queryKnowledgeGraph"
     configuration: QueryKnowledgeGraphAgentToolConfiguration | None = None
 
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         result = super().dump(camel_case=camel_case)
         if self.configuration:
@@ -417,6 +434,7 @@ class QueryTimeSeriesDatapointsAgentTool(AgentTool):
 
     _type: ClassVar[str] = "queryTimeSeriesDatapoints"
 
+    @override
     def as_write(self) -> QueryTimeSeriesDatapointsAgentToolUpsert:
         return QueryTimeSeriesDatapointsAgentToolUpsert(
             name=self.name,
@@ -471,6 +489,7 @@ class QueryAgentTool(AgentTool):
             configuration=QueryAgentToolConfiguration._load_if(resource.get("configuration")),
         )
 
+    @override
     def as_write(self) -> QueryAgentToolUpsert:
         return QueryAgentToolUpsert(
             name=self.name,
@@ -478,6 +497,7 @@ class QueryAgentTool(AgentTool):
             configuration=self.configuration,
         )
 
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         result = super().dump(camel_case=camel_case)
         if self.configuration:
@@ -498,6 +518,7 @@ class QueryAgentToolUpsert(AgentToolUpsert):
     _type: ClassVar[str] = "query"
     configuration: QueryAgentToolConfiguration | None = None
 
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         result = super().dump(camel_case=camel_case)
         if self.configuration:

--- a/cognite/client/data_classes/agents/agents.py
+++ b/cognite/client/data_classes/agents/agents.py
@@ -4,6 +4,8 @@ from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import Any
 
+from typing_extensions import override
+
 from cognite.client.data_classes._base import (
     CogniteResourceList,
     ExternalIDTransformerMixin,
@@ -98,6 +100,7 @@ class AgentUpsert(AgentCore):
         # This is useful while the API is evolving and new fields are added.
         self._unknown_properties: dict[str, object] = {}
 
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         result = super().dump(camel_case=camel_case)
         if self.tools:
@@ -198,6 +201,7 @@ class Agent(AgentCore):
         # This is useful while the API is evolving and new fields are added.
         self._unknown_properties: dict[str, object] = {}
 
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         result = super().dump(camel_case=camel_case)
         if self.tools is not None:

--- a/cognite/client/data_classes/agents/chat.py
+++ b/cognite/client/data_classes/agents/chat.py
@@ -8,6 +8,8 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, ClassVar, Literal
 
+from typing_extensions import override
+
 from cognite.client.data_classes._base import CogniteResource, CogniteResourceList
 from cognite.client.utils._text import convert_all_keys_to_camel_case
 
@@ -29,6 +31,7 @@ class MessageContent(CogniteResource, ABC):
         # Delegate to the concrete class' loader
         return content_class._load_content(data)
 
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         output = super().dump(camel_case=camel_case)
         output["type"] = self._type
@@ -146,6 +149,7 @@ class UnknownContent(MessageContent):
     type: str
     data: dict[str, Any] = field(default_factory=dict)
 
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         result = self.data.copy()
         result["type"] = self.type
@@ -202,6 +206,7 @@ class ClientToolAction(Action):
         str, object
     ]  # TODO: We do not want the user to have to handle this, instead e.g. set json schema from Pydantic classes, or function signatures, like ClientToolAction.from_function(func: Callable)
 
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         return {
             "type": self._type,
@@ -234,6 +239,7 @@ class UnknownAction(Action):
     type: str
     data: dict[str, object] = field(default_factory=dict)
 
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         result = self.data.copy()
         result["type"] = self.type
@@ -289,6 +295,7 @@ class ClientToolCall(ActionCall):
     name: str
     arguments: dict[str, object]  # Always a json string, in line with OpenAI's API pattern
 
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         return {
             "type": self._type,
@@ -338,6 +345,7 @@ class ToolConfirmationCall(ActionCall):
     tool_type: str
     details: dict[str, object] | None = None
 
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         result: dict[str, Any] = {
             "type": self._type,
@@ -383,6 +391,7 @@ class UnknownActionCall(ActionCall):
     type: str
     data: dict[str, object] = field(default_factory=dict)
 
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         result = self.data.copy()
         result["type"] = self.type
@@ -437,6 +446,7 @@ class Message(CogniteResource):
             self.content = parts
         self.role = role
 
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         return {
             "content": MessageContent._dump_content_value(self.content, camel_case=camel_case),
@@ -485,6 +495,7 @@ class ClientToolResult(ActionResult):
         object.__setattr__(self, "content", TextContent(text=content) if isinstance(content, str) else content)
         object.__setattr__(self, "data", data)
 
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         return {
             "role": self._role,
@@ -521,6 +532,7 @@ class ToolConfirmationResult(ActionResult):
     _type: ClassVar[str] = "toolConfirmation"
     status: Literal["ALLOW", "DENY"]
 
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         return {
             "role": self._role,
@@ -550,6 +562,7 @@ class AgentDataItem(CogniteResource):
     type: str
     data: dict[str, Any]
 
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         result = {"type": self.type}
         if self.data:
@@ -598,6 +611,7 @@ class ReasoningDataItem(CogniteResource, ABC):
 
     _type: ClassVar[str]
 
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         output = super().dump(camel_case=camel_case)
         output["type"] = self._type
@@ -625,6 +639,7 @@ class ToolCallReasoningDataItem(ReasoningDataItem):
     _type: ClassVar[str] = "toolCall"
     tool_call: ToolCallDetail | None = None
 
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         key = "toolCall" if camel_case else "tool_call"
         result: dict[str, Any] = {"type": self._type}
@@ -649,6 +664,7 @@ class UnknownReasoningDataItem(ReasoningDataItem):
     type: str
     data: dict[str, Any] = field(default_factory=dict)
 
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         result = self.data.copy()
         result["type"] = self.type
@@ -678,6 +694,7 @@ class AgentReasoningItem(CogniteResource):
     content: list[MessageContent]
     data: list[ReasoningDataItem] | None = None
 
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         result: dict[str, Any] = {"content": [item.dump(camel_case=camel_case) for item in self.content]}
         if self.data is not None:
@@ -709,6 +726,7 @@ class AgentMessage(CogniteResource):
     actions: list[ActionCall] | None = None
     role: Literal["agent"] = "agent"
 
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         result: dict[str, Any] = {"role": self.role}
         if self.content is not None:
@@ -763,6 +781,7 @@ class AgentChatResponse(CogniteResource):
         self.messages = messages
         self.type = type
 
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         result = {
             "agentExternalId" if camel_case else "agent_external_id": self.agent_external_id,

--- a/cognite/client/data_classes/aggregations.py
+++ b/cognite/client/data_classes/aggregations.py
@@ -15,6 +15,8 @@ from typing import (
     overload,
 )
 
+from typing_extensions import override
+
 from cognite.client.data_classes._base import CogniteResource, CogniteResourceList, UnknownCogniteResource
 from cognite.client.data_classes.labels import Label
 from cognite.client.utils._text import convert_all_keys_recursive
@@ -42,6 +44,7 @@ class Aggregation(CogniteResource, ABC):
             return Histogram(property=resource["histogram"]["property"], interval=resource["histogram"]["interval"])
         return cast(Aggregation, UnknownCogniteResource(resource))
 
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         output = {self._aggregation_name: {"property": self.property}}
         if camel_case:
@@ -93,6 +96,7 @@ class Histogram(Aggregation):
 
     interval: float
 
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         output = super().dump(camel_case)
         output[self._aggregation_name]["interval"] = self.interval
@@ -130,6 +134,7 @@ class AggregatedValue(CogniteResource, ABC):
             case _:
                 return cast(AggregatedValue, UnknownCogniteResource(resource))
 
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         return {"aggregate": self._aggregate, "property": self.property}
 
@@ -140,6 +145,7 @@ class AggregatedNumberedValue(AggregatedValue, ABC):
 
     value: float | None
 
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         output = super().dump(camel_case)
         if self.value is not None:
@@ -187,6 +193,7 @@ class Bucket:
     count: int
 
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
+        """Dump the instance into a json serializable Python data type."""
         return {"start": self.start, "count": self.count}
 
 
@@ -199,6 +206,7 @@ class Buckets(UserList, MutableSequence[Bucket]):
         super().__init__(buckets)
 
     def dump(self, camel_case: bool = True) -> list[dict[str, Any]]:
+        """Dump the list of buckets into a json serializable Python data type."""
         return [bucket.dump(camel_case) for bucket in self.data]
 
     @property
@@ -240,6 +248,7 @@ class HistogramValue(AggregatedValue):
         if isinstance(self.buckets, Collection):
             self.buckets = Buckets(self.buckets)
 
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         output = super().dump(camel_case)
         output["interval"] = self.interval
@@ -254,6 +263,7 @@ class AggregationFilter(ABC):
     _filter_name: ClassVar[str]
 
     def dump(self) -> dict[str, Any]:
+        """Dump the filter into a json serializable Python data type."""
         return {self._filter_name: self._filter_body()}
 
     @abstractmethod

--- a/cognite/client/data_classes/annotation_types/primitives.py
+++ b/cognite/client/data_classes/annotation_types/primitives.py
@@ -4,7 +4,7 @@ from abc import ABC
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Literal
 
-from typing_extensions import Self
+from typing_extensions import Self, override
 
 from cognite.client.data_classes._base import CogniteResource
 from cognite.client.utils._importing import local_import
@@ -15,6 +15,7 @@ if TYPE_CHECKING:
 
 
 class VisionResource(CogniteResource, ABC):
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         """Dump the instance into a json serializable Python data type.
 

--- a/cognite/client/data_classes/annotations.py
+++ b/cognite/client/data_classes/annotations.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 from abc import ABC
 from typing import Any, Literal, TypeAlias, cast
 
+from typing_extensions import override
+
 from cognite.client.data_classes._base import (
     CogniteFilter,
     CogniteObjectUpdate,
@@ -71,6 +73,7 @@ class AnnotationCore(WriteableCogniteResource["AnnotationWrite"], ABC):
         self.annotated_resource_type = annotated_resource_type
         self.annotated_resource_id = annotated_resource_id
 
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         result = super().dump(camel_case=camel_case)
         # Special handling of created_user, which has a valid None value
@@ -241,6 +244,7 @@ class AnnotationReverseLookupFilter(CogniteFilter):
         self.annotation_type = annotation_type
         self.data = data
 
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         result = super().dump(camel_case=camel_case)
         # Special handling for creating_user, which has a valid None value

--- a/cognite/client/data_classes/assets.py
+++ b/cognite/client/data_classes/assets.py
@@ -20,7 +20,7 @@ from typing import (
     cast,
 )
 
-from typing_extensions import Self
+from typing_extensions import Self, override
 
 from cognite.client.data_classes._base import (
     CogniteFilter,
@@ -299,6 +299,7 @@ class Asset(WriteableCogniteResourceWithClientRef["AssetWrite"]):
             raise ValueError(f"Unable to fetch related {resource}, asset is missing id")
         return remove_duplicates_keep_order([self.id, *user_kwargs.pop("asset_ids", [])])
 
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         result = super().dump(camel_case)
         if self.labels is not None:
@@ -405,12 +406,14 @@ class AssetWrite(WriteableCogniteResource["AssetWrite"]):
             geo_location=GeoLocation._load_if(resource.get("geoLocation")),
         )
 
+    @override
     def as_write(self) -> AssetWrite:
         return self
 
     def __hash__(self) -> int:
         return hash(self.external_id)
 
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         result = super().dump(camel_case)
         if self.labels is not None:
@@ -526,6 +529,7 @@ class AssetWriteList(CogniteResourceList[AssetWrite], ExternalIDTransformerMixin
 class AssetList(WriteableCogniteResourceListWithClientRef[AssetWrite, Asset], IdTransformerMixin):
     _RESOURCE = Asset
 
+    @override
     def as_write(self) -> AssetWriteList:
         return AssetWriteList([a.as_write() for a in self.data])
 
@@ -672,6 +676,7 @@ class AssetFilter(CogniteFilter):
         if labels is not None and not isinstance(labels, LabelFilter):
             raise TypeError("AssetFilter.labels must be of type LabelFilter")
 
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         result = super().dump(camel_case)
         if isinstance(self.labels, LabelFilter):

--- a/cognite/client/data_classes/capabilities.py
+++ b/cognite/client/data_classes/capabilities.py
@@ -13,7 +13,7 @@ from itertools import product
 from types import MappingProxyType
 from typing import Any, ClassVar, Literal, NamedTuple, NoReturn, cast
 
-from typing_extensions import Self
+from typing_extensions import Self, override
 
 from cognite.client.data_classes._base import CogniteResource, CogniteResourceList
 from cognite.client.utils._auxiliary import load_yaml_or_json, rename_and_exclude_keys
@@ -146,6 +146,7 @@ class Capability(ABC):
             )
 
         def dump(self, camel_case: bool = True) -> dict[str, Any]:
+            """Dump the scope to a dictionary."""
             if isinstance(self, UnknownScope):
                 return {self.name: self.data}
 
@@ -225,6 +226,7 @@ class Capability(ABC):
         raise ValueError(err_msg)
 
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
+        """Dump the capability to a dictionary."""
         if isinstance(self, UnknownAcl):
             return self.raw_data
         data = {
@@ -267,6 +269,7 @@ class ProjectScope(ABC):
         raise ValueError(f"Unknown project scope: {data}")
 
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
+        """Dump the project scope to a dictionary."""
         if isinstance(self, AllProjectsScope):
             return {self.name: {"allProjects": {}}}
         elif isinstance(self, ProjectsScope):
@@ -303,6 +306,7 @@ class ProjectCapability(CogniteResource):
             project_scope=ProjectScope.load(project_scope_dct),
         )
 
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         dumped = self.capability.dump(camel_case=camel_case)
         dumped.update(self.project_scope.dump(camel_case=camel_case))
@@ -463,6 +467,7 @@ class TableScope(Capability.Scope):
         # TableScope is frozen, so a bit awkward to set attribute:
         object.__setattr__(self, "dbs_to_tables", loaded)
 
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         key = "dbsToTables" if camel_case else "dbs_to_tables"
         return {self._scope_name: {key: {k: {"tables": v} for k, v in self.dbs_to_tables.items()}}}

--- a/cognite/client/data_classes/contextualization.py
+++ b/cognite/client/data_classes/contextualization.py
@@ -10,7 +10,7 @@ from dataclasses import dataclass
 from enum import Enum
 from typing import TYPE_CHECKING, Any, Generic, ParamSpec, TypeVar, cast, final
 
-from typing_extensions import Self
+from typing_extensions import Self, override
 
 from cognite.client.data_classes import Annotation, AnnotationWrite
 from cognite.client.data_classes._base import (
@@ -560,6 +560,7 @@ class DiagramConvertResults(ContextualizationJob):
     def update_status(self) -> str:
         return run_sync(self.update_status_async())
 
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         data = super().dump(camel_case=camel_case)
         data["items"] = [item.dump(camel_case=camel_case) for item in self.items]
@@ -688,6 +689,7 @@ class DiagramDetectResults(ContextualizationJob):
     def update_status(self) -> str:
         return run_sync(self.update_status_async())
 
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         data = super().dump(camel_case=camel_case)
         data["items"] = [item.dump(camel_case=camel_case) for item in self.items]
@@ -1093,6 +1095,7 @@ class VisionExtractItem(CogniteResource):
             error_message=resource.get("errorMessage"),
         )
 
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         item_dump = super().dump(camel_case=camel_case)
         item_dump["predictions"] = self.predictions.dump(camel_case=camel_case)
@@ -1158,6 +1161,7 @@ class VisionExtractJob(ContextualizationJob, Generic[P]):
     def update_status(self) -> str:
         return run_sync(self.update_status_async())
 
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         job_dump = super().dump(camel_case=camel_case)
         job_dump["items"] = [item.dump(camel_case=camel_case) for item in self.items]
@@ -1424,6 +1428,7 @@ class ConnectionFlags:
         }
 
     def dump(self, camel_case: bool = False) -> list[str]:
+        """Returns a list of flags that are set to True."""
         return [k for k, v in self._flags.items() if v]
 
     @classmethod
@@ -1516,6 +1521,7 @@ class DiagramDetectConfig(CogniteResource):
                 raise ValueError(f"Provided parameter name `{param_name}` collides with a known parameter `{known}`.")
             self._extra_params[param_name] = value
 
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         dumped = super().dump(camel_case=camel_case)
 

--- a/cognite/client/data_classes/data_modeling/aggregates.py
+++ b/cognite/client/data_classes/data_modeling/aggregates.py
@@ -25,7 +25,7 @@ from collections.abc import Mapping, Sequence
 from enum import Enum
 from typing import Any, ClassVar
 
-from typing_extensions import Self
+from typing_extensions import Self, override
 
 from cognite.client.data_classes._base import CogniteResource
 from cognite.client.data_classes.data_modeling._validation import validate_property_path
@@ -59,6 +59,7 @@ class Aggregate(CogniteResource):
     def _dump_body(self) -> dict[str, Any]:
         raise NotImplementedError
 
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         return {self._aggregate_name: _dump_aggregate_value(self._dump_body())}
 
@@ -336,6 +337,7 @@ class UnknownAggregate(Aggregate):
     def _dump_body(self) -> dict[str, Any]:  # never called: dump is overridden
         raise NotImplementedError
 
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         return dict(self._raw)
 
@@ -374,6 +376,7 @@ class Result(CogniteResource):
             return result_cls._load(resource)
         return UnknownResult._load(resource)
 
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         raise NotImplementedError
 
@@ -390,6 +393,7 @@ class MetricResult(Result):
         key = next(iter(resource))
         return cls(aggregate=key, value=resource[key])
 
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         return {self.aggregate: self.value}
 
@@ -404,6 +408,7 @@ class MovingFunctionResult(Result):
     def _load(cls, resource: dict[str, Any]) -> Self:
         return cls(fn_value=resource["fnValue"])
 
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         return {"fnValue" if camel_case else "fn_value": self.fn_value}
 
@@ -421,6 +426,7 @@ class UnknownResult(Result):
     def _load(cls, resource: dict[str, Any]) -> Self:
         return cls(resource)
 
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         if camel_case:
             return dict(self._raw_result)
@@ -459,6 +465,7 @@ class Bucket(CogniteResource):
             aggregates=_load_results(resource.get("aggregates")),
         )
 
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         output: dict[str, Any] = {"count": self.count}
         if self.value is not None:
@@ -490,6 +497,7 @@ class BucketResult(Result):
     def _load(cls, resource: dict[str, Any]) -> Self:
         return cls(buckets=[Bucket._load(bucket) for bucket in resource.get(cls._buckets_key, [])])
 
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         key = self._buckets_key if camel_case else to_snake_case(self._buckets_key)
         return {key: [bucket.dump(camel_case=camel_case) for bucket in self._buckets]}

--- a/cognite/client/data_classes/data_modeling/containers.py
+++ b/cognite/client/data_classes/data_modeling/containers.py
@@ -6,7 +6,7 @@ from collections.abc import Mapping, Sequence
 from dataclasses import dataclass, field
 from typing import Any, Literal, TypeVar, cast
 
-from typing_extensions import Self
+from typing_extensions import Self, override
 
 from cognite.client.data_classes._base import (
     CogniteFilter,
@@ -80,6 +80,7 @@ class ContainerCore(DataModelingSchemaResource["ContainerApply"], ABC):
             **extra_kwargs,
         )
 
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         output = super().dump(camel_case)
         if self.constraints:
@@ -189,6 +190,7 @@ class Container(ContainerCore):
             indexes={k: i.as_apply() for k, i in self.indexes.items()},
         )
 
+    @override
     def as_write(self) -> ContainerApply:
         return self.as_apply()
 
@@ -224,6 +226,7 @@ class ContainerList(WriteableCogniteResourceList[ContainerApply, Container]):
         """
         return [v.as_id() for v in self]
 
+    @override
     def as_write(self) -> ContainerApplyList:
         return self.as_apply()
 
@@ -262,6 +265,7 @@ class PropertyConstraintState(CogniteResource):
             max_text_size=resource.get("maxTextSize"),
         )
 
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, str]:
         output = {}
         for key in ["nullability", "max_list_size", "max_text_size"]:
@@ -315,6 +319,7 @@ class ContainerPropertyCore(CogniteResource, ABC):
         """Return the write version of this property."""
         raise NotImplementedError
 
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         output: dict[str, Any] = {}
         if self.type:
@@ -361,6 +366,7 @@ class ContainerProperty(ContainerPropertyCore):
             immutable=self.immutable,
         )
 
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         output = super().dump(camel_case)
         output["constraintState" if camel_case else "constraint_state"] = self.constraint_state.dump(camel_case)
@@ -376,6 +382,7 @@ class ConstraintCore(CogniteResource, ABC):
         """Return the write version of this constraint."""
         raise NotImplementedError
 
+    @override
     @abstractmethod
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         raise NotImplementedError
@@ -428,6 +435,7 @@ class RequiresConstraintApply(ConstraintApply):
         require = ContainerId.load(resource["require"])
         return cls(require=require)
 
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         output: dict[str, Any] = {"require": self.require.dump(camel_case)}
         key = "constraintType" if camel_case else "constraint_type"
@@ -450,6 +458,7 @@ class RequiresConstraint(Constraint):
     def as_apply(self) -> RequiresConstraintApply:
         return RequiresConstraintApply(require=self.require)
 
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         output: dict[str, Any] = {"require": self.require.dump(camel_case)}
         output["state"] = self.state
@@ -469,6 +478,7 @@ class UniquenessConstraintApply(ConstraintApply):
         properties = resource["properties"]
         return cls(properties=properties)
 
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         output: dict[str, Any] = {"properties": self.properties}
         key = "constraintType" if camel_case else "constraint_type"
@@ -491,6 +501,7 @@ class UniquenessConstraint(Constraint):
     def as_apply(self) -> UniquenessConstraintApply:
         return UniquenessConstraintApply(properties=self.properties)
 
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         output: dict[str, Any] = {"properties": self.properties}
         output["state"] = self.state
@@ -562,6 +573,7 @@ class BTreeIndexApply(IndexApply):
         cursorable = resource.get("cursorable", False)
         return cls(properties=properties, cursorable=cursorable)
 
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         dumped: dict[str, Any] = {"properties": self.properties}
         if self.cursorable is not None:
@@ -587,6 +599,7 @@ class BTreeIndex(Index):
     def as_apply(self) -> BTreeIndexApply:
         return BTreeIndexApply(properties=self.properties, cursorable=self.cursorable)
 
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         dumped: dict[str, Any] = {"properties": self.properties}
         if self.cursorable is not None:
@@ -608,6 +621,7 @@ class InvertedIndexApply(IndexApply):
         properties = resource["properties"]
         return cls(properties=properties)
 
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         dumped: dict[str, Any] = {"properties": self.properties}
         dumped["indexType" if camel_case else "index_type"] = "inverted"
@@ -629,6 +643,7 @@ class InvertedIndex(Index):
     def as_apply(self) -> InvertedIndexApply:
         return InvertedIndexApply(properties=self.properties)
 
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         dumped: dict[str, Any] = {"properties": self.properties}
         dumped["indexType" if camel_case else "index_type"] = "inverted"

--- a/cognite/client/data_classes/data_modeling/data_models.py
+++ b/cognite/client/data_classes/data_modeling/data_models.py
@@ -5,7 +5,7 @@ from collections.abc import Sequence
 from operator import attrgetter
 from typing import Any, Generic, Literal, TypeVar, cast
 
-from typing_extensions import Self
+from typing_extensions import Self, override
 
 from cognite.client.data_classes._base import (
     CogniteFilter,
@@ -87,6 +87,7 @@ class DataModelApply(DataModelCore):
             views=[cls._load_view(v) for v in resource["views"]] if "views" in resource else None,
         )
 
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         output = super().dump(camel_case)
 
@@ -184,6 +185,7 @@ class DataModel(DataModelCore, Generic[T_View]):
             views=views,
         )
 
+    @override
     def as_write(self) -> DataModelApply:
         return self.as_apply()
 
@@ -240,6 +242,7 @@ class DataModelList(WriteableCogniteResourceList[DataModelApply, DataModel[T_Vie
         """
         return [d.as_id() for d in self]
 
+    @override
     def as_write(self) -> DataModelApplyList:
         return self.as_apply()
 

--- a/cognite/client/data_classes/data_modeling/data_types.py
+++ b/cognite/client/data_classes/data_modeling/data_types.py
@@ -6,7 +6,7 @@ from collections.abc import Mapping
 from dataclasses import asdict, dataclass
 from typing import Any, ClassVar, TypeAlias, cast
 
-from typing_extensions import Self
+from typing_extensions import Self, override
 
 from cognite.client.data_classes._base import CogniteResource, UnknownCogniteResource
 from cognite.client.data_classes.data_modeling.ids import ContainerId, NodeId
@@ -24,6 +24,7 @@ class DirectRelationReference:
     external_id: str
 
     def dump(self, camel_case: bool = True) -> dict[str, str | dict]:
+        """Dump the DirectRelationReference to a dictionary."""
         return {
             "space": self.space,
             "externalId" if camel_case else "external_id": self.external_id,
@@ -93,6 +94,7 @@ class StateSetEntry:
         return cls(num_val, str_val, data.get("description"))
 
     def dump(self, camel_case: bool = True) -> dict[str, int | str]:
+        """Dump the StateSetEntry to a dictionary"""
         output: dict[str, int | str] = {
             "numericValue" if camel_case else "numeric_value": self.numeric_value,
             "stringValue" if camel_case else "string_value": self.string_value,
@@ -106,6 +108,7 @@ class StateSetEntry:
 class PropertyType(CogniteResource, ABC):
     _type: ClassVar[str]
 
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         output = asdict(self)
         output["type"] = self._type
@@ -226,6 +229,7 @@ class UnitReference:
     source_unit: str | None = None
 
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
+        """Dump the UnitReference to a dictionary."""
         output = {"externalId" if camel_case else "external_id": self.external_id}
         if self.source_unit:
             output["sourceUnit" if camel_case else "source_unit"] = self.source_unit
@@ -244,6 +248,7 @@ class UnitSystemReference:
     unit_system_name: str
 
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
+        """Dump the UnitSystemReference to a dictionary."""
         return {"unitSystemName" if camel_case else "unit_system_name": self.unit_system_name}
 
     @classmethod
@@ -255,6 +260,7 @@ class UnitSystemReference:
 class PropertyTypeWithUnit(ListablePropertyType, ABC):
     unit: UnitReference | None = None
 
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         output = super().dump(camel_case)
         if self.unit:
@@ -306,6 +312,7 @@ class DirectRelation(ListablePropertyType):
     _type = "direct"
     container: ContainerId | None = None
 
+    @override
     def dump(self, camel_case: bool = True) -> dict:
         output = super().dump(camel_case)
         if "container" in output:
@@ -336,6 +343,7 @@ class Enum(PropertyType):
     unknown_value: str | None = None
 
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
+        """Dump the Enum to a dictionary."""
         output = {
             "type": self._type,
             "values": {k: v.dump(camel_case) for k, v in self.values.items()},

--- a/cognite/client/data_classes/data_modeling/debug.py
+++ b/cognite/client/data_classes/data_modeling/debug.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass
 from functools import cache
 from typing import Any, ClassVar, Literal, NoReturn, cast, get_args, get_type_hints
 
-from typing_extensions import Self
+from typing_extensions import Self, override
 
 from cognite.client.data_classes._base import CogniteResource, CogniteResourceList
 from cognite.client.data_classes.data_modeling.ids import ContainerId
@@ -39,6 +39,7 @@ class DebugInfo(CogniteResource):
             plan=ExecutionPlan._load_if(data.get("plan")),
         )
 
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         obj: dict[str, Any] = {}
         if self.notices is not None:
@@ -68,6 +69,7 @@ class TranslatedQuery(CogniteResource):
     def _load(cls, data: dict[str, Any]) -> TranslatedQuery:
         return cls(query=data["query"], parameters=data["parameters"])
 
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         return {"query": self.query, "parameters": self.parameters}
 
@@ -95,6 +97,7 @@ class ExecutionPlan(CogniteResource):
             by_identifier=data["byIdentifier"],
         )
 
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         return {
             "fullPlan" if camel_case else "full_plan": self.full_plan,
@@ -128,6 +131,7 @@ class DebugParameters(CogniteResource):
     def requires_alpha_header(self) -> bool:
         return self.include_translated_query or self.include_plan or self.include_llm_prompt
 
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         res: dict[str, bool | int] = {
             "emitResults" if camel_case else "emit_results": self.emit_results,
@@ -174,6 +178,7 @@ class DebugNotice(CogniteResource, ABC):
         except KeyError:
             return cast(DebugNotice, UnknownDebugNotice._load(data))
 
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         return {
             "category": self.category,
@@ -205,6 +210,7 @@ class ExcessiveTimeoutNotice(InvalidDebugOptionsNotice):
             timeout=data["timeout"],
         )
 
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         obj = super().dump(camel_case=camel_case)
         obj["timeout"] = self.timeout
@@ -251,6 +257,7 @@ class IntractableDirectRelationsCursorNotice(CursoringNotice):
             result_expression=data["resultExpression"],
         )
 
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         obj = super().dump(camel_case=camel_case)
         obj["grade"] = self.grade
@@ -284,6 +291,7 @@ class UnindexedThroughNotice(IndexingNotice):
             property=data["property"],
         )
 
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         obj = super().dump(camel_case=camel_case)
         obj.update(
@@ -317,6 +325,7 @@ class ContainersWithoutIndexesInvolvedNotice(IndexingNotice):
             containers=[ContainerId.load(c) for c in data["containers"]],
         )
 
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         obj = super().dump(camel_case=camel_case)
         obj.update(
@@ -355,6 +364,7 @@ class SelectiveExternalIDFilterNotice(FilteringNotice):
             via_from=data.get("viaFrom"),
         )
 
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         obj = super().dump(camel_case=camel_case)
         obj.update(
@@ -388,6 +398,7 @@ class SignificantHasDataFiltersNotice(FilteringNotice):
             containers=[ContainerId.load(c) for c in data["containers"]],
         )
 
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         obj = super().dump(camel_case=camel_case)
         obj.update(
@@ -423,6 +434,7 @@ class SignificantPostFilteringNotice(FilteringNotice):
             max_involved_rows=data["maxInvolvedRows"],
         )
 
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         obj = super().dump(camel_case=camel_case)
         obj.update(
@@ -462,6 +474,7 @@ class SortNotBackedByIndexNotice(SortingNotice):
             sort=[InstanceSort.load(s) for s in data["sort"]],
         )
 
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         obj = super().dump(camel_case=camel_case)
         obj.update(
@@ -495,6 +508,7 @@ class FilterMatchesCursorableSortNotice(SortingNotice):
             sort=[InstanceSort.load(s) for s in data["sort"]],
         )
 
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         obj = super().dump(camel_case=camel_case)
         obj.update(
@@ -521,6 +535,7 @@ class UnknownDebugNotice(DebugNotice):
         level = data.pop("level", cls._MISSING)
         return cls(category=category, code=code, hint=hint, level=level, data=data)
 
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         if camel_case is False:
             import warnings

--- a/cognite/client/data_classes/data_modeling/extractor_extensions/v1.py
+++ b/cognite/client/data_classes/data_modeling/extractor_extensions/v1.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 from datetime import datetime
 from typing import Literal
 
+from typing_extensions import override
+
 from cognite.client._constants import OMITTED, Omitted
 from cognite.client.data_classes.data_modeling import DirectRelationReference
 from cognite.client.data_classes.data_modeling.ids import ViewId
@@ -78,6 +80,7 @@ class CogniteExtractorData(_CogniteExtractorDataProperties, TypedNode):
         TypedNode.__init__(self, space, external_id, version, last_updated_time, created_time, deleted_time, type)
         self.extracted_data = extracted_data
 
+    @override
     def as_write(self) -> CogniteExtractorDataApply:
         return CogniteExtractorDataApply(
             self.space,

--- a/cognite/client/data_classes/data_modeling/ids.py
+++ b/cognite/client/data_classes/data_modeling/ids.py
@@ -5,7 +5,7 @@ from collections.abc import Sequence
 from dataclasses import asdict, dataclass, field
 from typing import Any, ClassVar, Literal, Protocol, TypeVar, cast
 
-from typing_extensions import Self
+from typing_extensions import Self, override
 
 from cognite.client.data_classes._base import CogniteResource
 from cognite.client.utils._identifier import (
@@ -36,6 +36,7 @@ class DataModelingId(AbstractDataclass):
         return self.space, self.external_id
 
     def dump(self, camel_case: bool = True, include_type: bool = True) -> dict[str, str]:
+        """Dump the instance into a json serializable Python data type."""
         output = asdict(self)
         if include_type:
             output["type"] = self._type
@@ -73,6 +74,7 @@ class VersionedDataModelingId(AbstractDataclass):
         return self.space, self.external_id, self.version
 
     def dump(self, camel_case: bool = True, include_type: bool = True) -> dict[str, str]:
+        """Dump the instance into a json serializable Python data type."""
         output = asdict(self)
         if include_type:
             output["type"] = self._type
@@ -107,6 +109,7 @@ T_Versioned_DataModeling_Id = TypeVar("T_Versioned_DataModeling_Id", bound=Versi
 class NodeId(InstanceId):
     _instance_type: ClassVar[Literal["node", "edge"]] = "node"
 
+    @override
     def dump(self, camel_case: bool = True, include_instance_type: bool = True) -> dict[str, str]:
         output = super().dump(camel_case=camel_case)
         if include_instance_type:
@@ -118,6 +121,7 @@ class NodeId(InstanceId):
 class EdgeId(InstanceId):
     _instance_type: ClassVar[Literal["node", "edge"]] = "edge"
 
+    @override
     def dump(self, camel_case: bool = True, include_instance_type: bool = True) -> dict[str, str]:
         output = super().dump(camel_case=camel_case)
         if include_instance_type:
@@ -167,6 +171,7 @@ class PropertyId(CogniteResource):
             return ContainerId.load(view_or_container_id)
         raise ValueError(f"Invalid type {view_or_container_id}")
 
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         return {
             "source": self.source.dump(camel_case=camel_case, include_type=True),

--- a/cognite/client/data_classes/data_modeling/instances.py
+++ b/cognite/client/data_classes/data_modeling/instances.py
@@ -30,7 +30,7 @@ from typing import (
     overload,
 )
 
-from typing_extensions import Self
+from typing_extensions import Self, override
 
 from cognite.client._constants import OMITTED, Omitted
 from cognite.client.data_classes._base import (
@@ -132,6 +132,7 @@ class NodeOrEdgeData(CogniteResource):
             properties=resource["properties"],
         )
 
+    @override
     def dump(self, camel_case: bool = True) -> dict:
         properties = _PropertyValueSerializer.serialize_values(self.properties, camel_case)
         output: dict[str, Any] = {"properties": properties}
@@ -195,6 +196,7 @@ class InstanceApply(WritableInstanceCore[T_CogniteResource], ABC):
     def sources(self) -> list[NodeOrEdgeData]:
         return self.__sources
 
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         output: dict[str, Any] = {
             "space": self.space,
@@ -255,6 +257,7 @@ class Properties(MutableMapping[ViewIdentifier, MutableMapping[PropertyIdentifie
     load_if = _load_if  # Properties does not have a private load method, so these are the same
 
     def dump(self) -> dict[Space, dict[str, dict[PropertyIdentifier, PropertyValue]]]:
+        """Dump the properties into a json serializable Python data type."""
         props: dict[Space, dict[str, dict[PropertyIdentifier, PropertyValue]]] = defaultdict(dict)
         for view_id, properties in self.data.items():
             view_id_str = f"{view_id.external_id}/{view_id.version}"
@@ -422,6 +425,7 @@ class Instance(WritableInstanceCore[T_CogniteResource], ABC):
         except TypeError:
             self.__raise_if_non_singular_source(attr)
 
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         dumped = {
             "space": self.space,
@@ -570,6 +574,7 @@ class InspectionResults(CogniteResource):
             involved_containers=involved_containers,
         )
 
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         results = {}
         if self.involved_views:
@@ -618,6 +623,7 @@ class InstanceInspectResult(CogniteResource):
             inspection_results=InspectionResults.load(resource["inspectionResults"]),
         )
 
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         return {
             "space": self.space,
@@ -669,6 +675,7 @@ class NodeApply(InstanceApply["NodeApply"]):
             type=DirectRelationReference._load_if(resource.get("type")),
         )
 
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         output = super().dump(camel_case)
         if self.type:
@@ -736,12 +743,14 @@ class Node(Instance[NodeApply]):
             type=self.type,
         )
 
+    @override
     def as_write(self) -> NodeApply:
         return self.as_apply()
 
     def as_id(self) -> NodeId:
         return NodeId(space=self.space, external_id=self.external_id)
 
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         output = super().dump(camel_case)
         if self.type:
@@ -833,6 +842,7 @@ class EdgeApply(InstanceApply["EdgeApply"]):
     def as_id(self) -> EdgeId:
         return EdgeId(space=self.space, external_id=self.external_id)
 
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         output = super().dump(camel_case)
         # TODO: For subclasses of type "Typed-', sources' is a property, so this ends up doing repeated
@@ -924,12 +934,14 @@ class Edge(Instance[EdgeApply]):
             or None,
         )
 
+    @override
     def as_write(self) -> EdgeApply:
         return self.as_apply()
 
     def as_id(self) -> EdgeId:
         return EdgeId(space=self.space, external_id=self.external_id)
 
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         output = super().dump(camel_case)
         if self.type:
@@ -1388,6 +1400,7 @@ class TargetUnit(CogniteResource):
     property: str
     unit: UnitReference | UnitSystemReference
 
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         return {"property": self.property, "unit": self.unit.dump(camel_case)}
 
@@ -1411,6 +1424,7 @@ class TypePropertyDefinition(CogniteResource):
     name: str | None = None
     description: str | None = None
 
+    @override
     def dump(self, camel_case: bool = True, return_flat_dict: bool = False) -> dict[str, Any]:
         output: dict[str, Any] = {}
         if return_flat_dict:
@@ -1447,6 +1461,7 @@ class TypeInformation(UserDict, CogniteResource):
     def __init__(self, data: dict[str, dict[str, dict[str, TypePropertyDefinition]]] | None = None) -> None:
         super().__init__(data or {})
 
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         output: dict[str, Any] = {}
         for space_name, space_data in self.items():
@@ -1738,6 +1753,7 @@ class TypedNodeApply(NodeApply, TypedInstance):
     def sources(self) -> list[NodeOrEdgeData]:
         return [NodeOrEdgeData(source=self.get_source(), properties=self._dump_properties())]
 
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         output = super().dump(camel_case)
         # We want to send type=None even though DMS currently treats it "as if omitted":

--- a/cognite/client/data_classes/data_modeling/query.py
+++ b/cognite/client/data_classes/data_modeling/query.py
@@ -6,7 +6,7 @@ from collections.abc import Mapping, MutableMapping, Sequence
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, Generic, Literal, TypeVar
 
-from typing_extensions import Never, Self, assert_never
+from typing_extensions import Never, Self, assert_never, override
 
 from cognite.client.data_classes._base import CogniteResource, UnknownCogniteResource
 from cognite.client.data_classes.data_modeling.ids import ContainerId, PropertyId, ViewId, ViewIdentifier
@@ -34,6 +34,7 @@ class SourceSelector(CogniteResource):
     properties: list[str] | None = None
     target_units: list[TargetUnit] | None = None
 
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         output: dict[str, Any] = {"source": self.source.dump(camel_case)}
         if self.properties is not None:
@@ -85,6 +86,7 @@ class SourceSelector(CogniteResource):
 class SelectBase(CogniteResource, ABC):
     sources: list[SourceSelector] = field(default_factory=list)
 
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         output: dict[str, Any] = {}
         if self.sources:
@@ -133,6 +135,7 @@ class Select(SelectBase):
     sort: list[InstanceSort] = field(default_factory=list)
     limit: int | None = None
 
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         output = super().dump(camel_case)
         if self.sort:
@@ -179,6 +182,7 @@ class QueryBase(CogniteResource, ABC, Generic[_T_ResultSetExpression, _T_Select]
             for k, v in self.with_.items()
         }
 
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         output: dict[str, Any] = {
             "with": {k: v.dump(camel_case) for k, v in self.with_.items()},
@@ -255,6 +259,7 @@ class QuerySync(QueryBase["ResultSetExpressionSync", SelectSync]):
 
     allow_expired_cursors_and_accept_missed_deletes: bool = False
 
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         output = super().dump(camel_case)
         if self.allow_expired_cursors_and_accept_missed_deletes:
@@ -383,6 +388,7 @@ class NodeResultSetExpression(NodeOrEdgeResultSetExpression):
             limit=resource.get("limit"),
         )
 
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         nodes: dict[str, Any] = {}
         if self.from_:
@@ -446,6 +452,7 @@ class EdgeResultSetExpression(NodeOrEdgeResultSetExpression):
             limit=resource.get("limit"),
         )
 
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         edges: dict[str, Any] = {}
         if self.from_:
@@ -600,6 +607,7 @@ class NodeResultSetExpressionSync(ResultSetExpressionSync):
             backfill_sort=cls._load_sort(resource, "backfillSort"),
         )
 
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         nodes: dict[str, Any] = {}
         if self.from_:
@@ -682,6 +690,7 @@ class EdgeResultSetExpressionSync(ResultSetExpressionSync):
             backfill_sort=cls._load_sort(resource, "backfillSort"),
         )
 
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         edges: dict[str, Any] = {}
         if self.from_:
@@ -821,6 +830,7 @@ class Union(SetOperation):
             limit=resource.get("limit"),
         )
 
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         output: dict[str, Any] = {
             "union": [item if isinstance(item, str) else item.dump(camel_case) for item in self.union]
@@ -848,6 +858,7 @@ class UnionAll(SetOperation):
             limit=resource.get("limit"),
         )
 
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         output: dict[str, Any] = {
             "unionAll": [item if isinstance(item, str) else item.dump(camel_case) for item in self.union_all]
@@ -875,6 +886,7 @@ class Intersection(SetOperation):
             limit=resource.get("limit"),
         )
 
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         output: dict[str, Any] = {
             "intersection": [item if isinstance(item, str) else item.dump(camel_case) for item in self.intersection]

--- a/cognite/client/data_classes/data_modeling/records.py
+++ b/cognite/client/data_classes/data_modeling/records.py
@@ -5,7 +5,7 @@ from copy import deepcopy
 from dataclasses import dataclass
 from typing import Any, Literal
 
-from typing_extensions import Self
+from typing_extensions import Self, override
 
 from cognite.client.data_classes._base import (
     CogniteResource,
@@ -60,6 +60,7 @@ class RecordSource(CogniteResource):
             properties=resource["properties"],
         )
 
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         return {
             "source": self.source.dump(camel_case=camel_case),
@@ -94,6 +95,7 @@ class RecordWrite(WriteableCogniteResource["RecordWrite"]):
             sources=[RecordSource._load(s) for s in resource.get("sources", [])],
         )
 
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         return {
             "space": self.space,
@@ -101,6 +103,7 @@ class RecordWrite(WriteableCogniteResource["RecordWrite"]):
             "sources": [s.dump(camel_case=camel_case) for s in self.sources],
         }
 
+    @override
     def as_write(self) -> RecordWrite:
         return self
 
@@ -137,6 +140,7 @@ class RecordsAggregation(CogniteResource):
             typing=TypeInformation._load(resource["typing"]) if "typing" in resource else None,
         )
 
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         output: dict[str, Any] = {"aggregates": aggs._dump_results(self.aggregates, camel_case)}
         if self.typing is not None:
@@ -182,6 +186,7 @@ class Record(WriteableCogniteResource["RecordWrite"]):
             properties=resource.get("properties"),
         )
 
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         output: dict[str, Any] = {
             "space": self.space,
@@ -227,6 +232,7 @@ class RecordList(WriteableCogniteResourceList[RecordWrite, Record]):
     def as_ids(self) -> list[RecordId]:
         return [record.as_id() for record in self]
 
+    @override
     def as_write(self) -> RecordWriteList:
         return RecordWriteList([record.as_write() for record in self])
 
@@ -267,6 +273,7 @@ class TimeRange(CogniteResource):
     def _load(cls, resource: dict[str, Any]) -> Self:
         return cls(gte=resource.get("gte"), gt=resource.get("gt"), lte=resource.get("lte"), lt=resource.get("lt"))
 
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         return {
             key: value
@@ -295,6 +302,7 @@ class RecordSourceSelector(CogniteResource):
     def _load(cls, resource: dict[str, Any]) -> Self:
         return cls(source=RecordContainerId.load(resource["source"]), properties=resource["properties"])
 
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         return {"source": self.source.dump(camel_case=camel_case), "properties": self.properties}
 
@@ -321,6 +329,7 @@ class RecordTargetUnit(CogniteResource):
             else UnitSystemReference.load(resource["unit"]),
         )
 
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         return {"property": self.property, "unit": self.unit.dump(camel_case=camel_case)}
 
@@ -345,6 +354,7 @@ class RecordTargetUnits(CogniteResource):
             return cls(unit_system_name=resource["unitSystemName"])
         return cls()
 
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         if self.unit_system_name is not None:
             return {"unitSystemName" if camel_case else "unit_system_name": self.unit_system_name}
@@ -393,6 +403,7 @@ class SyncRecord(Record):
             properties=resource.get("properties"),
         )
 
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         output = super().dump(camel_case=camel_case)
         output["status"] = self.status

--- a/cognite/client/data_classes/data_modeling/spaces.py
+++ b/cognite/client/data_classes/data_modeling/spaces.py
@@ -5,7 +5,7 @@ from collections.abc import Iterable, Sequence
 from functools import cached_property
 from typing import Any, cast
 
-from typing_extensions import Self
+from typing_extensions import Self, override
 
 from cognite.client.data_classes._base import (
     CogniteResourceList,
@@ -92,6 +92,7 @@ class Space(SpaceCore):
             name=self.name,
         )
 
+    @override
     def as_write(self) -> SpaceApply:
         return self.as_apply()
 
@@ -164,5 +165,6 @@ class SpaceList(WriteableCogniteResourceList[SpaceApply, Space]):
         """
         return SpaceApplyList([item.as_apply() for item in self])
 
+    @override
     def as_write(self) -> SpaceApplyList:
         return self.as_apply()

--- a/cognite/client/data_classes/data_modeling/statistics.py
+++ b/cognite/client/data_classes/data_modeling/statistics.py
@@ -1,7 +1,7 @@
 from dataclasses import dataclass
 from typing import Any
 
-from typing_extensions import Self
+from typing_extensions import Self, override
 
 from cognite.client.data_classes._base import CogniteResource, CogniteResourceList
 from cognite.client.utils._text import convert_all_keys_to_camel_case
@@ -159,6 +159,7 @@ class ProjectStatistics(CogniteResource):
         instance.project = project
         return instance
 
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         dumped = {
             "spaces": self.spaces.dump(camel_case),

--- a/cognite/client/data_classes/data_modeling/streams.py
+++ b/cognite/client/data_classes/data_modeling/streams.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import Any, Literal
 
-from typing_extensions import Self
+from typing_extensions import Self, override
 
 from cognite.client.data_classes._base import (
     CogniteResource,
@@ -68,6 +68,7 @@ class StreamLimitSettings(CogniteResource):
             max_filtering_interval=resource.get("maxFilteringInterval"),
         )
 
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         out: dict[str, Any] = {
             "max_records_total": self.max_records_total.dump(camel_case=camel_case),
@@ -92,6 +93,7 @@ class StreamSettings(CogniteResource):
             limits=StreamLimitSettings._load(resource["limits"]),
         )
 
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         return {
             "lifecycle": self.lifecycle.dump(camel_case=camel_case),
@@ -129,6 +131,7 @@ class Stream(WriteableCogniteResource["StreamWrite"]):
             settings=StreamSettings._load(resource["settings"]),
         )
 
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         out = {
             "external_id": self.external_id,
@@ -139,6 +142,7 @@ class Stream(WriteableCogniteResource["StreamWrite"]):
         }
         return convert_all_keys_to_camel_case(out) if camel_case else out
 
+    @override
     def as_write(self) -> StreamWrite:
         return StreamWrite(
             external_id=self.external_id,
@@ -179,6 +183,7 @@ class StreamWriteSettings(CogniteResource):
     def _load(cls, resource: dict[str, Any]) -> Self:
         return cls(template=StreamTemplate._load(resource["template"]))
 
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         return {"template": self.template.dump(camel_case=camel_case)}
 
@@ -208,9 +213,11 @@ class StreamWrite(WriteableCogniteResource["StreamWrite"]):
             settings=StreamWriteSettings._load(resource["settings"]),
         )
 
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         out = {"external_id": self.external_id, "settings": self.settings.dump(camel_case=camel_case)}
         return convert_all_keys_to_camel_case(out) if camel_case else out
 
+    @override
     def as_write(self) -> StreamWrite:
         return self

--- a/cognite/client/data_classes/data_modeling/views.py
+++ b/cognite/client/data_classes/data_modeling/views.py
@@ -5,7 +5,7 @@ from collections.abc import Sequence
 from dataclasses import asdict, dataclass, field
 from typing import Any, Literal, TypeAlias, TypeVar, cast
 
-from typing_extensions import Self
+from typing_extensions import Self, override
 
 from cognite.client.data_classes._base import (
     CogniteFilter,
@@ -45,6 +45,7 @@ class ViewCore(DataModelingSchemaResource["ViewApply"], ABC):
         self.implements: list[ViewId] = implements or []
         self.version = version
 
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         output = super().dump(camel_case)
 
@@ -127,6 +128,7 @@ class ViewApply(ViewCore):
             properties=properties,
         )
 
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         output = super().dump(camel_case)
         if "properties" in output:
@@ -221,6 +223,7 @@ class RecordViewApply(CogniteResource):
             properties=properties,
         )
 
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         output = super().dump(camel_case)
         if self.implements:
@@ -233,6 +236,7 @@ class RecordViewApply(CogniteResource):
         return output
 
     def as_write(self) -> RecordViewApply:
+        """Returns this RecordViewApply instance as a write object."""
         return self
 
     def referenced_containers(self) -> set[ContainerId]:
@@ -327,6 +331,7 @@ class View(ViewCore):
         """Whether this view is used for Records"""
         return self.used_for == "record"
 
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         output = super().dump(camel_case)
         if "properties" in output:
@@ -410,6 +415,7 @@ class View(ViewCore):
             properties=properties,
         )
 
+    @override
     def as_write(self) -> ViewApply:
         return self.as_apply()
 
@@ -468,6 +474,7 @@ class ViewList(WriteableCogniteResourceList[ViewApply, View]):
         """
         return [v.as_id() for v in self]
 
+    @override
     def as_write(self) -> ViewApplyList:
         return self.as_apply()
 
@@ -532,6 +539,7 @@ class ViewProperty(CogniteResource, ABC):
         else:
             return MappedProperty.load(resource)
 
+    @override
     @abstractmethod
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         raise NotImplementedError
@@ -547,6 +555,7 @@ class ViewPropertyApply(CogniteResource, ABC):
         else:
             return MappedPropertyApply.load(resource)
 
+    @override
     @abstractmethod
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         raise NotImplementedError
@@ -570,6 +579,7 @@ class MappedPropertyApply(ViewPropertyApply):
             source=ViewId._load_if(resource.get("source")),
         )
 
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         key = "containerPropertyIdentifier" if camel_case else "container_property_identifier"
         output: dict[str, Any] = {
@@ -621,6 +631,7 @@ class MappedProperty(ViewProperty):
             object.__setattr__(prop, "constraint_state", PropertyConstraintState._load(constraint_state))
         return prop
 
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         output: dict[str, Any] = {}
         output["container"] = self.container.dump(camel_case, include_type=False)
@@ -669,6 +680,7 @@ class ConnectionDefinition(ViewProperty, ABC):
 
         return cast(Self, UnknownCogniteResource(resource))
 
+    @override
     @abstractmethod
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         raise NotImplementedError
@@ -709,6 +721,7 @@ class EdgeConnection(ConnectionDefinition, ABC):
 
         return instance
 
+    @override
     @abstractmethod
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         output = asdict(self)
@@ -724,6 +737,7 @@ class EdgeConnection(ConnectionDefinition, ABC):
 
 @dataclass
 class SingleEdgeConnection(EdgeConnection):
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         output: dict[str, Any] = super().dump(camel_case)
         if camel_case:
@@ -746,6 +760,7 @@ class SingleEdgeConnection(EdgeConnection):
 
 @dataclass
 class MultiEdgeConnection(EdgeConnection):
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         output: dict[str, Any] = super().dump(camel_case)
         if camel_case:
@@ -799,6 +814,7 @@ class ReverseDirectRelation(ConnectionDefinition, ABC):
             description=resource.get("description"),
         )
 
+    @override
     @abstractmethod
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         return {
@@ -811,6 +827,7 @@ class ReverseDirectRelation(ConnectionDefinition, ABC):
 
 @dataclass
 class SingleReverseDirectRelation(ReverseDirectRelation):
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         output: dict[str, Any] = super().dump(camel_case)
         if camel_case:
@@ -831,6 +848,7 @@ class SingleReverseDirectRelation(ReverseDirectRelation):
 
 @dataclass
 class MultiReverseDirectRelation(ReverseDirectRelation):
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         output: dict[str, Any] = super().dump(camel_case)
         if camel_case:
@@ -867,6 +885,7 @@ class ConnectionDefinitionApply(ViewPropertyApply, ABC):
             return cast(Self, MultiReverseDirectRelationApply.load(resource))
         return cast(Self, UnknownCogniteResource(resource))
 
+    @override
     @abstractmethod
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         raise NotImplementedError
@@ -912,6 +931,7 @@ class EdgeConnectionApply(ConnectionDefinitionApply, ABC):
             instance.direction = resource["direction"]
         return instance
 
+    @override
     @abstractmethod
     def dump(self, camel_case: bool = True) -> dict:
         output: dict[str, Any] = {
@@ -933,6 +953,7 @@ class EdgeConnectionApply(ConnectionDefinitionApply, ABC):
 
 @dataclass
 class SingleEdgeConnectionApply(EdgeConnectionApply):
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         output: dict[str, Any] = super().dump(camel_case)
         if camel_case:
@@ -945,6 +966,7 @@ class SingleEdgeConnectionApply(EdgeConnectionApply):
 
 @dataclass
 class MultiEdgeConnectionApply(EdgeConnectionApply):
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         output: dict[str, Any] = super().dump(camel_case)
         if camel_case:
@@ -992,6 +1014,7 @@ class ReverseDirectRelationApply(ConnectionDefinitionApply, ABC):
 
         return instance
 
+    @override
     @abstractmethod
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         output: dict[str, Any] = {
@@ -1008,6 +1031,7 @@ class ReverseDirectRelationApply(ConnectionDefinitionApply, ABC):
 
 @dataclass
 class SingleReverseDirectRelationApply(ReverseDirectRelationApply):
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         output: dict[str, Any] = super().dump(camel_case)
         if camel_case:
@@ -1020,6 +1044,7 @@ class SingleReverseDirectRelationApply(ReverseDirectRelationApply):
 
 @dataclass
 class MultiReverseDirectRelationApply(ReverseDirectRelationApply):
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         output: dict[str, Any] = super().dump(camel_case)
         if camel_case:

--- a/cognite/client/data_classes/data_sets.py
+++ b/cognite/client/data_classes/data_sets.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from typing_extensions import Self
+from typing_extensions import Self, override
 
 from cognite.client.data_classes._base import (
     CogniteFilter,
@@ -99,6 +99,7 @@ class DataSet(DataSetCore):
             metadata=resource.get("metadata"),
         )
 
+    @override
     def as_write(self) -> DataSetWrite:
         return DataSetWrite(
             external_id=self.external_id,
@@ -177,6 +178,7 @@ class DataSetFilter(CogniteFilter):
         self.external_id_prefix = external_id_prefix
         self.write_protected = write_protected
 
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         dumped = super().dump(camel_case=camel_case)
         if self.created_time and isinstance(self.created_time, TimestampRange):
@@ -264,5 +266,6 @@ class DataSetWriteList(CogniteResourceList[DataSetWrite], ExternalIDTransformerM
 class DataSetList(WriteableCogniteResourceList[DataSetWrite, DataSet], IdTransformerMixin):
     _RESOURCE = DataSet
 
+    @override
     def as_write(self) -> DataSetWriteList:
         return DataSetWriteList([ds.as_write() for ds in self.data])

--- a/cognite/client/data_classes/datapoints.py
+++ b/cognite/client/data_classes/datapoints.py
@@ -13,7 +13,7 @@ from types import MappingProxyType
 from typing import TYPE_CHECKING, Any, ClassVar, Literal, NoReturn, TypeAlias, TypeVar, overload
 from zoneinfo import ZoneInfo
 
-from typing_extensions import Self
+from typing_extensions import Self, override
 
 from cognite.client._constants import NUMPY_IS_AVAILABLE
 from cognite.client.data_classes._base import (
@@ -115,7 +115,9 @@ class StatusCode(IntEnum):
 @dataclass(slots=True, frozen=True)
 class MaxOrMinDatapoint:
     @abstractmethod
-    def dump(self, camel_case: bool = True) -> dict[str, Any]: ...
+    def dump(self, camel_case: bool = True) -> dict[str, Any]:
+        """Dump the datapoint to a dictionary."""
+        ...
 
     @classmethod
     @abstractmethod
@@ -144,6 +146,7 @@ class MinDatapoint(MaxOrMinDatapoint):
         assert "statusCode" not in dct
         return cls(dct["timestamp"], dct["value"])
 
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         return {"timestamp": self.timestamp, "value": self.value}
 
@@ -157,6 +160,7 @@ class MinDatapointWithStatus(MinDatapoint):
     def _load(cls, dct: dict[str, Any]) -> Self:
         return cls(dct["timestamp"], dct["value"], dct["statusCode"], dct["statusSymbol"])
 
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         return {
             "timestamp": self.timestamp,
@@ -188,6 +192,7 @@ class MaxDatapoint(MaxOrMinDatapoint):
         assert "statusCode" not in dct
         return cls(dct["timestamp"], dct["value"])
 
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         return {"timestamp": self.timestamp, "value": self.value}
 
@@ -201,6 +206,7 @@ class MaxDatapointWithStatus(MaxDatapoint):
     def _load(cls, dct: dict[str, Any]) -> Self:
         return cls(dct["timestamp"], dct["value"], dct["statusCode"], dct["statusSymbol"])
 
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         return {
             "timestamp": self.timestamp,
@@ -363,6 +369,7 @@ class DatapointsQuery:
         return json.dumps(self.dump(), indent=4)
 
     def dump(self) -> dict[str, Any]:
+        """Dump the query to a dictionary, excluding any attributes that are set to their default values."""
         # We need to dump only those fields specifically passed by the user:
         return {
             **self.identifier.as_dict(camel_case=False),
@@ -597,6 +604,7 @@ class Datapoint(CogniteResource):
             timezone=timezone,
         )
 
+    @override
     def dump(self, camel_case: bool = True, include_timezone: bool = True) -> dict[str, Any]:
         dumped = super().dump(camel_case=camel_case)
         # Keep value even if None (bad status codes support missing):
@@ -839,6 +847,7 @@ class DatapointsArray(CogniteResource):
         attrs, arrays = map(list, zip(*data_field_tuples))
         return attrs, arrays
 
+    @override
     def dump(self, camel_case: bool = True, convert_timestamps: bool = False) -> dict[str, Any]:
         """Dump the DatapointsArray into a json serializable Python data type.
 
@@ -1076,6 +1085,7 @@ class Datapoints(CogniteResource):
     def __iter__(self) -> Iterator[Datapoint]:
         yield from self.__get_datapoint_objects()
 
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         """Dump the datapoints into a json serializable Python data type.
 
@@ -1298,6 +1308,7 @@ class SyntheticDatapoints(CogniteResource):
             timezone=tz,
         )
 
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         """Dump the synthetic datapoints into a json serializable Python data type.
 
@@ -1385,6 +1396,7 @@ class SyntheticDatapointsList(CogniteResourceList[SyntheticDatapoints]):
         # Concatenate along columns (axis=1), aligning on timestamp index
         return pd.concat(dfs, axis=1)
 
+    @override
     def dump(self, camel_case: bool = True) -> NoReturn:
         raise NotImplementedError
 
@@ -1456,6 +1468,7 @@ class DatapointsArrayList(CogniteResourceListWithClientRef[DatapointsArray]):
             include_unit=include_unit,
         )
 
+    @override
     def dump(self, camel_case: bool = True, convert_timestamps: bool = False) -> list[dict[str, Any]]:
         """Dump the instance into a json serializable Python data type.
 
@@ -1614,6 +1627,7 @@ class LatestDatapoint(CogniteResource):
         """Whether a datapoint exists for this time series."""
         return bool(self)
 
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         """Dump the latest datapoint into a json serializable Python data type.
 

--- a/cognite/client/data_classes/datapoints_subscriptions.py
+++ b/cognite/client/data_classes/datapoints_subscriptions.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass
 from enum import auto
 from typing import TYPE_CHECKING, Any, Literal
 
-from typing_extensions import Self
+from typing_extensions import Self, override
 
 from cognite.client.data_classes._base import (
     CogniteListUpdate,
@@ -49,6 +49,7 @@ class DatapointSubscriptionCore(WriteableCogniteResource["DataPointSubscriptionW
         self.description = description
         self.data_set_id = data_set_id
 
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         data = super().dump(camel_case)
         if "filter" in data:
@@ -163,6 +164,7 @@ class DataPointSubscriptionWrite(DatapointSubscriptionCore):
             data_set_id=resource.get("dataSetId"),
         )
 
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         data = super().dump(camel_case)
         if self.instance_ids is not None:
@@ -293,6 +295,7 @@ class TimeSeriesID(CogniteResource):
             instance_id=NodeId._load_if(resource.get("instanceId")),
         )
 
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         resource: dict[str, Any] = {}
         if self.id is not None:
@@ -314,6 +317,7 @@ class DataDeletion:
         return cls(inclusive_begin=data["inclusiveBegin"], exclusive_end=data.get("exclusiveEnd"))
 
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
+        """Dumps the data deletion object to a dictionary."""
         resource: dict[str, Any] = {("inclusiveBegin" if camel_case else "inclusive_begin"): self.inclusive_begin}
         if self.exclusive_end is not None:
             resource["exclusiveEnd" if camel_case else "exclusive_end"] = self.exclusive_end
@@ -341,6 +345,7 @@ class DatapointsUpdate:
         )
 
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
+        """Dumps the datapoints update object to a dictionary."""
         resource: dict[str, Any] = {("timeSeries" if camel_case else "time_series"): self.time_series.dump(camel_case)}
         if self.upserts is not None:
             resource["upserts"] = self.upserts.dump(camel_case)
@@ -428,6 +433,7 @@ class SubscriptionDatapoints(CogniteResource):
     def __len__(self) -> int:
         return len(self.timestamp)
 
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         raise NotImplementedError
 
@@ -475,6 +481,7 @@ class SubscriptionTimeSeriesUpdate:
         )
 
     def dump(self, camel_case: bool = True) -> dict[str, list[dict[str, Any]]]:
+        """Dump the subscription time series update to a dictionary."""
         return {
             "added": [ts_id.dump() for ts_id in self.added],
             "removed": [ts_id.dump() for ts_id in self.removed],
@@ -491,6 +498,7 @@ class DatapointSubscriptionPartition:
         return cls(index=data["index"], cursor=data.get("nextCursor") or data.get("cursor"))
 
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
+        """Dump datapoint subscription partition to a dictionary."""
         output: dict[str, Any] = {"index": self.index}
         if self.cursor is not None:
             output["cursor"] = self.cursor
@@ -536,6 +544,7 @@ class _DatapointSubscriptionBatchWithPartitions:
         )
 
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
+        """Dumps the subscription batch to a dictionary."""
         resource: dict[str, Any] = {
             "updates": [u.dump(camel_case) for u in self.updates],
             "partitions": [p.dump(camel_case) for p in self.partitions],

--- a/cognite/client/data_classes/documents.py
+++ b/cognite/client/data_classes/documents.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass
 from enum import auto
 from typing import Any, Literal, TypeAlias
 
-from typing_extensions import Self
+from typing_extensions import Self, override
 
 from cognite.client.data_classes._base import (
     CogniteResource,
@@ -100,6 +100,7 @@ class DocumentsGeoJsonGeometry(CogniteResource):
             instance.geometries = [Geometry.load(geometry) for geometry in instance.geometries]
         return instance
 
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         output = super().dump(camel_case)
         if self.geometries:
@@ -173,6 +174,7 @@ class SourceFile(CogniteResource):
             metadata=resource.get("metadata"),
         )
 
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         output = super().dump(camel_case)
         if self.labels:
@@ -280,6 +282,7 @@ class Document(CogniteResource):
             geo_location=DocumentsGeoJsonGeometry._load_if(resource.get("geoLocation")),
         )
 
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         output = super().dump(camel_case)
         if self.source_file:
@@ -312,6 +315,7 @@ class Highlight(CogniteResource):
     name: list[str]
     content: list[str]
 
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         return {
             "name": self.name,
@@ -345,6 +349,7 @@ class DocumentHighlight(CogniteResource):
             document=Document._load(resource["document"]),
         )
 
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         output: dict[str, Any] = {}
         if self.highlight:
@@ -451,6 +456,7 @@ class TemporaryLink:
         )
 
     def dump(self) -> dict[str, Any]:
+        """Dump the temporary link to a dictionary."""
         return {
             "temporaryLink": self.url,
             "expirationTime": self.expires_at,

--- a/cognite/client/data_classes/events.py
+++ b/cognite/client/data_classes/events.py
@@ -4,7 +4,7 @@ from collections.abc import Sequence
 from enum import auto
 from typing import Any, Literal, TypeAlias
 
-from typing_extensions import Self
+from typing_extensions import Self, override
 
 from cognite.client.data_classes._base import (
     CogniteFilter,
@@ -179,6 +179,7 @@ class EventWrite(WriteableCogniteResource["EventWrite"]):
         self.asset_ids = asset_ids
         self.source = source
 
+    @override
     def as_write(self) -> EventWrite:
         return self
 
@@ -250,6 +251,7 @@ class EventFilter(CogniteFilter):
         self.last_updated_time = last_updated_time
         self.external_id_prefix = external_id_prefix
 
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         dumped = super().dump(camel_case)
         if self.end_time and isinstance(self.end_time, EndTimeFilter):
@@ -368,6 +370,7 @@ class EventWriteList(CogniteResourceList[EventWrite], ExternalIDTransformerMixin
 class EventList(WriteableCogniteResourceList[EventWrite, Event], IdTransformerMixin):
     _RESOURCE = Event
 
+    @override
     def as_write(self) -> EventWriteList:
         return EventWriteList([event.as_write() for event in self.data])
 

--- a/cognite/client/data_classes/extractionpipelines.py
+++ b/cognite/client/data_classes/extractionpipelines.py
@@ -4,7 +4,7 @@ from abc import ABC
 from dataclasses import dataclass
 from typing import Any, Literal
 
-from typing_extensions import Self
+from typing_extensions import Self, override
 
 from cognite.client.data_classes._base import (
     CogniteFilter,
@@ -121,6 +121,7 @@ class ExtractionPipelineCore(WriteableCogniteResource["ExtractionPipelineWrite"]
         self.notification_config = notification_config
         self.created_by = created_by
 
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         result = super().dump(camel_case)
         if self.contacts:
@@ -425,6 +426,7 @@ class ExtractionPipelineList(
 ):
     _RESOURCE = ExtractionPipeline
 
+    @override
     def as_write(self) -> ExtractionPipelineWriteList:
         return ExtractionPipelineWriteList([x.as_write() for x in self.data])
 
@@ -500,6 +502,7 @@ class ExtractionPipelineRun(ExtractionPipelineRunCore):
             created_time=resource.get("createdTime"),
         )
 
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         dct = super().dump(camel_case=camel_case)
         # Note: No way to make this id/xid API mixup completely correct. Either:
@@ -549,6 +552,7 @@ class ExtractionPipelineRunWrite(ExtractionPipelineRunCore):
             created_time=resource.get("createdTime"),
         )
 
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         dct = super().dump(camel_case=camel_case)
         # Note: No way to make this id/xid API mixup completely correct. Either:
@@ -577,6 +581,7 @@ class ExtractionPipelineRunList(
 ):
     _RESOURCE = ExtractionPipelineRun
 
+    @override
     def as_write(self) -> ExtractionPipelineRunWriteList:
         return ExtractionPipelineRunWriteList([x.as_write() for x in self.data])
 
@@ -758,5 +763,6 @@ class ExtractionPipelineConfigList(
 ):
     _RESOURCE = ExtractionPipelineConfig
 
+    @override
     def as_write(self) -> ExtractionPipelineConfigWriteList:
         return ExtractionPipelineConfigWriteList([x.as_write() for x in self.data])

--- a/cognite/client/data_classes/files.py
+++ b/cognite/client/data_classes/files.py
@@ -7,7 +7,7 @@ from contextlib import AbstractAsyncContextManager, AbstractContextManager
 from types import TracebackType
 from typing import TYPE_CHECKING, Any, BinaryIO, Literal, TypeVar
 
-from typing_extensions import Self
+from typing_extensions import Self, override
 
 from cognite.client.data_classes._base import (
     CogniteFilter,
@@ -91,6 +91,7 @@ class FileMetadataCore(WriteableCogniteResource["FileMetadataWrite"], ABC):
         self.source_modified_time = source_modified_time
         self.security_categories = security_categories
 
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         result = super().dump(camel_case)
         if self.labels is not None:
@@ -173,6 +174,7 @@ class FileMetadata(FileMetadataCore):
         self.uploaded = uploaded
         self.uploaded_time = uploaded_time
 
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         result = super().dump(camel_case)
         if self.instance_id is not None:
@@ -308,6 +310,7 @@ class FileMetadataWrite(FileMetadataCore):
             security_categories=resource.get("securityCategories"),
         )
 
+    @override
     def as_write(self) -> FileMetadataWrite:
         return self
 
@@ -381,6 +384,7 @@ class FileMetadataFilter(CogniteFilter):
         if geo_location is not None and not isinstance(geo_location, GeoLocationFilter):
             raise TypeError("FileMetadata.geo_location should be of type GeoLocationFilter")
 
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         result = super().dump(camel_case)
         if isinstance(self.labels, LabelFilter):
@@ -418,6 +422,7 @@ class FileMetadataUpdate(CogniteUpdate):
         if instance_id is not None:
             self.warn_on_instance_id_update()
 
+    @override
     def dump(self, camel_case: Literal[True] = True) -> dict[str, Any]:
         output = super().dump(camel_case=camel_case)
         if self.instance_id is not None:

--- a/cognite/client/data_classes/filters.py
+++ b/cognite/client/data_classes/filters.py
@@ -6,7 +6,7 @@ from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Literal, NoReturn, TypeAlias, cast, final
 
-from typing_extensions import Self
+from typing_extensions import Self, override
 
 from cognite.client.data_classes._base import EnumProperty
 from cognite.client.data_classes.data_modeling.data_types import DirectRelationReference
@@ -190,6 +190,7 @@ class UnknownFilter(Filter):
     def _load(cls, resource: dict[str, Any]) -> NoReturn:
         raise NotImplementedError("UnknownFilter cannot be loaded (is a fallback for unknown filter types)")
 
+    @override
     def dump(self, camel_case_property: bool = False) -> dict[str, Any]:
         return {self.__actual_filter_name: self._filter_body(camel_case_property)}
 
@@ -218,6 +219,7 @@ class InvalidFilter(Filter):
         else:
             return body
 
+    @override
     def dump(self, camel_case_property: bool = False) -> dict[str, Any]:
         return {self._filter_name: self._filter_body(camel_case_property)}
 

--- a/cognite/client/data_classes/functions.py
+++ b/cognite/client/data_classes/functions.py
@@ -716,6 +716,7 @@ class FunctionCall(CogniteResourceWithClientRef):
         )
 
     def as_write(self) -> NoReturn:
+        """FunctionCall is purely a read/response object and cannot be converted to a write object"""
         raise RuntimeError("FunctionCall is purely a read/response object and cannot be converted to a write object")
 
     async def get_response_async(self) -> dict[str, object] | None:

--- a/cognite/client/data_classes/geospatial.py
+++ b/cognite/client/data_classes/geospatial.py
@@ -4,7 +4,7 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, TypeVar
 
-from typing_extensions import Self
+from typing_extensions import Self, override
 
 from cognite.client.data_classes._base import (
     CogniteResource,
@@ -88,6 +88,7 @@ class FeatureType(FeatureTypeCore):
             search_spec=resource.get("searchSpec"),
         )
 
+    @override
     def as_write(self) -> FeatureTypeWrite:
         """Returns a write version of this feature type."""
         return FeatureTypeWrite(
@@ -132,6 +133,7 @@ class FeatureTypeWrite(FeatureTypeCore):
             search_spec=resource.get("searchSpec"),
         )
 
+    @override
     def as_write(self) -> FeatureTypeWrite:
         """Returns this FeatureTypeWrite instance."""
         return self
@@ -144,6 +146,7 @@ class FeatureTypeWriteList(CogniteResourceList[FeatureTypeWrite], ExternalIDTran
 class FeatureTypeList(WriteableCogniteResourceList[FeatureTypeWrite, FeatureType], ExternalIDTransformerMixin):
     _RESOURCE = FeatureType
 
+    @override
     def as_write(self) -> FeatureTypeWriteList:
         return FeatureTypeWriteList([feature_type.as_write() for feature_type in self])
 
@@ -182,6 +185,7 @@ class FeatureTypePatch(CogniteResource):
     property_patches: Patches | None = None
     search_spec_patches: Patches | None = None
 
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         item = {
             "external_id": self.external_id,
@@ -218,6 +222,7 @@ class FeatureCore(WriteableCogniteResource["FeatureWrite"], ABC):
         for key in properties:
             setattr(self, key, properties[key])
 
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         def handle_case(key: str) -> str:
             # Keep properties defined in Feature Type as is
@@ -271,6 +276,7 @@ class Feature(FeatureCore):
             **{_to_feature_property_name(key): value for key, value in resource.items() if key not in non_feature_keys},
         )
 
+    @override
     def as_write(self) -> FeatureWrite:
         """Returns a write version of this feature."""
         if self.external_id is None:
@@ -305,6 +311,7 @@ class FeatureWrite(FeatureCore):
             **{_to_feature_property_name(key): value for key, value in resource.items() if key != "externalId"},
         )
 
+    @override
     def as_write(self) -> FeatureWrite:
         """Returns this FeatureWrite instance."""
         return self
@@ -463,6 +470,7 @@ class FeatureListCore(WriteableCogniteResourceList[FeatureWrite, T_Feature], Ext
 class FeatureWriteList(FeatureListCore[FeatureWrite]):
     _RESOURCE = FeatureWrite
 
+    @override
     def as_write(self) -> FeatureWriteList:
         return self
 
@@ -470,6 +478,7 @@ class FeatureWriteList(FeatureListCore[FeatureWrite]):
 class FeatureList(FeatureListCore[Feature]):
     _RESOURCE = Feature
 
+    @override
     def as_write(self) -> FeatureWriteList:
         return FeatureWriteList([feature.as_write() for feature in self])
 
@@ -531,6 +540,7 @@ class CoordinateReferenceSystem(CoordinateReferenceSystemCore):
             proj_string=resource["projString"],
         )
 
+    @override
     def as_write(self) -> CoordinateReferenceSystemWrite:
         """Returns a write version of this coordinate reference system."""
         return CoordinateReferenceSystemWrite(srid=self.srid, wkt=self.wkt, proj_string=self.proj_string)
@@ -549,6 +559,7 @@ class CoordinateReferenceSystemWrite(CoordinateReferenceSystemCore):
     def _load(cls, resource: dict[str, Any]) -> CoordinateReferenceSystemWrite:
         return cls(srid=resource["srid"], wkt=resource["wkt"], proj_string=resource["projString"])
 
+    @override
     def as_write(self) -> CoordinateReferenceSystemWrite:
         """Returns this CoordinateReferenceSystemWrite instance."""
         return self
@@ -563,6 +574,7 @@ class CoordinateReferenceSystemList(
 ):
     _RESOURCE = CoordinateReferenceSystem
 
+    @override
     def as_write(self) -> CoordinateReferenceSystemWriteList:
         return CoordinateReferenceSystemWriteList(
             [coordinate_reference_system.as_write() for coordinate_reference_system in self]
@@ -667,5 +679,6 @@ class GeospatialComputedResponse(CogniteResource):
     def _load(cls, resource: dict[str, Any]) -> GeospatialComputedResponse:
         return cls(GeospatialComputedItemList._load(resource.get("items", [])))
 
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         return {"items": self.items.dump(camel_case=camel_case)}

--- a/cognite/client/data_classes/hosted_extractors/destinations.py
+++ b/cognite/client/data_classes/hosted_extractors/destinations.py
@@ -4,7 +4,7 @@ from abc import ABC
 from dataclasses import dataclass
 from typing import Any, NoReturn
 
-from typing_extensions import Self
+from typing_extensions import Self, override
 
 from cognite.client.data_classes._base import (
     CognitePrimitiveUpdate,
@@ -62,6 +62,7 @@ class DestinationWrite(_DestinationCore):
             target_data_set_id=resource.get("targetDataSetId"),
         )
 
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         output = super().dump(camel_case)
         if isinstance(self.credentials, SessionWrite):
@@ -69,6 +70,7 @@ class DestinationWrite(_DestinationCore):
 
         return output
 
+    @override
     def as_write(self) -> DestinationWrite:
         return self
 
@@ -115,6 +117,7 @@ class Destination(_DestinationCore):
             target_data_set_id=resource.get("targetDataSetId"),
         )
 
+    @override
     def as_write(self) -> NoReturn:
         raise TypeError(f"{self.__class__.__name__} cannot be converted to a write object")
 
@@ -154,5 +157,6 @@ class DestinationWriteList(CogniteResourceList[DestinationWrite], ExternalIDTran
 class DestinationList(WriteableCogniteResourceList[DestinationWrite, Destination], ExternalIDTransformerMixin):
     _RESOURCE = Destination
 
+    @override
     def as_write(self) -> NoReturn:
         raise TypeError(f"{self.__class__.__name__} cannot be converted to a write object")

--- a/cognite/client/data_classes/hosted_extractors/jobs.py
+++ b/cognite/client/data_classes/hosted_extractors/jobs.py
@@ -4,7 +4,7 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from typing import Any, ClassVar, Literal, TypeAlias, cast
 
-from typing_extensions import Self
+from typing_extensions import Self, override
 
 from cognite.client.data_classes._base import (
     CognitePrimitiveUpdate,
@@ -53,6 +53,7 @@ class JobFormat(CogniteResource, ABC):
             return UnknownCogniteResource(resource)  # type: ignore[return-value]
         return cast(Self, job_cls._load_job(resource))
 
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         output = super().dump(camel_case)
         output["type"] = self._type
@@ -87,6 +88,7 @@ class ValueFormat(JobFormat):
             prefix=Prefix._load_if(resource.get("prefix")),
         )
 
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         output = super().dump(camel_case)
         if self.prefix:
@@ -109,6 +111,7 @@ class RockwellFormat(JobFormat):
             prefix=Prefix._load_if(resource.get("prefix")),
         )
 
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         output = super().dump(camel_case)
         if self.prefix:
@@ -147,6 +150,7 @@ class CogniteFormat(JobFormat):
             prefix=Prefix._load_if(resource.get("prefix")),
         )
 
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         output = super().dump(camel_case)
         if self.prefix:
@@ -213,6 +217,7 @@ class IncrementalLoad(CogniteResource, ABC):
             return UnknownCogniteResource(resource)  # type: ignore[return-value]
         return cast(Self, incremental_load_cls._load_incremental_load(resource))
 
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         output = super().dump(camel_case)
         output["type"] = self._type
@@ -289,6 +294,7 @@ class RestConfig(JobConfig):
             pagination=IncrementalLoad._load_if(resource.get("pagination")),
         )
 
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         output = super().dump(camel_case)
         if self.incremental_load:
@@ -308,6 +314,7 @@ class _JobCore(WriteableCogniteResource["JobWrite"]):
         self.format = format
         self.config = config
 
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         output = super().dump(camel_case)
         output["format"] = self.format.dump(camel_case)
@@ -334,6 +341,7 @@ class JobWrite(_JobCore):
 
     """
 
+    @override
     def as_write(self) -> JobWrite:
         return self
 
@@ -386,6 +394,7 @@ class Job(_JobCore):
         self.created_time = created_time
         self.last_updated_time = last_updated_time
 
+    @override
     def as_write(self) -> JobWrite:
         return JobWrite(
             external_id=self.external_id,
@@ -417,6 +426,7 @@ class JobWriteList(CogniteResourceList[JobWrite], ExternalIDTransformerMixin):
 class JobList(WriteableCogniteResourceList[JobWrite, Job], ExternalIDTransformerMixin):
     _RESOURCE = Job
 
+    @override
     def as_write(self) -> JobWriteList:
         return JobWriteList([job.as_write() for job in self.data])
 

--- a/cognite/client/data_classes/hosted_extractors/mappings.py
+++ b/cognite/client/data_classes/hosted_extractors/mappings.py
@@ -4,7 +4,7 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from typing import Any, ClassVar, Literal, cast
 
-from typing_extensions import Self
+from typing_extensions import Self, override
 
 from cognite.client.data_classes._base import (
     CognitePrimitiveUpdate,
@@ -49,6 +49,7 @@ class InputMapping(CogniteResource, ABC):
             return UnknownCogniteResource(resource)  # type: ignore[return-value]
         return cast(Self, job_cls._load_input(resource))
 
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         output = super().dump(camel_case)
         output["type"] = self._type
@@ -82,6 +83,7 @@ class ProtoBufInput(InputMapping):
             files=[ProtoBufFile._load(file) for file in resource["files"]],
         )
 
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         return {
             "type": self._type,
@@ -128,6 +130,7 @@ class _MappingCore(WriteableCogniteResource["MappingWrite"]):
         self.mapping = mapping
         self.published = published
 
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         output = super().dump(camel_case)
         output["mapping"] = self.mapping.dump(camel_case)
@@ -172,9 +175,11 @@ class MappingWrite(_MappingCore):
             input=InputMapping._load(resource["input"]) if "input" in resource else JSONInput(),
         )
 
+    @override
     def as_write(self) -> MappingWrite:
         return self
 
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         output = super().dump(camel_case)
         if isinstance(self.input, InputMapping):
@@ -222,11 +227,13 @@ class Mapping(_MappingCore):
             last_updated_time=resource["lastUpdatedTime"],
         )
 
+    @override
     def as_write(self) -> MappingWrite:
         return MappingWrite(
             external_id=self.external_id, mapping=self.mapping, published=self.published, input=self.input
         )
 
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         output = super().dump(camel_case)
         output["input"] = self.input.dump(camel_case)
@@ -240,6 +247,7 @@ class MappingWriteList(CogniteResourceList[MappingWrite], ExternalIDTransformerM
 class MappingList(WriteableCogniteResourceList[MappingWrite, Mapping], ExternalIDTransformerMixin):
     _RESOURCE = Mapping
 
+    @override
     def as_write(self) -> MappingWriteList:
         return MappingWriteList([mapping.as_write() for mapping in self.data])
 

--- a/cognite/client/data_classes/hosted_extractors/sources.py
+++ b/cognite/client/data_classes/hosted_extractors/sources.py
@@ -6,7 +6,7 @@ from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import Any, ClassVar, Literal, NoReturn, cast
 
-from typing_extensions import Self
+from typing_extensions import Self, override
 
 from cognite.client.data_classes._base import (
     CognitePrimitiveUpdate,
@@ -56,6 +56,7 @@ class SourceWrite(CogniteResource, ABC):
             raise TypeError(f"Unknown source type: {type_}")
         return cast(Self, source_cls._load_source(resource))
 
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         output = super().dump(camel_case)
         output["type"] = self._type
@@ -95,6 +96,7 @@ class Source(WriteableCogniteResource[T_WriteClass], ABC):
             return UnknownCogniteResource(resource)  # type: ignore[return-value]
         return cast(Self, source_class._load_source(resource))
 
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         output = super().dump(camel_case)
         output["type"] = self._type
@@ -107,6 +109,7 @@ class SourceUpdate(CogniteUpdate, ABC):
     def __init__(self, external_id: str) -> None:
         super().__init__(external_id=external_id)
 
+    @override
     def dump(self, camel_case: Literal[True] = True) -> dict[str, Any]:
         output = super().dump(camel_case)
         output["type"] = self._type
@@ -126,6 +129,7 @@ class SourceWriteList(CogniteResourceList[SourceWrite], ExternalIDTransformerMix
 class SourceList(WriteableCogniteResourceList[SourceWrite, Source], ExternalIDTransformerMixin):
     _RESOURCE = Source
 
+    @override
     def as_write(self) -> NoReturn:
         raise TypeError(f"{type(self).__name__} cannot be converted to write")
 
@@ -165,6 +169,7 @@ class EventHubSourceWrite(SourceWrite):
         self.consumer_group = consumer_group
 
     def as_write(self) -> SourceWrite:
+        """Return a write version of this source."""
         return self
 
     @classmethod
@@ -216,6 +221,7 @@ class EventHubSource(Source):
         self.created_time = created_time
         self.last_updated_time = last_updated_time
 
+    @override
     def as_write(self) -> NoReturn:
         raise TypeError(f"{type(self).__name__} cannot be converted to write as id does not contain the secrets")
 
@@ -313,9 +319,11 @@ class _MQTTSource(Source, ABC):
             last_updated_time=resource["lastUpdatedTime"],
         )
 
+    @override
     def as_write(self) -> NoReturn:
         raise TypeError(f"{type(self).__name__} cannot be converted to write as id does not contain the secrets")
 
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         output = super().dump(camel_case)
         if self.authentication is not None:
@@ -423,6 +431,7 @@ class _MQTTSourceWrite(SourceWrite, ABC):
             auth_certificate=AuthCertificateWrite._load_if(resource.get("authCertificate")),
         )
 
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         output = super().dump(camel_case)
         if isinstance(self.authentication, AuthenticationWrite):
@@ -513,6 +522,7 @@ class KafkaSourceWrite(SourceWrite):
             auth_certificate=AuthCertificateWrite._load_if(resource.get("authCertificate")),
         )
 
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         output = super().dump(camel_case)
         output["bootstrapBrokers" if camel_case else "bootstrap_brokers"] = [
@@ -580,9 +590,11 @@ class KafkaSource(Source):
             last_updated_time=resource["lastUpdatedTime"],
         )
 
+    @override
     def as_write(self) -> KafkaSourceWrite:
         raise TypeError(f"{type(self).__name__} cannot be converted to write as id does not contain the secrets")
 
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         output = super().dump(camel_case)
         output["bootstrapBrokers" if camel_case else "bootstrap_brokers"] = [
@@ -700,6 +712,7 @@ class RestSourceWrite(SourceWrite):
 
         return cls(**args)
 
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         output = super().dump(camel_case)
         if isinstance(self.ca_certificate, CACertificateWrite):
@@ -762,9 +775,11 @@ class RestSource(Source):
             authentication=Authentication._load_if(resource.get("authentication")),
         )
 
+    @override
     def as_write(self) -> RestSourceWrite:
         raise TypeError(f"{type(self).__name__} cannot be converted to write as id does not contain the secrets")
 
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         output = super().dump(camel_case)
         if self.ca_certificate is not None:
@@ -850,6 +865,7 @@ class AuthenticationWrite(CogniteResource, ABC):
             raise TypeError(f"Unknown authentication type: {type_}")
         return cast(Self, authentication_cls._load_authentication(resource))
 
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         output = super().dump(camel_case)
         output["type"] = self._type
@@ -964,6 +980,7 @@ class Authentication(CogniteResource, ABC):
             return UnknownCogniteResource(resource)  # type: ignore[return-value]
         return cast(Self, authentication_class._load_authentication(resource))
 
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         output = super().dump(camel_case)
         output["type"] = self._type

--- a/cognite/client/data_classes/iam.py
+++ b/cognite/client/data_classes/iam.py
@@ -5,7 +5,7 @@ from collections.abc import Iterable
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, Literal, TypeAlias
 
-from typing_extensions import Self
+from typing_extensions import Self, override
 
 from cognite.client.data_classes._base import (
     CogniteResource,
@@ -45,6 +45,7 @@ class GroupAttributes(CogniteResource):
     token: GroupAttributesToken | None = None
     _unknown_properties: dict[str, Any] = field(default_factory=dict, init=False, repr=False)
 
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         """Dumps the attributes to a dictionary"""
         dumped = super().dump(camel_case=camel_case)
@@ -104,6 +105,7 @@ class GroupCore(WriteableCogniteResource["GroupWrite"], ABC):
             members=resource.get("members"),
         )
 
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         dumped = super().dump(camel_case=camel_case)
         if self.capabilities is not None:
@@ -155,6 +157,7 @@ class Group(GroupCore):
         self.is_deleted = is_deleted
         self.deleted_time = deleted_time
 
+    @override
     def as_write(self) -> GroupWrite:
         """Returns a write version of this group."""
         return GroupWrite(
@@ -255,6 +258,7 @@ class GroupList(WriteableCogniteResourceList[GroupWrite, Group], NameTransformer
     ) -> Self:
         return cls([cls._RESOURCE._load(res, allow_unknown) for res in resource_list])
 
+    @override
     def as_write(self) -> GroupWriteList:
         """Returns a write version of this group list."""
         return GroupWriteList([s.as_write() for s in self])
@@ -305,6 +309,7 @@ class SecurityCategory(SecurityCategoryCore):
     def _load(cls, resource: dict[str, Any]) -> Self:
         return cls(id=resource["id"], name=resource["name"])
 
+    @override
     def as_write(self) -> SecurityCategoryWrite:
         """Returns a write version of this security category."""
         return SecurityCategoryWrite(name=self.name)
@@ -326,6 +331,7 @@ class SecurityCategoryWrite(SecurityCategoryCore):
     def _load(cls, resource: dict) -> Self:
         return cls(name=resource["name"])
 
+    @override
     def as_write(self) -> SecurityCategoryWrite:
         """Returns this SecurityCategoryWrite instance."""
         return self
@@ -342,6 +348,7 @@ class SecurityCategoryList(
 ):
     _RESOURCE = SecurityCategory
 
+    @override
     def as_write(self) -> SecurityCategoryWriteList:
         """Returns a write version of this security category list."""
         return SecurityCategoryWriteList([s.as_write() for s in self])
@@ -367,6 +374,7 @@ class ProjectSpec(CogniteResource):
     def _load(cls, api_response: dict[str, Any]) -> ProjectSpec:
         return cls(url_name=api_response["projectUrlName"], groups=api_response["groups"])
 
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, str | list[int]]:
         return {
             "projectUrlName" if camel_case else "project_url_name": self.url_name,
@@ -415,6 +423,7 @@ class TokenInspection(CogniteResource):
             ),
         )
 
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         return {
             "subject": self.subject,

--- a/cognite/client/data_classes/labels.py
+++ b/cognite/client/data_classes/labels.py
@@ -4,7 +4,7 @@ from abc import ABC
 from collections.abc import Sequence
 from typing import Any
 
-from typing_extensions import Self
+from typing_extensions import Self, override
 
 from cognite.client.data_classes._base import (
     CogniteFilter,
@@ -79,6 +79,7 @@ class LabelDefinition(LabelDefinitionCore):
             data_set_id=resource.get("dataSetId"),
         )
 
+    @override
     def as_write(self) -> LabelDefinitionWrite:
         """Returns this LabelDefinition in its write version."""
         return LabelDefinitionWrite(
@@ -123,6 +124,7 @@ class LabelDefinitionWrite(LabelDefinitionCore):
             data_set_id=resource.get("dataSetId"),
         )
 
+    @override
     def as_write(self) -> LabelDefinitionWrite:
         """Returns this LabelDefinitionWrite instance."""
         return self
@@ -240,6 +242,7 @@ class LabelFilter(CogniteFilter):
             contains_all=[item["externalId"] for item in contains_all] if contains_all else None,
         )
 
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         dumped: dict[str, Any] = {}
         if self.contains_any:

--- a/cognite/client/data_classes/metering.py
+++ b/cognite/client/data_classes/metering.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from typing import Any
 
+from typing_extensions import override
+
 from cognite.client.data_classes._base import CogniteResource, CogniteResourceList, basic_instance_dump
 
 
@@ -50,6 +52,7 @@ class MeteringData(CogniteResource):
             datapoints=[MeteringDataPoint._load(dp) for dp in datapoints],
         )
 
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         result = basic_instance_dump(self, camel_case=camel_case)
         result["datapoints"] = [dp.dump(camel_case) for dp in self.datapoints]

--- a/cognite/client/data_classes/postgres_gateway/tables.py
+++ b/cognite/client/data_classes/postgres_gateway/tables.py
@@ -5,7 +5,7 @@ from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import Any, Literal, TypeAlias, cast
 
-from typing_extensions import Self
+from typing_extensions import Self, override
 
 from cognite.client.data_classes._base import (
     CogniteResource,
@@ -63,6 +63,7 @@ class Column(CogniteResource):
             type=resource["type"],
         )
 
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         return {
             "propertyName": self.name,
@@ -92,6 +93,7 @@ class _TableCore(WriteableCogniteResource["TableWrite"], ABC):
     def __init__(self, tablename: str):
         self.tablename = tablename
 
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         return {"tablename": self.tablename, "type": self._type}
 
@@ -102,6 +104,7 @@ class TableWrite(_TableCore, ABC):
     This is the write/request format of the table.
     """
 
+    @override
     def as_write(self) -> Self:
         return self
 
@@ -150,6 +153,7 @@ class RawTableWrite(TableWrite):
             columns=ColumnList._load_columns(data["columns"]),
         )
 
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         output = super().dump(camel_case=camel_case)
         output["options"] = self.options.dump(camel_case=camel_case)
@@ -180,6 +184,7 @@ class ViewTableWrite(TableWrite):
             options=ViewId.load(data["options"]),
         )
 
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         output = super().dump(camel_case=camel_case)
         output["options"] = self.options.dump(camel_case=camel_case, include_type=False)
@@ -250,12 +255,14 @@ class RawTable(Table):
             created_time=data.get("createdTime"),
         )
 
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         output = super().dump(camel_case=camel_case)
         output["options"] = self.options.dump(camel_case=camel_case)
         output["columns"] = self.columns.dump(camel_case=camel_case)
         return output
 
+    @override
     def as_write(self) -> RawTableWrite:
         return RawTableWrite(
             tablename=self.tablename,
@@ -289,11 +296,13 @@ class ViewTable(Table):
             created_time=data.get("created_time"),
         )
 
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         output = super().dump(camel_case=camel_case)
         output["options"] = self.options.dump(camel_case=camel_case)
         return output
 
+    @override
     def as_write(self) -> ViewTableWrite:
         return ViewTableWrite(
             tablename=self.tablename,
@@ -308,6 +317,7 @@ class TableWriteList(CogniteResourceList[TableWrite]):
 class TableList(WriteableCogniteResourceList[TableWrite, Table]):
     _RESOURCE = Table
 
+    @override
     def as_write(self) -> TableWriteList:
         return TableWriteList([item.as_write() for item in self.data])
 

--- a/cognite/client/data_classes/postgres_gateway/users.py
+++ b/cognite/client/data_classes/postgres_gateway/users.py
@@ -4,7 +4,7 @@ from abc import ABC
 from dataclasses import dataclass
 from typing import Any, Literal, NoReturn
 
-from typing_extensions import Self
+from typing_extensions import Self, override
 
 from cognite.client.data_classes._base import (
     CognitePrimitiveUpdate,
@@ -51,6 +51,7 @@ class UserWrite(_UserCore):
             credentials=SessionCredentials._load_if(resource.get("credentials")),
         )
 
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         output = super().dump(camel_case=camel_case)
         if isinstance(self.credentials, SessionCredentials):
@@ -58,6 +59,7 @@ class UserWrite(_UserCore):
 
         return output
 
+    @override
     def as_write(self) -> UserWrite:
         return self
 
@@ -96,6 +98,7 @@ class User(_UserCore):
             session_id=resource.get("sessionId"),
         )
 
+    @override
     def as_write(self) -> NoReturn:
         raise TypeError(f"{type(self).__name__} cannot be converted to a write object")
 
@@ -180,6 +183,7 @@ class UserWriteList(CogniteResourceList[UserWrite]):
 class UserList(WriteableCogniteResourceList[UserWrite, User]):
     _RESOURCE = User
 
+    @override
     def as_write(self) -> NoReturn:
         raise TypeError(f"{type(self).__name__} cannot be converted to a write object")
 
@@ -187,6 +191,7 @@ class UserList(WriteableCogniteResourceList[UserWrite, User]):
 class UserCreatedList(WriteableCogniteResourceList[UserWrite, UserCreated]):
     _RESOURCE = UserCreated
 
+    @override
     def as_write(self) -> NoReturn:
         raise TypeError(
             f"{type(self).__name__} cannot be converted to a {UserWrite.__name__} object. "

--- a/cognite/client/data_classes/principals.py
+++ b/cognite/client/data_classes/principals.py
@@ -4,7 +4,7 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from typing import Any, ClassVar, cast
 
-from typing_extensions import Self
+from typing_extensions import Self, override
 
 from cognite.client.data_classes._base import (
     CogniteResource,
@@ -41,6 +41,7 @@ class Principal(CogniteResource, ABC):
             ),
         )
 
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         """Dump the principal to a dictionary."""
         output = super().dump(camel_case=camel_case)
@@ -166,6 +167,7 @@ class ServicePrincipal(Principal):
             description=resource.get("description"),
         )
 
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         output = super().dump(camel_case=camel_case)
         output["createdBy" if camel_case else "created_by"] = self.created_by.dump(camel_case=camel_case)
@@ -200,6 +202,7 @@ class UnknownPrincipal(Principal):
             data={k: v for k, v in resource.items() if k not in {"id", "type"}},
         )
 
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         return {"id": self.id, "type": self.type, **self.__data}
 

--- a/cognite/client/data_classes/relationships.py
+++ b/cognite/client/data_classes/relationships.py
@@ -5,7 +5,7 @@ import typing
 from abc import ABC
 from typing import TYPE_CHECKING, Any, Literal, TypeAlias, cast
 
-from typing_extensions import Self
+from typing_extensions import Self, override
 
 if TYPE_CHECKING:
     from cognite.client import AsyncCogniteClient
@@ -81,6 +81,7 @@ class RelationshipCore(WriteableCogniteResource["RelationshipWrite"], ABC):
         self.data_set_id = data_set_id
         self.labels = labels
 
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         result: dict[str, Any] = super().dump(camel_case)
         if self.labels is not None:
@@ -210,6 +211,7 @@ class Relationship(RelationshipCore):
             labels=Label._load_list(labels) if labels else None,
         )
 
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         result: dict[str, Any] = super().dump(camel_case)
         if self.source is not None and not isinstance(self.source, dict):
@@ -346,6 +348,7 @@ class RelationshipFilter(CogniteFilter):
         self.active_at_time = active_at_time
         self.labels = labels
 
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         result = super().dump(camel_case)
         if isinstance(self.labels, LabelFilter):

--- a/cognite/client/data_classes/sequences.py
+++ b/cognite/client/data_classes/sequences.py
@@ -6,7 +6,7 @@ from collections.abc import Iterator
 from enum import auto
 from typing import TYPE_CHECKING, Any, Literal, NoReturn, TypeAlias, cast, get_args, overload
 
-from typing_extensions import Self
+from typing_extensions import Self, override
 
 from cognite.client.data_classes._base import (
     CogniteFilter,
@@ -274,6 +274,7 @@ class Sequence(WriteableCogniteResourceWithClientRef["SequenceWrite"]):
             columns=self.columns.as_write(),
         )
 
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         dumped = super().dump(camel_case)
         if self.columns is not None:
@@ -374,6 +375,7 @@ class SequenceWrite(WriteableCogniteResource["SequenceWrite"]):
             data_set_id=resource.get("dataSetId"),
         )
 
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         dumped = super().dump(camel_case)
         dumped["columns"] = self.columns.dump(camel_case)
@@ -690,6 +692,7 @@ class SequenceRows(CogniteResource):
         """Returns a list of lists of values"""
         return [list(row.values) for row in self.rows]
 
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         """Dump the sequence data into a json serializable Python data type.
 

--- a/cognite/client/data_classes/shared.py
+++ b/cognite/client/data_classes/shared.py
@@ -4,7 +4,7 @@ from collections.abc import Collection, Sequence
 from datetime import datetime
 from typing import Any, Literal
 
-from typing_extensions import Self
+from typing_extensions import Self, override
 
 from cognite.client.data_classes._base import CogniteFilter, CogniteResource, UnknownCogniteResource
 from cognite.client.utils._time import timestamp_to_ms
@@ -132,6 +132,7 @@ class Geometry(CogniteResource):
             geometries=raw_geometry.get("geometries"),
         )
 
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         dumped = super().dump(camel_case)
         if self.geometries:
@@ -243,6 +244,7 @@ class GeoLocation(CogniteResource):
         # Years ago, the API didn't enforce the current restriction on the type field:
         return UnknownCogniteResource(resource)  # type: ignore[return-value]
 
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         result = super().dump(camel_case)
         if self.geometry:
@@ -266,6 +268,7 @@ class GeoLocationFilter(CogniteResource):
     def _load(cls, resource: dict[str, Any]) -> GeoLocationFilter:
         return cls(relation=resource["relation"], shape=resource["shape"])
 
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         dumped = super().dump(camel_case)
         if isinstance(self.shape, GeometryFilter):

--- a/cognite/client/data_classes/simulators/filters.py
+++ b/cognite/client/data_classes/simulators/filters.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 from collections.abc import Sequence
 from typing import Any, Literal, cast
 
+from typing_extensions import override
+
 from cognite.client.data_classes._base import CogniteFilter, CogniteSort
 from cognite.client.data_classes.shared import TimestampRange
 from cognite.client.data_classes.simulators.runs import SimulatorRunStatus, SimulatorRunType
@@ -100,6 +102,7 @@ class PropertySort(CogniteSort):
     ):
         super().__init__(property, order)
 
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         dumped = super().dump(camel_case=camel_case)
         prop = cast(str, self.property)
@@ -115,6 +118,7 @@ class SimulationRunsSort(CogniteSort):
     ):
         super().__init__(property, order)
 
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         dumped = super().dump(camel_case=camel_case)
         prop = cast(str, self.property)

--- a/cognite/client/data_classes/simulators/logs.py
+++ b/cognite/client/data_classes/simulators/logs.py
@@ -4,7 +4,7 @@ from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import Any, Literal
 
-from typing_extensions import Self
+from typing_extensions import Self, override
 
 from cognite.client.data_classes._base import (
     CogniteResource,
@@ -83,6 +83,7 @@ class SimulatorLog(CogniteResource):
             severity=resource.get("severity"),
         )
 
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         output = super().dump(camel_case=camel_case)
         if isinstance(self.data, list) and all(isinstance(item, SimulatorLogData) for item in self.data):

--- a/cognite/client/data_classes/simulators/models.py
+++ b/cognite/client/data_classes/simulators/models.py
@@ -4,7 +4,7 @@ from abc import ABC
 from dataclasses import dataclass
 from typing import Any, Literal
 
-from typing_extensions import Self
+from typing_extensions import Self, override
 
 from cognite.client.data_classes._base import (
     CognitePrimitiveUpdate,
@@ -37,6 +37,7 @@ class SimulatorModelRevisionWrite(WriteableCogniteResource["SimulatorModelRevisi
         self.description = description
         self.external_dependencies = external_dependencies
 
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         output = super().dump(camel_case=camel_case)
         if self.external_dependencies is not None:
@@ -44,6 +45,7 @@ class SimulatorModelRevisionWrite(WriteableCogniteResource["SimulatorModelRevisi
 
         return output
 
+    @override
     def as_write(self) -> SimulatorModelRevisionWrite:
         return self
 
@@ -140,6 +142,7 @@ class SimulatorModelRevision(WriteableCogniteResourceWithClientRef["SimulatorMod
             else None,
         )
 
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         output = super().dump(camel_case=camel_case)
         if self.external_dependencies is not None:
@@ -147,6 +150,7 @@ class SimulatorModelRevision(WriteableCogniteResourceWithClientRef["SimulatorMod
 
         return output
 
+    @override
     def as_write(self) -> SimulatorModelRevisionWrite:
         """Returns this SimulatorModelRevision in its write version."""
         return SimulatorModelRevisionWrite(
@@ -225,6 +229,7 @@ class SimulatorModelCore(WriteableCogniteResource["SimulatorModelWrite"], ABC):
 
 
 class SimulatorModelWrite(SimulatorModelCore):
+    @override
     def as_write(self) -> SimulatorModelWrite:
         return self
 
@@ -312,6 +317,7 @@ class SimulatorModelWriteList(CogniteResourceList[SimulatorModelWrite], External
 class SimulatorModelList(WriteableCogniteResourceList[SimulatorModelWrite, SimulatorModel], IdTransformerMixin):
     _RESOURCE = SimulatorModel
 
+    @override
     def as_write(self) -> SimulatorModelWriteList:
         return SimulatorModelWriteList([a.as_write() for a in self.data])
 
@@ -325,6 +331,7 @@ class SimulatorModelRevisionList(
 ):
     _RESOURCE = SimulatorModelRevision
 
+    @override
     def as_write(self) -> SimulatorModelRevisionWriteList:
         return SimulatorModelRevisionWriteList([a.as_write() for a in self.data])
 
@@ -384,6 +391,7 @@ class SimulatorModelRevisionDependency(CogniteResource):
             arguments=resource["arguments"],
         )
 
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         output = super().dump(camel_case=camel_case)
         output["file"] = (
@@ -473,6 +481,7 @@ class SimulatorFlowsheetProperty(CogniteResource):
     def _load_list(cls, resource: list[dict[str, Any]]) -> list[SimulatorFlowsheetProperty]:
         return [cls._load(item) for item in resource]
 
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         output = super().dump(camel_case=camel_case)
         if self.unit is not None:
@@ -513,6 +522,7 @@ class SimulatorFlowsheetGraphicalObject(CogniteResource):
             active=resource.get("active"),
         )
 
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         output = super().dump(camel_case=camel_case)
         if self.position is not None:
@@ -543,6 +553,7 @@ class SimulatorFlowsheetObjectNode(CogniteResource):
             properties=SimulatorFlowsheetProperty._load_list(resource["properties"]),
         )
 
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         output = super().dump(camel_case=camel_case)
         if self.graphical_object is not None:
@@ -570,6 +581,7 @@ class SimulatorFlowsheet(CogniteResource):
     def _load_list(cls, resource: list[dict[str, Any]]) -> list[SimulatorFlowsheet]:
         return [cls._load(item) for item in resource]
 
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         output = super().dump(camel_case=camel_case)
         output["simulatorObjectNodes"] = [item.dump(camel_case=camel_case) for item in self.simulator_object_nodes]
@@ -634,6 +646,7 @@ class SimulatorModelRevisionData(CogniteResource):
             last_updated_time=resource["lastUpdatedTime"],
         )
 
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         output = super().dump(camel_case=camel_case)
         if self.flowsheets is not None:

--- a/cognite/client/data_classes/simulators/routine_revisions.py
+++ b/cognite/client/data_classes/simulators/routine_revisions.py
@@ -8,7 +8,7 @@ from collections.abc import MutableMapping, Sequence
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, ClassVar, Literal, cast
 
-from typing_extensions import Self
+from typing_extensions import Self, override
 
 from cognite.client.data_classes._base import (
     CogniteResource,
@@ -93,6 +93,7 @@ class SimulatorRoutineInput(CogniteResource, ABC):
             return UnknownCogniteResource(resource)  # type: ignore[return-value]
         return cast(Self, input_class._load_input(resource))
 
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         output = super().dump(camel_case)
         if self.unit is not None:
@@ -214,6 +215,7 @@ class SimulatorRoutineOutput(CogniteResource):
             save_timeseries_external_id=resource.get("saveTimeseriesExternalId"),
         )
 
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         output = super().dump(camel_case=camel_case)
         if self.unit is not None:
@@ -399,6 +401,7 @@ class SimulatorRoutineConfiguration(CogniteResource):
             outputs=outputs,
         )
 
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         output = super().dump(camel_case=camel_case)
         output["inputs"] = [input_.dump(camel_case=camel_case) for input_ in self.inputs] if self.inputs else None
@@ -443,6 +446,7 @@ class SimulatorRoutineStepArguments(CogniteResource, dict, MutableMapping[str, s
     def _load(cls, resource: dict[str, Any]) -> Self:
         return cls(resource)
 
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         return {key: value for key, value in self.items()}
 
@@ -476,6 +480,7 @@ class SimulatorRoutineStep(CogniteResource):
             description=resource.get("description"),
         )
 
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         output = super().dump(camel_case=camel_case)
         output["arguments"] = self.arguments.dump(camel_case=camel_case)
@@ -508,6 +513,7 @@ class SimulatorRoutineStage(CogniteResource):
             description=resource.get("description"),
         )
 
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         output = super().dump(camel_case=camel_case)
         output["steps"] = [step_.dump(camel_case=camel_case) for step_ in self.steps]
@@ -532,6 +538,7 @@ class SimulatorRoutineRevisionCore(WriteableCogniteResource["SimulatorRoutineRev
         else:
             self.script = script
 
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         output = super().dump(camel_case=camel_case)
         output["configuration"] = self.configuration.dump(camel_case=camel_case) if self.configuration else None
@@ -680,6 +687,7 @@ class SimulatorRoutineRevisionList(
 ):
     _RESOURCE = SimulatorRoutineRevision
 
+    @override
     def as_write(self) -> SimulatorRoutineRevisionWriteList:
         return SimulatorRoutineRevisionWriteList([a.as_write() for a in self.data])
 

--- a/cognite/client/data_classes/simulators/routines.py
+++ b/cognite/client/data_classes/simulators/routines.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from abc import ABC
 from typing import Any, Literal
 
-from typing_extensions import Self
+from typing_extensions import Self, override
 
 from cognite.client.data_classes._base import (
     CogniteResourceList,
@@ -173,5 +173,6 @@ class SimulatorRoutineWriteList(CogniteResourceList[SimulatorRoutineWrite], Exte
 class SimulatorRoutineList(WriteableCogniteResourceList[SimulatorRoutineWrite, SimulatorRoutine], IdTransformerMixin):
     _RESOURCE = SimulatorRoutine
 
+    @override
     def as_write(self) -> SimulatorRoutineWriteList:
         return SimulatorRoutineWriteList([a.as_write() for a in self.data])

--- a/cognite/client/data_classes/simulators/runs.py
+++ b/cognite/client/data_classes/simulators/runs.py
@@ -5,7 +5,7 @@ import time
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Literal
 
-from typing_extensions import Self
+from typing_extensions import Self, override
 
 from cognite.client.data_classes._base import (
     CogniteResource,
@@ -74,6 +74,7 @@ class SimulationInputOverride(CogniteResource):
     def __post_init__(self) -> None:
         _WARNING.warn()
 
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         output = super().dump(camel_case=camel_case)
         if self.unit is not None:
@@ -157,6 +158,7 @@ class SimulationRunWrite(WriteableCogniteResource["SimulationRunWrite"]):
             model_revision_external_id=model_revision_external_id,
         )
 
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         output = super().dump(camel_case=camel_case)
         if self.inputs is not None:
@@ -173,6 +175,7 @@ class SimulationRunWrite(WriteableCogniteResource["SimulationRunWrite"]):
 
         return output
 
+    @override
     def as_write(self) -> SimulationRunWrite:
         return self
 
@@ -250,6 +253,7 @@ class SimulationRun(WriteableCogniteResourceWithClientRef["SimulationRunWrite"])
         self.user_id = user_id
         self.log_id = log_id
 
+    @override
     def as_write(self) -> SimulationRunWrite:
         return SimulationRunWrite(
             routine_external_id=self.routine_external_id,
@@ -377,6 +381,7 @@ class SimulationValueBase(CogniteResource):
             timeseries_external_id=resource.get("timeseriesExternalId"),
         )
 
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         output = super().dump(camel_case=camel_case)
         if self.unit is not None:
@@ -426,6 +431,7 @@ class SimulationInput(SimulationValueBase):
             overridden=resource.get("overridden"),
         )
 
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         output = super().dump(camel_case=camel_case)
         if self.unit is not None:
@@ -470,6 +476,7 @@ class SimulationRunDataItem(CogniteResource):
             outputs=outputs,
         )
 
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         output = super().dump(camel_case=camel_case)
         output["inputs"] = [input_.dump(camel_case=camel_case) for input_ in self.inputs]
@@ -534,5 +541,6 @@ class SimulationRunWriteList(CogniteResourceList[SimulationRunWrite], ExternalID
 class SimulationRunList(WriteableCogniteResourceList[SimulationRunWrite, SimulationRun], IdTransformerMixin):
     _RESOURCE = SimulationRun
 
+    @override
     def as_write(self) -> SimulationRunWriteList:
         return SimulationRunWriteList([a.as_write() for a in self.data])

--- a/cognite/client/data_classes/simulators/simulators.py
+++ b/cognite/client/data_classes/simulators/simulators.py
@@ -4,7 +4,7 @@ from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import Any
 
-from typing_extensions import Self
+from typing_extensions import Self, override
 
 from cognite.client.data_classes._base import (
     CogniteResource,
@@ -72,6 +72,7 @@ class Simulator(CogniteResource):
             else None,
         )
 
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         output = super().dump(camel_case=camel_case)
         if isinstance(self.model_types, list) and all(
@@ -201,6 +202,7 @@ class SimulatorQuantity(CogniteResource):
         else:
             raise TypeError("Expected a dict or a list of dicts.")
 
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         output = super().dump(camel_case=camel_case)
         output["units"] = [unit.dump(camel_case=camel_case) for unit in self.units]
@@ -226,6 +228,7 @@ class SimulatorStepField(CogniteResource):
             else None,
         )
 
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         output = super().dump(camel_case=camel_case)
         if self.options is not None:
@@ -288,6 +291,7 @@ class SimulatorModelDependency(CogniteResource):
         else:
             raise TypeError("Expected a dict or a list of dicts.")
 
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         output = super().dump(camel_case=camel_case)
         output["fields"] = [field_.dump(camel_case=camel_case) for field_ in self.fields]
@@ -319,6 +323,7 @@ class SimulatorStep(CogniteResource):
         else:
             raise TypeError("Expected a dict or a list of dicts.")
 
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         output = super().dump(camel_case=camel_case)
         output["fields"] = [field_.dump(camel_case=camel_case) for field_ in self.fields]

--- a/cognite/client/data_classes/three_d.py
+++ b/cognite/client/data_classes/three_d.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from abc import ABC
 from typing import Any
 
-from typing_extensions import Self
+from typing_extensions import Self, override
 
 from cognite.client.data_classes._base import (
     CogniteLabelUpdate,
@@ -269,6 +269,7 @@ class ThreeDModelRevisionCore(WriteableCogniteResource["ThreeDModelRevisionWrite
         self.camera = camera
         self.metadata = metadata
 
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         result = super().dump(camel_case)
         if isinstance(self.camera, RevisionCameraProperties):
@@ -405,6 +406,7 @@ class ThreeDModelRevisionWrite(ThreeDModelRevisionCore):
             metadata=resource.get("metadata"),
         )
 
+    @override
     def as_write(self) -> ThreeDModelRevisionWrite:
         """Returns this ThreedModelRevisionWrite instance."""
         return self
@@ -493,6 +495,7 @@ class ThreeDModelRevisionList(
 ):
     _RESOURCE = ThreeDModelRevision
 
+    @override
     def as_write(self) -> ThreeDModelRevisionWriteList:
         """Returns this ThreedModelRevisionList in a write version."""
         return ThreeDModelRevisionWriteList([item.as_write() for item in self.data])
@@ -545,6 +548,7 @@ class ThreeDNode(CogniteResource):
             bounding_box=BoundingBox3D._load_if(resource.get("boundingBox")),
         )
 
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         result = super().dump(camel_case)
         if isinstance(self.bounding_box, BoundingBox3D):
@@ -607,6 +611,7 @@ class ThreeDAssetMapping(ThreeDAssetMappingCore):
             subtree_size=resource.get("subtreeSize"),
         )
 
+    @override
     def as_write(self) -> ThreeDAssetMappingWrite:
         """Returns this ThreedAssetMapping in a write version."""
         return ThreeDAssetMappingWrite(
@@ -634,6 +639,7 @@ class ThreeDAssetMappingWrite(ThreeDAssetMappingCore):
             asset_id=resource.get("assetId"),
         )
 
+    @override
     def as_write(self) -> ThreeDAssetMappingWrite:
         """Returns this ThreedAssetMappingWrite instance."""
         return self
@@ -646,6 +652,7 @@ class ThreeDAssetMappingWriteList(CogniteResourceList[ThreeDAssetMappingWrite]):
 class ThreeDAssetMappingList(WriteableCogniteResourceList[ThreeDAssetMappingWrite, ThreeDAssetMapping]):
     _RESOURCE = ThreeDAssetMapping
 
+    @override
     def as_write(self) -> ThreeDAssetMappingWriteList:
         """Returns this ThreedAssetMappingList in a write version."""
         return ThreeDAssetMappingWriteList([item.as_write() for item in self.data])

--- a/cognite/client/data_classes/time_series.py
+++ b/cognite/client/data_classes/time_series.py
@@ -6,7 +6,7 @@ from datetime import datetime
 from enum import auto
 from typing import TYPE_CHECKING, Any, Literal, TypeAlias, cast
 
-from typing_extensions import Self
+from typing_extensions import Self, override
 
 from cognite.client.data_classes._base import (
     CogniteFilter,
@@ -116,6 +116,7 @@ class TimeSeries(WriteableCogniteResourceWithClientRef["TimeSeriesWrite"]):
             data_set_id=resource.get("dataSetId"),
         )
 
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         output = super().dump(camel_case=camel_case)
         if self.instance_id is not None:
@@ -366,6 +367,7 @@ class TimeSeriesUpdate(CogniteUpdate):
         if instance_id is not None:
             self.warn_on_instance_id_update()
 
+    @override
     def dump(self, camel_case: Literal[True] = True) -> dict[str, Any]:
         output = super().dump(camel_case=camel_case)
         if self.instance_id is not None:

--- a/cognite/client/data_classes/transformations/__init__.py
+++ b/cognite/client/data_classes/transformations/__init__.py
@@ -5,6 +5,8 @@ from abc import abstractmethod
 from copy import deepcopy
 from typing import TYPE_CHECKING, Any, Literal, cast
 
+from typing_extensions import override
+
 from cognite.client.data_classes._base import (
     CogniteFilter,
     CogniteListUpdate,
@@ -72,6 +74,7 @@ class SessionDetails:
 
     @classmethod
     def load(cls, resource: dict[str, Any]) -> SessionDetails:
+        """Load a SessionDetails instance from a dictionary."""
         return cls(
             session_id=resource.get("sessionId"),
             client_id=resource.get("clientId"),
@@ -341,6 +344,7 @@ class Transformation(WriteableCogniteResourceWithClientRef["TransformationWrite"
             tags=self.tags,
         )
 
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         """Dump the instance into a json serializable Python data type.
 
@@ -507,6 +511,7 @@ class TransformationWrite(WriteableCogniteResource["TransformationWrite"], _Tran
             self.tags,
         )
 
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         """Dump the instance into a json serializable Python data type.
 
@@ -602,6 +607,7 @@ class TransformationUpdate(CogniteUpdate):
     def tags(self) -> _ListTransformationUpdate:
         return TransformationUpdate._ListTransformationUpdate(self, "tags")
 
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         obj = super().dump()
 
@@ -637,13 +643,16 @@ class TransformationWriteList(CogniteResourceList[TransformationWrite], External
 class TransformationList(WriteableCogniteResourceList[TransformationWrite, Transformation], IdTransformerMixin):
     _RESOURCE = Transformation
 
+    @override
     def as_write(self) -> TransformationWriteList:
         return TransformationWriteList([transformation.as_write() for transformation in self.data])
 
 
 class TagsFilter:
     @abstractmethod
-    def dump(self) -> dict[str, Any]: ...
+    def dump(self) -> dict[str, Any]:
+        """Dump the instance into a json serializable Python data type."""
+        ...
 
 
 class ContainsAny(TagsFilter):
@@ -663,6 +672,7 @@ class ContainsAny(TagsFilter):
     def __init__(self, tags: list[str] | None = None) -> None:
         self.tags = tags
 
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         contains_any_key = "containsAny" if camel_case else "contains_any"
         return {contains_any_key: self.tags}
@@ -711,6 +721,7 @@ class TransformationFilter(CogniteFilter):
         self.data_set_ids = data_set_ids
         self.tags = tags
 
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         obj = super().dump(camel_case=camel_case)
         if (value := obj.pop("includePublic" if camel_case else "include_public", None)) is not None:

--- a/cognite/client/data_classes/transformations/common.py
+++ b/cognite/client/data_classes/transformations/common.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from typing_extensions import Self
+from typing_extensions import Self, override
 
 from cognite.client.credentials import OAuthClientCredentials
 from cognite.client.data_classes._base import CogniteResource, UnknownCogniteResource
@@ -27,6 +27,7 @@ class TransformationDestination(CogniteResource):
     def __eq__(self, other: Any) -> bool:
         return isinstance(other, type(self)) and hash(other) == hash(self)
 
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         ret = basic_obj_dump(self, camel_case)
 
@@ -235,6 +236,7 @@ class EdgeType(CogniteResource):
             external_id=resource["externalId"],
         )
 
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         return basic_obj_dump(self, camel_case)
 
@@ -473,6 +475,7 @@ class TransformationBlockedInfo:
 
     @classmethod
     def load(cls, resource: dict[str, Any]) -> TransformationBlockedInfo:
+        """Load data into the instance."""
         return cls(reason=resource["reason"], created_time=resource["createdTime"])
 
     @classmethod
@@ -482,4 +485,5 @@ class TransformationBlockedInfo:
     load_if = _load_if  # TransformationBlockedInfo has no private load method, so these are the same
 
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
+        """Dump the instance into a json serializable Python data type."""
         return basic_obj_dump(self, camel_case)

--- a/cognite/client/data_classes/transformations/externaldata.py
+++ b/cognite/client/data_classes/transformations/externaldata.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from typing import Any, ClassVar, NoReturn
 
-from typing_extensions import Self
+from typing_extensions import Self, override
 
 from cognite.client.data_classes._base import (
     CogniteResource,
@@ -110,6 +110,7 @@ class OneLakeSettings(CogniteResource):
             location_description=OneLakeLocationDescription._load(resource["locationDescription"]),
         )
 
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         output = super().dump(camel_case=camel_case)
         output["credentials"] = self.credentials.dump(camel_case=camel_case)
@@ -137,6 +138,7 @@ class OneLakeSettingsWrite(CogniteResource):
             location_description=OneLakeLocationDescription._load(resource["locationDescription"]),
         )
 
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         output = super().dump(camel_case=camel_case)
         output["credentials"] = self.credentials.dump(camel_case=camel_case)
@@ -184,6 +186,7 @@ class ExternalDataSourceWrite(CogniteResource, ABC):
             )
         return source_cls._load_data_source(resource)
 
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         output = super().dump(camel_case=camel_case)
         output["format"] = self._format
@@ -253,6 +256,7 @@ class OneLakeExternalDataSourceWrite(ExternalDataSourceWrite):
             data_set_id=resource.get("dataSetId"),
         )
 
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         output = super().dump(camel_case=camel_case)
         output["settings"] = self.settings.dump(camel_case=camel_case)
@@ -309,11 +313,13 @@ class ExternalDataSource(WriteableCogniteResource[ExternalDataSourceWrite], ABC)
             return UnknownCogniteResource(resource)  # type: ignore[return-value]
         return source_class._load_data_source(resource)
 
+    @override
     def as_write(self) -> NoReturn:
         raise TypeError(
             f"{type(self).__name__} cannot be converted to write as the API does not return the client secret"
         )
 
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         output = super().dump(camel_case=camel_case)
         output["format"] = self._format
@@ -370,6 +376,7 @@ class OneLakeExternalDataSource(ExternalDataSource):
             data_set_id=resource.get("dataSetId"),
         )
 
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         output = super().dump(camel_case=camel_case)
         output["settings"] = self.settings.dump(camel_case=camel_case)
@@ -389,6 +396,7 @@ class ExternalDataSourceList(
 
     _RESOURCE = ExternalDataSource
 
+    @override
     def as_write(self) -> NoReturn:
         raise TypeError(f"{type(self).__name__} cannot be converted to write")
 
@@ -417,6 +425,7 @@ class ExternalDataSourceUsability(CogniteResource):
             usable_version=resource.get("usableVersion"),
         )
 
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         output = super().dump(camel_case=camel_case)
         key = "externalId" if camel_case else "external_id"

--- a/cognite/client/data_classes/transformations/jobs.py
+++ b/cognite/client/data_classes/transformations/jobs.py
@@ -4,7 +4,7 @@ import asyncio
 from enum import Enum
 from typing import Any, Literal
 
-from typing_extensions import Self
+from typing_extensions import Self, override
 
 from cognite.client.data_classes._base import (
     CogniteFilter,
@@ -210,6 +210,7 @@ class TransformationJob(CogniteResourceWithClientRef):
     def wait(self, polling_interval: float = 5, timeout: float | None = None) -> TransformationJob:
         return run_sync(self.wait_async(polling_interval, timeout))
 
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         output = super().dump(camel_case)
         if self.destination:

--- a/cognite/client/data_classes/transformations/schedules.py
+++ b/cognite/client/data_classes/transformations/schedules.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from abc import ABC
 from typing import Any
 
-from typing_extensions import Self
+from typing_extensions import Self, override
 
 from cognite.client.data_classes._base import (
     CognitePrimitiveUpdate,
@@ -157,5 +157,6 @@ class TransformationScheduleList(
 ):
     _RESOURCE = TransformationSchedule
 
+    @override
     def as_write(self) -> TransformationScheduleWriteList:
         return TransformationScheduleWriteList([x.as_write() for x in self.data])

--- a/cognite/client/data_classes/transformations/schema.py
+++ b/cognite/client/data_classes/transformations/schema.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import Any, Literal
 
-from typing_extensions import Self
+from typing_extensions import Self, override
 
 from cognite.client.data_classes._base import CogniteResource, CogniteResourceList
 from cognite.client.utils._text import convert_all_keys_recursive
@@ -38,6 +38,7 @@ class TransformationSchemaStructType(TransformationSchemaType):
         super().__init__(type=type)
         self.fields = fields
 
+    @override
     def dump(self, camel_case: bool = True) -> dict:
         dumped = super().dump(camel_case=camel_case)
         return convert_all_keys_recursive(dumped, camel_case=camel_case)  # <-- 'fields' is a nested object
@@ -76,6 +77,7 @@ class TransformationSchemaUnknownType(TransformationSchemaType):
         super().__init__(type=raw_schema.pop("type"))  # type is required
         self.__raw_schema = raw_schema
 
+    @override
     def dump(self, camel_case: Literal[True] = True) -> dict[str, Any]:  # type: ignore [override]
         return {"type": self.type, **self.__raw_schema}
 
@@ -106,6 +108,7 @@ class TransformationSchemaColumn(CogniteResource):
         self.type = type
         self.nullable = nullable
 
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         output = super().dump(camel_case)
         if isinstance(self.type, TransformationSchemaType):

--- a/cognite/client/data_classes/units.py
+++ b/cognite/client/data_classes/units.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any
 
-from typing_extensions import Self
+from typing_extensions import Self, override
 
 from cognite.client.data_classes._base import (
     CogniteResource,
@@ -35,6 +35,7 @@ class UnitConversion:
         )
 
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
+        """Dumps the instance into a json serializable Python data type."""
         return {
             "multiplier": self.multiplier,
             "offset": self.offset,
@@ -122,6 +123,7 @@ class Unit(CogniteResource):
             source_reference=resource.get("sourceReference"),
         )
 
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         dumped = super().dump(camel_case)
         dumped["conversion"] = self.conversion.dump(camel_case)
@@ -155,6 +157,7 @@ class UnitSystem(CogniteResource):
             quantities=[UnitID._load(quantity) for quantity in resource["quantities"]],
         )
 
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         return {"name": self.name, "quantities": [quantity.dump(camel_case) for quantity in self.quantities]}
 

--- a/cognite/client/data_classes/workflows.py
+++ b/cognite/client/data_classes/workflows.py
@@ -8,7 +8,7 @@ from dataclasses import dataclass
 from typing import Any, ClassVar, Literal, TypeAlias, cast, final
 from zoneinfo import ZoneInfo
 
-from typing_extensions import Self
+from typing_extensions import Self, override
 
 from cognite.client.data_classes._base import (
     CogniteResource,
@@ -263,6 +263,7 @@ class FunctionTaskParameters(WorkflowTaskParameters):
             is_async_complete=resource.get("isAsyncComplete", resource.get("asyncComplete")),
         )
 
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         function: dict[str, Any] = {
             ("externalId" if camel_case else "external_id"): self.external_id,
@@ -294,6 +295,7 @@ class UnknownWorkflowTaskParameters(WorkflowTaskParameters):
     def _load(cls, task_type: str, parameters: dict[str, Any]) -> Self:  # type: ignore [override]
         return cls(task_type, parameters)
 
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         if not camel_case:
             # We can not automatically convert to snake case, as we don't know if there is user data
@@ -349,6 +351,7 @@ class SimulationTaskParameters(WorkflowTaskParameters):
             else None,
         )
 
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         simulation: dict[str, Any] = {
             "routineExternalId" if camel_case else "routine_external_id": self.routine_external_id,
@@ -392,6 +395,7 @@ class TransformationTaskParameters(WorkflowTaskParameters):
             data.get("useTransformationCredentials", False),
         )
 
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         transformation = {
             "externalId" if camel_case else "external_id": self.external_id,
@@ -459,6 +463,7 @@ class CDFTaskParameters(WorkflowTaskParameters):
             cdf_request.get("requestTimeoutInMillis", 10000),
         )
 
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         output = super().dump(camel_case)
         return {
@@ -491,6 +496,7 @@ class SubworkflowTaskParameters(WorkflowTaskParameters):
             [WorkflowTask._load(task) for task in subworkflow["tasks"]],
         )
 
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         return {self.task_type: {"tasks": [task.dump(camel_case) for task in self.tasks]}}
 
@@ -518,6 +524,7 @@ class SubworkflowReferenceParameters(WorkflowTaskParameters):
 
         return cls(workflow_external_id=subworkflow["workflowExternalId"], version=subworkflow["version"])
 
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         return {
             self.task_type: {
@@ -566,6 +573,7 @@ class DynamicTaskParameters(WorkflowTaskParameters):
         # or can be resolved to a list of Tasks (i.e., during or after execution)
         return cls([WorkflowTask._load(task) for task in dynamic["tasks"]])
 
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         return {
             self.task_type: {
@@ -631,6 +639,7 @@ class WorkflowTask(CogniteResource):
             depends_on=[dep["externalId"] for dep in resource.get("dependsOn", [])] or None,
         )
 
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         output: dict[str, Any] = {
             "externalId" if camel_case else "external_id": self.external_id,
@@ -683,6 +692,7 @@ class WorkflowTaskOutput(CogniteResource, ABC):
             case task_type:
                 raise ValueError(f"Invalid taskType: {task_type!r}, must be str")
 
+    @override
     @abstractmethod
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         raise NotImplementedError
@@ -711,6 +721,7 @@ class FunctionTaskOutput(WorkflowTaskOutput):
         output = data["output"]
         return cls(output.get("callId"), output.get("functionId"), output.get("response"))
 
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         return {
             "callId" if camel_case else "call_id": self.call_id,
@@ -737,6 +748,7 @@ class UnknownWorkflowTaskOutput(WorkflowTaskOutput):
     def _load(cls, data: dict[str, Any]) -> Self:
         return cls(data["taskType"], data.get("output") or {})
 
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         if not camel_case:
             # We can not automatically convert to snake case, as we don't know if there is user data
@@ -784,6 +796,7 @@ class SimulationTaskOutput(WorkflowTaskOutput):
             status_message=output.get("statusMessage"),
         )
 
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         return {
             "runId" if camel_case else "run_id": self.run_id,
@@ -810,6 +823,7 @@ class TransformationTaskOutput(WorkflowTaskOutput):
         output = data["output"]
         return cls(output.get("jobId"))
 
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         return {"jobId" if camel_case else "job_id": self.job_id}
 
@@ -834,6 +848,7 @@ class CDFTaskOutput(WorkflowTaskOutput):
         output = data["output"]
         return cls(output.get("response"), output.get("statusCode"))
 
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         return {
             "response": self.response,
@@ -854,6 +869,7 @@ class DynamicTaskOutput(WorkflowTaskOutput):
     def _load(cls, data: dict[str, Any]) -> DynamicTaskOutput:
         return cls()
 
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         return {}
 
@@ -871,6 +887,7 @@ class SubworkflowTaskOutput(WorkflowTaskOutput):
     def _load(cls, data: dict[str, Any]) -> SubworkflowTaskOutput:
         return cls()
 
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         return {}
 
@@ -931,6 +948,7 @@ class WorkflowTaskExecution(CogniteResource):
             reason_for_incompletion=resource.get("reasonForIncompletion"),
         )
 
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         output: dict[str, Any] = super().dump(camel_case)
         output["input"] = self.input.dump(camel_case)
@@ -974,6 +992,7 @@ class WorkflowDefinitionCore(WriteableCogniteResource["WorkflowDefinitionUpsert"
             description=resource.get("description"),
         )
 
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         output: dict[str, Any] = {"tasks": [task.dump(camel_case) for task in self.tasks]}
         if self.description:
@@ -1005,6 +1024,7 @@ class WorkflowDefinitionUpsert(WorkflowDefinitionCore):
             description=resource.get("description"),
         )
 
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         output: dict[str, Any] = {"tasks": [task.dump(camel_case) for task in self.tasks]}
         if self.description:
@@ -1045,6 +1065,7 @@ class WorkflowDefinition(WorkflowDefinitionCore):
             description=resource.get("description"),
         )
 
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         output = super().dump(camel_case)
         output["hash"] = self.hash_
@@ -1108,6 +1129,7 @@ class WorkflowVersionUpsert(WorkflowVersionCore):
             workflow_definition=WorkflowDefinitionUpsert._load(resource["workflowDefinition"]),
         )
 
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         return {
             ("workflowExternalId" if camel_case else "workflow_external_id"): self.workflow_external_id,
@@ -1155,6 +1177,7 @@ class WorkflowVersion(WorkflowVersionCore):
             last_updated_time=resource["lastUpdatedTime"],
         )
 
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         return {
             "workflowExternalId" if camel_case else "workflow_external_id": self.workflow_external_id,
@@ -1325,6 +1348,7 @@ class WorkflowExecutionDetailed(WorkflowExecution):
             metadata=resource.get("metadata"),
         )
 
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         output = super().dump(camel_case)
         output["workflowDefinition" if camel_case else "workflow_definition"] = self.workflow_definition.dump(
@@ -1381,6 +1405,7 @@ class WorkflowVersionId:
         return cls(workflow_external_id=workflow_external_id, version=resource.get("version"))
 
     def dump(self, camel_case: bool = True, as_external_id_key: bool = False) -> dict[str, Any]:
+        """Dump the WorkflowVersionId to a dictionary."""
         if as_external_id_key:
             output: dict[str, Any] = {"externalId" if camel_case else "external_id": self.workflow_external_id}
         else:
@@ -1431,6 +1456,7 @@ class WorkflowIds(UserList):
         return cls(workflow_ids)
 
     def dump(self, camel_case: bool = True, as_external_id: bool = False) -> list[dict[str, Any]]:
+        """Dumps the list of WorkflowVersionId objects to a list of dictionaries."""
         return [workflow_id.dump(camel_case, as_external_id_key=as_external_id) for workflow_id in self.data]
 
 
@@ -1444,6 +1470,7 @@ class WorkflowTriggerRule(CogniteResource, ABC):
     def trigger_type(self) -> str:
         return self._trigger_type
 
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         dumped = super().dump(camel_case)
         dumped["triggerType" if camel_case else "trigger_type"] = self.trigger_type
@@ -1505,6 +1532,7 @@ class WorkflowScheduledTriggerRule(WorkflowTriggerRule):
         self.cron_expression = cron_expression
         self.timezone = timezone
 
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         # Override dump to handle timezone field specially:
         # 1. Only include timezone key when it has a value (avoid "timezone": null)
@@ -1551,6 +1579,7 @@ class WorkflowDataModelingTriggerRule(WorkflowTriggerRule):
             batch_timeout=data.get("batchTimeout"),
         )
 
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         item: dict[str, Any] = {
             "trigger_type": self.trigger_type,
@@ -1579,6 +1608,7 @@ class WorkflowRecordStreamSourceSelector(CogniteResource):
     def _load(cls, resource: dict[str, Any]) -> WorkflowRecordStreamSourceSelector:
         return cls(source=RecordContainerId.load(resource["source"]), properties=resource["properties"])
 
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         return {"source": self.source.dump(camel_case=camel_case), "properties": self.properties}
 
@@ -1627,6 +1657,7 @@ class WorkflowRecordStreamTriggerRule(WorkflowTriggerRule):
             initialize_cursor=data.get("initializeCursor"),
         )
 
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         item: dict[str, Any] = {
             "trigger_type": self.trigger_type,
@@ -1702,6 +1733,7 @@ class WorkflowTriggerUpsert(WorkflowTriggerCore):
         self.input = input
         self.metadata = metadata
 
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         item: dict[str, Any] = {
             "external_id": self.external_id,
@@ -1774,6 +1806,7 @@ class WorkflowTrigger(WorkflowTriggerCore):
         self.last_updated_time = last_updated_time
         self.is_paused = is_paused
 
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         item: dict[str, Any] = {
             "external_id": self.external_id,
@@ -1859,6 +1892,7 @@ class WorkflowTriggerRun(CogniteResource):
         self.status = status
         self.reason_for_failure = reason_for_failure
 
+    @override
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         item = {
             "external_id": self.external_id,


### PR DESCRIPTION
## Description
Many public methods do not have docstrings. It is possible to automate the check for missing docstrings using https://docs.astral.sh/ruff/rules/undocumented-public-method/.

This requires all public methods either to have a docstring, or to have a decorater indicating why they should not. The most common scenario is that a method inherits the docstring from some parent class. However, that this is the intention must be made clear by using the `@override` decorater introduced in Python 3.12 (and available in `typing_extensions`).

Because enabling this automated check will require a vast number of code line changes, it has been split up into multiple PRs. In this PR almost all `dump` and `as_write` methods have either got the `override` decorator or have got a docstring.

## Checklist:
- [ ] Tests added/updated.
- [x] Documentation updated. Documentation is generated from docstrings - these must be updated according to your change.
  If a new method has been added it should be referenced in [cognite.rst](https://github.com/cognitedata/cognite-sdk-python/blob/master/docs/source/cognite.rst) in order to generate docs based on its docstring.
- [x] The PR title follows the [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) spec.
