### PR TITLE
feat(state time series): add retrieve support for raw state datapoints (DM-4094)

### DIFF
--- a/cognite/client/_api/datapoint_tasks.py
+++ b/cognite/client/_api/datapoint_tasks.py
@@ -847,14 +847,19 @@ class BaseRawTaskOrchestrator(BaseTaskOrchestrator):
             self.dps_data[idx].append(arr)
             if missing_idxs:
                 self.null_timestamps.update(self.ts_data[idx][-1][missing_idxs].tolist())
+
         if self.query.include_status:
             self.status_code[idx].append(DpsUnpackFns.extract_status_code_numpy(dps))
             self.status_symbol[idx].append(DpsUnpackFns.extract_status_symbol_numpy(dps))
 
     def _unpack_and_store_basic(self, idx: tuple[float, ...], dps: DatapointsRaw) -> None:
         self.ts_data[idx].append(DpsUnpackFns.extract_timestamps(dps))
+
         if self.query.ignore_bad_datapoints:
-            self.dps_data[idx].append(DpsUnpackFns.extract_raw_dps(dps))
+            if self.is_state_dps:
+                self.dps_data[idx].append(DpsUnpackFns.extract_raw_num_and_str_state_dps(cast(StateDatapoints, dps)))
+            else:
+                self.dps_data[idx].append(DpsUnpackFns.extract_raw_dps(dps))
         else:
             self.dps_data[idx].append(DpsUnpackFns.extract_nullable_raw_dps(dps))
         if self.query.include_status:

--- a/cognite/client/_api/datapoint_tasks.py
+++ b/cognite/client/_api/datapoint_tasks.py
@@ -823,32 +823,37 @@ class BaseRawTaskOrchestrator(BaseTaskOrchestrator):
 
     def _unpack_and_store(self, idx: tuple[float, ...], dps: DatapointsRaw) -> None:  # type: ignore [override]
         if self.use_numpy:
-            self.ts_data[idx].append(DpsUnpackFns.extract_timestamps_numpy(dps))
-            assert self.raw_dtype_numpy is not None
-            if self.query.ignore_bad_datapoints:
-                self.dps_data[idx].append(DpsUnpackFns.extract_raw_dps_numpy(dps, self.raw_dtype_numpy))
-            else:
-                # After this step, missing values (represented with None) will become NaNs and thus become
-                # indistinguishable from any NaNs that was returned! We need to store these timestamps in a property
-                # to allow our users to inspect them - but maybe even more important, allow the SDK to accurately
-                # use the DatapointsArray to replicate datapoints (exactly).
-                arr, missing_idxs = DpsUnpackFns.extract_nullable_raw_dps_numpy(dps, self.raw_dtype_numpy)
-                self.dps_data[idx].append(arr)
-                if missing_idxs:
-                    self.null_timestamps.update(self.ts_data[idx][-1][missing_idxs].tolist())
-            if self.query.include_status:
-                self.status_code[idx].append(DpsUnpackFns.extract_status_code_numpy(dps))
-                self.status_symbol[idx].append(DpsUnpackFns.extract_status_symbol_numpy(dps))
-
+            self._unpack_and_store_numpy(idx, dps)
         else:
-            self.ts_data[idx].append(DpsUnpackFns.extract_timestamps(dps))
-            if self.query.ignore_bad_datapoints:
-                self.dps_data[idx].append(DpsUnpackFns.extract_raw_dps(dps))
-            else:
-                self.dps_data[idx].append(DpsUnpackFns.extract_nullable_raw_dps(dps))
-            if self.query.include_status:
-                self.status_code[idx].append(DpsUnpackFns.extract_status_code(dps))
-                self.status_symbol[idx].append(DpsUnpackFns.extract_status_symbol(dps))
+            self._unpack_and_store_basic(idx, dps)
+
+    def _unpack_and_store_numpy(self, idx: tuple[float, ...], dps: DatapointsRaw) -> None:
+        self.ts_data[idx].append(DpsUnpackFns.extract_timestamps_numpy(dps))
+        assert self.raw_dtype_numpy is not None
+        if self.query.ignore_bad_datapoints:
+            self.dps_data[idx].append(DpsUnpackFns.extract_raw_dps_numpy(dps, self.raw_dtype_numpy))
+        else:
+            # After this step, missing values (represented with None) will become NaNs and thus become
+            # indistinguishable from any NaNs that was returned! We need to store these timestamps in a property
+            # to allow our users to inspect them - but maybe even more important, allow the SDK to accurately
+            # use the DatapointsArray to replicate datapoints (exactly).
+            arr, missing_idxs = DpsUnpackFns.extract_nullable_raw_dps_numpy(dps, self.raw_dtype_numpy)
+            self.dps_data[idx].append(arr)
+            if missing_idxs:
+                self.null_timestamps.update(self.ts_data[idx][-1][missing_idxs].tolist())
+        if self.query.include_status:
+            self.status_code[idx].append(DpsUnpackFns.extract_status_code_numpy(dps))
+            self.status_symbol[idx].append(DpsUnpackFns.extract_status_symbol_numpy(dps))
+
+    def _unpack_and_store_basic(self, idx: tuple[float, ...], dps: DatapointsRaw) -> None:
+        self.ts_data[idx].append(DpsUnpackFns.extract_timestamps(dps))
+        if self.query.ignore_bad_datapoints:
+            self.dps_data[idx].append(DpsUnpackFns.extract_raw_dps(dps))
+        else:
+            self.dps_data[idx].append(DpsUnpackFns.extract_nullable_raw_dps(dps))
+        if self.query.include_status:
+            self.status_code[idx].append(DpsUnpackFns.extract_status_code(dps))
+            self.status_symbol[idx].append(DpsUnpackFns.extract_status_symbol(dps))
 
     def _store_first_batch(self, dps: DatapointsAny, first_limit: int) -> None:
         if self.query.include_outside_points:

--- a/cognite/client/_api/datapoint_tasks.py
+++ b/cognite/client/_api/datapoint_tasks.py
@@ -22,7 +22,7 @@ from typing import (
 from zoneinfo import ZoneInfo
 
 from cognite.client._constants import NUMPY_IS_AVAILABLE
-from cognite.client._proto.data_point_list_response_pb2 import DataPointListItem
+from cognite.client._proto.data_point_list_response_pb2 import TIMESERIES_TYPE_STATE, DataPointListItem, TimeSeriesType
 from cognite.client.data_classes.data_modeling import NodeId
 from cognite.client.data_classes.datapoint_aggregates import (
     _INT_AGGREGATES_CAMEL,
@@ -39,12 +39,14 @@ from cognite.client.utils._datapoints import (
     AggregateDatapoints,
     DatapointsRaw,
     DpsUnpackFns,
+    StateDatapoints,
     _DataContainer,
     create_aggregates_arrays_from_dps_container,
     create_aggregates_list_from_dps_container,
     create_array_from_dps_container,
     create_list_from_dps_container,
     create_object_array_from_container,
+    create_state_lists_from_dps_container,
     decide_numpy_dtype_from_is_string,
     ensure_int,
     ensure_int_numpy,
@@ -527,6 +529,7 @@ class BaseTaskOrchestrator(ABC):
         self.raw_dtype_numpy: type[np.object_] | type[np.float64] | None = None
         self._is_done = False
         self._final_result: Datapoints | DatapointsArray | None = None
+        self._is_state_dps: bool
 
         self.ts_data: _DataContainer = defaultdict(list)
         self.dps_data: _DataContainer = defaultdict(list)
@@ -580,6 +583,13 @@ class BaseTaskOrchestrator(ABC):
             return 0
         return len(self.ts_data[FIRST_IDX][0])
 
+    @property
+    def is_state_dps(self) -> bool:
+        return self._is_state_dps
+
+    def set_is_state_status(self, ts_type: TimeSeriesType) -> None:
+        self._is_state_dps = ts_type == TIMESERIES_TYPE_STATE
+
     def _extract_first_dps_batch(self, first_dps_batch: DataPointListItem, first_limit: int) -> None:
         dps = get_datapoints_from_proto(first_dps_batch)
         self._store_ts_info(first_dps_batch)
@@ -589,6 +599,7 @@ class BaseTaskOrchestrator(ABC):
         self._store_first_batch(dps, first_limit)
 
     def _store_ts_info(self, res: DataPointListItem) -> None:
+        self.set_is_state_status(res.type)
         self.ts_info.update(get_ts_info_from_proto(res))
         self.ts_info["timezone"] = self.query.original_timezone
         self.ts_info["granularity"] = self.query.original_granularity  # show '1quarter', not '3mo'

--- a/cognite/client/_api/datapoint_tasks.py
+++ b/cognite/client/_api/datapoint_tasks.py
@@ -996,6 +996,9 @@ class BaseAggTaskOrchestrator(BaseTaskOrchestrator):
         return Datapoints(timestamp=[], **self.ts_info, **convert_all_keys_to_snake_case(lst_dct))
 
     def _get_result(self) -> Datapoints | DatapointsArray:
+        if self.is_state_dps:
+            raise NotImplementedError("Retrieving aggregate state datapoints is not yet supported.")
+
         if not self.ts_data or self.query.limit == 0:
             return self._create_empty_result()
 

--- a/cognite/client/_api/datapoint_tasks.py
+++ b/cognite/client/_api/datapoint_tasks.py
@@ -721,11 +721,20 @@ class BaseRawTaskOrchestrator(BaseTaskOrchestrator):
         return 1  # millisecond
 
     def _create_empty_result(self) -> Datapoints | DatapointsArray:
-        status_cols: dict[str, Any] = {}
+        status_cols: dict[str, Any] = {}  # TODO: Perhaps better to make this "all info" instead of just status
         if not self.use_numpy:
             if self.query.include_status:
                 status_cols.update(status_code=[], status_symbol=[])
-            return Datapoints(**self.ts_info, timestamp=[], value=[], **status_cols)
+            if self.is_state_dps:
+                return Datapoints(**self.ts_info, timestamp=[], numeric_states=[], string_states=[], **status_cols)
+            else:
+                return Datapoints(**self.ts_info, timestamp=[], value=[], **status_cols)
+
+        if self.is_state_dps:
+            raise NotImplementedError(
+                "State datapoints are not yet supported when using `retrieve_arrays(...)`. "
+                "Please use `retrieve(...)` instead"
+            )
 
         if self.query.include_status:
             status_cols.update(status_code=np.array([], dtype=np.int32), status_symbol=np.array([], dtype=np.object_))

--- a/cognite/client/_api/datapoint_tasks.py
+++ b/cognite/client/_api/datapoint_tasks.py
@@ -805,7 +805,7 @@ class BaseRawTaskOrchestrator(BaseTaskOrchestrator):
             if not dp:
                 continue
             ts: list[int] | NumpyInt64Array = [dp[0]]
-            value: list[float | str] | NumpyFloat64Array | NumpyObjArray = [dp[1]]
+            value: list[float | str | tuple[int, str | None]] | NumpyFloat64Array | NumpyObjArray = [dp[1]]
             if self.use_numpy:
                 ts = np.array(ts, dtype=np.int64)
                 value = np.array(value, dtype=self.raw_dtype_numpy)
@@ -1008,6 +1008,9 @@ class BaseAggTaskOrchestrator(BaseTaskOrchestrator):
         return Datapoints(**self.ts_info, **convert_all_keys_to_snake_case(lst_dct))
 
     def _unpack_and_store(self, idx: tuple[float, ...], dps: AggregateDatapoints) -> None:  # type: ignore [override]
+        if self.is_state_dps:
+            raise NotImplementedError("Retrieving aggregate state datapoints is not yet supported.")
+
         # Object aggregates are unpacked similarly for basic and numpy and only converted later (for numpy)
         if self.object_aggs:
             for agg, unpack_fn in zip(self.object_aggs, self.object_agg_unpack_fns):

--- a/cognite/client/_api/datapoint_tasks.py
+++ b/cognite/client/_api/datapoint_tasks.py
@@ -773,17 +773,27 @@ class BaseRawTaskOrchestrator(BaseTaskOrchestrator):
                     **status_columns,
                 }
             )
-        if self.query.include_status:
-            status_columns.update(
-                status_code=create_list_from_dps_container(self.status_code),
-                status_symbol=create_list_from_dps_container(self.status_symbol),
+        else:
+            if self.query.include_status:
+                status_columns.update(
+                    status_code=create_list_from_dps_container(self.status_code),
+                    status_symbol=create_list_from_dps_container(self.status_symbol),
+                )
+            if self.is_state_dps:
+                value_col = None
+                num_state_col, str_state_col = create_state_lists_from_dps_container(self.dps_data)
+            else:
+                value_col = create_list_from_dps_container(self.dps_data)
+                num_state_col, str_state_col = None, None
+
+            return Datapoints(
+                **self.ts_info,
+                timestamp=create_list_from_dps_container(self.ts_data),
+                value=value_col,
+                numeric_states=num_state_col,
+                string_states=str_state_col,
+                **status_columns,
             )
-        return Datapoints(
-            **self.ts_info,
-            timestamp=create_list_from_dps_container(self.ts_data),
-            value=create_list_from_dps_container(self.dps_data),
-            **status_columns,
-        )
 
     def _include_outside_points_in_result(self) -> None:
         for dp, status_code, status_symbol, idx in zip(

--- a/cognite/client/_api/datapoint_tasks.py
+++ b/cognite/client/_api/datapoint_tasks.py
@@ -861,7 +861,13 @@ class BaseRawTaskOrchestrator(BaseTaskOrchestrator):
             else:
                 self.dps_data[idx].append(DpsUnpackFns.extract_raw_dps(dps))
         else:
-            self.dps_data[idx].append(DpsUnpackFns.extract_nullable_raw_dps(dps))
+            if self.is_state_dps:
+                self.dps_data[idx].append(
+                    DpsUnpackFns.extract_nullable_raw_num_and_str_state_dps(cast(StateDatapoints, dps))
+                )
+            else:
+                self.dps_data[idx].append(DpsUnpackFns.extract_nullable_raw_dps(dps))
+
         if self.query.include_status:
             self.status_code[idx].append(DpsUnpackFns.extract_status_code(dps))
             self.status_symbol[idx].append(DpsUnpackFns.extract_status_symbol(dps))

--- a/cognite/client/_api/datapoint_tasks.py
+++ b/cognite/client/_api/datapoint_tasks.py
@@ -828,7 +828,13 @@ class BaseRawTaskOrchestrator(BaseTaskOrchestrator):
             self._unpack_and_store_basic(idx, dps)
 
     def _unpack_and_store_numpy(self, idx: tuple[float, ...], dps: DatapointsRaw) -> None:
+        if self.is_state_dps:
+            raise NotImplementedError(
+                "Retrieving raw state datapoints using `retrieve_arrays(...)` is not yet supported. "
+                "Please use `retrieve(...)` instead."
+            )
         self.ts_data[idx].append(DpsUnpackFns.extract_timestamps_numpy(dps))
+
         assert self.raw_dtype_numpy is not None
         if self.query.ignore_bad_datapoints:
             self.dps_data[idx].append(DpsUnpackFns.extract_raw_dps_numpy(dps, self.raw_dtype_numpy))

--- a/cognite/client/data_classes/datapoints.py
+++ b/cognite/client/data_classes/datapoints.py
@@ -701,6 +701,8 @@ class Datapoint(CogniteResource):
         return cls(
             timestamp=resource["timestamp"],
             value=resource.get("value"),
+            numeric_state=resource.get("numericState"),
+            string_state=resource.get("stringState"),
             average=resource.get("average"),
             max=resource.get("max"),
             max_datapoint=max_datapoint,

--- a/cognite/client/data_classes/datapoints.py
+++ b/cognite/client/data_classes/datapoints.py
@@ -568,6 +568,8 @@ class Datapoint(CogniteResource):
     Args:
         timestamp (int): The data timestamp in milliseconds since the epoch (Jan 1, 1970). Can be negative to define a date before 1970. Minimum timestamp is 1900.01.01 00:00:00 UTC
         value (str | float | None): The raw data value. Can be string or numeric.
+        numeric_state (int | None): The numeric state value. Only returned for state time series.
+        string_state (str | None): The string state value. Only returned for state time series.
         average (float | None): The time-weighted average value in the aggregate interval.
         max (float | None): The maximum value in the aggregate interval.
         max_datapoint (MaxDatapoint | MaxDatapointWithStatus | None): Objects with the maximum values and their timestamps in the aggregate intervals, optionally including status codes and symbols.
@@ -595,6 +597,8 @@ class Datapoint(CogniteResource):
         self,
         timestamp: int,
         value: str | float | None = None,
+        numeric_state: int | None = None,
+        string_state: str | None = None,
         average: float | None = None,
         max: float | None = None,
         max_datapoint: MaxDatapoint | MaxDatapointWithStatus | None = None,
@@ -619,6 +623,8 @@ class Datapoint(CogniteResource):
     ) -> None:
         self.timestamp = timestamp
         self.value = value
+        self.numeric_state = numeric_state
+        self.string_state = string_state
         self.average = average
         self.max = max
         self.max_datapoint = max_datapoint
@@ -1066,6 +1072,8 @@ class Datapoints(CogniteResource):
         granularity (str | None): The granularity of the aggregate datapoints (does not apply to raw data)
         timestamp (list[int] | None): The data timestamps in milliseconds since the epoch (Jan 1, 1970). Can be negative to define a date before 1970. Minimum timestamp is 1900.01.01 00:00:00 UTC
         value (list[str] | list[float] | None): The raw data values. Can be string or numeric.
+        numeric_states (list[int] | None): The numeric state values. Only returned for state time series.
+        string_states (list[str | None] | None): The string state values. Only returned for state time series.
         average (list[float] | None): The time-weighted average values per aggregate interval.
         max (list[float] | None): The maximum values per aggregate interval.
         max_datapoint (list[MaxDatapoint] | list[MaxDatapointWithStatus] | None): Objects with the maximum values and their timestamps in the aggregate intervals, optionally including status codes and symbols.
@@ -1102,6 +1110,8 @@ class Datapoints(CogniteResource):
         granularity: str | None = None,
         timestamp: list[int] | None = None,
         value: list[str] | list[float] | None = None,
+        numeric_states: list[int] | None = None,
+        string_states: list[str | None] | None = None,
         average: list[float] | None = None,
         max: list[float] | None = None,
         max_datapoint: list[MaxDatapoint] | list[MaxDatapointWithStatus] | None = None,
@@ -1135,6 +1145,8 @@ class Datapoints(CogniteResource):
         self.granularity = granularity
         self.timestamp: list[int] = timestamp or []
         self.value = value
+        self.numeric_states = numeric_states
+        self.string_states = string_states
         self.average = average
         self.max = max
         self.max_datapoint = max_datapoint

--- a/cognite/client/utils/_datapoints.py
+++ b/cognite/client/utils/_datapoints.py
@@ -22,6 +22,7 @@ from cognite.client._proto.data_point_list_response_pb2 import (
 from cognite.client._proto.data_points_pb2 import (
     AggregateDatapoint,
     NumericDatapoint,
+    StateDatapoint,
     StringDatapoint,
 )
 from cognite.client.data_classes.data_modeling import NodeId
@@ -44,14 +45,15 @@ if TYPE_CHECKING:
 AggregateDatapoints = RepeatedCompositeFieldContainer[AggregateDatapoint]
 NumericDatapoints = RepeatedCompositeFieldContainer[NumericDatapoint]
 StringDatapoints = RepeatedCompositeFieldContainer[StringDatapoint]
+StateDatapoints = RepeatedCompositeFieldContainer[StateDatapoint]
 
-DatapointAny = AggregateDatapoint | NumericDatapoint | StringDatapoint
-DatapointsAny = AggregateDatapoints | NumericDatapoints | StringDatapoints
+DatapointAny = AggregateDatapoint | NumericDatapoint | StringDatapoint | StateDatapoint
+DatapointsAny = AggregateDatapoints | NumericDatapoints | StringDatapoints | StateDatapoints
 
-DatapointRaw = NumericDatapoint | StringDatapoint
-DatapointsRaw = NumericDatapoints | StringDatapoints
+DatapointRaw = NumericDatapoint | StringDatapoint | StateDatapoint
+DatapointsRaw = NumericDatapoints | StringDatapoints | StateDatapoints
 
-RawDatapointValue = float | str
+RawDatapointValue = float | str | tuple[int, str | None]
 DatapointsId = int | DatapointsQuery | Sequence[int | DatapointsQuery]
 DatapointsExternalId = str | DatapointsQuery | SequenceNotStr[str | DatapointsQuery]
 DatapointsInstanceId = NodeId | DatapointsQuery | Sequence[NodeId | DatapointsQuery]
@@ -69,6 +71,20 @@ class DpsUnpackFns:
     raw_dp: Callable[[DatapointRaw], RawDatapointValue] = op.attrgetter("value")
 
     @staticmethod
+    def state_num_and_str_dp(dp: StateDatapoint) -> tuple[int, str | None]:
+        # A state data point can have a numeric value, but no string value. This happens if the numeric value
+        # is no longer part of the state set. The safe way to handle this is to use `.HasField("stringValue")`,
+        # however since string values are enforced to be at least 1 character long, we use the significantly
+        # faster `or None`.
+        #
+        # Timings for 100k state datapoints (the per request limit):
+        # >>> [dp.stringValue or None for dp in proto_dps]
+        # 10.7 ms ± 123 μs per loop (mean ± std. dev. of 7 runs, 100 loops each)
+        # >>> [dp.stringValue if dp.HasField("stringValue") else None for dp in proto_dps]
+        # 16.8 ms ± 95.1 μs per loop (mean ± std. dev. of 7 runs, 100 loops each)
+        return dp.numericValue, dp.stringValue or None
+
+    @staticmethod
     def custom_from_aggregates(lst: list[str]) -> Callable[[AggregateDatapoint], tuple[float, ...]]:
         return op.attrgetter(*lst)
 
@@ -84,7 +100,13 @@ class DpsUnpackFns:
     @staticmethod
     def nullable_raw_dp(dp: DatapointRaw) -> float | str:
         # We pretend like float is always returned to not break every dps annot. in the entire SDK..
-        return dp.value if not dp.nullValue else None  # type: ignore [return-value]
+        return dp.value if not dp.nullValue else None  # type: ignore [return-value, union-attr]
+
+    @staticmethod
+    def nullable_raw_state_dp(dp: StateDatapoint) -> tuple[int, str | None] | tuple[None, None]:
+        if dp.HasField("numericValue"):  # no need to also check stringValue, either both are set or none
+            return dp.numericValue, dp.stringValue or None  # see state_num_and_str_dp for why we use `or None`
+        return None, None
 
     # minDatapoint and maxDatapoint are also objects in the response. The proto lookups doesn't fail,
     # so we must be very careful to only attach status codes if requested.
@@ -122,7 +144,7 @@ class DpsUnpackFns:
 
     @classmethod
     def extract_raw_dps(cls, dps: DatapointsRaw) -> list[float | str]:  # Actually: exclusively either one
-        return list(map(cls.raw_dp, dps))
+        return list(map(cls.raw_dp, dps))  # type: ignore [arg-type]
 
     @classmethod
     def extract_raw_dps_numpy(cls, dps: DatapointsRaw, dtype: type[np.float64] | type[np.object_]) -> npt.NDArray[Any]:
@@ -147,6 +169,14 @@ class DpsUnpackFns:
                 add_missing(i)
         arr = np.array(values, dtype=dtype)
         return arr, missing
+
+    @classmethod
+    def extract_raw_num_and_str_state_dps(cls, dps: StateDatapoints) -> list[tuple[int, str | None]]:
+        return list(map(cls.state_num_and_str_dp, dps))
+
+    @classmethod
+    def extract_nullable_raw_num_and_str_state_dps(cls, dps: StateDatapoints) -> list[tuple[int | None, str | None]]:
+        return list(map(cls.nullable_raw_state_dp, dps))
 
     # --------------- #
     # Status code related extract functions:
@@ -293,6 +323,16 @@ def create_aggregates_arrays_from_dps_container(container: _DataContainer, n_agg
 
 def create_list_from_dps_container(container: _DataContainer) -> list:
     return list(chain.from_iterable(datapoints_in_order(container)))
+
+
+def create_state_lists_from_dps_container(container: _DataContainer) -> tuple[list[int], list[str | None]]:
+    # Doing 2 passes through the dps is actually the most performant(!). Benchmarking N = 1 mill:
+    # 1. zip(*...):                61.5 ms ± 824 μs
+    # 2. Single-pass .append():    44.1 ms ± 310 μs
+    # 3. Pre-allocated indexing:   36.3 ms ± 781 μs
+    # 4. Dual list comprehensions: 26.6 ms ± 229 μs
+    state_tuples = list(chain.from_iterable(datapoints_in_order(container)))
+    return [num for num, _ in state_tuples], [string for _, string in state_tuples]
 
 
 def create_aggregates_list_from_dps_container(container: _DataContainer) -> Iterator[list[list]]:

--- a/tests/tests_integration/test_api/test_datapoints.py
+++ b/tests/tests_integration/test_api/test_datapoints.py
@@ -870,28 +870,28 @@ def use_beta_header_for_dps_client(async_client: AsyncCogniteClient) -> Iterator
 @pytest.mark.dsl
 @pytest.mark.usefixtures("use_beta_header_for_dps_client")
 class TestRetrieveStateDatapoints:
-    def test_retrieve_state_datapoints_gets_correct_ts_type(
+    def test_retrieve_state_datapoints_empty(
         self,
         cognite_client: CogniteClient,
         empty_state_ts: NodeApplyResult,
     ) -> None:
-        # Note: We do not have retrieve support yet, but it works as long as the time series is empty.
-        # TODO: Once retrieve works, this can be reworked into a more meaningful test.
         ts_id = empty_state_ts.as_id()
-        ts = cognite_client.time_series.retrieve(instance_id=ts_id)
-        assert ts is not None
-        if ts.count() > 0:
-            pytest.skip("Time series is not empty, so in order to not break CI for no reason, we skip for now")
-
-        dps = cognite_client.time_series.data.retrieve(instance_id=ts_id)
-        assert isinstance(dps, Datapoints)
-        assert dps.type == "state"
-        assert dps.to_pandas().empty
-
-        dps_arr = cognite_client.time_series.data.retrieve_arrays(instance_id=ts_id)
-        assert isinstance(dps_arr, DatapointsArray)
-        assert dps_arr.type == "state"
-        assert dps_arr.to_pandas().empty
+        dps_lst = cognite_client.time_series.data.retrieve(
+            instance_id=[
+                DatapointsQuery(instance_id=ts_id, limit=0),
+                DatapointsQuery(instance_id=ts_id, limit=1),  # should also be empty
+            ],
+            start="1h-ahead",
+            end="2h-ahead",
+        )
+        for dps in dps_lst:
+            assert isinstance(dps, Datapoints)
+            assert dps.type == "state"
+            assert len(dps) == 0
+            assert dps.timestamp == []
+            assert dps.value is None
+            assert dps.numeric_states == []
+            assert dps.string_states == []
 
 
 @pytest.fixture

--- a/tests/tests_integration/test_api/test_datapoints.py
+++ b/tests/tests_integration/test_api/test_datapoints.py
@@ -7,6 +7,7 @@ python scripts/create_ts_for_integration_tests.py
 
 from __future__ import annotations
 
+import functools
 import itertools
 import math
 import random
@@ -67,7 +68,7 @@ from cognite.client.data_classes.datapoints import (
     MinDatapointWithStatus,
 )
 from cognite.client.exceptions import CogniteAPIError, CogniteNotFoundError
-from cognite.client.utils._text import to_camel_case, to_snake_case
+from cognite.client.utils._text import random_string, to_camel_case, to_snake_case
 from cognite.client.utils._time import (
     MAX_TIMESTAMP_MS,
     MIN_TIMESTAMP_MS,
@@ -703,6 +704,101 @@ class TestInsertStateDatapoints:
             [StateDatapointsInsert(instance_id=state_ts.as_id(), datapoints=datapoints)]
         )
 
+    @pytest.mark.usefixtures("use_beta_header_for_dps_client")
+    def test_insert_state_dps_then_modify_state_set(
+        self,
+        cognite_client: CogniteClient,
+        async_client: AsyncCogniteClient,
+        space_for_time_series: Space,
+        request: pytest.FixtureRequest,
+    ) -> None:
+        # This test requires quite a lot of setup, so stay with me:
+        # 1. We need a (small) state set and a time series that uses it
+        # 2. Some datapoints, at least one per state
+        xid = f"dms-state-set-modify-test-{random_string(10)}"
+        node_id = NodeId(space_for_time_series.space, xid)
+        apply_ss_fn = functools.partial(
+            _create_state_set,
+            cognite_client=cognite_client,
+            async_client=async_client,
+            space=space_for_time_series,
+            external_id=xid,
+            name="PySDK integration test state set for modify test",
+        )
+        ss = apply_ss_fn(states=[StateSetEntry(10, "ten"), StateSetEntry(20, "twenty")])
+
+        # We create a time series with the same NodeId and add some cleanup logic to delete it after
+        # the test is done (or if it fails). The beauty of Data Modeling is that a node can be its
+        # own state set as well heh.. at least makes clean-up easier.
+        request.addfinalizer(lambda: cognite_client.data_modeling.instances.delete(node_id))
+        _create_state_time_series(
+            external_id=xid,
+            cognite_client=cognite_client,
+            async_client=async_client,
+            space_for_time_series=space_for_time_series,
+            state_set=ss,
+        )
+        cognite_client.time_series.data.insert_states(
+            StateDatapointsInsert(
+                instance_id=node_id,
+                datapoints=[
+                    StateDatapointWrite(timestamp=1010, status_symbol="Bad"),
+                    StateDatapointWrite(timestamp=2020, numeric_value=10),
+                    StateDatapointWrite(timestamp=3030, string_value="ten"),
+                    StateDatapointWrite(timestamp=4040, numeric_value=20),
+                    StateDatapointWrite(timestamp=5050, string_value="twenty"),
+                ],
+            )
+        )
+        # Now, the real test begins:
+        # 3. Implicitly drop the state with numeric value 20
+        # 4. Add new state with numeric value 30:
+        ss = apply_ss_fn(states=[StateSetEntry(10, "ten"), StateSetEntry(30, "thirty")])
+
+        # 5. Insert new datapoints into the same time series:
+        cognite_client.time_series.data.insert_states(
+            StateDatapointsInsert(
+                instance_id=node_id,
+                datapoints=[
+                    StateDatapointWrite(timestamp=6060, numeric_value=10),
+                    StateDatapointWrite(timestamp=7070, string_value="ten"),
+                    StateDatapointWrite(timestamp=8080, numeric_value=30),
+                    StateDatapointWrite(timestamp=9090, string_value="thirty"),
+                ],
+            )
+        )
+        dps_with_bad, dps_no_bad = cognite_client.time_series.data.retrieve(
+            instance_id=[
+                DatapointsQuery(instance_id=node_id, ignore_bad_datapoints=False),
+                DatapointsQuery(instance_id=node_id, ignore_bad_datapoints=True),
+            ],
+            limit=50,
+        )
+        exp_numeric_states = [10, 10, 20, 20, 10, 10, 30, 30]
+        exp_string_states = ["ten", "ten", None, None, "ten", "ten", "thirty", "thirty"]
+        assert dps_no_bad.numeric_states == exp_numeric_states
+        assert dps_no_bad.string_states == exp_string_states
+
+        # Ensure the bad datapoint with "double None" is present in the "dont ignore bad" response:
+        assert dps_with_bad.string_states == [None, *exp_string_states]
+        assert dps_with_bad.numeric_states == [None, *exp_numeric_states]
+
+        # Ensure writing state dp with 20 or "twenty" now fails:
+        with pytest.raises(CogniteAPIError) as e:
+            cognite_client.time_series.data.insert_states(
+                StateDatapointsInsert(
+                    instance_id=node_id,
+                    datapoints=[
+                        StateDatapointWrite(timestamp=101010, numeric_value=20),
+                        StateDatapointWrite(timestamp=111110, string_value="twenty"),
+                    ],
+                )
+            )
+        assert e.value.code == 400
+        contains_numeric = "numericValue 20 is not part of the state set" in e.value.message
+        contains_string = 'stringValue "twenty" is not part of the state set' in e.value.message
+        assert contains_numeric or contains_string
+
     def test_insert_duplicate_instance_ids_in_same_request(
         self,
         cognite_client: CogniteClient,
@@ -764,7 +860,7 @@ def empty_state_ts(
     )
 
 
-@pytest.fixture(scope="class")
+@pytest.fixture
 def use_beta_header_for_dps_client(async_client: AsyncCogniteClient) -> Iterator[None]:
     with pytest.MonkeyPatch.context() as mp:
         mp.setattr(async_client.time_series.data, "_api_subversion", "beta")

--- a/tests/tests_integration/test_api/test_datapoints.py
+++ b/tests/tests_integration/test_api/test_datapoints.py
@@ -893,6 +893,47 @@ class TestRetrieveStateDatapoints:
             assert dps.numeric_states == []
             assert dps.string_states == []
 
+    @pytest.mark.parametrize(
+        "retrieve_call",
+        [
+            pytest.param(
+                lambda client, ts_id: client.time_series.data.retrieve(
+                    instance_id=ts_id, aggregates="count", granularity="1h", limit=1
+                ),
+                id="aggregate states retrieve",
+            ),
+            pytest.param(
+                lambda client, ts_id: client.time_series.data.retrieve_arrays(
+                    instance_id=ts_id, aggregates="count", granularity="1h", limit=1
+                ),
+                id="aggregate states retrieve_arrays",
+            ),
+            pytest.param(
+                lambda client, ts_id: client.time_series.data.retrieve_arrays(instance_id=ts_id, limit=1),
+                id="raw states retrieve_arrays",
+            ),
+            pytest.param(
+                lambda client, ts_id: client.time_series.data.retrieve_dataframe(instance_id=ts_id, limit=1),
+                id="raw states retrieve_dataframe",
+            ),
+            pytest.param(
+                lambda client, ts_id: client.time_series.data.retrieve_dataframe(
+                    instance_id=ts_id, aggregates="count", granularity="1h", limit=1
+                ),
+                id="aggregate states retrieve_dataframe",
+            ),
+        ],
+    )
+    def test_unsupported_state_datapoint_retrievals_raise_not_implemented(
+        self,
+        cognite_client: CogniteClient,
+        empty_state_ts: NodeApplyResult,
+        retrieve_call: Callable,
+    ) -> None:
+        ts_id = empty_state_ts.as_id()
+        with pytest.raises(NotImplementedError, match=r"[sS]tate datapoints"):
+            retrieve_call(cognite_client, ts_id)
+
 
 @pytest.fixture
 def queries_for_iteration(all_test_time_series: TimeSeriesList) -> list[DatapointsQuery]:


### PR DESCRIPTION
This PR does/adds:
- extract functionality for state dps from the protobuf binary format
- extends `Datapoints` (and `Datapoint`) with `numeric_state(s)` and `string_state(s)`.
- adds `is_state_dps` property to track when retrieving state datapoints
- starts raising good error messages for all cases not yet implemented like state aggregates or any numpy functionality
- comprehensive test for state datapoint retrieval after *state set mutations*