### PR TITLE
feat(state time series): add retrieve support for simple state aggregate datapoints (DM-4096)

### DIFF
--- a/cognite/client/_api/datapoint_tasks.py
+++ b/cognite/client/_api/datapoint_tasks.py
@@ -26,7 +26,9 @@ from cognite.client._proto.data_point_list_response_pb2 import TIMESERIES_TYPE_S
 from cognite.client.data_classes.data_modeling import NodeId
 from cognite.client.data_classes.datapoint_aggregates import (
     _INT_AGGREGATES_CAMEL,
+    _NOT_YET_IMPLEMENTED_STATE_AGGS_CAMEL,
     _OBJECT_AGGREGATES_CAMEL,
+    _UNSUPPORTED_STATE_AGGS_CAMEL,
     Aggregate,
 )
 from cognite.client.data_classes.datapoints import (

--- a/cognite/client/_api/datapoint_tasks.py
+++ b/cognite/client/_api/datapoint_tasks.py
@@ -989,6 +989,32 @@ class BaseAggTaskOrchestrator(BaseTaskOrchestrator):
         self._set_aggregate_vars(query.aggs_camel_case, use_numpy, query.include_status)
         super().__init__(query=query, use_numpy=use_numpy, **kwargs)
 
+    def _store_ts_info(self, res: DataPointListItem) -> None:
+        super()._store_ts_info(res)
+
+        # We raise as soon as we learn the time series is state-based (only known once the API has responded),
+        # rather than waiting until we're deep into unpacking/result-building:
+        if not self.is_state_dps:
+            return
+
+        if self.use_numpy:
+            raise NotImplementedError(
+                "Retrieving aggregate state datapoints is not yet supported when using numpy arrays "
+                "(i.e. retrieve_arrays). Please use 'retrieve' instead for now."
+            )
+        if unsupported_aggs := _UNSUPPORTED_STATE_AGGS_CAMEL.intersection(self.all_aggregates):
+            raise NotImplementedError(
+                f"Retrieving the aggregate(s) {sorted(unsupported_aggs)} for state datapoints is not yet supported. "
+                "It may not be supported until the next major version due to technicalities in what constitutes a breaking "
+                "change in our data classes. If you have an immediate need for this, please reach out on Github: "
+                "https://github.com/cognitedata/cognite-sdk-python/issues"
+            )
+        if not_yet_aggs := _NOT_YET_IMPLEMENTED_STATE_AGGS_CAMEL.intersection(self.all_aggregates):
+            raise NotImplementedError(
+                f"Retrieving the aggregate(s) {sorted(not_yet_aggs)} for state datapoints is not implemented yet, "
+                "but it's coming soon!"
+            )
+
     @cached_property
     def offset_next(self) -> int:
         return granularity_to_ms(cast(str, self.query.granularity))

--- a/cognite/client/_api/datapoint_tasks.py
+++ b/cognite/client/_api/datapoint_tasks.py
@@ -1034,9 +1034,6 @@ class BaseAggTaskOrchestrator(BaseTaskOrchestrator):
         return Datapoints(timestamp=[], **self.ts_info, **convert_all_keys_to_snake_case(lst_dct))
 
     def _get_result(self) -> Datapoints | DatapointsArray:
-        if self.is_state_dps:
-            raise NotImplementedError("Retrieving aggregate state datapoints is not yet supported.")
-
         if not self.ts_data or self.query.limit == 0:
             return self._create_empty_result()
 
@@ -1071,9 +1068,6 @@ class BaseAggTaskOrchestrator(BaseTaskOrchestrator):
         return Datapoints(**self.ts_info, **convert_all_keys_to_snake_case(lst_dct))
 
     def _unpack_and_store(self, idx: tuple[float, ...], dps: AggregateDatapoints) -> None:  # type: ignore [override]
-        if self.is_state_dps:
-            raise NotImplementedError("Retrieving aggregate state datapoints is not yet supported.")
-
         # Object aggregates are unpacked similarly for basic and numpy and only converted later (for numpy)
         if self.object_aggs:
             for agg, unpack_fn in zip(self.object_aggs, self.object_agg_unpack_fns):

--- a/cognite/client/data_classes/datapoint_aggregates.py
+++ b/cognite/client/data_classes/datapoint_aggregates.py
@@ -28,6 +28,18 @@ _OBJECT_AGGREGATES_CAMEL: frozenset[Literal["maxDatapoint", "minDatapoint"]] = f
 )
 OBJECT_AGGREGATES: frozenset[Literal["max_datapoint", "min_datapoint"]] = frozenset({"max_datapoint", "min_datapoint"})
 
+# These currently break existing logic (because they reuse the old simple aggregate names), and we have no special
+# data class for state aggregate datapoints yet (breaking -> v9) so we simply don't support them for now:
+_UNSUPPORTED_STATE_AGGS_CAMEL: frozenset[Literal["interpolation", "stepInterpolation"]] = frozenset(
+    {"interpolation", "stepInterpolation"}
+)
+
+# These are per-distinct-state breakdown aggregates (one entry per state, per interval) returned in a nested/repeated
+# shape that none of our data classes can represent yet. Not started on, but planned:
+_NOT_YET_IMPLEMENTED_STATE_AGGS_CAMEL: frozenset[Literal["stateCount", "stateTransitions", "stateDuration"]] = (
+    frozenset({"stateCount", "stateTransitions", "stateDuration"})
+)
+
 # Assumption: All INT aggregates should adhere to the following logic: Missing values can be replace with 0.
 #             Thus, if you add a new aggregate here, and this is no longer the case, a refactor is needed:
 _INT_AGGREGATES_CAMEL = frozenset(

--- a/cognite/client/utils/_pandas_helpers.py
+++ b/cognite/client/utils/_pandas_helpers.py
@@ -462,6 +462,16 @@ def _extract_raw_column_info(
     return columns
 
 
+def get_unit_for_aggregate(dps: Datapoints | DatapointsArray, aggregate: str) -> str | None:
+    # We show physical unit if the aggregate somewhat makes sense (e.g. average, but also (..)_variance).
+    # State time series have no notion of a physical unit for any of their aggregates (e.g. 'interpolation'
+    # is not well-defined for a discrete state), so we never show unit for these, regardless of the aggregate:
+    if dps.type == "state" or aggregate not in _AGGREGATES_WITH_UNIT:
+        return None
+    # Note the '... or None' is there because the API returns empty string when missing for some reason:
+    return dps.unit_external_id or None
+
+
 def _extract_aggregate_column_info_from_dps(
     dps: Datapoints | DatapointsArray, identifier: NodeId | str | int, is_array: bool
 ) -> list[_DpsColumnInfo]:
@@ -473,9 +483,7 @@ def _extract_aggregate_column_info_from_dps(
             is_array=is_array,
             aggregate=agg,
             granularity=dps.granularity,
-            # We show physical unit if the aggregate somewhat makes sense (e.g. average, but also (..)_variance).
-            # Note the '... or None' is there because the API returns empty string when missing for some reason:
-            unit_xid=dps.unit_external_id or None if agg in _AGGREGATES_WITH_UNIT else None,
+            unit_xid=get_unit_for_aggregate(dps, agg),
         )
         for agg in aggregates
     ]
@@ -488,7 +496,6 @@ def _extract_column_info_from_dps_for_dataframe(
 
     identifier = _resolve_ts_identifier_as_df_column_name(dps)
     is_array = isinstance(dps, DatapointsArray)
-    # TODO: State raw vs aggregate dps must be routed differently (when we have support for the latter...)
     if dps.type == "state":
         if is_array:
             # Unreachable state in the SDK, but users may instantiate manually, so we need to handle it:
@@ -497,10 +504,7 @@ def _extract_column_info_from_dps_for_dataframe(
             )
         assert isinstance(dps, Datapoints)  # mypy doesn't understand the is-array-raise-check above...
         if dps.numeric_states is None or dps.string_states is None:
-            # ...also unreachable, but same gotcha as above:
-            raise NotImplementedError(
-                "State aggregate datapoints are not yet supported for conversion to pandas DataFrame"
-            )
+            return _extract_aggregate_column_info_from_dps(dps, identifier, is_array)
         else:
             return _extract_raw_states_column_info(
                 dps, identifier, include_status, include_numeric_states, include_string_states

--- a/tests/tests_integration/test_api/test_datapoints.py
+++ b/tests/tests_integration/test_api/test_datapoints.py
@@ -962,9 +962,9 @@ class TestRetrieveStateDatapoints:
         [
             pytest.param(
                 lambda client, ts_id: client.time_series.data.retrieve(
-                    instance_id=ts_id, aggregates="count", granularity="1h", limit=1
+                    instance_id=ts_id, aggregates="interpolation", granularity="1h", limit=1
                 ),
-                id="aggregate states retrieve",
+                id="interpolation aggregate states retrieve",
             ),
             pytest.param(
                 lambda client, ts_id: client.time_series.data.retrieve_arrays(

--- a/tests/tests_integration/test_api/test_datapoints.py
+++ b/tests/tests_integration/test_api/test_datapoints.py
@@ -94,6 +94,8 @@ from tests.utils import (
 DATAPOINTS_API = "cognite.client._api.datapoints.{}"
 WEEK_MS = UNIT_IN_MS["w"]
 DAY_MS = UNIT_IN_MS["d"]
+HOUR_MS = UNIT_IN_MS["h"]
+MINUTE_MS = UNIT_IN_MS["m"]
 YEAR_MS = {
     1950: -631152000000,
     1965: -157766400000,
@@ -993,6 +995,89 @@ class TestRetrieveStateDatapoints:
         ts_id = empty_state_ts.as_id()
         with pytest.raises(NotImplementedError, match=r"[sS]tate datapoints"):
             retrieve_call(cognite_client, ts_id)
+
+    @pytest.mark.allow_no_semaphore(
+        "StateDatapointsPoster._insert_datapoints holds the semaphore via outer "
+        "'async with' and calls the http client directly with semaphore=None to avoid double-acquiring."
+    )
+    def test_retrieve_state_aggregate_datapoints(
+        self,
+        cognite_client: CogniteClient,
+        async_client: AsyncCogniteClient,
+        space_for_time_series: Space,
+        state_set: NodeApplyResult,
+        request: pytest.FixtureRequest,
+    ) -> None:
+        # These are (currently) the only aggregates the API supports for state time series:
+        aggs = [
+            "count",
+            "count_good",
+            "count_uncertain",
+            "count_bad",
+            "duration_good",
+            "duration_uncertain",
+            "duration_bad",
+        ]
+        xid = f"dms-state-aggregates-{random_string(10)}"
+        node_id = NodeId(space_for_time_series.space, xid)
+        request.addfinalizer(lambda: cognite_client.data_modeling.instances.delete(node_id))
+        _create_state_time_series(
+            external_id=xid,
+            cognite_client=cognite_client,
+            async_client=async_client,
+            space_for_time_series=space_for_time_series,
+            state_set=state_set,
+        )
+
+        base = 1_700_000_000_000
+        base -= base % HOUR_MS  # align to an hour boundary so our buckets are exact
+        cognite_client.time_series.data.insert_states(
+            StateDatapointsInsert(
+                instance_id=node_id,
+                datapoints=[
+                    # Bucket 0, [base, base+1h): three good datapoints
+                    StateDatapointWrite(base, numeric_value=0),
+                    StateDatapointWrite(base + 10 * MINUTE_MS, numeric_value=1),
+                    StateDatapointWrite(base + 20 * MINUTE_MS, numeric_value=0),
+                    # Bucket 1, [base+1h, base+2h): one good, then one bad
+                    StateDatapointWrite(base + HOUR_MS, numeric_value=1),
+                    StateDatapointWrite(base + HOUR_MS + 10 * MINUTE_MS, status_symbol="Bad"),
+                    # Bucket 2, [base+2h, base+3h): an uncertain datapoint, closed off by a later good one. A status
+                    # with no datapoint after it *anywhere* in the retrieved data gets duration 0, since the API has
+                    # no way of knowing how long it persisted.
+                    StateDatapointWrite(base + 2 * HOUR_MS, numeric_value=0, status_symbol="Uncertain"),
+                    StateDatapointWrite(base + 2 * HOUR_MS + 40 * MINUTE_MS, numeric_value=1),
+                ],
+            )
+        )
+        dps = cognite_client.time_series.data.retrieve(
+            instance_id=node_id,
+            start=base,
+            end=base + 3 * HOUR_MS,
+            aggregates=aggs,
+            granularity="1h",
+        )
+        assert dps is not None
+        assert dps.type == "state"
+        assert len(dps) == 3
+        assert dps.count == [3, 1, 1]
+        assert dps.count_good == [3, 1, 1]
+        assert dps.count_uncertain == [0, 0, 1]
+        assert dps.count_bad == [0, 1, 0]
+
+        assert dps.duration_good is not None
+        assert dps.duration_uncertain is not None
+        assert dps.duration_bad is not None
+        assert all(d >= 0 for d in [*dps.duration_good, *dps.duration_uncertain, *dps.duration_bad])
+        assert dps.duration_good[0] == HOUR_MS  # good for the entire first bucket
+        assert dps.duration_good[1] == 10 * MINUTE_MS  # good until the bad datapoint arrives
+        assert dps.duration_bad[1] == 50 * MINUTE_MS  # bad until the next (good) datapoint, an hour later
+        assert dps.duration_uncertain[2] == 40 * MINUTE_MS  # uncertain until the closing good datapoint
+
+        df = dps.to_pandas(include_aggregate_name=True)
+        assert len(df) == 3
+        assert sorted(df.columns.get_level_values("aggregate")) == sorted(aggs)
+        assert set(df.columns.get_level_values("identifier")) == {node_id}
 
     @pytest.mark.parametrize("aggregate", ["interpolation", "step_interpolation"])
     def test_retrieve_state_aggregate_datapoints_interpolation_raises(

--- a/tests/tests_integration/test_api/test_datapoints.py
+++ b/tests/tests_integration/test_api/test_datapoints.py
@@ -994,6 +994,28 @@ class TestRetrieveStateDatapoints:
         with pytest.raises(NotImplementedError, match=r"[sS]tate datapoints"):
             retrieve_call(cognite_client, ts_id)
 
+    @pytest.mark.parametrize("aggregate", ["interpolation", "step_interpolation"])
+    def test_retrieve_state_aggregate_datapoints_interpolation_raises(
+        self,
+        cognite_client: CogniteClient,
+        empty_state_ts: NodeApplyResult,
+        aggregate: str,
+    ) -> None:
+        ts_id = empty_state_ts.as_id()
+        with pytest.raises(NotImplementedError, match="not yet supported"):
+            cognite_client.time_series.data.retrieve(instance_id=ts_id, aggregates=aggregate, granularity="1h")
+
+    @pytest.mark.parametrize("aggregate", ["state_count", "state_transitions", "state_duration"])
+    def test_retrieve_state_aggregate_datapoints_not_yet_implemented_raises(
+        self,
+        cognite_client: CogniteClient,
+        empty_state_ts: NodeApplyResult,
+        aggregate: str,
+    ) -> None:
+        ts_id = empty_state_ts.as_id()
+        with pytest.raises(NotImplementedError, match="coming soon"):
+            cognite_client.time_series.data.retrieve(instance_id=ts_id, aggregates=aggregate, granularity="1h")
+
 
 @pytest.fixture
 def queries_for_iteration(all_test_time_series: TimeSeriesList) -> list[DatapointsQuery]:


### PR DESCRIPTION
Adds support for aggregate datapoints for calls to `client.time_series.data.retrieve` for simple aggregates:
```
[
    "count",
    "count_good",
    "count_uncertain",
    "count_bad",
    "duration_good",
    "duration_uncertain",
    "duration_bad",
]
```
and specific errors for unsupported / not-yet-added:
```
[
    "interpolation",
    "step_interpolation",
    "state_count",
    "state_transitions",
    "state_duration",
]
```