### PR TITLE
feat(integrations): Add Integrations API data classes

### DIFF
--- a/cognite/client/data_classes/integrations/__init__.py
+++ b/cognite/client/data_classes/integrations/__init__.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+from cognite.client.data_classes.integrations.actions import (
+    Action,
+    ActionList,
+    ActionWrite,
+    ActionWriteList,
+)
+from cognite.client.data_classes.integrations.config import (
+    ConfigRevision,
+    ConfigRevisionMetadata,
+    ConfigRevisionMetadataList,
+    ConfigRevisionWrite,
+)
+from cognite.client.data_classes.integrations.errors import (
+    IntegrationError,
+    IntegrationErrorList,
+)
+from cognite.client.data_classes.integrations.integrations import (
+    Extractor,
+    Integration,
+    IntegrationList,
+    IntegrationUpdate,
+    IntegrationWrite,
+    IntegrationWriteList,
+    Task,
+)
+from cognite.client.data_classes.integrations.tasks import (
+    SyncResult,
+    TaskHistory,
+    TaskHistoryList,
+)
+
+__all__ = [
+    "Action",
+    "ActionList",
+    "ActionWrite",
+    "ActionWriteList",
+    "ConfigRevision",
+    "ConfigRevisionMetadata",
+    "ConfigRevisionMetadataList",
+    "ConfigRevisionWrite",
+    "Extractor",
+    "Integration",
+    "IntegrationError",
+    "IntegrationErrorList",
+    "IntegrationList",
+    "IntegrationUpdate",
+    "IntegrationWrite",
+    "IntegrationWriteList",
+    "SyncResult",
+    "Task",
+    "TaskHistory",
+    "TaskHistoryList",
+]

--- a/cognite/client/data_classes/integrations/actions.py
+++ b/cognite/client/data_classes/integrations/actions.py
@@ -1,0 +1,127 @@
+from __future__ import annotations
+
+from abc import ABC
+from typing import Any, Literal, TypeAlias
+
+from typing_extensions import Self
+
+from cognite.client.data_classes._base import (
+    CogniteResourceList,
+    ExternalIDTransformerMixin,
+    WriteableCogniteResource,
+    WriteableCogniteResourceList,
+)
+
+ActionType: TypeAlias = Literal["start_task", "stop_task", "custom"]
+ActionStatus: TypeAlias = Literal["pending", "running", "failed", "succeeded", "cancel_pending", "canceled"]
+
+
+class ActionCore(WriteableCogniteResource["ActionWrite"], ABC):
+    """An action is a request for an integration to do something outside its normal task loop,
+    e.g. restart, reload config, or start/stop a task.
+
+    The extractor polls for pending actions (through check-in) and reports the outcome back; no inbound
+    connectivity is required on the extractor side.
+
+    Args:
+        external_id (str): External id of the action. Must be unique for the resource type.
+        action_name (str): Name of the action to trigger. Must match a name the extractor has registered as available.
+        call_metadata (dict[str, str] | None): Custom, application specific metadata passed to the extractor along with the action.
+    """
+
+    def __init__(
+        self,
+        external_id: str,
+        action_name: str,
+        call_metadata: dict[str, str] | None = None,
+    ) -> None:
+        self.external_id = external_id
+        self.action_name = action_name
+        self.call_metadata = call_metadata
+
+
+class ActionWrite(ActionCore):
+    """An action is a request for an integration to do something outside its normal task loop.
+    This is the write/create format of the action.
+
+    Args:
+        external_id (str): External id of the action. Must be unique for the resource type.
+        action_name (str): Name of the action to trigger. Must match a name the extractor has registered as available.
+        call_metadata (dict[str, str] | None): Custom, application specific metadata passed to the extractor along with the action.
+    """
+
+    @classmethod
+    def _load(cls, resource: dict[str, Any]) -> Self:
+        return cls(
+            external_id=resource["externalId"],
+            action_name=resource["actionName"],
+            call_metadata=resource.get("callMetadata"),
+        )
+
+    def as_write(self) -> ActionWrite:
+        return self
+
+
+class Action(ActionCore):
+    """An action is a request for an integration to do something outside its normal task loop.
+    This is the read/response format of the action.
+
+    Args:
+        external_id (str): External id of the action. Must be unique for the resource type.
+        action_name (str): Name of the action to trigger. Must match a name the extractor has registered as available.
+        status (ActionStatus): Current status of the action.
+        created_time (int): The time when this action was created, in milliseconds since epoch.
+        last_updated_time (int): The time when this action was last updated, in milliseconds since epoch.
+        call_metadata (dict[str, str] | None): Custom, application specific metadata passed to the extractor along with the action.
+        result_message (str | None): Message reported by the extractor when the action completed or failed.
+        result_metadata (dict[str, str] | None): Custom, application specific metadata reported by the extractor when the action completed or failed.
+    """
+
+    def __init__(
+        self,
+        external_id: str,
+        action_name: str,
+        status: ActionStatus,
+        created_time: int,
+        last_updated_time: int,
+        call_metadata: dict[str, str] | None = None,
+        result_message: str | None = None,
+        result_metadata: dict[str, str] | None = None,
+    ) -> None:
+        super().__init__(external_id=external_id, action_name=action_name, call_metadata=call_metadata)
+        self.status = status
+        self.created_time = created_time
+        self.last_updated_time = last_updated_time
+        self.result_message = result_message
+        self.result_metadata = result_metadata
+
+    @classmethod
+    def _load(cls, resource: dict[str, Any]) -> Self:
+        return cls(
+            external_id=resource["externalId"],
+            action_name=resource["actionName"],
+            status=resource["status"],
+            created_time=resource["createdTime"],
+            last_updated_time=resource["lastUpdatedTime"],
+            call_metadata=resource.get("callMetadata"),
+            result_message=resource.get("resultMessage"),
+            result_metadata=resource.get("resultMetadata"),
+        )
+
+    def as_write(self) -> ActionWrite:
+        """Returns this Action as an ActionWrite"""
+        return ActionWrite(external_id=self.external_id, action_name=self.action_name, call_metadata=self.call_metadata)
+
+    def __hash__(self) -> int:
+        return hash(self.external_id)
+
+
+class ActionWriteList(CogniteResourceList[ActionWrite], ExternalIDTransformerMixin):
+    _RESOURCE = ActionWrite
+
+
+class ActionList(WriteableCogniteResourceList[ActionWrite, Action], ExternalIDTransformerMixin):
+    _RESOURCE = Action
+
+    def as_write(self) -> ActionWriteList:
+        return ActionWriteList([item.as_write() for item in self.data])

--- a/cognite/client/data_classes/integrations/config.py
+++ b/cognite/client/data_classes/integrations/config.py
@@ -1,0 +1,133 @@
+from __future__ import annotations
+
+from abc import ABC
+from typing import Any
+
+from typing_extensions import Self
+
+from cognite.client.data_classes._base import (
+    CogniteResource,
+    CogniteResourceList,
+    ExternalIDTransformerMixin,
+    WriteableCogniteResource,
+)
+
+
+class ConfigRevisionCore(WriteableCogniteResource["ConfigRevisionWrite"], ABC):
+    """A versioned configuration document associated with an integration.
+
+    Every write creates a new, immutable revision rather than overwriting the previous one.
+
+    Args:
+        external_id (str): External id of the integration this config revision belongs to.
+        config (str | None): Contents of this configuration revision.
+        description (str | None): Short description of this configuration revision.
+    """
+
+    def __init__(self, external_id: str, config: str | None = None, description: str | None = None) -> None:
+        self.external_id = external_id
+        self.config = config
+        self.description = description
+
+
+class ConfigRevisionWrite(ConfigRevisionCore):
+    """A new configuration revision to create for an integration.
+
+    Args:
+        external_id (str): External id of the integration to create the config revision for.
+        config (str | None): Contents of this configuration revision.
+        description (str | None): Short description of this configuration revision.
+    """
+
+    @classmethod
+    def _load(cls, resource: dict[str, Any]) -> Self:
+        return cls(
+            external_id=resource["externalId"],
+            config=resource.get("config"),
+            description=resource.get("description"),
+        )
+
+    def as_write(self) -> ConfigRevisionWrite:
+        return self
+
+
+class ConfigRevision(ConfigRevisionCore):
+    """A single configuration revision for an integration, including its contents.
+
+    Args:
+        external_id (str): External id of the integration this config revision belongs to.
+        revision (int): The revision number of this config revision.
+        created_time (int): Time the config revision was created, in milliseconds since epoch.
+        last_updated_time (int): Time the config revision was last updated, in milliseconds since epoch.
+        config (str | None): Contents of this configuration revision.
+        description (str | None): Short description of this configuration revision.
+    """
+
+    def __init__(
+        self,
+        external_id: str,
+        revision: int,
+        created_time: int,
+        last_updated_time: int,
+        config: str | None = None,
+        description: str | None = None,
+    ) -> None:
+        super().__init__(external_id=external_id, config=config, description=description)
+        self.revision = revision
+        self.created_time = created_time
+        self.last_updated_time = last_updated_time
+
+    @classmethod
+    def _load(cls, resource: dict[str, Any]) -> Self:
+        return cls(
+            external_id=resource["externalId"],
+            revision=resource["revision"],
+            created_time=resource["createdTime"],
+            last_updated_time=resource["lastUpdatedTime"],
+            config=resource.get("config"),
+            description=resource.get("description"),
+        )
+
+    def as_write(self) -> ConfigRevisionWrite:
+        """Returns this ConfigRevision as a ConfigRevisionWrite"""
+        return ConfigRevisionWrite(external_id=self.external_id, config=self.config, description=self.description)
+
+
+class ConfigRevisionMetadata(CogniteResource):
+    """Metadata about a configuration revision, without the config contents itself.
+
+    Args:
+        external_id (str): External id of the integration this config revision belongs to.
+        revision (int): The revision number of this config revision.
+        created_time (int): Time the config revision was created, in milliseconds since epoch.
+        last_updated_time (int): Time the config revision was last updated, in milliseconds since epoch.
+        description (str | None): Short description of this configuration revision.
+    """
+
+    def __init__(
+        self,
+        external_id: str,
+        revision: int,
+        created_time: int,
+        last_updated_time: int,
+        description: str | None = None,
+    ) -> None:
+        self.external_id = external_id
+        self.revision = revision
+        self.created_time = created_time
+        self.last_updated_time = last_updated_time
+        self.description = description
+
+    @classmethod
+    def _load(cls, resource: dict[str, Any]) -> Self:
+        return cls(
+            external_id=resource["externalId"],
+            revision=resource["revision"],
+            created_time=resource["createdTime"],
+            last_updated_time=resource["lastUpdatedTime"],
+            description=resource.get("description"),
+        )
+
+
+class ConfigRevisionMetadataList(CogniteResourceList[ConfigRevisionMetadata], ExternalIDTransformerMixin):
+    _RESOURCE = ConfigRevisionMetadata

--- a/cognite/client/data_classes/integrations/errors.py
+++ b/cognite/client/data_classes/integrations/errors.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+from typing import Any, Literal, TypeAlias
+
+from typing_extensions import Self
+
+from cognite.client.data_classes._base import CogniteResource, CogniteResourceList, ExternalIDTransformerMixin
+from cognite.client.data_classes.integrations.integrations import ActiveConfigRevision
+
+ErrorLevel: TypeAlias = Literal["warning", "error", "fatal"]
+IntegrationErrorType: TypeAlias = Literal["general", "config", "task_never_closed", "seen_deadline_missed"]
+
+
+class IntegrationError(CogniteResource):
+    """A problem an extractor encountered while running a task, reported to CDF.
+
+    Args:
+        external_id (str): External id of the integration the error belongs to.
+        level (ErrorLevel): Severity of the error.
+        description (str): Short description of the error.
+        start_time (int): Time the error started, in milliseconds since epoch.
+        details (str | None): Full details of the error, e.g. a stack trace.
+        end_time (int | None): Time the error was resolved, in milliseconds since epoch. Not set while unresolved.
+        task (str | None): Name of the task the error occurred in. Not set if the error applies to the extractor generally.
+        type (IntegrationErrorType | None): Category of the error.
+        active_config_revision (ActiveConfigRevision | None): The config revision (or "local") active when the error occurred.
+    """
+
+    def __init__(
+        self,
+        external_id: str,
+        level: ErrorLevel,
+        description: str,
+        start_time: int,
+        details: str | None = None,
+        end_time: int | None = None,
+        task: str | None = None,
+        type: IntegrationErrorType | None = None,
+        active_config_revision: ActiveConfigRevision | None = None,
+    ) -> None:
+        self.external_id = external_id
+        self.level = level
+        self.description = description
+        self.details = details
+        self.start_time = start_time
+        self.end_time = end_time
+        self.task = task
+        self.type = type
+        self.active_config_revision = active_config_revision
+
+    @classmethod
+    def _load(cls, resource: dict[str, Any]) -> Self:
+        return cls(
+            external_id=resource["externalId"],
+            level=resource["level"],
+            description=resource["description"],
+            details=resource.get("details"),
+            start_time=resource["startTime"],
+            end_time=resource.get("endTime"),
+            task=resource.get("task"),
+            type=resource.get("type"),
+            active_config_revision=resource.get("activeConfigRevision"),
+        )
+
+
+class IntegrationErrorList(CogniteResourceList[IntegrationError], ExternalIDTransformerMixin):
+    _RESOURCE = IntegrationError

--- a/cognite/client/data_classes/integrations/integrations.py
+++ b/cognite/client/data_classes/integrations/integrations.py
@@ -1,0 +1,304 @@
+from __future__ import annotations
+
+from abc import ABC
+from typing import Any, Literal, TypeAlias
+
+from typing_extensions import Self
+
+from cognite.client.data_classes._base import (
+    CogniteObjectUpdate,
+    CognitePrimitiveUpdate,
+    CogniteResource,
+    CogniteResourceList,
+    CogniteUpdate,
+    ExternalIDTransformerMixin,
+    PropertySpec,
+    WriteableCogniteResource,
+    WriteableCogniteResourceList,
+)
+
+ActiveConfigRevision: TypeAlias = int | Literal["local"]
+
+
+class Extractor(CogniteResource):
+    """The extractor (or other process) that reports as this integration.
+
+    Args:
+        external_id (str): External id of the extractor, e.g. "cognite-simple-influxdb-extractor" for a Cognite-built extractor.
+        version (str | None): The version of the extractor.
+    """
+
+    def __init__(self, external_id: str, version: str | None = None) -> None:
+        self.external_id = external_id
+        self.version = version
+
+    @classmethod
+    def _load(cls, resource: dict[str, Any]) -> Self:
+        return cls(external_id=resource["externalId"], version=resource.get("version"))
+
+
+class Task(CogniteResource):
+    """A named unit of work in an integration, reported by the extractor.
+
+    Args:
+        type (Literal['continuous', 'batch']): Whether the task runs for the lifetime of the extractor (continuous) or runs to completion and exits (batch).
+        name (str): Name of the task, unique within the integration.
+        action (bool): Whether this task can be triggered through an Action. Defaults to False.
+        description (str | None): Description of the task.
+        sources (list[str] | None): Lineage: URIs of the systems/resources this task reads from.
+        targets (list[str] | None): Lineage: URIs of the CDF (or other) resources this task writes to.
+    """
+
+    def __init__(
+        self,
+        type: Literal["continuous", "batch"],
+        name: str,
+        action: bool = False,
+        description: str | None = None,
+        sources: list[str] | None = None,
+        targets: list[str] | None = None,
+    ) -> None:
+        self.type = type
+        self.name = name
+        self.action = action
+        self.description = description
+        self.sources = sources
+        self.targets = targets
+
+    @classmethod
+    def _load(cls, resource: dict[str, Any]) -> Self:
+        return cls(
+            type=resource["type"],
+            name=resource["name"],
+            action=resource.get("action", False),
+            description=resource.get("description"),
+            sources=resource.get("sources"),
+            targets=resource.get("targets"),
+        )
+
+
+class IntegrationCore(WriteableCogniteResource["IntegrationWrite"], ABC):
+    """An integration is a record of an extractor or other process that sends data to CDF.
+
+    It identifies the extractor type and holds the configuration, task history, and error history for that data
+    pipeline. Note that an integration isn't an extraction pipeline: don't use both for the same external ID.
+
+    Args:
+        external_id (str): The external ID provided by the client. Must be unique for the resource type.
+        extractor (Extractor): The extractor (or other process) that reports as this integration.
+        name (str | None): Name of the integration.
+        description (str | None): Description of the integration.
+        documentation (str | None): Documentation for the integration, formatted as markdown.
+        metadata (dict[str, str] | None): Custom, application specific metadata. String key -> String value.
+        allowed_not_seen_minutes (int | None): Number of minutes the integration is allowed to not report in before it's flagged as inactive. Defaults to 1440 (1 day) server-side.
+    """
+
+    def __init__(
+        self,
+        external_id: str,
+        extractor: Extractor,
+        name: str | None = None,
+        description: str | None = None,
+        documentation: str | None = None,
+        metadata: dict[str, str] | None = None,
+        allowed_not_seen_minutes: int | None = None,
+    ) -> None:
+        self.external_id = external_id
+        self.extractor = extractor
+        self.name = name
+        self.description = description
+        self.documentation = documentation
+        self.metadata = metadata
+        self.allowed_not_seen_minutes = allowed_not_seen_minutes
+
+    def dump(self, camel_case: bool = True) -> dict[str, Any]:
+        result = super().dump(camel_case)
+        result["extractor"] = self.extractor.dump(camel_case)
+        return result
+
+
+class IntegrationWrite(IntegrationCore):
+    """An integration is a record of an extractor or other process that sends data to CDF.
+    This is the write/create format of the integration.
+
+    Args:
+        external_id (str): The external ID provided by the client. Must be unique for the resource type.
+        extractor (Extractor): The extractor (or other process) that reports as this integration.
+        name (str | None): Name of the integration.
+        description (str | None): Description of the integration.
+        documentation (str | None): Documentation for the integration, formatted as markdown.
+        metadata (dict[str, str] | None): Custom, application specific metadata. String key -> String value.
+        allowed_not_seen_minutes (int | None): Number of minutes the integration is allowed to not report in before it's flagged as inactive. Defaults to 1440 (1 day) server-side.
+    """
+
+    @classmethod
+    def _load(cls, resource: dict[str, Any]) -> Self:
+        return cls(
+            external_id=resource["externalId"],
+            extractor=Extractor._load(resource["extractor"]),
+            name=resource.get("name"),
+            description=resource.get("description"),
+            documentation=resource.get("documentation"),
+            metadata=resource.get("metadata"),
+            allowed_not_seen_minutes=resource.get("allowedNotSeenMinutes"),
+        )
+
+    def as_write(self) -> IntegrationWrite:
+        return self
+
+
+class Integration(IntegrationCore):
+    """An integration is a record of an extractor or other process that sends data to CDF.
+    This is the read/response format of the integration.
+
+    Args:
+        external_id (str): The external ID provided by the client. Must be unique for the resource type.
+        extractor (Extractor): The extractor (or other process) that reports as this integration.
+        created_time (int): The time when this integration was created, in milliseconds since epoch.
+        last_updated_time (int): The time when this integration was last updated, in milliseconds since epoch.
+        name (str | None): Name of the integration.
+        description (str | None): Description of the integration.
+        documentation (str | None): Documentation for the integration, formatted as markdown.
+        metadata (dict[str, str] | None): Custom, application specific metadata. String key -> String value.
+        allowed_not_seen_minutes (int | None): Number of minutes the integration is allowed to not report in before it's flagged as inactive.
+        last_seen (int | None): The time this integration was last seen (checked in), in milliseconds since epoch.
+        last_config_revision (int | None): The revision number of the last config revision created for this integration.
+        active_config_revision (ActiveConfigRevision | None): The config revision currently reported active by the extractor, or "local" if it's using a local config file instead of a revision managed through CDF.
+        tasks (list[Task] | None): The tasks the extractor has reported as part of this integration.
+    """
+
+    def __init__(
+        self,
+        external_id: str,
+        extractor: Extractor,
+        created_time: int,
+        last_updated_time: int,
+        name: str | None = None,
+        description: str | None = None,
+        documentation: str | None = None,
+        metadata: dict[str, str] | None = None,
+        allowed_not_seen_minutes: int | None = None,
+        last_seen: int | None = None,
+        last_config_revision: int | None = None,
+        active_config_revision: ActiveConfigRevision | None = None,
+        tasks: list[Task] | None = None,
+    ) -> None:
+        super().__init__(
+            external_id=external_id,
+            extractor=extractor,
+            name=name,
+            description=description,
+            documentation=documentation,
+            metadata=metadata,
+            allowed_not_seen_minutes=allowed_not_seen_minutes,
+        )
+        self.created_time = created_time
+        self.last_updated_time = last_updated_time
+        self.last_seen = last_seen
+        self.last_config_revision = last_config_revision
+        self.active_config_revision = active_config_revision
+        self.tasks = tasks or []
+
+    def dump(self, camel_case: bool = True) -> dict[str, Any]:
+        result = super().dump(camel_case)
+        result["tasks"] = [task.dump(camel_case) for task in self.tasks or []]
+        return result
+
+    @classmethod
+    def _load(cls, resource: dict[str, Any]) -> Self:
+        return cls(
+            external_id=resource["externalId"],
+            extractor=Extractor._load(resource["extractor"]),
+            created_time=resource["createdTime"],
+            last_updated_time=resource["lastUpdatedTime"],
+            name=resource.get("name"),
+            description=resource.get("description"),
+            documentation=resource.get("documentation"),
+            metadata=resource.get("metadata"),
+            allowed_not_seen_minutes=resource.get("allowedNotSeenMinutes"),
+            last_seen=resource.get("lastSeen"),
+            last_config_revision=resource.get("lastConfigRevision"),
+            active_config_revision=resource.get("activeConfigRevision"),
+            tasks=[Task._load(task) for task in resource.get("tasks") or []],
+        )
+
+    def as_write(self) -> IntegrationWrite:
+        """Returns this Integration as an IntegrationWrite"""
+        return IntegrationWrite(
+            external_id=self.external_id,
+            extractor=self.extractor,
+            name=self.name,
+            description=self.description,
+            documentation=self.documentation,
+            metadata=self.metadata,
+            allowed_not_seen_minutes=self.allowed_not_seen_minutes,
+        )
+
+    def __hash__(self) -> int:
+        return hash(self.external_id)
+
+
+class IntegrationWriteList(CogniteResourceList[IntegrationWrite], ExternalIDTransformerMixin):
+    _RESOURCE = IntegrationWrite
+
+
+class IntegrationList(WriteableCogniteResourceList[IntegrationWrite, Integration], ExternalIDTransformerMixin):
+    _RESOURCE = Integration
+
+    def as_write(self) -> IntegrationWriteList:
+        return IntegrationWriteList([item.as_write() for item in self.data])
+
+
+class IntegrationUpdate(CogniteUpdate):
+    """Changes applied to an integration
+
+    Args:
+        external_id (str): The external ID provided by the client. Must be unique for the resource type.
+    """
+
+    def __init__(self, external_id: str) -> None:
+        super().__init__(external_id=external_id)
+
+    class _PrimitiveIntegrationUpdate(CognitePrimitiveUpdate):
+        def set(self, value: Any) -> IntegrationUpdate:
+            return self._set(value)
+
+    class _ObjectIntegrationUpdate(CogniteObjectUpdate):
+        def set(self, value: dict) -> IntegrationUpdate:
+            return self._set(value)
+
+        def add(self, value: dict) -> IntegrationUpdate:
+            return self._add(value)
+
+        def remove(self, value: list) -> IntegrationUpdate:
+            return self._remove(value)
+
+    @property
+    def name(self) -> _PrimitiveIntegrationUpdate:
+        return IntegrationUpdate._PrimitiveIntegrationUpdate(self, "name")
+
+    @property
+    def description(self) -> _PrimitiveIntegrationUpdate:
+        return IntegrationUpdate._PrimitiveIntegrationUpdate(self, "description")
+
+    @property
+    def documentation(self) -> _PrimitiveIntegrationUpdate:
+        return IntegrationUpdate._PrimitiveIntegrationUpdate(self, "documentation")
+
+    @property
+    def allowed_not_seen_minutes(self) -> _PrimitiveIntegrationUpdate:
+        return IntegrationUpdate._PrimitiveIntegrationUpdate(self, "allowedNotSeenMinutes")
+
+    @property
+    def metadata(self) -> _ObjectIntegrationUpdate:
+        return IntegrationUpdate._ObjectIntegrationUpdate(self, "metadata")
+
+    @classmethod
+    def _get_update_properties(cls, item: CogniteResource | None = None) -> list[PropertySpec]:
+        return [
+            PropertySpec("name"),
+            PropertySpec("description"),
+            PropertySpec("documentation"),
+            PropertySpec("allowed_not_seen_minutes"),
+            PropertySpec("metadata", is_object=True),
+        ]

--- a/cognite/client/data_classes/integrations/tasks.py
+++ b/cognite/client/data_classes/integrations/tasks.py
@@ -1,0 +1,113 @@
+from __future__ import annotations
+
+from typing import Any
+
+from typing_extensions import Self
+
+from cognite.client.data_classes._base import CogniteResource, CogniteResourceList, ExternalIDTransformerMixin
+from cognite.client.data_classes.integrations.errors import IntegrationErrorList
+from cognite.client.data_classes.integrations.integrations import ActiveConfigRevision
+
+
+class TaskHistory(CogniteResource):
+    """A single start/stop event of a task, reported by the extractor.
+
+    Args:
+        external_id (str): External id of the integration the task belongs to.
+        task_name (str): Name of the task.
+        start_time (int): Time the task started, in milliseconds since epoch.
+        end_time (int | None): Time the task ended, in milliseconds since epoch. Not set while the task is still running.
+        message (str | None): Optional message reported when the task started or ended.
+        error_count (int): Number of errors reported for this task run.
+        warning_count (int): Number of warnings reported for this task run.
+        fatal_count (int): Number of fatal errors reported for this task run.
+        active_config_revision (ActiveConfigRevision | None): The config revision (or "local") active at the time of this task run.
+        sources (list[str] | None): Lineage: URIs of the systems/resources this task read from.
+        targets (list[str] | None): Lineage: URIs of the CDF (or other) resources this task wrote to.
+    """
+
+    def __init__(
+        self,
+        external_id: str,
+        task_name: str,
+        start_time: int,
+        end_time: int | None = None,
+        message: str | None = None,
+        error_count: int = 0,
+        warning_count: int = 0,
+        fatal_count: int = 0,
+        active_config_revision: ActiveConfigRevision | None = None,
+        sources: list[str] | None = None,
+        targets: list[str] | None = None,
+    ) -> None:
+        self.external_id = external_id
+        self.task_name = task_name
+        self.start_time = start_time
+        self.end_time = end_time
+        self.message = message
+        self.error_count = error_count
+        self.warning_count = warning_count
+        self.fatal_count = fatal_count
+        self.active_config_revision = active_config_revision
+        self.sources = sources
+        self.targets = targets
+
+    @classmethod
+    def _load(cls, resource: dict[str, Any]) -> Self:
+        return cls(
+            external_id=resource["externalId"],
+            task_name=resource["taskName"],
+            start_time=resource["startTime"],
+            end_time=resource.get("endTime"),
+            message=resource.get("message"),
+            error_count=resource.get("errorCount", 0),
+            warning_count=resource.get("warningCount", 0),
+            fatal_count=resource.get("fatalCount", 0),
+            active_config_revision=resource.get("activeConfigRevision"),
+            sources=resource.get("sources"),
+            targets=resource.get("targets"),
+        )
+
+
+class TaskHistoryList(CogniteResourceList[TaskHistory], ExternalIDTransformerMixin):
+    _RESOURCE = TaskHistory
+
+
+class SyncResult(CogniteResource):
+    """The result of a single call to the incremental integration sync endpoint.
+
+    Args:
+        next_cursor (str): Cursor to pass into the next call to continue from where this page left off.
+        more_data (bool): Whether there is more data available immediately (True), or whether the caller should back off before polling again (False).
+        history (TaskHistoryList | None): Task history entries since the previous cursor, if requested.
+        errors (IntegrationErrorList | None): Errors reported since the previous cursor, if requested.
+    """
+
+    def __init__(
+        self,
+        next_cursor: str,
+        more_data: bool = False,
+        history: TaskHistoryList | None = None,
+        errors: IntegrationErrorList | None = None,
+    ) -> None:
+        self.next_cursor = next_cursor
+        self.more_data = more_data
+        self.history = history
+        self.errors = errors
+
+    def dump(self, camel_case: bool = True) -> dict[str, Any]:
+        result = super().dump(camel_case)
+        if self.history is not None:
+            result["history"] = self.history.dump(camel_case)
+        if self.errors is not None:
+            result["errors"] = self.errors.dump(camel_case)
+        return result
+
+    @classmethod
+    def _load(cls, resource: dict[str, Any]) -> Self:
+        return cls(
+            next_cursor=resource["nextCursor"],
+            more_data=resource.get("moreData", False),
+            history=TaskHistoryList._load(resource["history"]) if resource.get("history") is not None else None,
+            errors=IntegrationErrorList._load(resource["errors"]) if resource.get("errors") is not None else None,
+        )

--- a/tests/tests_unit/test_data_classes/test_integrations.py
+++ b/tests/tests_unit/test_data_classes/test_integrations.py
@@ -1,0 +1,206 @@
+from __future__ import annotations
+
+from cognite.client.data_classes.integrations import (
+    Action,
+    ConfigRevision,
+    Extractor,
+    Integration,
+    IntegrationError,
+    IntegrationUpdate,
+    Task,
+)
+from cognite.client.data_classes.integrations.tasks import SyncResult, TaskHistory
+
+INTEGRATION_DUMPED = {
+    "externalId": "my-integration",
+    "extractor": {"externalId": "cognite-simple-influxdb-extractor", "version": "1.0.0"},
+    "name": "My integration",
+    "description": "A test integration",
+    "metadata": {"key": "value"},
+    "allowedNotSeenMinutes": 60,
+    "lastSeen": 123,
+    "lastConfigRevision": 2,
+    "activeConfigRevision": "local",
+    "tasks": [{"type": "continuous", "name": "poll", "action": True, "description": "Polls for data"}],
+    "createdTime": 1,
+    "lastUpdatedTime": 2,
+}
+
+
+class TestIntegration:
+    def test_load_dump_round_trip(self) -> None:
+        loaded = Integration._load(INTEGRATION_DUMPED)
+
+        assert loaded.external_id == "my-integration"
+        assert loaded.extractor.external_id == "cognite-simple-influxdb-extractor"
+        assert loaded.tasks[0].name == "poll"
+        assert loaded.tasks[0].action is True
+        assert loaded.active_config_revision == "local"
+
+        assert loaded.dump(camel_case=True) == INTEGRATION_DUMPED
+
+    def test_load_with_explicit_null_tasks(self) -> None:
+        dumped = {**INTEGRATION_DUMPED, "tasks": None}
+        loaded = Integration._load(dumped)
+
+        assert loaded.tasks == []
+        assert loaded.dump(camel_case=True)["tasks"] == []
+
+    def test_as_write(self) -> None:
+        loaded = Integration._load(INTEGRATION_DUMPED)
+        write = loaded.as_write()
+
+        assert write.external_id == loaded.external_id
+        assert write.extractor.external_id == loaded.extractor.external_id
+        assert write.dump(camel_case=True) == {
+            "externalId": "my-integration",
+            "extractor": {"externalId": "cognite-simple-influxdb-extractor", "version": "1.0.0"},
+            "name": "My integration",
+            "description": "A test integration",
+            "metadata": {"key": "value"},
+            "allowedNotSeenMinutes": 60,
+        }
+
+
+class TestIntegrationUpdate:
+    def test_set_and_set_null(self) -> None:
+        update = IntegrationUpdate(external_id="my-integration")
+        update.name.set("New name")
+        update.description.set(None)
+
+        assert update.dump() == {
+            "externalId": "my-integration",
+            "update": {"name": {"set": "New name"}, "description": {"setNull": True}},
+        }
+
+    def test_metadata_add_remove(self) -> None:
+        update = IntegrationUpdate(external_id="my-integration")
+        update.metadata.add({"key": "value"})
+
+        assert update.dump() == {
+            "externalId": "my-integration",
+            "update": {"metadata": {"add": {"key": "value"}}},
+        }
+
+    def test_metadata_set(self) -> None:
+        update = IntegrationUpdate(external_id="my-integration")
+        update.metadata.set({"key": "value"})
+
+        assert update.dump() == {
+            "externalId": "my-integration",
+            "update": {"metadata": {"set": {"key": "value"}}},
+        }
+
+
+class TestAction:
+    def test_load_dump_round_trip(self) -> None:
+        dumped = {
+            "externalId": "my-action",
+            "actionName": "restart",
+            "status": "succeeded",
+            "callMetadata": {"reason": "manual"},
+            "resultMessage": "Done",
+            "resultMetadata": {"durationMs": "42"},
+            "createdTime": 1,
+            "lastUpdatedTime": 2,
+        }
+        loaded = Action._load(dumped)
+
+        assert loaded.status == "succeeded"
+        assert loaded.dump(camel_case=True) == dumped
+
+    def test_as_write(self) -> None:
+        loaded = Action._load(
+            {
+                "externalId": "my-action",
+                "actionName": "restart",
+                "status": "pending",
+                "createdTime": 1,
+                "lastUpdatedTime": 2,
+            }
+        )
+        write = loaded.as_write()
+
+        assert write.dump(camel_case=True) == {"externalId": "my-action", "actionName": "restart"}
+
+
+class TestSyncResult:
+    def test_load_dump_round_trip(self) -> None:
+        dumped = {
+            "nextCursor": "abc123",
+            "moreData": True,
+            "history": [
+                {
+                    "externalId": "my-integration",
+                    "taskName": "poll",
+                    "startTime": 100,
+                    "errorCount": 0,
+                    "warningCount": 0,
+                    "fatalCount": 0,
+                }
+            ],
+            "errors": [
+                {
+                    "externalId": "my-integration",
+                    "level": "warning",
+                    "description": "Slow response",
+                    "startTime": 100,
+                }
+            ],
+        }
+        loaded = SyncResult._load(dumped)
+
+        assert loaded.next_cursor == "abc123"
+        assert loaded.more_data is True
+        assert loaded.history is not None
+        assert loaded.errors is not None
+        assert isinstance(loaded.history[0], TaskHistory)
+        assert isinstance(loaded.errors[0], IntegrationError)
+
+        assert loaded.dump(camel_case=True) == dumped
+
+    def test_load_with_explicit_null_history_and_errors(self) -> None:
+        loaded = SyncResult._load({"nextCursor": "abc123", "moreData": False, "history": None, "errors": None})
+
+        assert loaded.history is None
+        assert loaded.errors is None
+
+
+class TestConfigRevision:
+    def test_load_dump_round_trip(self) -> None:
+        dumped = {
+            "externalId": "my-integration",
+            "revision": 3,
+            "description": "A config revision",
+            "config": "key: value",
+            "createdTime": 1,
+            "lastUpdatedTime": 2,
+        }
+        loaded = ConfigRevision._load(dumped)
+
+        assert loaded.revision == 3
+        assert loaded.dump(camel_case=True) == dumped
+
+        write = loaded.as_write()
+        assert write.dump(camel_case=True) == {
+            "externalId": "my-integration",
+            "config": "key: value",
+            "description": "A config revision",
+        }
+
+
+def test_extractor_load_dump() -> None:
+    dumped = {"externalId": "cognite-simple-influxdb-extractor", "version": "1.0.0"}
+    assert Extractor._load(dumped).dump(camel_case=True) == dumped
+
+
+def test_task_load_dump() -> None:
+    dumped = {
+        "type": "batch",
+        "name": "sync",
+        "action": True,
+        "description": "Syncs data",
+        "sources": ["cdf://cluster/project/service/resource"],
+        "targets": ["cdf://cluster/project/timeseries/my-ts"],
+    }
+    assert Task._load(dumped).dump(camel_case=True) == dumped


### PR DESCRIPTION
## Summary
Adds the data classes for the new Integrations API (Integration, Task, Extractor, Action, ConfigRevision, IntegrationError, TaskHistory, SyncResult) with load/dump round-trip tests. No API client or SDK wiring yet - the classes are not reachable from `CogniteClient` until the follow-up PR lands.

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Refactor (no functional change)
- [ ] Documentation update
- [ ] Chore / tooling / CI

## What changed
- New package `cognite/client/data_classes/integrations/` with `integrations.py`, `actions.py`, `config.py`, `errors.py`, `tasks.py`, and an `__init__.py` that re-exports everything with an explicit `__all__` (not re-exported from the top-level `data_classes/__init__.py`, matching the `simulators` alpha-module precedent).
- `Integration`/`IntegrationWrite`/`IntegrationList`/`IntegrationUpdate` (external-id-keyed, standard set/set_null/metadata add-remove update pattern), `Extractor`, `Task`.
- `Action`/`ActionWrite`/`ActionList` for the remote-command sub-resource.
- `ConfigRevision`/`ConfigRevisionWrite`/`ConfigRevisionMetadata` for versioned config.
- `IntegrationError`/`IntegrationErrorList` and `TaskHistory`/`TaskHistoryList`/`SyncResult` for error reporting and task history.
- All list classes use `ExternalIDTransformerMixin` - this API has no internal numeric `id`, everything is keyed by external ID only.
- 13 new unit tests in `tests/tests_unit/test_data_classes/test_integrations.py` covering load/dump round-trips for every class, including explicit-`null` handling for `tasks`/`history`/`errors`.

## Why it changed
- Related issue: EDG-827

## What to focus on during review
- `ActiveConfigRevision: TypeAlias = int | Literal["local"]` in `integrations.py` - shared by `tasks.py`/`errors.py` and by `checkin.py` in the PR that follows this one.
- `Integration.__init__` guarantees `self.tasks = tasks or []` (never `None`), and `_load`/`dump` explicitly handle the server sending JSON `null` for `tasks` (not just an absent key) - see `test_load_with_explicit_null_tasks`.

## Test evidence
- `pytest tests/tests_unit/test_data_classes/test_integrations.py -q` → 13 passed
- `ruff check` / `ruff format --check` → clean
- `mypy` (via `poetry run dmypy run -- cognite tests`) → no issues

## Risks and unknowns
- These classes are not yet wired into any client - they're inert until the next PR. Reviewing this PR in isolation means judging shapes/types without seeing how they're used; the API layer PR follows immediately after.

## Rollout and rollback
- No migrations, no config changes. Purely additive new files; revert is a straight revert of this commit.

## Checklist
- [x] Self-reviewed the diff
- [x] Tests added or updated (or N/A with reason)
- [ ] Docs updated (or N/A) - N/A, no public docs page exists yet for this alpha/beta API
- [x] No secrets, credentials, or PII committed
- [ ] Breaking changes called out above and communicated to affected teams - N/A, no breaking changes