### PR TITLE
chore(state time series): Make the SDK recognize time series with `type="state"`

### DIFF
--- a/cognite/client/utils/_datapoints.py
+++ b/cognite/client/utils/_datapoints.py
@@ -13,7 +13,9 @@ from google.protobuf.internal.containers import RepeatedCompositeFieldContainer
 from cognite.client._constants import NUMPY_IS_AVAILABLE
 from cognite.client._proto.data_point_list_response_pb2 import (
     TIMESERIES_TYPE_NUMERIC,
+    TIMESERIES_TYPE_STATE,
     TIMESERIES_TYPE_STRING,
+    TIMESERIES_TYPE_UNSPECIFIED,
     DataPointListItem,
     TimeSeriesType,
 )
@@ -53,6 +55,13 @@ RawDatapointValue = float | str
 DatapointsId = int | DatapointsQuery | Sequence[int | DatapointsQuery]
 DatapointsExternalId = str | DatapointsQuery | SequenceNotStr[str | DatapointsQuery]
 DatapointsInstanceId = NodeId | DatapointsQuery | Sequence[NodeId | DatapointsQuery]
+
+_PROTO_TYPE_TO_STR: dict[TimeSeriesType, Literal["numeric", "string", "state", "unspecified"]] = {
+    TIMESERIES_TYPE_UNSPECIFIED: "unspecified",  # 0
+    TIMESERIES_TYPE_NUMERIC: "numeric",  # 1
+    TIMESERIES_TYPE_STRING: "string",  # 2
+    TIMESERIES_TYPE_STATE: "state",  # 3
+}
 
 
 class DpsUnpackFns:
@@ -226,23 +235,22 @@ def get_datapoints_from_proto(res: DataPointListItem) -> DatapointsAny:
     return cast(DatapointsAny, [])
 
 
-def proto_type_to_str(ts_type: TimeSeriesType) -> Literal["numeric", "string"]:
-    if ts_type == TIMESERIES_TYPE_NUMERIC:  # 1
-        return "numeric"
-    elif ts_type == TIMESERIES_TYPE_STRING:  # 2
-        return "string"
-    elif ts_type >= 3:
-        from cognite.client._version import __version__
+def proto_type_to_str(ts_type: TimeSeriesType) -> Literal["numeric", "string", "state", "unspecified", "unknown"]:
+    try:
+        return _PROTO_TYPE_TO_STR[ts_type]
+    except KeyError:
+        pass
 
-        warnings.warn(
-            f"Unknown time series type ({ts_type}) received from the API. "
-            "Please upgrade to a newer version of the Cognite SDK to handle this type "
-            f"(current version={__version__!r}).",
-            UserWarning,
-            stacklevel=3,
-        )
-    # We also return 'unknown' for TIMESERIES_TYPE_UNSPECIFIED (0):
-    return "unknown"  # type: ignore [return-value]
+    from cognite.client._version import __version__
+
+    warnings.warn(
+        f"Unknown time series type ({ts_type}) received from the API. "
+        "Please upgrade to a newer version of the Cognite SDK to handle this type "
+        f"(current version={__version__!r}).",
+        UserWarning,
+        stacklevel=3,
+    )
+    return "unknown"
 
 
 def get_ts_info_from_proto(res: DataPointListItem) -> dict[str, int | str | bool | NodeId | None]:

--- a/tests/tests_integration/test_api/test_datapoints.py
+++ b/tests/tests_integration/test_api/test_datapoints.py
@@ -716,6 +716,85 @@ class TestInsertStateDatapoints:
         )
 
 
+@pytest.fixture(scope="session")
+def empty_state_set(
+    cognite_client: CogniteClient,
+    async_client: AsyncCogniteClient,
+    space_for_time_series: Space,
+    os_and_py_version: str,
+) -> NodeApplyResult:
+    from cognite.client.data_classes.data_modeling.cdm.v1 import CogniteStateSetApply
+
+    state_set_apply = CogniteStateSetApply(
+        space=space_for_time_series.space,
+        external_id=f"dms-state-set-EMPTY-{os_and_py_version}",
+        states=[],  # how about no
+        name="EMPTY PySDK integration test state set",
+    )
+    # State sets require beta flag:
+    with pytest.MonkeyPatch.context() as mp:
+        mp.setattr(async_client.data_modeling.instances, "_api_subversion", "beta")
+        (node,) = cognite_client.data_modeling.instances.apply(state_set_apply).nodes
+    return node
+
+
+@pytest.fixture(scope="session")
+def empty_state_ts(
+    cognite_client: CogniteClient,
+    async_client: AsyncCogniteClient,
+    space_for_time_series: Space,
+    os_and_py_version: str,
+    empty_state_set: NodeApplyResult,
+) -> NodeApplyResult:
+    from cognite.client.data_classes.data_modeling.cdm.v1 import CogniteTimeSeriesApply
+
+    state_ts = CogniteTimeSeriesApply(
+        space=space_for_time_series.space,
+        external_id=f"dms-state-ts-EMPTY-(please)-{os_and_py_version}",
+        is_step=False,
+        time_series_type="state",
+        state_set=(empty_state_set.space, empty_state_set.external_id),
+    )
+    with pytest.MonkeyPatch.context() as mp:
+        mp.setattr(async_client.data_modeling.instances, "_api_subversion", "beta")
+        (node,) = cognite_client.data_modeling.instances.apply(state_ts).nodes
+    return node
+
+
+@pytest.fixture(scope="class")
+def use_beta_header_for_dps_client(async_client: AsyncCogniteClient) -> Iterator[None]:
+    with pytest.MonkeyPatch.context() as mp:
+        mp.setattr(async_client.time_series.data, "_api_subversion", "beta")
+        yield
+
+
+@pytest.mark.dsl
+@pytest.mark.usefixtures("use_beta_header_for_dps_client")
+class TestRetrieveStateDatapoints:
+    def test_retrieve_state_datapoints_gets_correct_ts_type(
+        self,
+        cognite_client: CogniteClient,
+        empty_state_ts: NodeApplyResult,
+    ) -> None:
+        # Note: We do not have retrieve support yet, but it works as long as the time series is empty.
+        # TODO: Once retrieve works, this can be reworked into a more meaningful test.
+        ts_id = empty_state_ts.as_id()
+        ts = cognite_client.time_series.retrieve(instance_id=ts_id)
+        assert ts is not None
+        if ts.count() > 0:
+            pytest.skip("Time series is not empty, so in order to not break CI for no reason, we skip for now")
+
+        dps = cognite_client.time_series.data.retrieve(instance_id=ts_id)
+        assert isinstance(dps, Datapoints)
+        assert dps.type == "state"
+        assert dps.to_pandas().empty
+
+        dps_arr = cognite_client.time_series.data.retrieve_arrays(instance_id=ts_id)
+        assert isinstance(dps_arr, DatapointsArray)
+        assert dps_arr.type == "state"
+        assert dps_arr.to_pandas().empty
+
+
 @pytest.fixture
 def queries_for_iteration(all_test_time_series: TimeSeriesList) -> list[DatapointsQuery]:
     # Mix of ids, external_ids, and instance_ids

--- a/tests/tests_integration/test_api/test_datapoints.py
+++ b/tests/tests_integration/test_api/test_datapoints.py
@@ -46,7 +46,12 @@ from cognite.client.data_classes import (
     TimeSeriesWrite,
 )
 from cognite.client.data_classes.data_modeling import NodeApply, NodeOrEdgeData, Space
-from cognite.client.data_classes.data_modeling.cdm.v1 import CogniteTimeSeries
+from cognite.client.data_classes.data_modeling.cdm.v1 import (
+    CogniteStateSetApply,
+    CogniteTimeSeries,
+    CogniteTimeSeriesApply,
+)
+from cognite.client.data_classes.data_modeling.data_types import StateSetEntry
 from cognite.client.data_classes.data_modeling.ids import NodeId
 from cognite.client.data_classes.data_modeling.instances import NodeApplyResult
 from cognite.client.data_classes.data_modeling.spaces import SpaceApply
@@ -490,8 +495,6 @@ def space_for_time_series(cognite_client: CogniteClient) -> Iterator[Space]:
 def ts_create_in_dms(
     cognite_client: CogniteClient, space_for_time_series: Space, os_and_py_version: str
 ) -> NodeApplyResult:
-    from cognite.client.data_classes.data_modeling.cdm.v1 import CogniteTimeSeriesApply
-
     dms_ts = CogniteTimeSeriesApply(
         space=space_for_time_series.space,
         # One per test runner, per OS, to avoid conflicts:
@@ -540,11 +543,10 @@ def state_set(
     space_for_time_series: Space,
     os_and_py_version: str,
 ) -> NodeApplyResult:
-    from cognite.client.data_classes.data_modeling.cdm.v1 import CogniteStateSetApply
-    from cognite.client.data_classes.data_modeling.data_types import StateSetEntry
-
-    state_set_apply = CogniteStateSetApply(
-        space=space_for_time_series.space,
+    return _create_state_set(
+        cognite_client=cognite_client,
+        async_client=async_client,
+        space=space_for_time_series,
         external_id=f"dms-state-set-{os_and_py_version}",
         states=[
             StateSetEntry(-(2**31), "small"),
@@ -553,13 +555,7 @@ def state_set(
             StateSetEntry(1, "on"),
             StateSetEntry(2**31 - 1, "bigly"),
         ],
-        name="PySDK integration test state set",
     )
-    # State sets require beta flag:
-    with pytest.MonkeyPatch.context() as mp:
-        mp.setattr(async_client.data_modeling.instances, "_api_subversion", "beta")
-        (node,) = cognite_client.data_modeling.instances.apply(state_set_apply).nodes
-    return node
 
 
 def _create_state_time_series(
@@ -569,8 +565,6 @@ def _create_state_time_series(
     space_for_time_series: Space,
     state_set: NodeApplyResult,
 ) -> NodeApplyResult:
-    from cognite.client.data_classes.data_modeling.cdm.v1 import CogniteTimeSeriesApply
-
     state_ts = CogniteTimeSeriesApply(
         space=space_for_time_series.space,
         external_id=external_id,
@@ -581,6 +575,26 @@ def _create_state_time_series(
     with pytest.MonkeyPatch.context() as mp:
         mp.setattr(async_client.data_modeling.instances, "_api_subversion", "beta")
         (node,) = cognite_client.data_modeling.instances.apply(state_ts).nodes
+    return node
+
+
+def _create_state_set(
+    cognite_client: CogniteClient,
+    async_client: AsyncCogniteClient,
+    space: Space,
+    external_id: str,
+    states: list,
+    name: str = "PySDK integration test state set",
+) -> NodeApplyResult:
+    state_set_apply = CogniteStateSetApply(
+        space=space.space,
+        external_id=external_id,
+        states=states,
+        name=name,
+    )
+    with pytest.MonkeyPatch.context() as mp:
+        mp.setattr(async_client.config, "api_subversion", "beta")
+        (node,) = cognite_client.data_modeling.instances.apply(state_set_apply).nodes
     return node
 
 
@@ -723,19 +737,14 @@ def empty_state_set(
     space_for_time_series: Space,
     os_and_py_version: str,
 ) -> NodeApplyResult:
-    from cognite.client.data_classes.data_modeling.cdm.v1 import CogniteStateSetApply
-
-    state_set_apply = CogniteStateSetApply(
-        space=space_for_time_series.space,
+    return _create_state_set(
+        cognite_client=cognite_client,
+        async_client=async_client,
+        space=space_for_time_series,
         external_id=f"dms-state-set-EMPTY-{os_and_py_version}",
         states=[],  # how about no
         name="EMPTY PySDK integration test state set",
     )
-    # State sets require beta flag:
-    with pytest.MonkeyPatch.context() as mp:
-        mp.setattr(async_client.data_modeling.instances, "_api_subversion", "beta")
-        (node,) = cognite_client.data_modeling.instances.apply(state_set_apply).nodes
-    return node
 
 
 @pytest.fixture(scope="session")

--- a/tests/tests_integration/test_api/test_datapoints.py
+++ b/tests/tests_integration/test_api/test_datapoints.py
@@ -593,7 +593,7 @@ def _create_state_set(
         name=name,
     )
     with pytest.MonkeyPatch.context() as mp:
-        mp.setattr(async_client.config, "api_subversion", "beta")
+        mp.setattr(async_client.data_modeling.instances, "_api_subversion", "beta")
         (node,) = cognite_client.data_modeling.instances.apply(state_set_apply).nodes
     return node
 

--- a/tests/tests_integration/test_api/test_datapoints.py
+++ b/tests/tests_integration/test_api/test_datapoints.py
@@ -746,19 +746,13 @@ def empty_state_ts(
     os_and_py_version: str,
     empty_state_set: NodeApplyResult,
 ) -> NodeApplyResult:
-    from cognite.client.data_classes.data_modeling.cdm.v1 import CogniteTimeSeriesApply
-
-    state_ts = CogniteTimeSeriesApply(
-        space=space_for_time_series.space,
+    return _create_state_time_series(
         external_id=f"dms-state-ts-EMPTY-(please)-{os_and_py_version}",
-        is_step=False,
-        time_series_type="state",
-        state_set=(empty_state_set.space, empty_state_set.external_id),
+        cognite_client=cognite_client,
+        async_client=async_client,
+        space_for_time_series=space_for_time_series,
+        state_set=empty_state_set,
     )
-    with pytest.MonkeyPatch.context() as mp:
-        mp.setattr(async_client.data_modeling.instances, "_api_subversion", "beta")
-        (node,) = cognite_client.data_modeling.instances.apply(state_ts).nodes
-    return node
 
 
 @pytest.fixture(scope="class")


### PR DESCRIPTION
This has no real implications outside of "tests", so keeping this a `chore`, not a `feat`. Still very much needed for the next PRs adding retrieve support though!