### PR TITLE
chore(state datapoints): Fix state datapoints getitem, slicing and iteration (DM-4093)

### DIFF
--- a/cognite/client/data_classes/datapoints.py
+++ b/cognite/client/data_classes/datapoints.py
@@ -1059,7 +1059,7 @@ class DatapointsArray(CogniteResource):
         if self.null_timestamps:
             for dp in datapoints:
                 if dp["timestamp"] in self.null_timestamps:  # ...luckily, we know :3
-                    dp["value"] = None  # type: ignore [assignment]
+                    dp["value"] = None
         dumped["datapoints"] = datapoints
 
         if camel_case:
@@ -1241,6 +1241,9 @@ class Datapoints(CogniteResource):
         dp_args: dict[str, Any] = {"timezone": self.timezone}
         for attr, values in self._get_non_empty_data_fields():
             dp_args[attr] = values[item]
+        for key in ("numeric_states", "string_states"):
+            if key in dp_args:
+                dp_args[key[:-1]] = dp_args.pop(key)  # quick way to get non-plural version of the key
 
         if self.status_code is not None:
             dp_args.update(status_code=self.status_code[item], status_symbol=self.status_symbol[item])  # type: ignore [index]
@@ -1397,6 +1400,9 @@ class Datapoints(CogniteResource):
             dp_args: dict[str, Any] = {"timezone": self.timezone}
             for attr, value in fields:
                 dp_args[to_camel_case(attr)] = value[i]
+            for key in ("numericStates", "stringStates"):
+                if key in dp_args:
+                    dp_args[key[:-1]] = dp_args.pop(key)  # get non-plural version of the key
             if self.status_code is not None:
                 dp_args.update(
                     statusCode=self.status_code[i],

--- a/cognite/client/data_classes/datapoints.py
+++ b/cognite/client/data_classes/datapoints.py
@@ -1025,6 +1025,25 @@ class DatapointsArray(CogniteResource):
         convert_fn = partial(numpy_dtype_fix, camel_case=camel_case)
         datapoints = [dict(zip(attrs, map(convert_fn, row))) for row in zip(*arrays)]
 
+        if self.numeric_states is not None:
+            num_key = "numericState" if camel_case else "numeric_state"
+            plural_num_key = f"{num_key}s"
+            if self.numeric_states.dtype == np.float64:
+                # As numpy int arrays can't represent NaN, float64 is used when we need to accommodate for missing
+                # values. Thus, we need to convert both back to int and convert NaN to None:
+                for dp in datapoints:
+                    val = dp.pop(plural_num_key)
+                    dp[num_key] = None if math.isnan(val) else int(val)  # type: ignore [arg-type]
+            else:
+                for dp in datapoints:
+                    dp[num_key] = dp.pop(plural_num_key)
+
+        if self.string_states is not None:
+            str_key = "stringState" if camel_case else "string_state"
+            plural_str_key = f"{str_key}s"
+            for dp in datapoints:
+                dp[str_key] = dp.pop(plural_str_key)
+
         if self.status_code is not None or self.status_symbol is not None:
             if (
                 self.status_code is None

--- a/cognite/client/data_classes/datapoints.py
+++ b/cognite/client/data_classes/datapoints.py
@@ -866,7 +866,12 @@ class DatapointsArray(CogniteResource):
             for row in dps_dct["datapoints"]:
                 for attr, value in row.items():
                     datapoints_by_attr[attr].append(value)
+
+            # Pop away special attributes that need separate handling:
             status = datapoints_by_attr.pop("status", None)
+            numeric_state = datapoints_by_attr.pop("numericState", None)
+            string_state = datapoints_by_attr.pop("stringState", None)
+
             for attr, values in datapoints_by_attr.items():
                 if attr == "timestamp":
                     array_by_attr[attr] = np.array(values, dtype="datetime64[ms]").astype("datetime64[ns]")
@@ -877,9 +882,18 @@ class DatapointsArray(CogniteResource):
                         array_by_attr[attr] = np.array(values, dtype=np.float64)
                     except ValueError:
                         array_by_attr[attr] = np.array(values, dtype=np.object_)
+
             if status is not None:
                 array_by_attr["statusCode"] = np.array([s["code"] for s in status], dtype=np.uint32)
                 array_by_attr["statusSymbol"] = np.array([s["symbol"] for s in status], dtype=np.object_)
+
+            if numeric_state is not None:
+                num_arr = np.array(numeric_state, dtype=np.float64)
+                if not np.isnan(num_arr).any():
+                    array_by_attr["numericStates"] = num_arr.astype(np.int32)
+
+            if string_state is not None:
+                array_by_attr["stringStates"] = np.array(string_state, dtype=np.object_)
 
         timezone = dps_dct.get("timezone")
         if isinstance(timezone, str):

--- a/cognite/client/data_classes/datapoints.py
+++ b/cognite/client/data_classes/datapoints.py
@@ -568,6 +568,9 @@ class LatestDatapointQuery:
         return self._identifier  # type: ignore [attr-defined]
 
 
+# TODO: Absolutely need a refactor/split in v9. Now represent a simple raw datapoint, state datapoint
+#       and aggregate datapoints (yes multiple)
+#       Should probably just be removed. Iterating over Datapoints should not be a thing.
 class Datapoint(CogniteResource):
     """An object representing a datapoint.
 

--- a/cognite/client/data_classes/datapoints.py
+++ b/cognite/client/data_classes/datapoints.py
@@ -78,8 +78,8 @@ _T_DPS = TypeVar("_T_DPS", "Datapoints", "DatapointsArray")
 
 
 def numpy_dtype_fix(
-    element: np.float64 | str | MaxOrMinDatapoint, camel_case: bool = False
-) -> float | str | dict[str, int | float | str]:
+    element: np.float64 | str | MaxOrMinDatapoint | None, camel_case: bool = False
+) -> float | str | dict[str, int | float | str] | None:
     try:
         # Using .item() on numpy scalars gives us vanilla python types:
         return element.item()  # type: ignore [union-attr]
@@ -89,6 +89,10 @@ def numpy_dtype_fix(
             return element
         elif isinstance(element, MaxOrMinDatapoint):
             return element.dump(camel_case=camel_case)
+        elif element is None:
+            # State dps (string version) holds None whenever the state no longer exists in the StateSet
+            # mapping (ie. this is expected also outside of the "missing-due-to-bad-status" scenario):
+            return None
         raise
 
 

--- a/cognite/client/data_classes/datapoints.py
+++ b/cognite/client/data_classes/datapoints.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import contextlib
 import datetime
 import json
+import math
 from abc import abstractmethod
 from collections import ChainMap, defaultdict
 from collections.abc import Iterator, MutableSequence, Sequence
@@ -893,6 +894,8 @@ class DatapointsArray(CogniteResource):
             unit_external_id=dps_dct.get("unitExternalId"),
             timestamp=array_by_attr.get("timestamp"),
             value=array_by_attr.get("value"),
+            numeric_states=array_by_attr.get("numericStates"),
+            string_states=array_by_attr.get("stringStates"),
             average=array_by_attr.get("average"),
             max=array_by_attr.get("max"),
             min=array_by_attr.get("min"),
@@ -935,6 +938,7 @@ class DatapointsArray(CogniteResource):
     def __getitem__(self, item: int | slice) -> Datapoint | DatapointsArray:
         if isinstance(item, slice):
             return self._slice(item)
+
         attrs, arrays = self._data_fields()
         timestamp = arrays[0][item].item() // 1_000_000
         data: dict[str, float | str | dict | None] = {
@@ -943,8 +947,16 @@ class DatapointsArray(CogniteResource):
         for key in ("min_datapoint", "max_datapoint"):
             if key in data:
                 data[key] = getattr(self, key)[item]
+        for key in ("numeric_states", "string_states"):
+            if key in data:
+                data[key[:-1]] = data.pop(key)  # quick way to get non-plural version of the key
+        if isinstance(val := data.get("numeric_state"), float):
+            # Map floats back to int, but convert NaN to None:
+            data["numeric_state"] = None if math.isnan(val) else int(val)
+
         if self.status_code is not None:
             data.update(status_code=self.status_code[item], status_symbol=self.status_symbol[item])  # type: ignore [index]
+
         if self.null_timestamps and timestamp in self.null_timestamps:
             data["value"] = None
         return Datapoint(timestamp=timestamp, **data, timezone=self.timezone)  # type: ignore [arg-type]
@@ -968,12 +980,9 @@ class DatapointsArray(CogniteResource):
         )
 
     def _data_fields(self) -> tuple[list[str], list[npt.NDArray]]:
-        # Note: Does not return status-related fields
-        data_field_tuples = [
-            (attr, arr)
-            for attr in ("timestamp", "value", *ALL_SORTED_DP_AGGS)  # ts must be first
-            if (arr := getattr(self, attr)) is not None
-        ]
+        # Note: Does not return status-related fields. ts must be first:
+        fields = ("timestamp", "value", "numeric_states", "string_states", *ALL_SORTED_DP_AGGS)
+        data_field_tuples = [(attr, arr) for attr in fields if (arr := getattr(self, attr)) is not None]
         attrs, arrays = map(list, zip(*data_field_tuples))
         return attrs, arrays
 

--- a/tests/tests_unit/test_data_classes/test_datapoints.py
+++ b/tests/tests_unit/test_data_classes/test_datapoints.py
@@ -63,6 +63,64 @@ class TestDatapoint:
         assert pd.Timestamp(expected) == df1.index[0] == df2.index[0]
 
 
+class TestStateDatapoint:
+    @pytest.fixture
+    def state_dps(self) -> Datapoints:
+        return Datapoints(
+            id=123,
+            is_string=False,
+            is_step=False,
+            type="state",
+            timestamp=[1000, 2000, 3000],
+            # For bad datapoints, even numeric can be missing (None); 0 is a valid state, not missing:
+            numeric_states=[10, None, 0],  # type: ignore [list-item]
+            string_states=["on", None, None],
+        )
+
+    def test_getitem(self, state_dps: Datapoints) -> None:
+        dp = state_dps[0]
+        assert isinstance(dp, Datapoint)
+        assert dp.numeric_state == 10
+        assert dp.string_state == "on"
+
+        dp_missing = state_dps[1]
+        assert isinstance(dp_missing, Datapoint)
+        assert dp_missing.numeric_state is None
+        assert dp_missing.string_state is None
+
+    def test_getitem_slice(self, state_dps: Datapoints) -> None:
+        sliced = state_dps[1:3]
+        assert isinstance(sliced, Datapoints)
+        assert sliced.numeric_states == [None, 0]
+        assert sliced.string_states == [None, None]
+
+    def test_iteration_yields_correct_state_values(self, state_dps: Datapoints) -> None:
+        for dp in state_dps:
+            assert isinstance(dp, Datapoint)
+        assert [dp.numeric_state for dp in state_dps] == [10, None, 0]
+        assert [dp.string_state for dp in state_dps] == ["on", None, None]
+
+    def test_iteration_yields_correct_state_values_no_states(self) -> None:
+        non_state_dps = Datapoints(
+            id=1,
+            is_string=False,
+            is_step=True,
+            type="numeric",
+            timestamp=[1000, 2000, 3000],
+            value=[1.0, 2.0, 3.0],
+        )
+        # Note that a single Datapoint object (what we get while iterating) can't distinguish between
+        # None being a missing, but real value and no value, e.g. for something that is not a state dp:
+        assert [dp.numeric_state for dp in non_state_dps] == [None, None, None]
+        assert [dp.string_state for dp in non_state_dps] == [None, None, None]
+
+    def test_dump_uses_singular_state_keys(self, state_dps: Datapoints) -> None:
+        # singular meaning 'numericState' not 'numericStates' etc.
+        dumped = state_dps.dump()["datapoints"]
+        assert [dp.get("numericState") for dp in dumped] == [10, None, 0]
+        assert [dp.get("stringState") for dp in dumped] == ["on", None, None]
+
+
 @pytest.mark.dsl
 class TestDatapointsArray:
     def test_dump_converts_missing_values_to_none(self) -> None:

--- a/tests/tests_unit/test_data_classes/test_datapoints.py
+++ b/tests/tests_unit/test_data_classes/test_datapoints.py
@@ -143,6 +143,67 @@ class TestDatapointsArray:
 
 
 @pytest.mark.dsl
+class TestStateDatapointsArray:
+    @pytest.fixture
+    def bad_state_arr(self) -> DatapointsArray:
+        import numpy as np
+
+        return DatapointsArray(
+            id=123,
+            is_string=False,
+            is_step=False,
+            type="state",
+            timestamp=np.array([1000, 2000, 3000], dtype="datetime64[ns]"),
+            # When 'ignore_bad_datapoints=False' upcasts to float64, using NaN for missing:
+            numeric_states=np.array([10, np.nan, 0], dtype=np.float64),
+            string_states=np.array(["on", None, None], dtype=object),
+        )
+
+    def test_getitem(self, bad_state_arr: DatapointsArray) -> None:
+        dp = bad_state_arr[0]
+        assert isinstance(dp, Datapoint)
+
+        # The numeric values (float64) should be converted to int:
+        assert isinstance(dp.numeric_state, int)
+        assert dp.numeric_state == 10
+        assert dp.string_state == "on"
+
+        dp_missing = bad_state_arr[1]
+        # NaN should be converted to None:
+        assert dp_missing.numeric_state is None
+        assert dp_missing.string_state is None
+
+    def test_slice(self, bad_state_arr: DatapointsArray) -> None:
+        import numpy as np
+
+        sliced = bad_state_arr[1:3]
+        assert isinstance(sliced, DatapointsArray)
+
+        assert sliced.numeric_states is not None
+        assert math.isnan(sliced.numeric_states[0])
+        assert sliced.numeric_states[1] == 0
+        np.testing.assert_array_equal(sliced.string_states, np.array([None, None], dtype=object))
+
+    @pytest.mark.parametrize(
+        "keys, use_camel_case",
+        [
+            (("numericState", "stringState"), True),
+            (("numeric_state", "string_state"), False),
+        ],
+    )
+    def test_dump(
+        self,
+        bad_state_arr: DatapointsArray,
+        keys: tuple[str, str],
+        use_camel_case: bool,
+    ) -> None:
+        num_key, str_key = keys
+        dumped = bad_state_arr.dump(camel_case=use_camel_case)["datapoints"]
+        assert [dp[num_key] for dp in dumped] == [10.0, None, 0.0]
+        assert [dp[str_key] for dp in dumped] == ["on", None, None]
+
+
+@pytest.mark.dsl
 class TestToPandas:
     @pytest.mark.parametrize("dps_lst_cls", [DatapointsList, DatapointsArrayList])
     def test_identifier_priority(self, dps_lst_cls: type[CogniteResourceList]) -> None:


### PR DESCRIPTION
Add proper support for state datapoints (`numeric_states`, `string_states`) in `DatapointsArray` and `Datapoints`: `__getitem__`/slicing, & iteration.

**Changes:**
- Added `numeric_states` and `string_states` fields to DatapointsArray initialization and `_data_fields()`
- Fixed `__getitem__()` and iteration to:
  - Convert `float64` arrays back to int (with `NaN` -> `None`)
  - Map plural state keys (`numeric_states` → `numeric_state`) for single `Datapoint` objects
- Fixed `dump()` to output singular state keys (`numericState`/`numeric_state`) in JSON
- Added test coverage for state datapoint getitem, slicing, iteration, and dump behavior
