### PR TITLE
fix(transformations): external data sources endpoint is create-only, not upsert

### DIFF
--- a/cognite/client/_api/transformations/externaldata.py
+++ b/cognite/client/_api/transformations/externaldata.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import AsyncIterator, Sequence
-from typing import TYPE_CHECKING, Literal, overload
+from typing import TYPE_CHECKING, overload
 
 from cognite.client._api_client import APIClient
 from cognite.client._constants import DEFAULT_LIMIT_READ
@@ -97,32 +97,27 @@ class TransformationExternalDataSourcesAPI(APIClient):
         )
 
     @overload
-    async def upsert(
-        self, data_source: ExternalDataSourceWrite, upsert_mode: Literal["replace"] = "replace"
-    ) -> ExternalDataSource: ...
+    async def create(self, data_source: ExternalDataSourceWrite) -> ExternalDataSource: ...
 
     @overload
-    async def upsert(
-        self, data_source: Sequence[ExternalDataSourceWrite], upsert_mode: Literal["replace"] = "replace"
-    ) -> ExternalDataSourceList: ...
+    async def create(self, data_source: Sequence[ExternalDataSourceWrite]) -> ExternalDataSourceList: ...
 
-    async def upsert(
-        self,
-        data_source: ExternalDataSourceWrite | Sequence[ExternalDataSourceWrite],
-        upsert_mode: Literal["replace"] = "replace",
+    async def create(
+        self, data_source: ExternalDataSourceWrite | Sequence[ExternalDataSourceWrite]
     ) -> ExternalDataSource | ExternalDataSourceList:
-        """`Upsert external data sources <https://api-docs.cognite.com/20230101-beta/tag/Transformation-External-Data-Sources/operation/upsertExternalDataSources>`_.
+        """`Create external data sources <https://api-docs.cognite.com/20230101-beta/tag/Transformation-External-Data-Sources/operation/createExternalDataSources>`_.
 
-        Each item replaces the stored data source in full, so every request must contain complete settings
-        including the client secret. Reading a data source never returns the client secret, so re-registering
-        one means constructing a new write object with the secret filled in.
+        Fails with a 409 if any external ID in the request already exists for the project; no items
+        are created in that case. To modify an existing data source, delete it and create a replacement.
 
         Args:
-            data_source (ExternalDataSourceWrite | Sequence[ExternalDataSourceWrite]): The data source(s) to create or replace.
-            upsert_mode (Literal['replace']): How existing data sources are updated. Currently only "replace" is supported, which fully replaces the existing data source. Defaults to "replace".
+            data_source (ExternalDataSourceWrite | Sequence[ExternalDataSourceWrite]): The data source(s) to create.
 
         Returns:
-            ExternalDataSource | ExternalDataSourceList: The created or replaced data source(s).
+            ExternalDataSource | ExternalDataSourceList: The created data source(s).
+
+        Raises:
+            CogniteDuplicatedError: If an external ID in the request already exists for the project.
 
         Examples:
 
@@ -154,7 +149,7 @@ class TransformationExternalDataSourcesAPI(APIClient):
                 ...         ),
                 ...     ),
                 ... )
-                >>> res = client.transformations.external_data_sources.upsert(data_source)
+                >>> res = client.transformations.external_data_sources.create(data_source)
         """
         self._warning.warn()
         return await self._create_multiple(

--- a/cognite/client/_sync_api/transformations/externaldata.py
+++ b/cognite/client/_sync_api/transformations/externaldata.py
@@ -1,6 +1,6 @@
 """
 ===============================================================================
-8a68955cabb05edf6b593b4560f01814
+efc34b01e5ba2da8b6d7f803bede9c00
 This file is auto-generated from the Async API modules, - do not edit manually!
 ===============================================================================
 """
@@ -8,7 +8,7 @@ This file is auto-generated from the Async API modules, - do not edit manually!
 from __future__ import annotations
 
 from collections.abc import Iterator, Sequence
-from typing import TYPE_CHECKING, Literal, overload
+from typing import TYPE_CHECKING, overload
 
 from cognite.client import AsyncCogniteClient
 from cognite.client._constants import DEFAULT_LIMIT_READ
@@ -89,33 +89,28 @@ class SyncTransformationExternalDataSourcesAPI(SyncAPIClient):
         return run_sync(self.__async_client.transformations.external_data_sources.list(limit=limit))
 
     @overload
-    def upsert(
-        self, data_source: ExternalDataSourceWrite, upsert_mode: Literal["replace"] = "replace"
-    ) -> ExternalDataSource: ...
+    def create(self, data_source: ExternalDataSourceWrite) -> ExternalDataSource: ...
 
     @overload
-    def upsert(
-        self, data_source: Sequence[ExternalDataSourceWrite], upsert_mode: Literal["replace"] = "replace"
-    ) -> ExternalDataSourceList: ...
+    def create(self, data_source: Sequence[ExternalDataSourceWrite]) -> ExternalDataSourceList: ...
 
-    def upsert(
-        self,
-        data_source: ExternalDataSourceWrite | Sequence[ExternalDataSourceWrite],
-        upsert_mode: Literal["replace"] = "replace",
+    def create(
+        self, data_source: ExternalDataSourceWrite | Sequence[ExternalDataSourceWrite]
     ) -> ExternalDataSource | ExternalDataSourceList:
         """
-        `Upsert external data sources <https://api-docs.cognite.com/20230101-beta/tag/Transformation-External-Data-Sources/operation/upsertExternalDataSources>`_.
+        `Create external data sources <https://api-docs.cognite.com/20230101-beta/tag/Transformation-External-Data-Sources/operation/createExternalDataSources>`_.
 
-        Each item replaces the stored data source in full, so every request must contain complete settings
-        including the client secret. Reading a data source never returns the client secret, so re-registering
-        one means constructing a new write object with the secret filled in.
+        Fails with a 409 if any external ID in the request already exists for the project; no items
+        are created in that case. To modify an existing data source, delete it and create a replacement.
 
         Args:
-            data_source (ExternalDataSourceWrite | Sequence[ExternalDataSourceWrite]): The data source(s) to create or replace.
-            upsert_mode (Literal['replace']): How existing data sources are updated. Currently only "replace" is supported, which fully replaces the existing data source. Defaults to "replace".
+            data_source (ExternalDataSourceWrite | Sequence[ExternalDataSourceWrite]): The data source(s) to create.
 
         Returns:
-            ExternalDataSource | ExternalDataSourceList: The created or replaced data source(s).
+            ExternalDataSource | ExternalDataSourceList: The created data source(s).
+
+        Raises:
+            CogniteDuplicatedError: If an external ID in the request already exists for the project.
 
         Examples:
 
@@ -147,13 +142,9 @@ class SyncTransformationExternalDataSourcesAPI(SyncAPIClient):
                 ...         ),
                 ...     ),
                 ... )
-                >>> res = client.transformations.external_data_sources.upsert(data_source)
+                >>> res = client.transformations.external_data_sources.create(data_source)
         """
-        return run_sync(
-            self.__async_client.transformations.external_data_sources.upsert(
-                data_source=data_source, upsert_mode=upsert_mode
-            )
-        )
+        return run_sync(self.__async_client.transformations.external_data_sources.create(data_source=data_source))
 
     def delete(self, external_id: str | SequenceNotStr[str]) -> None:
         """

--- a/cognite/client/data_classes/transformations/externaldata.py
+++ b/cognite/client/data_classes/transformations/externaldata.py
@@ -122,7 +122,7 @@ class OneLakeSettingsWrite(CogniteResource):
     """Connection settings for the external data source.
 
     Args:
-        credentials (OneLakeCredentialsWrite): Azure credentials for the upsert.
+        credentials (OneLakeCredentialsWrite): Azure credentials for the data source.
         location_description (OneLakeLocationDescription): Fabric workspace and lakehouse identifiers.
     """
 
@@ -146,7 +146,7 @@ class OneLakeSettingsWrite(CogniteResource):
 
 
 class ExternalDataSourceWrite(CogniteResource, ABC):
-    """Upsert model for an external data source to create or replace in CDF.
+    """Write model for an external data source to create in CDF.
 
     Format-specific subclasses (e.g. :class:`OneLakeExternalDataSourceWrite`) hold typed settings.
 
@@ -191,11 +191,11 @@ class ExternalDataSourceWrite(CogniteResource, ABC):
 
 
 class OneLakeExternalDataSourceWrite(ExternalDataSourceWrite):
-    """Upsert model for registering a Fabric OneLake external data source in CDF.
+    """Write model for registering a Fabric OneLake external data source in CDF.
 
     Registers Azure credentials and lakehouse location so transforms can read via ``ext_onelake()``.
-    Does not write data into OneLake. Each upsert replaces the stored data source in full, so every
-    request must contain complete ``settings`` including ``client_secret``.
+    Does not write data into OneLake. Fails if a data source with the given ``external_id`` already
+    exists; it is not merged or replaced.
 
     Args:
         external_id (str): External ID for the data source. Must be unique.
@@ -205,7 +205,7 @@ class OneLakeExternalDataSourceWrite(ExternalDataSourceWrite):
 
     Examples:
 
-        Construct a Fabric OneLake source for upsert:
+        Construct a Fabric OneLake source for creation:
 
             >>> import os
             >>> from cognite.client.data_classes.transformations.externaldata import (

--- a/docs/source/transformations_external_data_sources.rst
+++ b/docs/source/transformations_external_data_sources.rst
@@ -46,7 +46,7 @@ Every operation is governed by ``transformationsExternalDataSourcesAcl``, availa
 Operation                                 Action
 ========================================= ==========
 ``list()``                                ``READ``
-``upsert()``                              ``WRITE``
+``create()``                              ``WRITE``
 ``delete()``                              ``WRITE``
 ``verify_usability()``                    ``USE``
 ========================================= ==========
@@ -57,8 +57,9 @@ transformation and destination capabilities.
 Register a data source
 ----------------------
 
-An upsert creates the data source if it does not exist and replaces it in full if it does, matched on
-external ID. Every request must therefore carry complete settings, including the client secret:
+Creating a data source requires a unique external ID. If an external ID you submit already exists for
+the project, the request is rejected with a 409 and no items are created — there is no in-place update.
+To modify an existing data source, delete it and create a replacement (see `Rotate credentials`_):
 
 .. code-block:: python
 
@@ -90,7 +91,7 @@ external ID. Every request must therefore carry complete settings, including the
             ),
         ),
     )
-    registered = client.transformations.external_data_sources.upsert(data_source)
+    registered = client.transformations.external_data_sources.create(data_source)
 
 Verify that a data source is usable
 -----------------------------------
@@ -176,10 +177,13 @@ Rotate credentials
 ------------------
 
 Because a read model never carries the client secret, it cannot be turned back into a write model —
-``as_write()`` raises a ``TypeError``. Rotating a secret means building a new write model with the new
-secret and upserting it under the same external ID, which replaces the stored data source:
+``as_write()`` raises a ``TypeError``. There is no update endpoint for this resource, so rotating a
+secret (or changing any other setting) means deleting the existing data source and creating a
+replacement with the same external ID:
 
 .. code-block:: python
+
+    client.transformations.external_data_sources.delete("fabric-lakehouse-prod")
 
     rotated = OneLakeExternalDataSourceWrite(
         external_id="fabric-lakehouse-prod",
@@ -197,7 +201,7 @@ secret and upserting it under the same external ID, which replaces the stored da
             ),
         ),
     )
-    client.transformations.external_data_sources.upsert(rotated)
+    client.transformations.external_data_sources.create(rotated)
 
 Delete a data source
 --------------------

--- a/tests/tests_integration/test_api/test_transformations/test_externaldata.py
+++ b/tests/tests_integration/test_api/test_transformations/test_externaldata.py
@@ -13,6 +13,7 @@ from cognite.client.data_classes.transformations.externaldata import (
     OneLakeLocationDescription,
     OneLakeSettingsWrite,
 )
+from cognite.client.exceptions import CogniteDuplicatedError
 from cognite.client.utils._text import random_string
 
 # The OneLake data source is verified against a live Fabric lakehouse, so these tests only run when
@@ -32,7 +33,7 @@ pytestmark = pytest.mark.skipif(
 
 
 class TestExternalDataSources:
-    def test_upsert_list_verify_usability_delete(self, cognite_client: CogniteClient) -> None:
+    def test_create_list_verify_usability_delete(self, cognite_client: CogniteClient) -> None:
         api = cognite_client.transformations.external_data_sources
         external_id = f"sdk-integration-test-{random_string(6, string.ascii_letters)}"
         data_source = OneLakeExternalDataSourceWrite(
@@ -52,11 +53,14 @@ class TestExternalDataSources:
         )
         created = False
         try:
-            upserted = api.upsert(data_source)
+            source = api.create(data_source)
             created = True
-            assert isinstance(upserted, OneLakeExternalDataSource)
-            assert upserted.external_id == external_id
-            assert upserted.settings.credentials.client_id == os.environ["ONELAKE_CLIENT_ID"]
+            assert isinstance(source, OneLakeExternalDataSource)
+            assert source.external_id == external_id
+            assert source.settings.credentials.client_id == os.environ["ONELAKE_CLIENT_ID"]
+
+            with pytest.raises(CogniteDuplicatedError):
+                api.create(data_source)
 
             assert external_id in api.list(limit=-1).as_external_ids()
 

--- a/tests/tests_unit/test_api/test_transformations_external_data.py
+++ b/tests/tests_unit/test_api/test_transformations_external_data.py
@@ -15,6 +15,7 @@ from cognite.client.data_classes.transformations.externaldata import (
     OneLakeLocationDescription,
     OneLakeSettingsWrite,
 )
+from cognite.client.exceptions import CogniteDuplicatedError
 from tests.utils import get_url, jsgz_load
 
 
@@ -117,7 +118,7 @@ class TestTransformationExternalDataSourcesAPI:
         assert [len(chunk) for chunk in chunks] == [25, 5]
         assert all(isinstance(chunk, ExternalDataSourceList) for chunk in chunks)
 
-    def test_upsert_single(
+    def test_create_single(
         self,
         cognite_client: CogniteClient,
         httpx_mock: HTTPXMock,
@@ -128,7 +129,7 @@ class TestTransformationExternalDataSourcesAPI:
             method="POST", url=external_data_url, status_code=201, json={"items": [onelake_read_item]}
         )
 
-        result = cognite_client.transformations.external_data_sources.upsert(make_write_source("fabric-lakehouse-prod"))
+        result = cognite_client.transformations.external_data_sources.create(make_write_source("fabric-lakehouse-prod"))
 
         assert isinstance(result, OneLakeExternalDataSource)
         assert result.external_id == "fabric-lakehouse-prod"
@@ -144,7 +145,7 @@ class TestTransformationExternalDataSourcesAPI:
             "locationDescription": {"workspaceId": "my-workspace-id", "containerId": "my-container-id"},
         }
 
-    def test_upsert_multiple(
+    def test_create_multiple(
         self,
         cognite_client: CogniteClient,
         httpx_mock: HTTPXMock,
@@ -156,13 +157,37 @@ class TestTransformationExternalDataSourcesAPI:
             method="POST", url=external_data_url, status_code=201, json={"items": [onelake_read_item, second_item]}
         )
 
-        result = cognite_client.transformations.external_data_sources.upsert(
+        result = cognite_client.transformations.external_data_sources.create(
             [make_write_source("fabric-lakehouse-prod"), make_write_source("fabric-lakehouse-staging")]
         )
 
         assert isinstance(result, ExternalDataSourceList)
         assert result.as_external_ids() == ["fabric-lakehouse-prod", "fabric-lakehouse-staging"]
         assert len(jsgz_load(httpx_mock.get_requests()[-1].content)["items"]) == 2
+
+    def test_create_existing_external_id_raises_duplicated(
+        self,
+        cognite_client: CogniteClient,
+        httpx_mock: HTTPXMock,
+        external_data_url: str,
+    ) -> None:
+        httpx_mock.add_response(
+            method="POST",
+            url=external_data_url,
+            status_code=409,
+            json={
+                "error": {
+                    "code": 409,
+                    "message": "Duplicated external ids",
+                    "duplicated": [{"externalId": "fabric-lakehouse-prod"}],
+                }
+            },
+        )
+
+        with pytest.raises(CogniteDuplicatedError) as exc_info:
+            cognite_client.transformations.external_data_sources.create(make_write_source("fabric-lakehouse-prod"))
+
+        assert exc_info.value.duplicated == [{"externalId": "fabric-lakehouse-prod"}]
 
     def test_delete(self, cognite_client: CogniteClient, httpx_mock: HTTPXMock, external_data_url: str) -> None:
         httpx_mock.add_response(method="POST", url=external_data_url + "/delete", status_code=200, json={})


### PR DESCRIPTION
## Summary
- The Transformations "external data sources" endpoint (`POST /transformations/externaldata`) is now create-only on the backend (jetfire-backend) and in the `service-contracts` OpenAPI spec: a request whose `externalId` already exists for the project is rejected with `409` and nothing is created. Previously it was a true upsert (replace-in-place).
- Renamed `TransformationExternalDataSourcesAPI.upsert()` → `create()` and dropped the now-meaningless `upsert_mode: Literal["replace"]` kwarg (it was doc-only, never functional).
- Regenerated the sync API via `scripts/sync_client_codegen`.
- Updated the "upsert model" docstrings on `ExternalDataSourceWrite`/`OneLakeExternalDataSourceWrite`.
- Updated the narrative guide (`docs/source/transformations_external_data_sources.rst`): permissions table, registration section, and rewrote "Rotate credentials" to delete-then-create since there's no update path.
- Renamed `test_upsert_*` tests to `test_create_*`; added a unit test asserting `CogniteDuplicatedError` on a 409/duplicate response, and a live second-create-same-id assertion in the integration test.

This SDK client is `sdk_maturity="alpha"` and was never in a tagged release, so this is not marked as a breaking change.

## Test plan
- [x] `ruff check` / `ruff format --check` on all changed files
- [x] `pytest tests/tests_unit/test_api/test_transformations_external_data.py -v` — 9/9 pass, including the new 409 test
- [x] `pytest tests/tests_unit/test_data_classes/test_transformations/test_externaldata.py -v` — unchanged, 10/10 pass
- [x] Broader `tests/tests_unit -k "external_data or externaldata or transformations"` — 257/257 pass
