### PR TITLE
chore: Fix test pollution

### DIFF
--- a/tests/tests_unit/test_docstring_examples.py
+++ b/tests/tests_unit/test_docstring_examples.py
@@ -155,7 +155,16 @@ class TestDocstringExamples:
         run_docstring_tests(units)
 
     def test_config(self) -> None:
-        run_docstring_tests(config)
+        # Note: GlobalConfig's docstring examples mutate the real, singleton 'global_config'.
+        # Doctests have no monkeypatch/fixture teardown, so we need to very carefully do this
+        # ourselves to not get test pollution... (this was painful to debug)
+        original_settings = vars(config.global_config).copy()
+        original_settings["status_forcelist"] = original_settings["status_forcelist"].copy()
+        try:
+            run_docstring_tests(config)
+        finally:
+            for key, value in original_settings.items():
+                setattr(config.global_config, key, value)
 
     def test_hosted_extractors(self) -> None:
         run_docstring_tests(mappings)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -13,12 +13,12 @@ import random
 import string
 import typing
 from collections.abc import Mapping
-from contextlib import ExitStack, contextmanager
+from contextlib import contextmanager
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from types import UnionType
 from typing import Any, Literal, TypeVar, get_args, get_origin, get_type_hints
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 from zoneinfo import ZoneInfo
 
 import cognite.client.utils._auxiliary
@@ -273,21 +273,23 @@ def fresh_concurrency_state() -> typing.Iterator[Any]:
                     assert isinstance(v, dict), f"expected a cache dict for {sub.api_name}.{k}"
                     v.clear()
 
-    # Why is this so complicated?? Well... we use patch.object on each attribute's current value to both unfreeze it
-    # for the duration of the block and ensure it's reverted after the ctx mngr exits, no matter how it got mutated.
-    # Any *_cache attrs are skipped here and instead cleared via clear_caches(). This is because patch.object would
-    # just restore the same dict object by ref, (ie the mutated one), so nothing would actually revert:
-    with ExitStack() as stack:
-        stack.enter_context(patch.object(cs, "_ConcurrencySettings__frozen", False))
-        for sub in subs:
-            for key, value in vars(sub).items():
-                if not key.endswith("_cache"):
-                    stack.enter_context(patch.object(sub, key, value))
+    # Snapshot every non-cache attribute (read/write/delete/etc.) so they can be restored regardless of how they got
+    # changed inside the with block. '*_cache' attrs are excluded here and cleared instead via clear_caches():
+    # restoring a shallow-copied dict would just alias the same mutated dict, so nothing would actually revert.
+    orig_frozen = cs.is_frozen
+    orig_states = [{k: v for k, v in vars(sub).items() if not k.endswith("_cache")} for sub in subs]
+
+    cs._ConcurrencySettings__frozen = False  # type: ignore[attr-defined]
+    clear_caches()
+    try:
+        yield cs
+    finally:
+        cs._ConcurrencySettings__frozen = False  # type: ignore[attr-defined]
+        for sub, state in zip(subs, orig_states):
+            for k, v in state.items():
+                setattr(sub, k, v)
         clear_caches()
-        try:
-            yield cs
-        finally:
-            clear_caches()
+        cs._ConcurrencySettings__frozen = orig_frozen  # type: ignore[attr-defined]
 
 
 @contextmanager

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -13,12 +13,12 @@ import random
 import string
 import typing
 from collections.abc import Mapping
-from contextlib import contextmanager
+from contextlib import ExitStack, contextmanager
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from types import UnionType
 from typing import Any, Literal, TypeVar, get_args, get_origin, get_type_hints
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 from zoneinfo import ZoneInfo
 
 import cognite.client.utils._auxiliary
@@ -253,8 +253,10 @@ def random_gamma_dist_integer(inclusive_max: int, max_tries: int = 100) -> int:
 
 @contextmanager
 def fresh_concurrency_state() -> typing.Iterator[Any]:
-    """Clears all per-loop/-project semaphore caches and unfreezes ``global_config.concurrency_settings``
-    for the duration of the block, then restores the original frozen state.
+    """Clears all per-loop/-project semaphore (and, for 'files', open-file-handle) caches and
+    unfreezes 'global_config.concurrency_settings' for the duration of the block, then restores
+    the original frozen state and the original read/write/delete/etc. values of every sub-config
+    (e.g. 'cs.general.read')
 
     Use this when a test needs to mutate concurrency settings or observe semaphore creation
     on a clean slate. Yields the (singleton) ``ConcurrencySettings`` for convenience.
@@ -262,17 +264,30 @@ def fresh_concurrency_state() -> typing.Iterator[Any]:
     from cognite.client import global_config
 
     cs = global_config.concurrency_settings
-    orig_frozen = cs.is_frozen
-    cs._ConcurrencySettings__frozen = False  # type: ignore[attr-defined]
-    for sub in cs._all_concurrency_configs:
-        sub._semaphore_cache.clear()
-    try:
-        yield cs
-    finally:
-        cs._ConcurrencySettings__frozen = False  # type: ignore[attr-defined]
-        for sub in cs._all_concurrency_configs:
-            sub._semaphore_cache.clear()
-        cs._ConcurrencySettings__frozen = orig_frozen  # type: ignore[attr-defined]
+    subs = cs._all_concurrency_configs
+
+    def clear_caches() -> None:
+        for sub in subs:
+            for k, v in vars(sub).items():
+                if k.endswith("_cache"):
+                    assert isinstance(v, dict), f"expected a cache dict for {sub.api_name}.{k}"
+                    v.clear()
+
+    # Why is this so complicated?? Well... we use patch.object on each attribute's current value to both unfreeze it
+    # for the duration of the block and ensure it's reverted after the ctx mngr exits, no matter how it got mutated.
+    # Any *_cache attrs are skipped here and instead cleared via clear_caches(). This is because patch.object would
+    # just restore the same dict object by ref, (ie the mutated one), so nothing would actually revert:
+    with ExitStack() as stack:
+        stack.enter_context(patch.object(cs, "_ConcurrencySettings__frozen", False))
+        for sub in subs:
+            for key, value in vars(sub).items():
+                if not key.endswith("_cache"):
+                    stack.enter_context(patch.object(sub, key, value))
+        clear_caches()
+        try:
+            yield cs
+        finally:
+            clear_caches()
 
 
 @contextmanager


### PR DESCRIPTION
Recent CI flakiness has come from test pollution causing failures depending on bad luck for ordering the tests run in.

I found three examples:

```
1. 
tests/tests_unit/test_http_client.py::TestGetGlobalAsyncHttpxClient::test_pyodide_client_no_warning_at_default_settings
-> polluting: tests/tests_unit/test_docstring_examples.py::TestDocstringExamples::test_config

2.
failig: tests/tests_unit/test_cognite_client.py::TestCogniteClient::test_verify_ssl_enabled_by_default
-> polluting: tests/tests_unit/test_docstring_examples.py::TestDocstringExamples::test_config

3.
failig: tests/tests_unit/test_api_client.py::TestStandardList::test_list_partitions_with_failure
-> polluting: tests/tests_unit/test_utils/test_concurrency_threading.py::TestSyncClientMultiThreadedEnv::test_semaphore_limits_concurrent_operations_via_background_loop
```

This PR adresses all three of them.