### PR TITLE
ci: Randomize test module ordering in CI

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -4210,4 +4210,4 @@ yaml = ["PyYAML"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">= 3.10, <4"
-content-hash = "9ec022be836385ee633541d304ec30e5c3baad0f1af26b0cd27784fa4933793e"
+content-hash = "99591bd9b96dbda2621eb210400951ed49b38140e579221c514ddb8718d7c743"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ dependencies = [
     "pip >=20", # make optional once poetry doesn't auto-remove it on "simple install"
     "typing_extensions >=4",
     # Windows does not have a ANSI database and need tzdata...:
-    "tzdata >=2024.1; sys_platform == 'win32' or sys_platform=='emscripten'"
+    "tzdata >=2024.1; sys_platform == 'win32' or sys_platform=='emscripten'",
 ]
 
 [project.optional-dependencies]
@@ -51,7 +51,7 @@ all = [
 
 [dependency-groups]
 dev = [
-    "pytest >=7",
+    "pytest (>=9)",
     "pytest-cov (>=3, <7)",  # pytest-cov 7+ has issues with coverage measurement
     "coverage (>=7, <7.11)",  # 7.11+ has issues with editable installs in parallel test execution
     "pytest-rerunfailures >=10",
@@ -78,7 +78,7 @@ dev = [
     "types-authlib (>=1.6.2.20250825, <2)",
     "anyio (>=4.11.0, <5)",
     "testbook (>=0.4.2, <0.5)",
-    "ipykernel (>=7.2.0, <8)"
+    "ipykernel (>=7.2.0, <8)",
 ]
 docs = [
     "sphinx ==8.1.*",  # Increase when Python 3.10 support is dropped

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -112,10 +112,16 @@ def pytest_addoption(parser: pytest.Parser) -> None:
     )
 
 
-def pytest_collection_modifyitems(config: pytest.Config, items: list[pytest.Item]) -> None:
+def apply_coredeps_skips(config: pytest.Config, items: list[pytest.Item]) -> None:
+    """Skip @pytest.mark.coredeps tests unless --test-deps-only-core is set."""
     if config.getoption("--test-deps-only-core"):
-        return None
+        return
+
     skip_core = pytest.mark.skip(reason="need --test-deps-only-core option to run")
     for item in items:
         if "coredeps" in item.keywords:
             item.add_marker(skip_core)
+
+
+def pytest_collection_modifyitems(config: pytest.Config, items: list[pytest.Item]) -> None:
+    apply_coredeps_skips(config, items)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,11 @@
 from __future__ import annotations
 
+import os
 import platform
+import random
+from collections import defaultdict
 from collections.abc import Callable, Iterator
+from pathlib import Path
 from typing import Any
 
 import dotenv
@@ -123,5 +127,54 @@ def apply_coredeps_skips(config: pytest.Config, items: list[pytest.Item]) -> Non
             item.add_marker(skip_core)
 
 
+def shuffle_test_modules(items: list[pytest.Item]) -> None:
+    """Shuffles test file (module) execution order in CI to prevent issues and smear out load.
+
+    Why this exists:
+    When GitHub Actions launches a matrix build (OS x Python version), dozens of worker processes
+    execute the test suite in lockstep (currently 2 x 5 = 10). Because collection is deterministic by
+    default, every runner hits the exact same Cognite CDF endpoints simultaneously, causing high peak
+    traffic, increasing the chance for rate-limit errors on shared resources.
+
+    How this function works:
+    - Deterministic per matrix job: Generates a seed based on GITHUB_RUN_ID, GITHUB_JOB,
+      RUNNER_OS, and the Python version. This forces each matrix runner (e.g., Linux 3.10
+      and Windows 3.14) to run test files in a completely different order.
+    - xdist-safe: All 8 workers inside the SAME matrix runner calculate the exact same
+      seed, preserving `--dist loadscope` scheduling efficiency.
+    - Module-level only: Shuffles test files while preserving the internal test order
+      within each file, protecting sequential tests and module-scoped fixtures.
+
+    When running tests locally this logic is skipped entirely. There's no "matrix parallelism",
+    so just using the standard & predictable test ordering makes debugging easier.
+    """
+    if os.getenv("GITHUB_ACTIONS") != "true":
+        return
+
+    # Build a seed unique to each matrix runner using Github Actions env vars + the Python runtime:
+    seed_parts = (
+        os.getenv("GITHUB_RUN_ID", ""),  # Differentiates workflow runs
+        os.getenv("GITHUB_RUN_ATTEMPT", ""),  # Differentiates workflow retries
+        os.getenv("GITHUB_JOB", ""),  # Job ID defined in your workflow file
+        os.getenv("RUNNER_OS", ""),  # Operating system (Linux/Windows)
+        platform.python_version(),
+    )
+    rng = random.Random(":".join(seed_parts))
+
+    # We need to group all tests by their resolved file path:
+    modules: defaultdict[Path, list[pytest.Item]] = defaultdict(list)
+    for item in items:
+        modules[item.path].append(item)
+
+    shuffled_modules = list(modules.keys())
+    rng.shuffle(shuffled_modules)
+
+    # We need to mutate 'items' in-place with out new ordering:
+    items.clear()
+    items.extend(item for module in shuffled_modules for item in modules[module])
+
+
 def pytest_collection_modifyitems(config: pytest.Config, items: list[pytest.Item]) -> None:
     apply_coredeps_skips(config, items)
+    if items:
+        shuffle_test_modules(items)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -161,7 +161,7 @@ def shuffle_test_modules(items: list[pytest.Item]) -> None:
     )
     rng = random.Random(":".join(seed_parts))
 
-    # We need to group all tests by their resolved file path:
+    # We need to group all tests by their file paths:
     modules: defaultdict[Path, list[pytest.Item]] = defaultdict(list)
     for item in items:
         modules[item.path].append(item)
@@ -169,7 +169,7 @@ def shuffle_test_modules(items: list[pytest.Item]) -> None:
     shuffled_modules = list(modules.keys())
     rng.shuffle(shuffled_modules)
 
-    # We need to mutate 'items' in-place with out new ordering:
+    # We need to mutate 'items' in-place with our new ordering:
     items.clear()
     items.extend(item for module in shuffled_modules for item in modules[module])
 


### PR DESCRIPTION
I am repeatedly seeing Data Modeling tests fail due to too many 429s in a row, while the error also claims "above concurrency budget of 40 (!!!!!??) concurrent read requests". I feel like there must be something wrong with how we calculate the number of in-flight requests... but that is another story. 

Edit: At second thought, it probably is correct, as we have 10 github workers X 8 parallel xdist runners = 80 parallel processes using the same credentials 😅 🚒 

Example of failed run simply due to load:
```
FAILED tests/tests_integration/test_api/test_data_modeling/test_graphql.py::TestDataModelingGraphQLAPI::test_apply_dml - cognite.client.exceptions.CogniteGraphQLError: [GraphQLErrorSpec(message=Client request(POST https://api.cognitedata.com/api/v1/projects/python-sdk-contributor/models/datamodels/byids?includeGraphqlSchema=true&inlineViews=true) invalid: 429 Too Many Requests. Text: "{
  "error": {
    "code": 429,
    "message": "User exceeded maximum number='40' of concurrent requests. Please try again later."
  }
}", locations=[{'line': 3, 'column': 5}], path=['upsertGraphQlDmlVersion'], extensions={'classification': 'DataFetchingException'})]

(...)

FAILED tests/tests_integration/test_api/test_functions.py::TestFunctionSchedulesAPI::test_create_with_nonce - 
CogniteAPIError: Rate limit exceeded: 10 requests per 1 minute. Please try again later. | code: 429 | X-Request-ID: f2a4cac2-bd50-9534-b35a-ff41d2d9cc32 | cluster: api | project: python-sdk-contributor
```

This PR randomizes the test module ordering per matrix runner (while keeping the same ordering inside each module) so that e.g. Linux@3.10 and Windows@3.14 run in a different order. I hope this will help smear traffic out against our different APIs and not overload single endpoints to the same degree.

----

Also bumps pytest to latest, v9 after https://github.com/cognitedata/cognite-sdk-python/pull/2786 fixed a lot of deprecated usage.