### PR TITLE
fix: Avoid throwing noisy warning in pyodide

### DIFF
--- a/cognite/client/_http_client.py
+++ b/cognite/client/_http_client.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 import functools
 import logging
+import warnings
 from collections.abc import (
     AsyncIterable,
     AsyncIterator,
@@ -18,7 +19,8 @@ from typing import Any, Literal, TypeAlias
 
 import httpx2
 
-from cognite.client.config import global_config
+from cognite.client._constants import _RUNNING_IN_PYODIDE
+from cognite.client.config import _DEFAULT_MAX_CONNECTION_POOL_SIZE, global_config
 from cognite.client.exceptions import (
     CogniteConnectionError,
     CogniteConnectionRefused,
@@ -54,7 +56,17 @@ def get_global_async_httpx_client() -> httpx2.AsyncClient:
     except KeyError:
         pass
 
-    client = _global_async_httpx_clients[loop] = httpx2.AsyncClient(
+    if _RUNNING_IN_PYODIDE:
+        client = _build_pyodide_httpx_client()
+    else:
+        client = _build_httpx_client()
+
+    _global_async_httpx_clients[loop] = client
+    return client
+
+
+def _build_httpx_client() -> httpx2.AsyncClient:
+    return httpx2.AsyncClient(
         proxy=global_config.proxy,
         verify=False if global_config.disable_ssl else (global_config.ssl_context or True),
         limits=httpx2.Limits(
@@ -65,7 +77,29 @@ def get_global_async_httpx_client() -> httpx2.AsyncClient:
         follow_redirects=global_config.follow_redirects,
         cookies=NoCookiesPlease(),
     )
-    return client
+
+
+def _build_pyodide_httpx_client() -> httpx2.AsyncClient:
+    # In Pyodide/Emscripten, networking is handled by browser's JS runtime, so we can't control any of
+    # 'verify', 'proxy' or 'limits' parameters ourselves. We warn the user if they have customized any
+    # of these settings.
+    # We also don't pass any of them to httpx2.AsyncClient() as httpx2-jsfetch will throw warnings using
+    # differently named settings, e.g. 'verify' instead of 'disable_ssl' or 'ssl_context' (which is confusing).
+    settings = (
+        ("disable_ssl", global_config.disable_ssl),
+        ("ssl_context", global_config.ssl_context is not None),
+        ("proxy", global_config.proxy is not None),
+        ("max_connection_pool_size", global_config.max_connection_pool_size != _DEFAULT_MAX_CONNECTION_POOL_SIZE),
+    )
+    if ignored := [name for name, is_customized in settings if is_customized]:
+        settings_str = ", ".join(f"global_config.{name}" for name in ignored)
+        warnings.warn(
+            f"{settings_str} {'has' if len(ignored) == 1 else 'have'} no effect when running in a browser "
+            "(Pyodide/JupyterLite/Streamlit): networking there is handled by the browser itself, not by the SDK.",
+            RuntimeWarning,
+            stacklevel=2,
+        )
+    return httpx2.AsyncClient(follow_redirects=global_config.follow_redirects, cookies=NoCookiesPlease())
 
 
 class AsyncHTTPClientWithRetryConfig:

--- a/cognite/client/config.py
+++ b/cognite/client/config.py
@@ -57,8 +57,9 @@ class GlobalConfig:
             features. Defaults to False.
 
     Note:
-        ``disable_ssl``, ``ssl_context``, and ``proxy`` are ignored when running in a browser (Pyodide/JupyterLite/Streamlit):
-        networking there is handled by the browser's JS runtime, which controls certificate validation and proxying itself.
+        When running in a browser environment (e.g. Pyodide/JupyterLite/Streamlit) the settings ``disable_ssl``, ``ssl_context``,
+        ``proxy``, and ``max_connection_pool_size`` are all ignored. Networking is handled by the browser's JS runtime, which
+        controls certificate validation, proxying, and connection pooling itself.
     """
 
     _instance: ClassVar[GlobalConfig]

--- a/cognite/client/config.py
+++ b/cognite/client/config.py
@@ -15,6 +15,9 @@ from cognite.client.utils._auxiliary import is_non_negative_int, is_positive_int
 from cognite.client.utils._concurrency import ConcurrencySettings
 from cognite.client.utils._importing import local_import
 
+# For "pyodide reasons", we need to know if the user has changed this to a non-default value:
+_DEFAULT_MAX_CONNECTION_POOL_SIZE = 20
+
 
 class GlobalConfig:
     """Global configuration object
@@ -52,6 +55,10 @@ class GlobalConfig:
             translates to 65536 (64KiB chunks).
         silence_feature_preview_warnings (bool): Whether or not to silence warnings triggered by using alpha or beta
             features. Defaults to False.
+
+    Note:
+        ``disable_ssl``, ``ssl_context``, and ``proxy`` are ignored when running in a browser (Pyodide/JupyterLite/Streamlit):
+        networking there is handled by the browser's JS runtime, which controls certificate validation and proxying itself.
     """
 
     _instance: ClassVar[GlobalConfig]
@@ -74,7 +81,7 @@ class GlobalConfig:
         self.max_retries: int = 10
         self.max_retries_connect: int = 3
         self.max_retry_backoff: int = 60
-        self.max_connection_pool_size: int = 20
+        self.max_connection_pool_size: int = _DEFAULT_MAX_CONNECTION_POOL_SIZE
         self.disable_ssl: bool = False
         self.ssl_context: ssl.SSLContext | None = None
         self.proxy: str | None = None

--- a/tests/tests_unit/test_http_client.py
+++ b/tests/tests_unit/test_http_client.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import ssl
+import warnings
 from collections.abc import AsyncIterator, Iterator
 
 import httpx2
@@ -227,6 +228,13 @@ class TestGetGlobalAsyncHttpxClient:
         assert pool._keepalive_expiry == 5
         assert pool._ssl_context.verify_mode == ssl.CERT_NONE  # disable_ssl should cause this
         assert pool._ssl_context.check_hostname is False
+
+    async def test_pyodide_client_no_warning_at_default_settings(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr("cognite.client._http_client._RUNNING_IN_PYODIDE", True)
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")  # fail the test if anything warns
+            get_global_async_httpx_client()
 
 
 def make_response(status_code: int) -> CogniteHTTPResponse:

--- a/tests/tests_unit/test_http_client.py
+++ b/tests/tests_unit/test_http_client.py
@@ -229,6 +229,17 @@ class TestGetGlobalAsyncHttpxClient:
         assert pool._ssl_context.verify_mode == ssl.CERT_NONE  # disable_ssl should cause this
         assert pool._ssl_context.check_hostname is False
 
+    async def test_pyodide_client_warns_about_settings_with_no_effect(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr("cognite.client._http_client._RUNNING_IN_PYODIDE", True)
+        monkeypatch.setattr(global_config, "disable_ssl", True)
+        monkeypatch.setattr(global_config, "proxy", "http://explicit:1234")
+
+        with pytest.warns(
+            RuntimeWarning,
+            match="global_config.disable_ssl.*global_config.proxy.*no effect when running in a browser",
+        ):
+            get_global_async_httpx_client()
+
     async def test_pyodide_client_no_warning_at_default_settings(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setattr("cognite.client._http_client._RUNNING_IN_PYODIDE", True)
 

--- a/tests/tests_unit/test_http_client.py
+++ b/tests/tests_unit/test_http_client.py
@@ -229,6 +229,23 @@ class TestGetGlobalAsyncHttpxClient:
         assert pool._ssl_context.verify_mode == ssl.CERT_NONE  # disable_ssl should cause this
         assert pool._ssl_context.check_hostname is False
 
+    async def test_pyodide_client_never_passes_ignored_options(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # when using pyodide, we should not pass any of the unsupported options to httpx2.AsyncClient
+        monkeypatch.setattr("cognite.client._http_client._RUNNING_IN_PYODIDE", True)
+        monkeypatch.setattr(global_config, "max_connection_pool_size", 69)
+        monkeypatch.setattr(global_config, "disable_ssl", True)
+        monkeypatch.setattr(global_config, "proxy", "http://explicit:1234")
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")  # actual warnings are tested separately
+            client = get_global_async_httpx_client()
+
+        assert not client._mounts  # proxy was not forwarded
+
+        pool = client._transport._pool  # type: ignore[attr-defined]
+        assert pool._max_connections != 69  # limits was not forwarded
+        assert pool._ssl_context.verify_mode == ssl.CERT_REQUIRED  # verify was not forwarded
+
     async def test_pyodide_client_warns_about_settings_with_no_effect(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setattr("cognite.client._http_client._RUNNING_IN_PYODIDE", True)
         monkeypatch.setattr(global_config, "disable_ssl", True)


### PR DESCRIPTION
Quite a few of the options to `httpx2.AsyncClient` are not configurable while in the browser. This PR avoid passing them + throws warning for any setting the user may have customized that are in conflict.

<img width="1950" height="356" alt="image" src="https://github.com/user-attachments/assets/3bed7f7a-0076-4ec6-ab98-a6cd8ae56be8" />
