### PR TITLE
fix(ClientConfig): Make API subversion mutable at runtime + easy to override per API class

### DIFF
--- a/cognite/client/_api_client.py
+++ b/cognite/client/_api_client.py
@@ -847,6 +847,7 @@ class APIClient(BasicAsyncAPIClient):
         returns_items: bool = False,
         delete_endpoint: str = "/delete",
         override_semaphore: asyncio.BoundedSemaphore | None = None,
+        api_subversion: str | None = None,
     ) -> list | None:
         resource_path = (resource_path or self._RESOURCE_PATH) + delete_endpoint
         extra_body_fields = extra_body_fields or {}
@@ -859,6 +860,7 @@ class APIClient(BasicAsyncAPIClient):
                 params=params,
                 headers=headers,
                 semaphore=semaphore,
+                api_subversion=api_subversion,
             )
             for chunk in identifiers.chunked(self._DELETE_LIMIT)
         ]

--- a/cognite/client/_basic_api_client.py
+++ b/cognite/client/_basic_api_client.py
@@ -187,7 +187,7 @@ class BasicAsyncAPIClient:
     def __init__(self, config: ClientConfig, api_version: str | None, cognite_client: AsyncCogniteClient) -> None:
         self._config = config
         self._api_version = api_version
-        self._api_subversion = config.api_subversion
+        self.__api_subversion_override: str | None = None
         self._cognite_client = cognite_client
         self._init_async_http_clients()
 
@@ -206,6 +206,21 @@ class BasicAsyncAPIClient:
             config=AsyncHTTPClientWithRetryConfig(),
             refresh_auth_header=self._refresh_auth_header,
         )
+
+    @property
+    def _api_subversion(self) -> str:
+        """Get the API subversion to use for this API class.
+
+        Uses the API subversion from the ClientConfig, unless specifically overridden. To reset the override,
+        simply set `_api_subversion` to None.
+        """
+        if self.__api_subversion_override is None:
+            return self._config.api_subversion
+        return self.__api_subversion_override
+
+    @_api_subversion.setter
+    def _api_subversion(self, value: str | None) -> None:
+        self.__api_subversion_override = value
 
     def __getstate__(self) -> dict[str, Any]:
         """Prepare object for pickling by removing unpicklable async clients."""

--- a/cognite/client/_basic_api_client.py
+++ b/cognite/client/_basic_api_client.py
@@ -238,9 +238,14 @@ class BasicAsyncAPIClient:
         return self._http_client_with_retry if is_retryable else self._http_client
 
     def _alpha_version_header(self) -> dict[str, str]:
-        subversion = self._config.api_subversion
-        version = subversion if "alpha" in subversion else subversion + "-alpha"
-        return {"cdf-version": version}
+        sub = self._api_subversion
+        if "alpha" in sub:
+            return {"cdf-version": sub}
+        elif sub.isdecimal():  # default is something like "20230101" (see __api_subversion__ in _version.py)
+            return {"cdf-version": f"{sub}-alpha"}
+        else:
+            # Maybe the user has set "beta" or something else, whatever the case, we just return "alpha":
+            return {"cdf-version": "alpha"}
 
     @property
     def _base_url_with_base_path(self) -> str:

--- a/cognite/client/config.py
+++ b/cognite/client/config.py
@@ -224,7 +224,7 @@ class ClientConfig:
         self.client_name = client_name
         self.project = project
         self.credentials = credentials
-        self.api_subversion = api_subversion
+        self.api_subversion = api_subversion or __api_subversion__  # to avoid breaking changes, can be remove in v9
         self.base_url = self._validate_base_url_or_cluster(base_url, cluster)
         self._cluster = cluster
         self.headers = headers or {}

--- a/cognite/client/config.py
+++ b/cognite/client/config.py
@@ -196,7 +196,7 @@ class ClientConfig:
         client_name (str): A user-defined name for the client. Used to identify number of unique applications/scripts running on top of CDF.
         project (str): CDF Project name.
         credentials (CredentialProvider): Credentials. e.g. Token, ClientCredentials.
-        api_subversion (str | None): API subversion
+        api_subversion (str): API subversion. Set to e.g. "alpha" or "beta" to access restricted preview features.
         base_url (str | None): Base url to send requests to. Typically on the form ``https://<cluster>.cognitedata.com``.
             Either base_url or cluster must be provided.
         cluster (str | None): The cluster where the CDF project is located. When passed, it is assumed that the base
@@ -213,7 +213,7 @@ class ClientConfig:
         client_name: str,
         project: str,
         credentials: CredentialProvider,
-        api_subversion: str | None = None,
+        api_subversion: str = __api_subversion__,
         base_url: str | None = None,
         cluster: str | None = None,
         headers: dict[str, str] | None = None,
@@ -224,7 +224,7 @@ class ClientConfig:
         self.client_name = client_name
         self.project = project
         self.credentials = credentials
-        self.api_subversion = api_subversion or __api_subversion__
+        self.api_subversion = api_subversion
         self.base_url = self._validate_base_url_or_cluster(base_url, cluster)
         self._cluster = cluster
         self.headers = headers or {}
@@ -354,7 +354,7 @@ class ClientConfig:
             client_name=loaded["client_name"],
             project=loaded["project"],
             credentials=credentials,
-            api_subversion=loaded.get("api_subversion"),
+            api_subversion=loaded.get("api_subversion") or __api_subversion__,
             base_url=loaded.get("base_url"),
             cluster=loaded.get("cluster"),
             headers=loaded.get("headers"),

--- a/cognite/client/utils/_pyodide_helpers.py
+++ b/cognite/client/utils/_pyodide_helpers.py
@@ -4,6 +4,7 @@ import logging
 import os
 
 import cognite.client as cc  # Do not import individual entities
+from cognite.client._version import __api_subversion__
 from cognite.client.config import ClientConfig, global_config
 from cognite.client.credentials import CredentialProvider
 
@@ -116,7 +117,7 @@ class FusionNotebookConfig(ClientConfig):
     def __init__(
         self,
         client_name: str = "DSHubLite",
-        api_subversion: str | None = None,
+        api_subversion: str = __api_subversion__,
         headers: dict[str, str] | None = None,
         timeout: int | None = None,
         file_transfer_timeout: int | None = None,


### PR DESCRIPTION
3 things discovered while annoyingly trying to temporarily change API version for state time series tests in need of the "beta" flag.
- `ClientConfig.api_subversion` is typed as `str | None` but is always `str`
- Is set in stone once per API class at init, while we should be able to mutate it
- Fixes the helper function `_alpha_version_header` that could return "beta-alpha" which is kinda weird thing to ask for 😉 